### PR TITLE
Remove unused errorSample

### DIFF
--- a/src/engine/audio/Audio.cpp
+++ b/src/engine/audio/Audio.cpp
@@ -232,9 +232,16 @@ namespace Audio {
         BeginSampleRegistration();
     }
 
+    // return the handle to a Sample, -1 if not found
     sfxHandle_t RegisterSFX(Str::StringRef filename) {
         // TODO: what should we do if we aren't initialized?
-        return RegisterSample(filename)->GetHandle();
+        auto sample = RegisterSample(filename);
+        if (sample == nullptr)
+        {
+            Log::Warn ( "RegisterSFX: Sample %s not found", filename );
+            return -1;
+        }
+        return sample->GetHandle();
     }
 
     void EndRegistration() {

--- a/src/engine/audio/Sample.cpp
+++ b/src/engine/audio/Sample.cpp
@@ -70,8 +70,6 @@ namespace Audio {
 
     // Implementation of the sample storage
 
-    static const char errorSampleName[] = "sound/feedback/hit.wav";
-    static std::shared_ptr<Sample> errorSample = nullptr;
     bool initialized = false;
 
     void InitSamples() {
@@ -79,11 +77,7 @@ namespace Audio {
             return;
         }
 
-        sampleManager = new Resource::Manager<Sample>(errorSampleName);
-
-        // Work around for the lack of VM Handles, initiliaze the HandledResource
-        auto errorSample = sampleManager->GetResource(errorSampleName).Get();
-        errorSample->InitHandle(errorSample);
+        sampleManager = new Resource::Manager<Sample>();
 
         initialized = true;
     }
@@ -92,8 +86,6 @@ namespace Audio {
         if (not initialized) {
             return;
         }
-
-        errorSample = nullptr;
 
         delete sampleManager;
         sampleManager = nullptr;


### PR DESCRIPTION
AFAIS errorSample is unused, but still "sound/feedback/hit.wav" needs to be present. So removing it also removes the need for an external file.