### PR TITLE
add WORKING_DIRECTORY to git revision check, set to CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
             COMMAND ${GIT_EXECUTABLE} describe --tags --long --match v* --dirty=+dirty
             OUTPUT_VARIABLE GIT_DESCRIBE_REPORT
             OUTPUT_STRIP_TRAILING_WHITESPACE
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
         )
         message(STATUS "git reported ${GIT_DESCRIBE_REPORT}")
         # this may fail with annotated non-release tags


### PR DESCRIPTION
This fixes [Unvanquished/Unvanquished issue #1002](https://github.com/Unvanquished/Unvanquished/issues/1002) as soon as that project gets updated to this daemon commit.