### PR TITLE
fix badly rendered skyboxes

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -2703,7 +2703,7 @@ static void ParseSkyParms( const char **text )
 	{
 		Q_strncpyz( prefix, token, sizeof( prefix ) );
 
-		shader.sky.outerbox = R_FindCubeImage( prefix, IF_NONE, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_EDGE_CLAMP );
+		shader.sky.outerbox = R_FindCubeImage( prefix, IF_NOCOMPRESSION, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_EDGE_CLAMP );
 
 		if ( !shader.sky.outerbox )
 		{


### PR DESCRIPTION
fix badly rendered skyboxes, @gimhael's suggestion.

example of bad rendering:
[![badly rendered skybox](http://dl.illwieckz.net/b/unvanquished/bugs/ugly-skybox/unvanquished_2017-08-09_042549_000.jpg)](http://dl.illwieckz.net/b/unvanquished/bugs/ugly-skybox/unvanquished_2017-08-09_042549_000.jpg)
[![badly rendered skybox](http://dl.illwieckz.net/b/unvanquished/bugs/ugly-skybox/unvanquished_2017-08-09_055650_000.jpg)](http://dl.illwieckz.net/b/unvanquished/bugs/ugly-skybox/unvanquished_2017-08-09_055650_000.jpg)
[![badly rendered skybox](http://dl.illwieckz.net/b/unvanquished/bugs/ugly-skybox/unvanquished_2017-08-09_060043_000.jpg)](http://dl.illwieckz.net/b/unvanquished/bugs/ugly-skybox/unvanquished_2017-08-09_060043_000.jpg)