### PR TITLE
Fix a bunch of PVS-Studio static analyser warnings №2

### DIFF
--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -185,15 +185,17 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define NOEXCEPT_IF(x) noexcept(x)
 #define NOEXCEPT_EXPR(x) false
 #define HAS_EXPLICIT_DEFAULT
+#define CONSTEXPR constexpr
 #else
 #define NOEXCEPT
 #define NOEXCEPT_IF(x)
 #define NOEXCEPT_EXPR(x) false
-#endif
 // Work around lack of C99 support
 #define __func__ __FUNCTION__
 // Work around lack of constexpr
 #define CONSTEXPR const
+#endif
+
 #define ATTRIBUTE_NO_SANITIZE_ADDRESS
 
 // Other compilers, unsupported

--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1048,7 +1048,7 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 {
 	Util::optional<uint32_t> realChecksum;
 	bool hasDeps = false;
-	offset_t depsOffset;
+	offset_t depsOffset = 0;
 	ZipArchive zipFile;
 
 	// Check if this pak has already been loaded to avoid recursive dependencies

--- a/src/common/Log.cpp
+++ b/src/common/Log.cpp
@@ -36,7 +36,7 @@ namespace Log {
     :filterLevel("logs.logLevel." + name, "Log::Level - logs from '" + name + "' below the level specified are filtered", 0, defaultLevel), prefix(prefix) {
     }
 
-    std::string Logger::Prefix(std::string message) {
+    std::string Logger::Prefix(std::string message) const {
         if (prefix.empty()) {
             return message;
         } else {

--- a/src/common/Log.h
+++ b/src/common/Log.h
@@ -102,7 +102,7 @@ namespace Log {
             void DoDebugCode(F&& code);
 
         private:
-            std::string Prefix(std::string message);
+            std::string Prefix(std::string message) const;
 
             // the cvar logs.logLevel.<name>
             Cvar::Cvar<Level> filterLevel;

--- a/src/common/String.h
+++ b/src/common/String.h
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define COMMON_STRING_H_
 
 #include <algorithm>
+#include <limits>
 #include "Compiler.h"
 
 namespace Str {
@@ -45,7 +46,7 @@ namespace Str {
 
     template<typename T> class BasicStringRef {
     public:
-        static const size_t npos = -1;
+        static CONSTEXPR size_t npos = std::numeric_limits<size_t>::max();
 
         BasicStringRef(const std::basic_string<T>& other)
             : ptr(other.c_str()), len(other.size()) {}

--- a/src/common/System.h
+++ b/src/common/System.h
@@ -78,7 +78,7 @@ public:
 NORETURN void Drop(Str::StringRef errorMessage);
 
 // Variadic wrappers for Error and Drop
-template<typename ... Args> void Error(Str::StringRef format, Args&& ... args)
+template<typename ... Args> NORETURN void Error(Str::StringRef format, Args&& ... args)
 {
 	Error(Str::Format(format, std::forward<Args>(args)...));
 }

--- a/src/common/System.h
+++ b/src/common/System.h
@@ -42,7 +42,7 @@ public:
 	using rep = duration::rep;
 	using period = duration::period;
 	using time_point = std::chrono::time_point<SteadyClock>;
-	static const bool is_steady = true;
+	static CONSTEXPR bool is_steady = true;
 
 	static time_point now() NOEXCEPT;
 };

--- a/src/common/cm/cm_load.cpp
+++ b/src/common/cm/cm_load.cpp
@@ -771,7 +771,7 @@ void CMod_LoadSurfaces(const byte *const cmod_base, lump_t *surfs, lump_t *verts
 	drawVert_t    *dv, *dv_p;
 	dsurface_t    *in;
 	int           count;
-	int           i, j;
+	int           i;
 	cSurface_t    *surface;
 	int           numVertexes;
 	static vec3_t vertexes[ SHADER_MAX_VERTEXES ];
@@ -811,8 +811,6 @@ void CMod_LoadSurfaces(const byte *const cmod_base, lump_t *surfs, lump_t *verts
 	{
 		if ( LittleLong( in->surfaceType ) == mapSurfaceType_t::MST_PATCH )
 		{
-			int j = 0;
-
 			// FIXME: check for non-colliding patches
 			cm.surfaces[ i ] = surface = ( cSurface_t * ) CM_Alloc( sizeof( *surface ) );
 			surface->type = mapSurfaceType_t::MST_PATCH;
@@ -829,7 +827,7 @@ void CMod_LoadSurfaces(const byte *const cmod_base, lump_t *surfs, lump_t *verts
 
 			dv_p = dv + LittleLong( in->firstVert );
 
-			for ( j = 0; j < numVertexes; j++, dv_p++ )
+			for ( int j = 0; j < numVertexes; j++, dv_p++ )
 			{
 				vertexes[ j ][ 0 ] = LittleFloat( dv_p->xyz[ 0 ] );
 				vertexes[ j ][ 1 ] = LittleFloat( dv_p->xyz[ 1 ] );
@@ -860,7 +858,7 @@ void CMod_LoadSurfaces(const byte *const cmod_base, lump_t *surfs, lump_t *verts
 
 			dv_p = dv + LittleLong( in->firstVert );
 
-			for ( j = 0; j < numVertexes; j++, dv_p++ )
+			for ( int j = 0; j < numVertexes; j++, dv_p++ )
 			{
 				vertexes[ j ][ 0 ] = LittleFloat( dv_p->xyz[ 0 ] );
 				vertexes[ j ][ 1 ] = LittleFloat( dv_p->xyz[ 1 ] );
@@ -876,7 +874,7 @@ void CMod_LoadSurfaces(const byte *const cmod_base, lump_t *surfs, lump_t *verts
 
 			index_p = index + LittleLong( in->firstIndex );
 
-			for ( j = 0; j < numIndexes; j++, index_p++ )
+			for ( int j = 0; j < numIndexes; j++, index_p++ )
 			{
 				indexes[ j ] = LittleLong( *index_p );
 

--- a/src/engine/audio/Emitter.cpp
+++ b/src/engine/audio/Emitter.cpp
@@ -41,7 +41,7 @@ namespace Audio {
     static entityData_t entities[MAX_GENTITIES];
     static int listenerEntity = -1;
 
-    // Keep Entitymitters in an array because there is at most one per entity.
+    // Keep entity Emitters in an array because there is at most one per entity.
     static std::shared_ptr<Emitter> entityEmitters[MAX_GENTITIES];
 
     // Position Emitters can be reused so we keep the list of all of them

--- a/src/engine/botlib/bot_debug.cpp
+++ b/src/engine/botlib/bot_debug.cpp
@@ -33,10 +33,14 @@ Maryland 20850 USA.
 */
 #include "client/client.h"
 #include "DetourDebugDraw.h"
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
 #include "DebugDraw.h"
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 #include "bot_local.h"
 #include "nav.h"
 #include "bot_debug.h"

--- a/src/engine/botlib/bot_nav_edit.cpp
+++ b/src/engine/botlib/bot_nav_edit.cpp
@@ -33,10 +33,14 @@ Maryland 20850 USA.
 */
 #include "client/client.h"
 #include "DetourDebugDraw.h"
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
 #include "DebugDraw.h"
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 #include "bot_navdraw.h"
 #include "nav.h"
 

--- a/src/engine/framework/BaseCommands.cpp
+++ b/src/engine/framework/BaseCommands.cpp
@@ -517,7 +517,7 @@ namespace Cmd {
             }
 
             void Run(const Cmd::Args& args) const OVERRIDE {
-                int oldValue, start, end;
+                int oldValue = 0, start = 0, end = 0;
                 if (args.Argc() < 4 || args.Argc() > 5 ||
                     !Str::ParseInt(oldValue, Cvar::GetValue(args.Argv(1))) ||
                     !Str::ParseInt(start, args.Argv(2)) ||

--- a/src/engine/framework/Resource.h
+++ b/src/engine/framework/Resource.h
@@ -236,7 +236,7 @@ namespace Resource {
         Prune();
 
         // And then load the new ones, so as to reduce peak memory usage.
-        for (auto it = resources.begin(); it != resources.end(); it ++) {
+        for (auto it = resources.begin(); it != resources.end(); ++it) {
             if (not it->second->loaded) {
                 if (not it->second->TryLoad()) {
                     it->second->Cleanup();
@@ -286,7 +286,7 @@ namespace Resource {
                 it->second->Cleanup();
                 it = resources.erase(it);
             } else {
-                it ++;
+                ++it;
             }
         }
     }

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -522,8 +522,8 @@ static void Init(int argc, char** argv)
 #ifdef _WIN32
 	// If we were launched from a console, make our output visible on it
 	if (AttachConsole(ATTACH_PARENT_PROCESS)) {
-		freopen("CONOUT$", "w", stdout);
-		freopen("CONOUT$", "w", stderr);
+		Q_UNUSED(freopen("CONOUT$", "w", stdout));
+		Q_UNUSED(freopen("CONOUT$", "w", stderr));
 	}
 #endif
 

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -522,8 +522,8 @@ static void Init(int argc, char** argv)
 #ifdef _WIN32
 	// If we were launched from a console, make our output visible on it
 	if (AttachConsole(ATTACH_PARENT_PROCESS)) {
-		Q_UNUSED(freopen("CONOUT$", "w", stdout));
-		Q_UNUSED(freopen("CONOUT$", "w", stderr));
+		freopen("CONOUT$", "w", stdout);
+		freopen("CONOUT$", "w", stderr);
 	}
 #endif
 

--- a/src/engine/qcommon/net_ip.cpp
+++ b/src/engine/qcommon/net_ip.cpp
@@ -1718,7 +1718,7 @@ NET_OpenIP
 static void NET_OpenIP()
 {
 	int i;
-	int err;
+	int err = 0;
 	int port = PORT_ANY;
 	int port6 = PORT_ANY;
 

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -778,7 +778,7 @@ void GLShaderManager::buildAll()
 	while ( !_shaderBuildQueue.empty() )
 	{
 		GLShader& shader = *_shaderBuildQueue.front();
-		size_t numPermutations = 1 << shader.GetNumOfCompiledMacros();
+		size_t numPermutations = static_cast<size_t>(1) << shader.GetNumOfCompiledMacros();
 		size_t i;
 
 		for( i = 0; i < numPermutations; i++ )
@@ -799,7 +799,7 @@ void GLShaderManager::buildAll()
 
 void GLShaderManager::InitShader( GLShader *shader )
 {
-	shader->_shaderPrograms = std::vector<shaderProgram_t>( 1 << shader->_compileMacros.size() );
+	shader->_shaderPrograms = std::vector<shaderProgram_t>( static_cast<size_t>(1) << shader->_compileMacros.size() );
 
 	shader->_uniformStorageSize = 0;
 	for ( std::size_t i = 0; i < shader->_uniforms.size(); i++ )

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -93,7 +93,8 @@ class GLShader
 {
 	friend class GLShaderManager;
 private:
-	GLShader &operator             = ( const GLShader & );
+	GLShader( const GLShader & ) = delete;
+	GLShader &operator             = ( const GLShader & ) = delete;
 
 	std::string                    _name;
 	std::string                    _mainShaderName;

--- a/src/engine/renderer/tr_animation.cpp
+++ b/src/engine/renderer/tr_animation.cpp
@@ -519,7 +519,7 @@ qhandle_t RE_RegisterAnimation( const char *name )
 	R_SyncRenderThread();
 
 	// load and parse the .md5anim file
-	int bufferLen = ri.FS_ReadFile( name, ( void ** ) &buffer );
+	ri.FS_ReadFile( name, ( void ** ) &buffer );
 
 	if ( !buffer )
 	{
@@ -647,7 +647,6 @@ void R_AddMD5Surfaces( trRefEntity_t *ent )
 {
 	md5Model_t   *model;
 	md5Surface_t *surface;
-	shader_t     *shader;
 	int          i;
 	bool     personalModel;
 	int          fogNum;
@@ -679,6 +678,8 @@ void R_AddMD5Surfaces( trRefEntity_t *ent )
 	if ( !r_vboModels->integer || !model->numVBOSurfaces ||
 	     ( !glConfig2.vboVertexSkinningAvailable && ent->e.skeleton.type == refSkeletonType_t::SK_ABSOLUTE ) )
 	{
+		shader_t *shader;
+
 		// finally add surfaces
 		for ( i = 0, surface = model->surfaces; i < model->numSurfaces; i++, surface++ )
 		{
@@ -915,7 +916,6 @@ void R_AddMD5Interactions( trRefEntity_t *ent, trRefLight_t *light, interactionT
 	int               i;
 	md5Model_t        *model;
 	md5Surface_t      *surface;
-	shader_t          *shader = 0;
 	bool          personalModel;
 	byte              cubeSideBits = CUBESIDE_CLIPALL;
 
@@ -979,6 +979,8 @@ void R_AddMD5Interactions( trRefEntity_t *ent, trRefLight_t *light, interactionT
 	if ( !r_vboModels->integer || !model->numVBOSurfaces ||
 	     ( !glConfig2.vboVertexSkinningAvailable && ent->e.skeleton.type == refSkeletonType_t::SK_ABSOLUTE ) )
 	{
+		shader_t *shader = 0;
+
 		// generate interactions with all surfaces
 		for ( i = 0, surface = model->surfaces; i < model->numSurfaces; i++, surface++ )
 		{

--- a/src/engine/renderer/tr_animation.cpp
+++ b/src/engine/renderer/tr_animation.cpp
@@ -519,7 +519,7 @@ qhandle_t RE_RegisterAnimation( const char *name )
 	R_SyncRenderThread();
 
 	// load and parse the .md5anim file
-	ri.FS_ReadFile( name, ( void ** ) &buffer );
+	int bufferLen = ri.FS_ReadFile( name, ( void ** ) &buffer );
 
 	if ( !buffer )
 	{

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1122,7 +1122,7 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips,
 
 				if( image->bits & IF_NORMALMAP ) {
 					c = scaledWidth * scaledHeight;
-					for ( i = 0; i < c; i++ )
+					for ( int i = 0; i < c; i++ )
 					{
 						vec3_t n;
 

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1122,19 +1122,19 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips,
 
 				if( image->bits & IF_NORMALMAP ) {
 					c = scaledWidth * scaledHeight;
-					for ( int i = 0; i < c; i++ )
+					for ( int j = 0; j < c; j++ )
 					{
 						vec3_t n;
 
-						n[ 0 ] = Tex_ByteToFloat( scaledBuffer[ i * 4 + 0 ] );
-						n[ 1 ] = Tex_ByteToFloat( scaledBuffer[ i * 4 + 1 ] );
-						n[ 2 ] = Tex_ByteToFloat( scaledBuffer[ i * 4 + 2 ] );
+						n[ 0 ] = Tex_ByteToFloat( scaledBuffer[ j * 4 + 0 ] );
+						n[ 1 ] = Tex_ByteToFloat( scaledBuffer[ j * 4 + 1 ] );
+						n[ 2 ] = Tex_ByteToFloat( scaledBuffer[ j * 4 + 2 ] );
 
 						VectorNormalize( n );
 
-						scaledBuffer[ i * 4 + 0 ] = Tex_FloatToByte( n[ 0 ] );
-						scaledBuffer[ i * 4 + 1 ] = Tex_FloatToByte( n[ 1 ] );
-						scaledBuffer[ i * 4 + 2 ] = Tex_FloatToByte( n[ 2 ] );
+						scaledBuffer[ j * 4 + 0 ] = Tex_FloatToByte( n[ 0 ] );
+						scaledBuffer[ j * 4 + 1 ] = Tex_FloatToByte( n[ 1 ] );
+						scaledBuffer[ j * 4 + 2 ] = Tex_FloatToByte( n[ 2 ] );
 					}
 				}
 			}

--- a/src/engine/renderer/tr_image_crn.cpp
+++ b/src/engine/renderer/tr_image_crn.cpp
@@ -23,10 +23,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 #include "tr_local.h"
+#ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-pedantic"
+#endif
 #include "crunch/crn_decomp.h"
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
 void LoadCRN( const char *name, byte **data, int *width, int *height,
 	      int *numLayers, int *numMips, int *bits, byte )

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -91,6 +91,8 @@ void SV_UpdateConfigStrings()
 		// spawning a new server
 		if ( sv.state == serverState_t::SS_GAME || sv.restarting )
 		{
+			len = strlen( sv.configstrings[ index ] );
+
 			// send the data to all relevent clients
 			for ( i = 0, client = svs.clients; i < sv_maxclients->integer; i++, client++ )
 			{
@@ -104,8 +106,6 @@ void SV_UpdateConfigStrings()
 				{
 					continue;
 				}
-
-				len = strlen( sv.configstrings[ index ] );
 
 				if ( len >= maxChunkSize )
 				{

--- a/src/engine/sys/sdl_input.cpp
+++ b/src/engine/sys/sdl_input.cpp
@@ -1161,139 +1161,136 @@ static void IN_Xbox360ControllerMove()
 	// update hat state
 	if ( hat != stick_state.oldhats )
 	{
-		if ( hat != stick_state.oldhats )
+		int       key;
+
+		const int allHatDirections = ( SDL_HAT_UP |
+		                               SDL_HAT_RIGHT |
+		                               SDL_HAT_DOWN |
+		                               SDL_HAT_LEFT );
+
+		if ( in_xbox360ControllerDebug->integer )
 		{
-			int       key;
-
-			const int allHatDirections = ( SDL_HAT_UP |
-			                               SDL_HAT_RIGHT |
-			                               SDL_HAT_DOWN |
-			                               SDL_HAT_LEFT );
-
-			if ( in_xbox360ControllerDebug->integer )
-			{
-				switch ( hat & allHatDirections )
-				{
-					case SDL_HAT_UP:
-						key = K_XBOX360_DPAD_UP;
-						break;
-
-					case SDL_HAT_RIGHT:
-						key = K_XBOX360_DPAD_RIGHT;
-						break;
-
-					case SDL_HAT_DOWN:
-						key = K_XBOX360_DPAD_DOWN;
-						break;
-
-					case SDL_HAT_LEFT:
-						key = K_XBOX360_DPAD_LEFT;
-						break;
-
-					case SDL_HAT_RIGHTUP:
-						key = K_XBOX360_DPAD_RIGHTUP;
-						break;
-
-					case SDL_HAT_RIGHTDOWN:
-						key = K_XBOX360_DPAD_RIGHTDOWN;
-						break;
-
-					case SDL_HAT_LEFTUP:
-						key = K_XBOX360_DPAD_LEFTUP;
-						break;
-
-					case SDL_HAT_LEFTDOWN:
-						key = K_XBOX360_DPAD_LEFTDOWN;
-						break;
-
-					default:
-						key = 0;
-						break;
-				}
-
-				if ( hat != SDL_HAT_CENTERED )
-				{
-					Log::Notice( "xbox hat bits = %i to key = Q:0x%02x(%s)\n", hat, key, Key_KeynumToString( key ) );
-				}
-			}
-
-			// release event
-			switch ( stick_state.oldhats & allHatDirections )
-			{
-				case SDL_HAT_UP:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_UP, false, 0, nullptr );
-					break;
-
-				case SDL_HAT_RIGHT:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHT, false, 0, nullptr );
-					break;
-
-				case SDL_HAT_DOWN:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_DOWN, false, 0, nullptr );
-					break;
-
-				case SDL_HAT_LEFT:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFT, false, 0, nullptr );
-					break;
-
-				case SDL_HAT_RIGHTUP:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHTUP, false, 0, nullptr );
-					break;
-
-				case SDL_HAT_RIGHTDOWN:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHTDOWN, false, 0, nullptr );
-					break;
-
-				case SDL_HAT_LEFTUP:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFTUP, false, 0, nullptr );
-					break;
-
-				case SDL_HAT_LEFTDOWN:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFTDOWN, false, 0, nullptr );
-					break;
-
-				default:
-					break;
-			}
-
-			// press event
 			switch ( hat & allHatDirections )
 			{
 				case SDL_HAT_UP:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_UP, true, 0, nullptr );
+					key = K_XBOX360_DPAD_UP;
 					break;
 
 				case SDL_HAT_RIGHT:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHT, true, 0, nullptr );
+					key = K_XBOX360_DPAD_RIGHT;
 					break;
 
 				case SDL_HAT_DOWN:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_DOWN, true, 0, nullptr );
+					key = K_XBOX360_DPAD_DOWN;
 					break;
 
 				case SDL_HAT_LEFT:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFT, true, 0, nullptr );
+					key = K_XBOX360_DPAD_LEFT;
 					break;
 
 				case SDL_HAT_RIGHTUP:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHTUP, true, 0, nullptr );
+					key = K_XBOX360_DPAD_RIGHTUP;
 					break;
 
 				case SDL_HAT_RIGHTDOWN:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHTDOWN, true, 0, nullptr );
+					key = K_XBOX360_DPAD_RIGHTDOWN;
 					break;
 
 				case SDL_HAT_LEFTUP:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFTUP, true, 0, nullptr );
+					key = K_XBOX360_DPAD_LEFTUP;
 					break;
 
 				case SDL_HAT_LEFTDOWN:
-					Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFTDOWN, true, 0, nullptr );
+					key = K_XBOX360_DPAD_LEFTDOWN;
 					break;
 
 				default:
+					key = 0;
 					break;
 			}
+
+			if ( hat != SDL_HAT_CENTERED )
+			{
+				Log::Notice( "xbox hat bits = %i to key = Q:0x%02x(%s)\n", hat, key, Key_KeynumToString( key ) );
+			}
+		}
+
+		// release event
+		switch ( stick_state.oldhats & allHatDirections )
+		{
+			case SDL_HAT_UP:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_UP, false, 0, nullptr );
+				break;
+
+			case SDL_HAT_RIGHT:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHT, false, 0, nullptr );
+				break;
+
+			case SDL_HAT_DOWN:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_DOWN, false, 0, nullptr );
+				break;
+
+			case SDL_HAT_LEFT:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFT, false, 0, nullptr );
+				break;
+
+			case SDL_HAT_RIGHTUP:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHTUP, false, 0, nullptr );
+				break;
+
+			case SDL_HAT_RIGHTDOWN:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHTDOWN, false, 0, nullptr );
+				break;
+
+			case SDL_HAT_LEFTUP:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFTUP, false, 0, nullptr );
+				break;
+
+			case SDL_HAT_LEFTDOWN:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFTDOWN, false, 0, nullptr );
+				break;
+
+			default:
+				break;
+		}
+
+		// press event
+		switch ( hat & allHatDirections )
+		{
+			case SDL_HAT_UP:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_UP, true, 0, nullptr );
+				break;
+
+			case SDL_HAT_RIGHT:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHT, true, 0, nullptr );
+				break;
+
+			case SDL_HAT_DOWN:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_DOWN, true, 0, nullptr );
+				break;
+
+			case SDL_HAT_LEFT:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFT, true, 0, nullptr );
+				break;
+
+			case SDL_HAT_RIGHTUP:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHTUP, true, 0, nullptr );
+				break;
+
+			case SDL_HAT_RIGHTDOWN:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_RIGHTDOWN, true, 0, nullptr );
+				break;
+
+			case SDL_HAT_LEFTUP:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFTUP, true, 0, nullptr );
+				break;
+
+			case SDL_HAT_LEFTDOWN:
+				Com_QueueEvent( 0, sysEventType_t::SE_KEY, K_XBOX360_DPAD_LEFTDOWN, true, 0, nullptr );
+				break;
+
+			default:
+				break;
 		}
 	}
 


### PR DESCRIPTION
This a PR replaying Unvanquished/Unvanquished#935 by @dimhotepus on Unvanquished source tree after the engine split.

It obsoletes Unvanquished/Unvanquished#935

This is all @dimhotepus' work, except a small commit I just added to rename an iterator to prevent misread.