### PR TITLE
introduce dpk format

### DIFF
--- a/src/common/Assert.h
+++ b/src/common/Assert.h
@@ -154,4 +154,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #define ASSERT_GE DAEMON_ASSERT_GE
 #endif
 
+// You can put UNREACHABLE() in places that must be never reached.
+#define UNREACHABLE() DAEMON_ASSERT_CALLSITE(false, , false, "Unreachable code hit.")
+
 #endif // COMMON_ASEERT_H_

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -41,6 +41,12 @@ namespace FS {
 
 bool UseLegacyPaks();
 
+// Pak zip and directory extensions
+const char LEGACY_PAK_ZIP_EXT[] = ".pk3";
+const char LEGACY_PAK_DIR_EXT[] = ".pk3dir/";
+const char PAK_ZIP_EXT[] = ".dpk";
+const char PAK_DIR_EXT[] = ".dpkdir/";
+
 // File offset type. Using 64bit to allow large files.
 using offset_t = int64_t;
 

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -449,9 +449,9 @@ static void ParseCmdline(int argc, char** argv, cmdlineArgs_t& cmdlineArgs)
             std::string helpUrl = Application::GetTraits().supportsUri ? " [" URI_SCHEME "ADDRESS[:PORT]]" : "";
 			printf("Usage: %s [-OPTION]...%s [+COMMAND]...\n",  argv[0], helpUrl.c_str());
 			printf("Possible options are:\n"
-			       "  -homepath <path>         set the path used for user-specific configuration files and downloaded pk3 files\n"
+			       "  -homepath <path>         set the path used for user-specific configuration files and downloaded dpk files\n"
 			       "  -libpath <path>          set the path containing additional executables and libraries\n"
-			       "  -pakpath <path>          add another path from which pk3 files are loaded\n"
+			       "  -pakpath <path>          add another path from which dpk files are loaded\n"
 			       "  -resetconfig             reset all cvars and keybindings to their default value\n"
 #ifdef USE_CURSES
 			       "  -curses                  activate the curses interface\n"

--- a/src/engine/framework/VirtualMachine.h
+++ b/src/engine/framework/VirtualMachine.h
@@ -71,11 +71,11 @@ namespace VM {
  * - Native exe: no sandboxing, no leaks, hard to debug. Might be used by server owners for perf.
  */
 enum vmType_t {
-	// Loads the VM as an nacl executable from the homepath, potentially from a pk3
+	// Loads the VM as an nacl executable from the homepath, potentially from a dpk
 	// USE THIS BY DEFAULT FOR PROD
 	TYPE_NACL,
 
-	// Loads the VM as an nacl executable from the libpath, for freshly compiled NaCl VMs (no need to put it in a pk3)
+	// Loads the VM as an nacl executable from the libpath, for freshly compiled NaCl VMs (no need to put it in a dpk)
 	TYPE_NACL_LIBPATH,
 
 	// Loads the VM as a native exe from the libpath

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -509,7 +509,7 @@ int FS_Seek( fileHandle_t f, long offset, fsOrigin_t origin );
 
 const char* FS_LoadedPaks();
 
-// Returns a space separated string containing all loaded pk3 files.
+// Returns a space separated string containing all loaded dpk/pk3 files.
 
 bool     FS_LoadPak( const char *name );
 void     FS_LoadBasePak();

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -599,7 +599,7 @@ void SV_SpawnServer(const std::string pakname, const std::string server)
 	sv.time += FRAMETIME;
 
 	// the server sends these to the clients so they can figure
-	// out which pk3s should be auto-downloaded
+	// out which dpk/pk3s should be auto-downloaded
 
 	Cvar_Set( "sv_paks", FS_LoadedPaks() );
 
@@ -660,7 +660,7 @@ void SV_Init()
 	sv_pure = Cvar_Get( "sv_pure", "1", CVAR_SYSTEMINFO );
 #else
 	// Use OS shared libs for the client at startup. This prevents crashes due to mismatching syscall ABIs
-	// from loading outdated vms pk3s. The correct vms pk3 will be loaded upon connecting to a pure server.
+	// from loading outdated vms dpks. The correct vms dpk will be loaded upon connecting to a pure server.
 	sv_pure = Cvar_Get( "sv_pure", "0", CVAR_SYSTEMINFO );
 #endif
 	Cvar_Get( "sv_paks", "", CVAR_SYSTEMINFO | CVAR_ROM );


### PR DESCRIPTION
See [this forum post](http://forums.unvanquished.net/viewtopic.php?f=58&t=2122&p=17813) for the reasons and explanations behind this change.
See [this merge request](https://gitlab.com/xonotic/netradiant/merge_requests/39) for related changes in NetRadiant/q3map2.


What this PR does:

- dpk/dpkdir format for versioned packages

- pk3/pk3dir are for legacy unversioned packages

- legacy pk3/pk3dir now uses internal version "" so
  * it's always smaller than a dpk/dpkdir version since dpk/dpkdir forbid this version
  * code can rely on that version to know if it's a legacy pak, and it now does

- the engine now loads dpk as versioned ones and pk3 as legacy unversioned one
  when fs_legacypaks is set to on,  previously the code was loading versioned pk3
  as unversioned one when fs_legacypaks was set to on

- the engine now prefers the versioned pak over the unversioned one if both exist

- this code fixes the autodownload mechanism for legacy pk3s
  for sure, it was not able to work before since the code was adding version string
  to legacy pk3s that do not have version string, now the code relies on that
  special internal "" version to compute legacy pk3 names

- modify FS::MakePakeName() to include + extension
  * engine/qcommon/files.cpp uses it now instead of calling FS::MakePakName()
  plus adding extension on every FS::MakePakName() call
  * src/engine/server/sv_client.cpp uses it instead of duplicating Fs:MakePakName()
  plus adding extension

- factorise pak name parsing
  FS:PakParseName is used to parse both legacy and non-legacy pak names

- always look for pak with version, this way, if server host a legacy pak
  but the client owns both legacy and non-legacy paks sharing the same name,
  the client is ensured to load the legacy one.

- do not compare pk3 checksum
  legacy paks can't have checksum, so do not check it

- ensure dpk paks with bad version are not loaded when fs_legacypaks is enabled

- do not read DEPS from legacy paks

- enable pk3 downloading

Previously, the server was sending pak list to client that way:

[
	name1_version_checksum,
	name2,
	n_a_m_e_3,
	name4_version_checksum,
]

So, the client was not able to parse this names with dpk/pk3
specificities, and to know the file format.

Now, the server sends pak list to client that way:

[
	name1_version_checksum.dpk,
	name2.pk3,
	n_a_m_e_3.pk3,
	name4_version_checksum.dpk,
]

Extension is used by client to know how to parse these names (pk3 have
empty version and name can't contain checksum) and reconstruct final
file name in local file system. On local file system the package can
be a dpkdir or pk3dir, that information is not told in that list since
there is no need to tell it.

So, this PR not only introduces `dpk` format, it is also meant to fix autodownloading legacy `pk3` that was broken before, and factorize some code.