### PR TITLE
Remove the need for tr.charsetImage

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -24,6 +24,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "tr_local.h"
 #include "gl_shader.h"
+#if defined( REFBONE_NAMES )
+	#include <client/client.h>
+#endif
 
 backEndData_t  *backEndData[ SMP_FRAMES ];
 backEndState_t backEnd;
@@ -3622,7 +3625,13 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetUniform_Color( Color::Black );
 
 		// bind u_ColorMap
-		GL_BindToTMU( 0, tr.charsetImage );
+#if defined( REFBONE_NAMES )
+		GL_BindToTMU( 0, r_imageHashTable [ tr.charsetImageHash ] );
+		int width = r_imageHashTable [ tr.charsetImageHash ]->width;
+		int height = r_imageHashTable [ tr.charsetImageHash ]->height;
+#else
+		GL_BindToTMU( 0, tr.whiteImage );
+#endif
 		gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
 
 		ent = backEnd.refdef.entities;
@@ -3782,9 +3791,6 @@ static void RB_RenderDebugUtils()
 						for ( k = 0; ( unsigned ) k < strlen( skel->bones[ j ].name ); k++ )
 						{
 							int   ch;
-							int   row, col;
-							float frow, fcol;
-							float size;
 
 							ch = skel->bones[ j ].name[ k ];
 							ch &= 255;
@@ -3794,15 +3800,15 @@ static void RB_RenderDebugUtils()
 								break;
 							}
 
-							row = ch >> 4;
-							col = ch & 15;
+							glyphInfo_t *glyph = &cls.consoleFont->glyphBlock[ ch / 256][ ch % 256 ];
+							re.GlyphChar( cls.consoleFont, ch, glyph );
 
-							frow = row * 0.0625;
-							fcol = col * 0.0625;
-							size = 0.0625;
-
-							VectorMA( worldOrigins[ j ], - ( k + 2.0f ), left, origin );
-							Tess_AddQuadStampExt( origin, left, up, Color::White, fcol, frow, fcol + size, frow + size );
+							// factor 1.5 improves readability
+							VectorMA( worldOrigins[ j ], - ( k*1.5f + 2.0f ), left, origin );
+							float pixelheight = 1.0f/(float)height;
+							int heightAdj = 16 - glyph->height;
+							Tess_AddQuadStampExt( origin, left, up, Color::White, glyph->s,
+												  glyph->t-pixelheight*heightAdj, glyph->s2, glyph->t2);
 						}
 
 						Tess_UpdateVBOs( );

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3800,7 +3800,7 @@ static void RB_RenderDebugUtils()
 								break;
 							}
 
-							glyphInfo_t *glyph = &cls.consoleFont->glyphBlock[ ch / 256][ ch % 256 ];
+							glyphInfo_t *glyph = &cls.consoleFont->glyphBlock[ 0 ][ ch ];
 							re.GlyphChar( cls.consoleFont, ch, glyph );
 
 							// factor 1.5 improves readability

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2797,8 +2797,6 @@ R_InitImages
 */
 void R_InitImages()
 {
-	const char *charsetImage = "gfx/2d/consolechars";
-
 	Log::Debug("------- R_InitImages -------" );
 
 	Com_Memset( r_imageHashTable, 0, sizeof( r_imageHashTable ) );
@@ -2815,12 +2813,14 @@ void R_InitImages()
 	// create default texture and white texture
 	R_CreateBuiltinImages();
 
-	tr.charsetImage = R_FindImageFile( charsetImage, IF_NOCOMPRESSION | IF_NOPICMIP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
-
-	if ( !tr.charsetImage )
-	{
-		ri.Error( errorParm_t::ERR_FATAL, "R_InitImages: could not load '%s'", charsetImage );
-	}
+#if defined( REFBONE_NAMES )
+	char fileName [ MAX_QPATH ];
+	char strippedName [ MAX_QPATH ];
+	char* fontname = Cvar_Get ( "cl_consoleFont", "fonts/unifont.ttf",  CVAR_LATCH )->string;
+	COM_StripExtension2( fontname, strippedName, sizeof( strippedName ) );
+	Com_sprintf( fileName, sizeof( fileName ), "%s_%i_%i_%i.png", strippedName, 0, 0, 16 );
+	tr.charsetImageHash = GenerateImageHashValue ( fileName );
+#endif
 }
 
 /*

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2816,7 +2816,7 @@ void R_InitImages()
 #if defined( REFBONE_NAMES )
 	char fileName [ MAX_QPATH ];
 	char strippedName [ MAX_QPATH ];
-	char* fontname = Cvar_Get ( "cl_consoleFont", "fonts/unifont.ttf",  CVAR_LATCH )->string;
+	char* fontname = Cvar_VariableString ( "cl_consoleFont" );
 	COM_StripExtension2( fontname, strippedName, sizeof( strippedName ) );
 	Com_sprintf( fileName, sizeof( fileName ), "%s_%i_%i_%i.png", strippedName, 0, 0, 16 );
 	tr.charsetImageHash = GenerateImageHashValue ( fileName );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2652,7 +2652,9 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		image_t *sunShadowClipMapFBOImage[ MAX_SHADOWMAPS * 2 ];
 
 		// external images
-		image_t *charsetImage;
+#if defined( REFBONE_NAMES )
+		int      charsetImageHash;
+#endif
 		image_t *colorGradeImage;
 		GLuint   colorGradePBO;
 


### PR DESCRIPTION
Alternative approach to https://github.com/DaemonEngine/Daemon/pull/11
Difference is that in this approach the console font bitmap is reused for the bone names. Not as clean as https://github.com/DaemonEngine/Daemon/pull/11