### PR TITLE
cmake: Prefer to find the raw lua library instead of a versioned one

### DIFF
--- a/cmake/FindLua.cmake
+++ b/cmake/FindLua.cmake
@@ -111,7 +111,7 @@ find_path(LUA_INCLUDE_DIR lua.h
 unset(_lua_include_subdirs)
 
 find_library(LUA_LIBRARY
-  NAMES ${_lua_library_names} lua
+  NAMES lua ${_lua_library_names}
   HINTS
     ENV LUA_DIR
   PATH_SUFFIXES lib


### PR DESCRIPTION
The FindLua.cmake function prefers to find the lua library that is
formatted like lua<version>.<os suffix>. This leads to it picking
incompatible headers and libraries on certain distros (notably
Arch). Therefore, if we prefer to find lua.<os suffix> it is more
likely to match with the includes.