### PR TITLE
FileSystem: Replace bad assert with a verbose log

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -2285,7 +2285,7 @@ static void FindPaksInPath(Str::StringRef basePath, Str::StringRef subPath)
 			} else if (Str::IsSuffix("/", filename)) {
 				FindPaksInPath(basePath, Path::Build(subPath, filename));
 			} else {
-				ASSERT_UNREACHABLE();
+				fsLogs.Verbose("Ignoring file: %s", filename);
 			}
 		}
 	} catch (std::system_error&) {


### PR DESCRIPTION
This assert will trigger everytime there is an unrecongized file
in the pakpath. This is bad and wrong.