### PR TITLE
Turn off debug assertions in RelWithDebInfo builds.

### DIFF
--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -330,6 +330,6 @@ if (APPLE)
 endif()
 
 # Configuration specific definitions
-if (CMAKE_BUILD_TYPE STREQUAL Debug OR CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
+if (CMAKE_BUILD_TYPE STREQUAL Debug)
     add_definitions(-DDEBUG_BUILD)
 endif()


### PR DESCRIPTION
[This](https://github.com/DaemonEngine/Daemon/blob/b6e41f7baae75adbd7121e70d7b73b7e19ec4b6a/src/common/Assert.h) is the only usage of the DEBUG_BUILD flag. As RelWithDebInfo is a "release" configuration, assertions should not be enabled. If anyone wants to debug with optimizations enabled, we could add another option for that.