### PR TITLE
FindLua: Also prefer to find ${PREFIX}/include/lua before versioned lua

### DIFF
--- a/cmake/FindLua.cmake
+++ b/cmake/FindLua.cmake
@@ -99,7 +99,7 @@ set_lua_version_vars()
 find_path(LUA_INCLUDE_DIR lua.h
   HINTS
     ENV LUA_DIR
-  PATH_SUFFIXES ${_lua_include_subdirs} include/lua include
+  PATH_SUFFIXES include/lua ${_lua_include_subdirs} include
   PATHS
   ~/Library/Frameworks
   /Library/Frameworks


### PR DESCRIPTION
This fixes a bug where the game finds liblua.so, but picks include/lua53
as the include path, causing a mismatch.