### PR TITLE
add some unreachable builtin on UNREACHABLE() assert macro

### DIFF
--- a/src/common/Assert.h
+++ b/src/common/Assert.h
@@ -154,7 +154,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #define ASSERT_GE DAEMON_ASSERT_GE
 #endif
 
-// You can put UNREACHABLE() in places that must be never reached.
-#define UNREACHABLE() DAEMON_ASSERT_CALLSITE(false, , false, "Unreachable code hit.")
+// You can put ASSERT_UNREACHABLE() in places that must never be reached.
+#define ASSERT_UNREACHABLE() DAEMON_ASSERT_CALLSITE(false, , false, "Unreachable code hit."); UNREACHABLE();
 
-#endif // COMMON_ASEERT_H_
+#endif // COMMON_ASSERT_H_

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -235,4 +235,31 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #   define CONSTEXPR_FUNCTION_RELAXED
 #endif
 
+/* Compiler can be fooled when calling ASSERT_UNREACHABLE() macro at end of non-void function.
+ * In this case, compiler is complaining because control reaches end of non-void function,
+ * even if the execution flow is expected to be taken down by assert before.
+ *
+ * That's why we use these compiler specific unreachable builtin on modern compilers,
+ * ASSERT_UNREACHABLE() macro makes use of this UNREACHABLE() macro, preventing useless warnings.
+ * Unsupported compilers will raise "control reaches end of non-void function" warnings but
+ * that's not a big issue and that's likely to never happen (these compilers would be too old and
+ * would lack too much features to compile Daemon anyway).
+ *
+ * See http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0627r0.pdf
+*/
+#if defined(_MSC_VER) //UNREACHABLE
+	#define UNREACHABLE() __assume(0)
+// both gcc, clang and icc defines __GNUC__, so the order is important
+#elif defined(__INTEL_COMPILER)
+	#define UNREACHABLE() __builtin_unreachable()
+#elif defined(__clang__)
+	#if __has_builtin(__builtin_unreachable)
+		#define UNREACHABLE() __builtin_unreachable()
+	#endif
+#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
+	#define UNREACHABLE() __builtin_unreachable()
+#else // UNREACHABLE
+	#define UNREACHABLE()
+#endif // UNREACHABLE
+
 #endif // COMMON_COMPILER_H_

--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1069,7 +1069,7 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 			fsLogs.Notice("Loading legacy pakdir '%s'...", pak.path.c_str());
 		}
 	} else {
-		UNREACHABLE();
+		ASSERT_UNREACHABLE();
 	}
 
 	loadedPaks.emplace_back();
@@ -1144,7 +1144,7 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 		if (err)
 			return;
 	} else {
-		UNREACHABLE();
+		ASSERT_UNREACHABLE();
 	}
 
 	// Save the real checksum in the list of loaded paks (empty for directories, not used for legacy paks)
@@ -1194,7 +1194,7 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 			if (err)
 				return;
 		} else {
-			UNREACHABLE();
+			ASSERT_UNREACHABLE();
 		}
 		ParseDeps(pak, depsData, err);
 	}
@@ -1307,9 +1307,9 @@ std::string ReadFile(Str::StringRef path, std::error_code& err)
 			return "";
 
 		return out;
-	} else {
-		UNREACHABLE();
 	}
+
+	ASSERT_UNREACHABLE();
 }
 
 void CopyFile(Str::StringRef path, const File& dest, std::error_code& err)
@@ -1358,9 +1358,9 @@ void CopyFile(Str::StringRef path, const File& dest, std::error_code& err)
 
 		// Close file and check for CRC errors
 		zipFile.CloseFile(err);
-	} else {
-		UNREACHABLE();
 	}
+
+	ASSERT_UNREACHABLE();
 }
 
 bool FileExists(Str::StringRef path)
@@ -1402,9 +1402,9 @@ std::chrono::system_clock::time_point FileTimestamp(Str::StringRef path, std::er
 #endif
 	} else if (pak.type == pakType_t::PAK_ZIP) {
 		return pak.timestamp;
-	} else {
-		UNREACHABLE();
 	}
+
+	ASSERT_UNREACHABLE();
 }
 
 bool DirectoryRange::InternalAdvance()
@@ -2233,7 +2233,7 @@ static void FindPaksInPath(Str::StringRef basePath, Str::StringRef subPath)
 			} else if (Str::IsSuffix("/", filename)) {
 				FindPaksInPath(basePath, Path::Build(subPath, filename));
 			} else {
-				UNREACHABLE();
+				ASSERT_UNREACHABLE();
 			}
 		}
 	} catch (std::system_error&) {
@@ -2425,7 +2425,7 @@ bool ParsePakName(const char* begin, const char* end, std::string& name, std::st
 	} else if (Str::IsSuffix(PAK_DIR_EXT, begin)) {
 		end -= strlen(PAK_DIR_EXT);
 	} else {
-		UNREACHABLE();
+		ASSERT_UNREACHABLE();
 	}
 
 	nameStart = std::find(std::reverse_iterator<const char*>(end), std::reverse_iterator<const char*>(begin), '/').base();


### PR DESCRIPTION
On @Kangz [suggest](https://github.com/DaemonEngine/Daemon/pull/14#discussion_r114242327), I added an `UNREACHABLE()` assert macro, but  now the compiler raises some miswarning:

```
warning: control reaches end of non-void function [-Wreturn-type]
```

But we know the code asserts before reaching end of non-void function.
So, instead of adding some useless `return` after the `UNREACHABLE()` assert macro everwhere the compiler raises mistakenly a warning, I added support for some builtin that tells the compiler this code can't be reached.

If the compiler is too old or is'nt supported, it will raise the useless warning, which is not a big issue.

The `UNREACHABLE()` assert macro was renamed to `ASSERT_UNREACHABLE()` like
other assert macros.