### PR TITLE
don't substract player count by allowed privateClients number

### DIFF
--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -627,13 +627,18 @@ void SVC_Info( netadr_t from, const Cmd::Args& args )
 		}
 	}
 
+	// do not disclose private slot number except for those taken
+	int maxclients = sv_maxclients->integer - sv_privateClients->integer;
+	int clients = count + botCount;
+	maxclients = clients > maxclients ? clients : maxclients;
+
 	info_map["protocol"] = std::to_string( PROTOCOL_VERSION );
 	info_map["hostname"] = sv_hostname->string;
 	info_map["serverload"] = std::to_string( svs.serverLoad );
 	info_map["mapname"] = sv_mapname->string;
 	info_map["clients"] = std::to_string( count );
 	info_map["bots"] = std::to_string( botCount );
-	info_map["sv_maxclients"] = std::to_string( sv_maxclients->integer - sv_privateClients->integer );
+	info_map["sv_maxclients"] = std::to_string( maxclients );
 	info_map["pure"] = std::to_string( sv_pure->integer );
 
 	if ( sv_statsURL->string[0] )

--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -571,11 +571,10 @@ void SVC_Info( netadr_t from, const Cmd::Args& args )
 
 	SV_ResolveMasterServers();
 
-	// don't count privateclients
 	int botCount = 0;
 	int count = 0;
 
-	for ( int i = sv_privateClients->integer; i < sv_maxclients->integer; i++ )
+	for ( int i = 0; i < sv_maxclients->integer; i++ )
 	{
 		if ( svs.clients[ i ].state >= clientState_t::CS_CONNECTED )
 		{


### PR DESCRIPTION
## don't substract player count by allowed privateClients number

A private client is a kind of slot only available to someone having the password,
allowed to ensure this one can join even if the server is full.

1. this is a real kind of players so there is no reason to substract the number
of private client to player count.
2. It makes no sense to substract all the time, even when no one private client
is connected…

Fix Unvanquished/Unvanquished#1028

## do not disclose private slot number except for those taken

returns to client sv_maxclients as sv_maxclients - sv_privateClients
except if client count + bot count is greater (which means some private
slots are taken) so returns client count + bot count in this case instead.

i.e. hide private slot number when possible, but never returns a sv_maxclient
count that is smaller than the advertised client number.