### PR TITLE
do not prefer sound file path with same extension, always use newer one

### DIFF
--- a/src/engine/audio/SoundCodec.cpp
+++ b/src/engine/audio/SoundCodec.cpp
@@ -55,21 +55,6 @@ AudioData LoadSoundCodec(std::string filename)
 
 	std::string ext = FS::Path::Extension(filename);
 
-	// if filename has extension, try to load it
-	if (ext != "") {
-		// look for the correct loader and use it
-		for (int i = 0; i < numSoundLoaders; i++) {
-			if (ext == soundLoaders[i].ext) {
-				// if file exists, load it
-				if (FS::PakPath::FileExists(filename)) {
-					return soundLoaders[i].SoundLoader(filename);
-				}
-			}
-		}
-	}
-
-	// if filename does not have extension or there is no file with such extension
-	// or if there is no codec available for this file format,
 	// try and find a suitable match using all the sound file formats supported
 	// prioritize with the pak priority
 	int bestLoader = -1;


### PR DESCRIPTION
- before 4ae82bf daemon was not able to load extension independent sound file path
- before this commit, daemon was preferring sound file path with given extension
  it was not a good idea, if a legacy pk3 provided sound.wav and an updated pk3
  provides sound.ogg and the game code looks for sound.wav, the newer sound.ogg
  will never be read, this commit fixes that issue

With this fix, daemon loading behavior for sound file paths becomes truly extension independent.

This is needed since we plan to update sound assets, we must be sure the latest one is loaded.