### PR TITLE
Remove IF_NOCOMPRESSION and compression-related cvars.

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -479,7 +479,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 				width = height = 0;
 				LoadRGBEToBytes( va( "%s/%s", mapName, lightmapFiles[ i ] ), &ldrImage, &width, &height );
 
-				auto image = R_CreateImage( va( "%s/%s", mapName, lightmapFiles[ i ] ), (const byte **)&ldrImage, width, height, 1, IF_NOPICMIP | IF_LIGHTMAP | IF_NOCOMPRESSION, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
+				auto image = R_CreateImage( va( "%s/%s", mapName, lightmapFiles[ i ] ), (const byte **)&ldrImage, width, height, 1, IF_NOPICMIP | IF_LIGHTMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
 
 				Com_AddToGrowList( &tr.lightmaps, image );
 
@@ -498,7 +498,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 				for (int i = 0; i < numLightmaps; i++) {
 					Log::Debug("...loading external lightmap '%s/%s'", mapName, lightmapFiles[i]);
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NORMALMAP | IF_NOCOMPRESSION, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP);
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NORMALMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP);
 					Com_AddToGrowList(&tr.deluxemaps, image);
 				}
 			}
@@ -521,10 +521,10 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 				Log::Debug("...loading external lightmap '%s/%s'", mapName, lightmapFiles[i]);
 
 				if (!tr.worldDeluxeMapping || i % 2 == 0) {
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_LIGHTMAP | IF_NOCOMPRESSION, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_LIGHTMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
 					Com_AddToGrowList(&tr.lightmaps, image);
 				} else {
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NORMALMAP | IF_NOCOMPRESSION, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NORMALMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
 					Com_AddToGrowList(&tr.deluxemaps, image);
 				}
 			}
@@ -607,7 +607,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 		tr.fatLightmap = R_CreateImage( va( "_fatlightmap%d", 0 ), (const byte **)&fatbuffer,
 						tr.fatLightmapSize, tr.fatLightmapSize, 1,
-						IF_LIGHTMAP | IF_NOCOMPRESSION, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
+						IF_LIGHTMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
 		Com_AddToGrowList( &tr.lightmaps, tr.fatLightmap );
 
 		ri.Hunk_FreeTempMemory( fatbuffer );
@@ -3939,11 +3939,11 @@ void R_LoadLightGrid( lump_t *l )
 
 		tr.lightGrid1Image = R_Create3DImage("<lightGrid1>", (const byte *)w->lightGridData1,
 						     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-						     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE | IF_NOCOMPRESSION,
+						     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
 						     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
 		tr.lightGrid2Image = R_Create3DImage("<lightGrid2>", (const byte *)w->lightGridData2,
 						     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-						     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE | IF_NOCOMPRESSION,
+						     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
 						     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
 
 		return;
@@ -4103,11 +4103,11 @@ void R_LoadLightGrid( lump_t *l )
 
 	tr.lightGrid1Image = R_Create3DImage("<lightGrid1>", (const byte *)w->lightGridData1,
 					     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-					     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE | IF_NOCOMPRESSION,
+					     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
 					     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
 	tr.lightGrid2Image = R_Create3DImage("<lightGrid2>", (const byte *)w->lightGridData2,
 					     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-					     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE | IF_NOCOMPRESSION,
+					     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
 					     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
 
 	Log::Debug("%i light grid points created", w->numLightGridPoints );

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1038,14 +1038,7 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips,
 		// select proper internal format
 		if ( samples == 3 )
 		{
-			if ( glConfig.textureCompression == textureCompression_t::TC_S3TC && !(image->bits & IF_NOCOMPRESSION ) )
-			{
-				internalFormat = GL_COMPRESSED_RGB_S3TC_DXT1_EXT;
-			}
-			else
-			{
-				internalFormat = GL_RGB8;
-			}
+			internalFormat = GL_RGB8;
 		}
 		else if ( samples == 4 )
 		{
@@ -1055,25 +1048,7 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips,
 			}
 			else
 			{
-				if ( glConfig.textureCompression == textureCompression_t::TC_S3TC && !( image->bits & IF_NOCOMPRESSION ) )
-				{
-					if ( image->bits & IF_DISPLACEMAP )
-					{
-						internalFormat = GL_COMPRESSED_RGBA_S3TC_DXT3_EXT;
-					}
-					else if ( image->bits & IF_ALPHATEST )
-					{
-						internalFormat = GL_COMPRESSED_RGBA_S3TC_DXT1_EXT;
-					}
-					else
-					{
-						internalFormat = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
-					}
-				}
-				else
-				{
-					internalFormat = GL_RGBA8;
-				}
+				internalFormat = GL_RGBA8;
 			}
 		}
 	}
@@ -1804,8 +1779,6 @@ image_t        *R_FindImageFile( const char *imageName, int bits, filterType_t f
 	if ( bits & IF_LIGHTMAP )
 	{
 		R_ProcessLightmap( pic[ 0 ], 4, width, height, bits, pic[ 0 ] );
-
-		bits |= IF_NOCOMPRESSION;
 	}
 
 	image = R_CreateImage( ( char * ) buffer, (const byte **)pic,
@@ -2353,7 +2326,7 @@ static void R_CreateContrastRenderFBOImage()
 	width = glConfig.vidWidth * 0.25f;
 	height = glConfig.vidHeight * 0.25f;
 
-	tr.contrastRenderFBOImage = R_CreateImage( "_contrastRenderFBO", nullptr, width, height, 1, IF_NOPICMIP | IF_NOCOMPRESSION, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP );
+	tr.contrastRenderFBOImage = R_CreateImage( "_contrastRenderFBO", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP );
 }
 
 static void R_CreateBloomRenderFBOImage()
@@ -2366,7 +2339,7 @@ static void R_CreateBloomRenderFBOImage()
 
 	for ( i = 0; i < 2; i++ )
 	{
-		tr.bloomRenderFBOImage[ i ] = R_CreateImage( va( "_bloomRenderFBO%d", i ), nullptr, width, height, 1, IF_NOPICMIP | IF_NOCOMPRESSION, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP );
+		tr.bloomRenderFBOImage[ i ] = R_CreateImage( va( "_bloomRenderFBO%d", i ), nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP );
 	}
 }
 
@@ -2377,9 +2350,9 @@ static void R_CreateCurrentRenderImage()
 	width = glConfig.vidWidth;
 	height = glConfig.vidHeight;
 
-	tr.currentRenderImage[0] = R_CreateImage( "_currentRender[0]", nullptr, width, height, 1, IF_NOPICMIP | IF_NOCOMPRESSION, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-	tr.currentRenderImage[1] = R_CreateImage( "_currentRender[1]", nullptr, width, height, 1, IF_NOPICMIP | IF_NOCOMPRESSION, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-	tr.currentDepthImage = R_CreateImage( "_currentDepth", nullptr, width, height, 1, IF_NOPICMIP | IF_NOCOMPRESSION | IF_PACKED_DEPTH24_STENCIL8, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	tr.currentRenderImage[0] = R_CreateImage( "_currentRender[0]", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	tr.currentRenderImage[1] = R_CreateImage( "_currentRender[1]", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	tr.currentDepthImage = R_CreateImage( "_currentDepth", nullptr, width, height, 1, IF_NOPICMIP | IF_PACKED_DEPTH24_STENCIL8, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
 }
 
 static void R_CreateDepthRenderImage()
@@ -2416,7 +2389,7 @@ static void R_CreatePortalRenderImage()
 	width = glConfig.vidWidth;
 	height = glConfig.vidHeight;
 
-	tr.portalRenderImage = R_CreateImage( "_portalRender", nullptr, width, height, 1, IF_NOPICMIP | IF_NOCOMPRESSION, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	tr.portalRenderImage = R_CreateImage( "_portalRender", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
 }
 
 static void R_CreateDepthToColorFBOImages()
@@ -2427,8 +2400,8 @@ static void R_CreateDepthToColorFBOImages()
 	height = glConfig.vidHeight;
 
 	{
-		tr.depthToColorBackFacesFBOImage = R_CreateImage( "_depthToColorBackFacesFBORender", nullptr, width, height, 1, IF_NOPICMIP | IF_NOCOMPRESSION, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-		tr.depthToColorFrontFacesFBOImage = R_CreateImage( "_depthToColorFrontFacesFBORender", nullptr, width, height, 1, IF_NOPICMIP | IF_NOCOMPRESSION, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+		tr.depthToColorBackFacesFBOImage = R_CreateImage( "_depthToColorBackFacesFBORender", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+		tr.depthToColorFrontFacesFBOImage = R_CreateImage( "_depthToColorFrontFacesFBORender", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
 	}
 }
 
@@ -2440,11 +2413,11 @@ static void R_CreateDownScaleFBOImages()
 	width = glConfig.vidWidth * 0.25f;
 	height = glConfig.vidHeight * 0.25f;
 
-	tr.downScaleFBOImage_quarter = R_CreateImage( "_downScaleFBOImage_quarter", nullptr, width, height, 1, IF_NOPICMIP | IF_NOCOMPRESSION, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	tr.downScaleFBOImage_quarter = R_CreateImage( "_downScaleFBOImage_quarter", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
 
 	width = height = 64;
 
-	tr.downScaleFBOImage_64x64 = R_CreateImage( "_downScaleFBOImage_64x64", nullptr, width, height, 1, IF_NOPICMIP | IF_NOCOMPRESSION, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	tr.downScaleFBOImage_64x64 = R_CreateImage( "_downScaleFBOImage_64x64", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
 }
 
 // *INDENT-OFF*
@@ -2665,7 +2638,7 @@ static void R_CreateColorGradeImage()
 					      REF_COLORGRADEMAP_SIZE,
 					      REF_COLORGRADEMAP_SIZE,
 					      REF_COLORGRADE_SLOTS * REF_COLORGRADEMAP_SIZE,
-					      IF_NOPICMIP | IF_NOCOMPRESSION | IF_NOLIGHTSCALE,
+					      IF_NOPICMIP | IF_NOLIGHTSCALE,
 					      filterType_t::FT_LINEAR,
 						  wrapTypeEnum_t::WT_EDGE_CLAMP );
 
@@ -2769,7 +2742,7 @@ void R_CreateBuiltinImages()
 
 	tr.quadraticImage =
 		R_CreateImage( "_quadratic", ( const byte ** ) &dataPtr,
-			       DEFAULT_SIZE, DEFAULT_SIZE, 1, IF_NOPICMIP | IF_NOCOMPRESSION, filterType_t::FT_LINEAR,
+			       DEFAULT_SIZE, DEFAULT_SIZE, 1, IF_NOPICMIP, filterType_t::FT_LINEAR,
 					   wrapTypeEnum_t::WT_CLAMP );
 
 	R_CreateRandomNormalsImage();
@@ -2890,5 +2863,5 @@ qhandle_t RE_GenerateTexture( const byte *pic, int width, int height )
 {
 	const char *name = va( "rocket%d", numTextures++ );
 	R_SyncRenderThread();
-	return RE_RegisterShaderFromImage( name, R_CreateImage( name, &pic, width, height, 1, IF_NOCOMPRESSION | IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP ) );
+	return RE_RegisterShaderFromImage( name, R_CreateImage( name, &pic, width, height, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP ) );
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -82,9 +82,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_dynamicLightCastShadows;
 	cvar_t      *r_precomputedLighting;
 	cvar_t      *r_vertexLighting;
-	cvar_t      *r_compressDiffuseMaps;
-	cvar_t      *r_compressSpecularMaps;
-	cvar_t      *r_compressNormalMaps;
 	cvar_t      *r_exportTextures;
 	cvar_t      *r_heatHaze;
 	cvar_t      *r_noMarksOnTrisurfs;
@@ -1103,9 +1100,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 		r_dynamicLightCastShadows = ri.Cvar_Get( "r_dynamicLightCastShadows", "1", 0 );
 		r_precomputedLighting = ri.Cvar_Get( "r_precomputedLighting", "1", CVAR_SHADER );
 		r_vertexLighting = ri.Cvar_Get( "r_vertexLighting", "0", CVAR_LATCH | CVAR_ARCHIVE );
-		r_compressDiffuseMaps = ri.Cvar_Get( "r_compressDiffuseMaps", "1", CVAR_LATCH );
-		r_compressSpecularMaps = ri.Cvar_Get( "r_compressSpecularMaps", "1", CVAR_LATCH );
-		r_compressNormalMaps = ri.Cvar_Get( "r_compressNormalMaps", "0", CVAR_LATCH );
 		r_exportTextures = ri.Cvar_Get( "r_exportTextures", "0", 0 );
 		r_heatHaze = ri.Cvar_Get( "r_heatHaze", "1", 0 );
 		r_noMarksOnTrisurfs = ri.Cvar_Get( "r_noMarksOnTrisurfs", "1", CVAR_CHEAT );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -512,30 +512,29 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	{
 	  IF_NONE,
 	  IF_NOPICMIP = BIT( 0 ),
-	  IF_NOCOMPRESSION = BIT( 1 ),
-	  IF_ALPHA = BIT( 2 ),
-	  IF_NORMALMAP = BIT( 3 ),
-	  IF_RGBA16F = BIT( 4 ),
-	  IF_RGBA32F = BIT( 5 ),
-	  IF_TWOCOMP16F = BIT( 6 ),
-	  IF_TWOCOMP32F = BIT( 7 ),
-	  IF_ONECOMP16F = BIT( 8 ),
-	  IF_ONECOMP32F = BIT( 9 ),
-	  IF_DEPTH16 = BIT( 10 ),
-	  IF_DEPTH24 = BIT( 11 ),
-	  IF_DEPTH32 = BIT( 12 ),
-	  IF_PACKED_DEPTH24_STENCIL8 = BIT( 13 ),
-	  IF_LIGHTMAP = BIT( 14 ),
-	  IF_RGBA16 = BIT( 15 ),
-	  IF_RGBE = BIT( 16 ),
-	  IF_ALPHATEST = BIT( 17 ),
-	  IF_DISPLACEMAP = BIT( 18 ),
-	  IF_NOLIGHTSCALE = BIT( 19 ),
-	  IF_BC1 = BIT( 20 ),
-	  IF_BC3 = BIT( 21 ),
-	  IF_BC4 = BIT( 22 ),
-	  IF_BC5 = BIT( 23 ),
-	  IF_RGBA32UI = BIT( 24 )
+	  IF_ALPHA = BIT( 1 ),
+	  IF_NORMALMAP = BIT( 2 ),
+	  IF_RGBA16F = BIT( 3 ),
+	  IF_RGBA32F = BIT( 4 ),
+	  IF_TWOCOMP16F = BIT( 5 ),
+	  IF_TWOCOMP32F = BIT( 6 ),
+	  IF_ONECOMP16F = BIT( 7 ),
+	  IF_ONECOMP32F = BIT( 8 ),
+	  IF_DEPTH16 = BIT( 9 ),
+	  IF_DEPTH24 = BIT( 10 ),
+	  IF_DEPTH32 = BIT( 11 ),
+	  IF_PACKED_DEPTH24_STENCIL8 = BIT( 12 ),
+	  IF_LIGHTMAP = BIT( 13 ),
+	  IF_RGBA16 = BIT( 14 ),
+	  IF_RGBE = BIT( 15 ),
+	  IF_ALPHATEST = BIT( 16 ),
+	  IF_DISPLACEMAP = BIT( 17 ),
+	  IF_NOLIGHTSCALE = BIT( 18 ),
+	  IF_BC1 = BIT( 19 ),
+	  IF_BC3 = BIT( 20 ),
+	  IF_BC4 = BIT( 21 ),
+	  IF_BC5 = BIT( 22 ),
+	  IF_RGBA32UI = BIT( 23 )
 	};
 
 	enum class filterType_t
@@ -1110,7 +1109,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		bool        overrideWrapType;
 		wrapType_t      wrapType;
 
-		bool        uncompressed;
 		bool        highQuality;
 		bool        forceHighQuality;
 
@@ -1230,7 +1228,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		bool       polygonOffset; // set for decals and other items that must be offset
 		float          polygonOffsetValue;
 
-		bool       uncompressed;
 		bool       noPicMip; // for images that must always be full resolution
 		filterType_t   filterType; // for console fonts, 2D elements, etc.
 		wrapType_t     wrapType;
@@ -2843,9 +2840,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_dynamicLightCastShadows;
 	extern cvar_t *r_precomputedLighting;
 	extern cvar_t *r_vertexLighting;
-	extern cvar_t *r_compressDiffuseMaps;
-	extern cvar_t *r_compressSpecularMaps;
-	extern cvar_t *r_compressNormalMaps;
 	extern cvar_t *r_exportTextures;
 	extern cvar_t *r_heatHaze;
 	extern cvar_t *r_noMarksOnTrisurfs;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1420,11 +1420,6 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer )
 		imageBits |= IF_DISPLACEMAP;
 	}
 
-	if ( stage->uncompressed || stage->highQuality || stage->forceHighQuality || shader.uncompressed )
-	{
-		imageBits |= IF_NOCOMPRESSION;
-	}
-
 	if ( stage->stateBits & ( GLS_ATEST_BITS ) )
 	{
 		imageBits |= IF_ALPHATEST;
@@ -1757,10 +1752,9 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 		{
 			stage->overrideWrapType = true;
 		}
-		// uncompressed
+		// uncompressed (removed option)
 		else if ( !Q_stricmp( token, "uncompressed" ) )
 		{
-			stage->uncompressed = true;
 		}
 		// highQuality
 		else if ( !Q_stricmp( token, "highQuality" ) )
@@ -2703,7 +2697,7 @@ static void ParseSkyParms( const char **text )
 	{
 		Q_strncpyz( prefix, token, sizeof( prefix ) );
 
-		shader.sky.outerbox = R_FindCubeImage( prefix, IF_NOCOMPRESSION, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_EDGE_CLAMP );
+		shader.sky.outerbox = R_FindCubeImage( prefix, IF_NONE, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_EDGE_CLAMP );
 
 		if ( !shader.sky.outerbox )
 		{
@@ -2991,11 +2985,6 @@ static void ParseDiffuseMap( shaderStage_t *stage, const char **text )
 	stage->rgbGen = colorGen_t::CGEN_IDENTITY;
 	stage->stateBits = GLS_DEFAULT;
 
-	if ( !r_compressDiffuseMaps->integer )
-	{
-		stage->uncompressed = true;
-	}
-
 	if ( ParseMap( text, buffer, sizeof( buffer ) ) )
 	{
 		LoadMap( stage, buffer );
@@ -3010,11 +2999,6 @@ static void ParseNormalMap( shaderStage_t *stage, const char **text )
 	stage->type = stageType_t::ST_NORMALMAP;
 	stage->rgbGen = colorGen_t::CGEN_IDENTITY;
 	stage->stateBits = GLS_DEFAULT;
-
-	if ( !r_compressNormalMaps->integer )
-	{
-		stage->uncompressed = true;
-	}
 
 	if ( r_highQualityNormalMapping->integer )
 	{
@@ -3039,11 +3023,6 @@ static void ParseSpecularMap( shaderStage_t *stage, const char **text )
 	stage->rgbGen = colorGen_t::CGEN_IDENTITY;
 	stage->stateBits = GLS_DEFAULT;
 
-	if ( !r_compressSpecularMaps->integer )
-	{
-		stage->uncompressed = true;
-	}
-
 	if ( ParseMap( text, buffer, sizeof( buffer ) ) )
 	{
 		LoadMap( stage, buffer );
@@ -3058,11 +3037,6 @@ static void ParseMaterialMap( shaderStage_t *stage, const char **text )
 	stage->type = stageType_t::ST_MATERIALMAP;
 	stage->rgbGen = colorGen_t::CGEN_IDENTITY;
 	stage->stateBits = GLS_DEFAULT;
-
-	if ( !r_compressSpecularMaps->integer )
-	{
-		stage->uncompressed = true;
-	}
 
 	if ( ParseMap( text, buffer, sizeof( buffer ) ) )
 	{
@@ -3359,15 +3333,14 @@ static bool ParseShader( const char *_text )
 			shader.noPicMip = true;
 			continue;
 		}
-		// RF, allow each shader to permit compression if available
+		// RF, allow each shader to permit compression if available (removed option)
 		else if ( !Q_stricmp( token, "allowcompress" ) )
 		{
-			shader.uncompressed = false;
 			continue;
 		}
+		// (removed option)
 		else if ( !Q_stricmp( token, "nocompress" ) )
 		{
-			shader.uncompressed = true;
 			continue;
 		}
 		// polygonOffset
@@ -4807,7 +4780,7 @@ shader_t       *R_FindShader( const char *name, shaderType_t type,
 		shader.noPicMip = true;
 
 	if( flags & RSF_NOLIGHTSCALE )
-		bits |= IF_NOLIGHTSCALE | IF_NOCOMPRESSION;
+		bits |= IF_NOLIGHTSCALE;
 
 	// choosing filter based on the NOMIP flag seems strange,
 	// maybe it should be changed to type == SHADER_2D


### PR DESCRIPTION
This change removes support for on-the-fly texture compression in the Daemon engine. The cvars /r_compress*Maps have been removed and the "nocompress" shader keyword has no function, but is kept for backward compatibility.

Anybody who wants to use compressed textures should use an offline texture compression tool, and provide the textures in .dds or .crn format.