### PR TITLE
Clean up the demo console interface

### DIFF
--- a/cmake/DaemonCBSE.cmake
+++ b/cmake/DaemonCBSE.cmake
@@ -33,19 +33,6 @@ function(maybe_add_dep target dep)
 endfunction()
 
 function(CBSE target definition output)
-    # Check if we need to initialize submodule
-    file(GLOB RESULT ${CMAKE_SOURCE_DIR}/src/utils/cbse)
-    list(LENGTH ${RESULT} RES_LEN)
-    if(RES_LEN EQUAL 0)
-        if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-            find_package(Git REQUIRED)
-            if (GIT_FOUND)
-                execute_process(
-                    COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
-                    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-            endif()
-        endif()
-    endif()
     # Check if python has all the dependencies
     # TODO: Execute pip directly here and install them
     execute_process(

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1009,7 +1009,7 @@ void CL_SetCGameTime()
 
 	// a timedemo will always use a deterministic set of time samples
 	// no matter what speed machine it is run on
-	if ( cl_timedemo->integer )
+	if ( cvar_cl_demo_print_time.Get() )
 	{
 		if ( !clc.timeDemoStart )
 		{

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -947,48 +947,39 @@ void CL_SetCGameTime()
 
 	cl.oldFrameServerTime = cl.snap.serverTime;
 
-	// get our current view of time
+    // cl_timeNudge is a user adjustable cvar that allows more
+    // or less latency to be added in the interest of better
+    // smoothness or better responsiveness.
+    int tn;
 
-	if ( clc.demoplaying && cl_freezeDemo->integer )
-	{
-		// cl_freezeDemo is used to lock a demo in place for single frame advances
-	}
-	else
-	{
-		// cl_timeNudge is a user adjustable cvar that allows more
-		// or less latency to be added in the interest of better
-		// smoothness or better responsiveness.
-		int tn;
+    tn = cl_timeNudge->integer;
 
-		tn = cl_timeNudge->integer;
+    if ( tn < -30 )
+    {
+        tn = -30;
+    }
+    else if ( tn > 30 )
+    {
+        tn = 30;
+    }
 
-		if ( tn < -30 )
-		{
-			tn = -30;
-		}
-		else if ( tn > 30 )
-		{
-			tn = 30;
-		}
+    cl.serverTime = cls.realtime + cl.serverTimeDelta - tn;
 
-		cl.serverTime = cls.realtime + cl.serverTimeDelta - tn;
+    // guarantee that time will never flow backwards, even if
+    // serverTimeDelta made an adjustment or cl_timeNudge was changed
+    if ( cl.serverTime < cl.oldServerTime )
+    {
+        cl.serverTime = cl.oldServerTime;
+    }
 
-		// guarantee that time will never flow backwards, even if
-		// serverTimeDelta made an adjustment or cl_timeNudge was changed
-		if ( cl.serverTime < cl.oldServerTime )
-		{
-			cl.serverTime = cl.oldServerTime;
-		}
+    cl.oldServerTime = cl.serverTime;
 
-		cl.oldServerTime = cl.serverTime;
-
-		// note if we are almost past the latest frame (without timeNudge),
-		// so we will try and adjust back a bit when the next snapshot arrives
-		if ( cls.realtime + cl.serverTimeDelta >= cl.snap.serverTime - 5 )
-		{
-			cl.extrapolatedSnapshot = true;
-		}
-	}
+    // note if we are almost past the latest frame (without timeNudge),
+    // so we will try and adjust back a bit when the next snapshot arrives
+    if ( cls.realtime + cl.serverTimeDelta >= cl.snap.serverTime - 5 )
+    {
+        cl.extrapolatedSnapshot = true;
+    }
 
 	// if we have gotten new snapshots, drift serverTimeDelta
 	// don't do this every frame, or a period of packet loss would

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1000,7 +1000,7 @@ void CL_SetCGameTime()
 
 	// a timedemo will always use a deterministic set of time samples
 	// no matter what speed machine it is run on
-	if ( cvar_cl_demo_print_time.Get() )
+	if ( cvar_demo_timedemo.Get() )
 	{
 		if ( !clc.timeDemoStart )
 		{

--- a/src/engine/client/cl_keys.cpp
+++ b/src/engine/client/cl_keys.cpp
@@ -1801,16 +1801,6 @@ void CL_KeyEvent( int key, bool down, unsigned time )
 
 	// most keys during demo playback will bring up the menu, but non-ascii
 
-	/* Do something better than this :)
-	// keys can still be used for bound actions
-	if ( down && ( key < 128 || key == K_MOUSE1 )
-	         && ( clc.demoplaying || cls.state == CA_CINEMATIC ) && !cls.keyCatchers ) {
-
-	        Cvar_Set( "nextdemo","" );
-	        key = K_ESCAPE;
-	}
-	*/
-
 	// escape is always handled special
 	if ( key == K_ESCAPE && down )
 	{

--- a/src/engine/client/cl_keys.cpp
+++ b/src/engine/client/cl_keys.cpp
@@ -1816,7 +1816,7 @@ void CL_KeyEvent( int key, bool down, unsigned time )
 	{
 		if ( !( cls.keyCatchers & KEYCATCH_UI ) )
 		{
-			if ( cls.state == connstate_t::CA_ACTIVE && !clc.demoplaying )
+			if ( cls.state == connstate_t::CA_ACTIVE )
 			{
 				// Arnout: on request
 				if ( cls.keyCatchers & KEYCATCH_CONSOLE ) // get rid of the console

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -99,6 +99,13 @@ Cvar::Cvar<std::string> cvar_cl_demo_status_filename(
     ""
 );
 
+Cvar::Cvar<std::string> cvar_cl_demo_next(
+    "cl_demo_next",
+    "Name of the demo to play after the current one",
+    Cvar::NONE,
+    ""
+);
+
 cvar_t *cl_aviFrameRate;
 
 cvar_t *cl_freelook;
@@ -877,19 +884,16 @@ If the "nextdemo" cvar is set, that command will be issued
 */
 void CL_NextDemo()
 {
-	char v[ MAX_STRING_CHARS ];
+	std::string v = cvar_cl_demo_next.Get();
 
-	Q_strncpyz( v, Cvar_VariableString( "nextdemo" ), sizeof( v ) );
-	v[ MAX_STRING_CHARS - 1 ] = 0;
-	Log::Debug( "CL_NextDemo: %s", v );
-
-	if ( !v[ 0 ] )
+	if ( v.empty() )
 	{
 		return;
 	}
 
-	Cvar_Set( "nextdemo", "" );
-	Cmd::BufferCommandTextAfter(v, true);
+	Log::Debug( "CL_NextDemo: %s", v );
+	cvar_cl_demo_next.Set("");
+	Cmd::BufferCommandTextAfter("demo_play " + v, false);
 	Cmd::ExecuteCommandBuffer();
 }
 

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -729,10 +729,6 @@ void CL_WriteWaveOpen()
 		return;
 	}
 
-	// yes ... no ? leave it up to them imo
-	//if (cl_avidemo.integer)
-	//  return;
-
 	if ( Cmd_Argc() == 2 )
 	{
 		s = Cmd_Argv( 1 );
@@ -1419,8 +1415,6 @@ void CL_Connect_f()
 		cls.state = connstate_t::CA_CONNECTING;
 	}
 
-	Cvar_Set( "cl_avidemo", "0" );
-
 	// we need to setup a correct default for this, otherwise the first val we set might reappear
 	Cvar_Set( "com_errorMessage", "" );
 
@@ -1794,7 +1788,6 @@ void CL_Vid_Restart_f()
 	// settings may have changed so stop recording now
 	if ( CL_VideoRecording() )
 	{
-		Cvar_Set( "cl_avidemo", "0" );
 		CL_CloseAVI();
 	}
 

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -738,7 +738,7 @@ void CL_ShutdownAll()
 	cls.soundRegistered = false;
 
 	// Gordon: stop recording on map change etc, demos aren't valid over map changes anyway
-    CL_StopRecord();
+	CL_StopRecord();
 }
 
 /*

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -329,10 +329,10 @@ void CL_StopRecord()
     Log::Notice("%s", "Stopped demo.\n" );
 }
 
-class DemoStopRecordCmd: public Cmd::StaticCmd
+class DemoRecordStopCmd: public Cmd::StaticCmd
 {
 public:
-    DemoStopRecordCmd()
+    DemoRecordStopCmd()
         : Cmd::StaticCmd("demo_record_stop", Cmd::SYSTEM, "Stops recording a demo")
     {}
 
@@ -346,7 +346,7 @@ public:
         CL_StopRecord();
     }
 };
-static DemoStopRecordCmd DemoStopRecordCmdRegistration;
+static DemoRecordStopCmd DemoRecordStopCmdRegistration;
 
 
 class DemoRecordCmd : public Cmd::StaticCmd

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -78,7 +78,27 @@ cvar_t *cl_shownet = nullptr; // NERVE - SMF - This is referenced in msg.c and w
 cvar_t *cl_shownuments; // DHM - Nerve
 cvar_t *cl_showSend;
 cvar_t *cl_showServerCommands; // NERVE - SMF
-cvar_t *cl_timedemo;
+
+Cvar::Cvar<bool> cvar_cl_demo_print_time(
+    "cl_demo_print_time",
+    "Whether to show timing statistics at the end of a demo",
+    Cvar::NONE,
+    false
+);
+
+Cvar::Cvar<bool> cvar_cl_demo_status_isrecording(
+    "cl_demo_status_isrecording",
+    "(Read-only) Whether there is a demo currently being recorded",
+    Cvar::ROM,
+    false
+);
+
+Cvar::Cvar<std::string> cvar_cl_demo_status_filename(
+    "cl_demo_status_filename",
+    "(Read-only) Name of the demo currently being recorded",
+    Cvar::ROM,
+    ""
+);
 
 cvar_t *cl_aviFrameRate;
 
@@ -118,9 +138,6 @@ cvar_t *cl_allowDownload;
 cvar_t *cl_inGameVideo;
 
 cvar_t *cl_serverStatusResendTime;
-
-cvar_t                 *cl_demorecording; // fretn
-cvar_t                 *cl_demofilename; // bani
 
 cvar_t                 *cl_waverecording; //bani
 cvar_t                 *cl_wavefilename; //bani
@@ -318,8 +335,8 @@ void CL_StopRecord()
     clc.demofile = 0;
 
     clc.demorecording = false;
-    Cvar_Set( "cl_demorecording", "0" );  // fretn
-    Cvar_Set( "cl_demofilename", "" );  // bani
+    Cvar::SetValueForce(cvar_cl_demo_status_isrecording.Name(), "0");
+    Cvar::SetValueForce(cvar_cl_demo_status_filename.Name(), "");
     Log::Notice("%s", "Stopped demo.\n" );
 }
 
@@ -428,9 +445,9 @@ void CL_Record(std::string demo_name)
     Log::Notice( "recording to %s.\n", file_name );
 
     clc.demorecording = true;
-    Cvar::SetValueCProxy("cl_demorecording", "1");
     Q_strncpyz(clc.demoName, demo_name.c_str(), std::min<std::size_t>(demo_name.size(), MAX_QPATH));
-    Cvar::SetValueCProxy("cl_demofilename", clc.demoName);
+    Cvar::SetValueForce(cvar_cl_demo_status_isrecording.Name(), "1");
+    Cvar::SetValueForce(cvar_cl_demo_status_filename.Name(), demo_name);
 
     // don't start saving messages until a non-delta compressed message is received
     clc.demowaiting = true;
@@ -517,7 +534,7 @@ CL_DemoCompleted
 
 void CL_DemoCompleted()
 {
-	if ( cl_timedemo && cl_timedemo->integer )
+	if ( cvar_cl_demo_print_time.Get() )
 	{
 		int time;
 
@@ -3521,7 +3538,6 @@ void CL_Init()
 	cl_activeAction = Cvar_Get( "activeAction", "", CVAR_TEMP );
 	cl_autorecord = Cvar_Get( "cl_autorecord", "0", CVAR_TEMP );
 
-	cl_timedemo = Cvar_Get( "timedemo", "0", 0 );
 	cl_aviFrameRate = Cvar_Get( "cl_aviFrameRate", "25", 0 );
 
 	// XreaL BEGIN
@@ -3596,8 +3612,6 @@ void CL_Init()
 	cl_altTab = Cvar_Get( "cl_altTab", "1", 0 );
 
 	//bani - make these cvars visible to cgame
-	cl_demorecording = Cvar_Get( "cl_demorecording", "0", CVAR_ROM );
-	cl_demofilename = Cvar_Get( "cl_demofilename", "", CVAR_ROM );
 	cl_waverecording = Cvar_Get( "cl_waverecording", "0", CVAR_ROM );
 	cl_wavefilename = Cvar_Get( "cl_wavefilename", "", CVAR_ROM );
 	cl_waveoffset = Cvar_Get( "cl_waveoffset", "0", CVAR_ROM );

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -326,7 +326,7 @@ void CL_StopRecord()
     clc.demorecording = false;
     Cvar::SetValueForce(cvar_demo_status_isrecording.Name(), "0");
     Cvar::SetValueForce(cvar_demo_status_filename.Name(), "");
-    Log::Notice("%s", "Stopped demo.\n" );
+    Log::Notice("%s", "Stopped demo." );
 }
 
 class DemoRecordStopCmd: public Cmd::StaticCmd
@@ -340,7 +340,7 @@ public:
     {
         if ( !clc.demorecording )
         {
-            Log::Notice("%s", "Not recording a demo.\n" );
+            Log::Notice("%s", "Not recording a demo." );
             return;
         }
         CL_StopRecord();
@@ -366,13 +366,13 @@ public:
 
         if ( clc.demorecording )
         {
-            Log::Warn("Already recording." );
+            Log::Warn("Already recording.");
             return;
         }
 
         if ( cls.state != connstate_t::CA_ACTIVE )
         {
-            Log::Warn("You must be in a level to record." );
+            Log::Warn("You must be in a level to record.");
             return;
         }
 
@@ -431,7 +431,7 @@ void CL_Record(std::string demo_name)
         Log::Warn("couldn't open %s.", file_name);
         return;
     }
-    Log::Notice( "recording to %s.\n", file_name );
+    Log::Notice( "recording to %s.", file_name );
 
     clc.demorecording = true;
     Q_strncpyz(clc.demoName, demo_name.c_str(), std::min<std::size_t>(demo_name.size(), MAX_QPATH));
@@ -531,7 +531,7 @@ void CL_DemoCompleted()
 
 		if ( time > 0 )
 		{
-			Log::Notice( "%i frames, %3.1fs: %3.1f fps\n", clc.timeDemoFrames,
+			Log::Notice( "%i frames, %3.1fs: %3.1f fps", clc.timeDemoFrames,
 			            time / 1000.0, clc.timeDemoFrames * 1000.0 / time );
 		}
 	}
@@ -599,7 +599,7 @@ void CL_ReadDemoMessage()
 
 	if ( r != buf.cursize )
 	{
-		Log::Notice("%s", "Demo file was truncated.\n" );
+		Log::Notice("%s", "Demo file was truncated.");
 		CL_DemoCompleted();
 		return;
 	}
@@ -1731,7 +1731,7 @@ public:
 
         if ( !clc.demoplaying )
         {
-            Log::Notice("%s", "The demo_video command can only be used when playing back demos\n" );
+            Log::Notice("%s", "The demo_video command can only be used when playing back demos");
             return;
         }
 

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -72,7 +72,6 @@ cvar_t *cl_maxpackets;
 cvar_t *cl_packetdup;
 cvar_t *cl_timeNudge;
 cvar_t *cl_showTimeDelta;
-cvar_t *cl_freezeDemo;
 
 cvar_t *cl_shownet = nullptr; // NERVE - SMF - This is referenced in msg.c and we need to make sure it is nullptr
 cvar_t *cl_shownuments; // DHM - Nerve
@@ -3527,7 +3526,6 @@ void CL_Init()
 	cl_showServerCommands = Cvar_Get( "cl_showServerCommands", "0", 0 );
 	cl_showSend = Cvar_Get( "cl_showSend", "0", CVAR_TEMP );
 	cl_showTimeDelta = Cvar_Get( "cl_showTimeDelta", "0", CVAR_TEMP );
-	cl_freezeDemo = Cvar_Get( "cl_freezeDemo", "0", CVAR_TEMP );
 	cl_activeAction = Cvar_Get( "activeAction", "", CVAR_TEMP );
 	cl_autorecord = Cvar_Get( "cl_autorecord", "0", CVAR_TEMP );
 

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -81,7 +81,6 @@ cvar_t *cl_showServerCommands; // NERVE - SMF
 cvar_t *cl_timedemo;
 
 cvar_t *cl_aviFrameRate;
-cvar_t *cl_forceavidemo;
 
 cvar_t *cl_freelook;
 cvar_t *cl_sensitivity;
@@ -3182,7 +3181,7 @@ void CL_Frame( int msec )
 	if ( CL_VideoRecording() && cl_aviFrameRate->integer && msec )
 	{
 		// save the current screen
-		if ( cls.state == connstate_t::CA_ACTIVE || cl_forceavidemo->integer )
+		if ( cls.state == connstate_t::CA_ACTIVE )
 		{
 			CL_TakeVideoFrame();
 
@@ -3523,7 +3522,6 @@ void CL_Init()
 	cl_autorecord = Cvar_Get( "cl_autorecord", "0", CVAR_TEMP );
 
 	cl_timedemo = Cvar_Get( "timedemo", "0", 0 );
-	cl_forceavidemo = Cvar_Get( "cl_forceavidemo", "0", 0 );
 	cl_aviFrameRate = Cvar_Get( "cl_aviFrameRate", "25", 0 );
 
 	// XreaL BEGIN

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -76,29 +76,22 @@ cvar_t *cl_shownuments; // DHM - Nerve
 cvar_t *cl_showSend;
 cvar_t *cl_showServerCommands; // NERVE - SMF
 
-Cvar::Cvar<bool> cvar_cl_demo_print_time(
-    "cl_demo_print_time",
-    "Whether to show timing statistics at the end of a demo",
-    Cvar::NONE,
-    false
-);
-
-Cvar::Cvar<bool> cvar_cl_demo_status_isrecording(
-    "cl_demo_status_isrecording",
+Cvar::Cvar<bool> cvar_demo_status_isrecording(
+    "demo.status.isrecording",
     "(Read-only) Whether there is a demo currently being recorded",
     Cvar::ROM,
     false
 );
 
-Cvar::Cvar<std::string> cvar_cl_demo_status_filename(
-    "cl_demo_status_filename",
+Cvar::Cvar<std::string> cvar_demo_status_filename(
+    "demo.status.filename",
     "(Read-only) Name of the demo currently being recorded",
     Cvar::ROM,
     ""
 );
 
-Cvar::Cvar<std::string> cvar_cl_demo_next(
-    "cl_demo_next",
+Cvar::Cvar<std::string> cvar_demo_next(
+    "demo.next",
     "Name of the demo to play after the current one",
     Cvar::NONE,
     ""
@@ -331,8 +324,8 @@ void CL_StopRecord()
     clc.demofile = 0;
 
     clc.demorecording = false;
-    Cvar::SetValueForce(cvar_cl_demo_status_isrecording.Name(), "0");
-    Cvar::SetValueForce(cvar_cl_demo_status_filename.Name(), "");
+    Cvar::SetValueForce(cvar_demo_status_isrecording.Name(), "0");
+    Cvar::SetValueForce(cvar_demo_status_filename.Name(), "");
     Log::Notice("%s", "Stopped demo.\n" );
 }
 
@@ -442,8 +435,8 @@ void CL_Record(std::string demo_name)
 
     clc.demorecording = true;
     Q_strncpyz(clc.demoName, demo_name.c_str(), std::min<std::size_t>(demo_name.size(), MAX_QPATH));
-    Cvar::SetValueForce(cvar_cl_demo_status_isrecording.Name(), "1");
-    Cvar::SetValueForce(cvar_cl_demo_status_filename.Name(), demo_name);
+    Cvar::SetValueForce(cvar_demo_status_isrecording.Name(), "1");
+    Cvar::SetValueForce(cvar_demo_status_filename.Name(), demo_name);
 
     // don't start saving messages until a non-delta compressed message is received
     clc.demowaiting = true;
@@ -530,7 +523,7 @@ CL_DemoCompleted
 
 void CL_DemoCompleted()
 {
-	if ( cvar_cl_demo_print_time.Get() )
+	if ( cvar_demo_timedemo.Get() )
 	{
 		int time;
 
@@ -692,12 +685,12 @@ static DemoPlayCmd DemoPlayCmdRegistration;
 CL_NextDemo
 
 Called when a demo or cinematic finishes
-If the "nextdemo" cvar is set, that command will be issued
+If the "demo.next" cvar is set, that command will be issued
 ==================
 */
 void CL_NextDemo()
 {
-	std::string v = cvar_cl_demo_next.Get();
+	std::string v = cvar_demo_next.Get();
 
 	if ( v.empty() )
 	{
@@ -705,7 +698,7 @@ void CL_NextDemo()
 	}
 
 	Log::Debug( "CL_NextDemo: %s", v );
-	cvar_cl_demo_next.Set("");
+	cvar_demo_next.Set("");
 	Cmd::BufferCommandTextAfter("demo_play " + v, false);
 	Cmd::ExecuteCommandBuffer();
 }

--- a/src/engine/client/cl_parse.cpp
+++ b/src/engine/client/cl_parse.cpp
@@ -234,43 +234,7 @@ void CL_ParseSnapshot( msg_t *msg )
 		{
 			if ( cl_autorecord->integer /*&& Cvar_VariableValue( "g_synchronousClients") */ )
 			{
-				char    name[ 256 ];
-				char    mapname[ MAX_QPATH ];
-				char    *period;
-				qtime_t time;
-
-				Com_RealTime( &time );
-
-				Q_strncpyz( mapname, cl.mapname, MAX_QPATH );
-
-				for ( period = mapname; *period; period++ )
-				{
-					if ( *period == '.' )
-					{
-						*period = '\0';
-						break;
-					}
-				}
-
-				for ( period = mapname; *period; period++ )
-				{
-					if ( *period == '/' )
-					{
-						break;
-					}
-				}
-
-				if ( *period )
-				{
-					period++;
-				}
-
-				Com_sprintf( name, sizeof( name ), "demos/%s_%04i-%02i-%02i_%02i%02i%02i.dm_%d", period,
-				             1900 + time.tm_year, time.tm_mon + 1, time.tm_mday,
-				             time.tm_hour, time.tm_min, time.tm_sec,
-				             PROTOCOL_VERSION );
-
-				CL_Record( name );
+				CL_Record("");
 			}
 		}
 	}

--- a/src/engine/client/cl_parse.cpp
+++ b/src/engine/client/cl_parse.cpp
@@ -226,13 +226,10 @@ void CL_ParseSnapshot( msg_t *msg )
 		if ( clc.demorecording )
 		{
 			clc.demowaiting = false; // we can start recording now
-//          if(cl_autorecord->integer) {
-//              Cvar_Set( "g_synchronousClients", "0" );
-//          }
 		}
 		else
 		{
-			if ( cl_autorecord->integer /*&& Cvar_VariableValue( "g_synchronousClients") */ )
+			if ( cl_autorecord->integer )
 			{
 				CL_Record("");
 			}

--- a/src/engine/client/cl_scrn.cpp
+++ b/src/engine/client/cl_scrn.cpp
@@ -230,26 +230,6 @@ void SCR_DrawSmallStringExt( int x, int y, const char *string,
 	re.SetColor( Color::White );
 }
 
-//===============================================================================
-
-/*
-=================
-SCR_DrawDemoRecording
-=================
-*/
-void SCR_DrawDemoRecording()
-{
-	if ( !clc.demorecording )
-	{
-		return;
-	}
-
-	//bani
-	Cvar_Set( "cl_demooffset", va( "%d", FS_FTell( clc.demofile ) ) );
-}
-
-//=============================================================================
-
 /*
 ==================
 SCR_Init
@@ -317,7 +297,6 @@ void SCR_DrawScreenField()
 
 			case connstate_t::CA_ACTIVE:
 				CL_CGameRendering();
-				SCR_DrawDemoRecording();
 				break;
 		}
 	}

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -231,10 +231,6 @@ struct clientConnection_t
 	bool     firstDemoFrameSkipped;
 	fileHandle_t demofile;
 
-	bool     waverecording;
-	fileHandle_t wavefile;
-	int          wavetime;
-
 	int          timeDemoFrames; // counter of rendered frames
 	int          timeDemoStart; // cls.realtime before first frame
 	int          timeDemoBaseTime; // each frame will be at this time + frameNum * 50

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -544,7 +544,7 @@ bool    CL_InitRef();
 
 int         CL_ServerStatus( const char *serverAddress, char *serverStatusString, int maxLen );
 
-void CL_Record( const char *name );
+void CL_Record(std::string demo_name);
 
 //
 // cl_keys (for input usage)

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -416,7 +416,6 @@ extern cvar_t *cl_showSend;
 extern cvar_t *cl_showServerCommands; // NERVE - SMF
 extern cvar_t *cl_timeNudge;
 extern cvar_t *cl_showTimeDelta;
-extern cvar_t *cl_freezeDemo;
 
 extern cvar_t *cl_yawspeed;
 extern cvar_t *cl_pitchspeed;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -456,7 +456,7 @@ extern cvar_t *cl_IRC_nickname;
 extern cvar_t *cl_IRC_kick_rejoin;
 extern cvar_t *cl_IRC_reconnect_delay;
 
-extern Cvar::Cvar<bool> cvar_cl_demo_print_time;
+extern Cvar::Cvar<bool> cvar_demo_timedemo;
 
 extern cvar_t *cl_activeAction;
 extern cvar_t *cl_autorecord;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -461,7 +461,7 @@ extern cvar_t *cl_IRC_nickname;
 extern cvar_t *cl_IRC_kick_rejoin;
 extern cvar_t *cl_IRC_reconnect_delay;
 
-extern cvar_t *cl_timedemo;
+extern Cvar::Cvar<bool> cvar_cl_demo_print_time;
 
 extern cvar_t *cl_activeAction;
 extern cvar_t *cl_autorecord;

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -74,7 +74,13 @@ cvar_t *com_speeds;
 cvar_t *com_developer;
 cvar_t *com_timescale;
 cvar_t *com_dropsim; // 0.0 to 1.0, simulated packet drops
-cvar_t *com_timedemo;
+
+Cvar::Cvar<bool> cvar_demo_timedemo(
+    "demo.timedemo",
+    "Whether to show timing statistics at the end of a demo",
+    Cvar::CHEAT,
+    false
+);
 cvar_t *com_sv_running;
 cvar_t *com_cl_running;
 cvar_t *com_logfile; // 1 = buffer log, 2 = flush after each print, 3 = append + flush
@@ -1239,7 +1245,6 @@ void Com_Init( char *commandLine )
 	com_timescale = Cvar_Get( "timescale", "1", CVAR_CHEAT | CVAR_SYSTEMINFO );
 	com_dropsim = Cvar_Get( "com_dropsim", "0", CVAR_CHEAT );
 	com_speeds = Cvar_Get( "com_speeds", "0", 0 );
-	com_timedemo = Cvar_Get( "timedemo", "0", CVAR_CHEAT );
 
 	cl_paused = Cvar_Get( "cl_paused", "0", CVAR_ROM );
 	sv_paused = Cvar_Get( "sv_paused", "0", CVAR_ROM );
@@ -1523,7 +1528,7 @@ void Com_Frame()
 	}
 
 	// we may want to spin here if things are going too fast
-	if ( !com_timedemo->integer )
+	if ( !cvar_demo_timedemo.Get() )
 	{
 		if ( Com_IsDedicatedServer() )
 		{


### PR DESCRIPTION
This is part of the work to improve demos (see Unvanquished/Unvanquished#988).
It does the following:
* Renames cvars to `demo.*`
* Renames commands to `demo_*`
* Removes demo-related functionality that is completely broken (eg: audio recording)
* Fixes CMake to avoid overwriting submodules during builds