### PR TITLE
Revert "bump protocol since dpk/pk3 support introduced pak list incompatibilities"

### DIFF
--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -283,7 +283,7 @@ The server you are attempting to join is running an incompatible version of the 
 The server you attempted to join is running an incompatible version of the game.\n\
 You or the server may be running older versions of the game."
 
-#define PROTOCOL_VERSION       87
+#define PROTOCOL_VERSION       86
 
 #define URI_SCHEME             GAMENAME_STRING "://"
 #define URI_SCHEME_LENGTH      ( ARRAY_LEN( URI_SCHEME ) - 1 )


### PR DESCRIPTION
See #18 for the initial change that is now to be reverted.

The reverted change was motivated by the fact the VFS change to introduced DPK support and enable legacy PK3 download brokes too many things (which has implication on package downloading) so it sounded like a good idea to raise protocol number.

Well, it raises many other issues. First, protocol number is hardcoded in client, it can be fixed easily but _meh_. Second, unlike some idtech derivative games that has history of multiple protocol, tremulous never changed the number and unvanquished neither, because of that, no one third-party tool implemented a way to ask for server from all numbers, but they all hardcode the protocol number, it means `qstat`, `xqf`, `apelsin`, `osavul` and `obozrenie` will be broken, and most of them would have to be recompiled, which looks to be unlikely to happen for some of them. For example some people who plays both tremulous and unvanquished still use apelsin today. Bumping the protocol means Unvanquished will disappear from their screens.

I've checked, and we introduced enough compat breaking changes to not have to worry. I verified that Unvanquished 0.50.0 client can't connect to Unvanquished 0.51.0 server and Unvanquished 0.51.0 client can't connect to Unvanquished 0.50.0 (it just returns to main menu in both case). The same way you can't connect from early Unvanquished client to current server just thanks to introduced incompatibilities and it was considered OK at this time.

This reverts commit a2177af6e3f709bcbbef07ff0bc43f28daa3b76d.