### PR TITLE
Fix some issues regarding private client slots

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -308,7 +308,7 @@ extern cvar_t         *sv_privatePassword;
 extern cvar_t         *sv_allowDownload;
 extern cvar_t         *sv_maxclients;
 
-extern cvar_t         *sv_privateClients;
+extern Cvar::Range<Cvar::Cvar<int>> sv_privateClients;
 extern cvar_t         *sv_hostname;
 extern cvar_t         *sv_statsURL;
 extern cvar_t         *sv_master[ MAX_MASTER_SERVERS ];

--- a/src/engine/server/sv_bot.cpp
+++ b/src/engine/server/sv_bot.cpp
@@ -44,7 +44,7 @@ SV_BotAllocateClient
 int SV_BotAllocateClient()
 {
 	int i;
-	for (i = std::max(1, sv_privateClients->integer); i < sv_maxclients->integer; i++) {
+	for (i = std::max(1, sv_privateClients.Get()); i < sv_maxclients->integer; i++) {
 		if (svs.clients[i].state == clientState_t::CS_FREE) {
 			break;
 		}

--- a/src/engine/server/sv_client.cpp
+++ b/src/engine/server/sv_client.cpp
@@ -144,7 +144,7 @@ void SV_DirectConnect( netadr_t from, const Cmd::Args& args )
 		if ( userinfo["password"] != sv_privatePassword->string )
 		{
 			// skip past the reserved slots
-			startIndex = sv_privateClients->integer;
+			startIndex = std::min(sv_privateClients.Get(), sv_maxclients->integer);
 		}
 
 		new_client = std::find_if(clients_begin, clients_end,

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -646,7 +646,6 @@ void SV_Init()
 	Cvar_Get( "pakname", "", CVAR_SERVERINFO | CVAR_ROM );
 	Cvar_Get( "layout", "", CVAR_SERVERINFO | CVAR_ROM );
 	Cvar_Get( "g_layouts", "", 0 ); // FIXME
-	sv_privateClients = Cvar_Get( "sv_privateClients", "0", CVAR_SERVERINFO );
 	sv_hostname = Cvar_Get( "sv_hostname", UNNAMED_SERVER, CVAR_SERVERINFO  );
 	sv_maxclients = Cvar_Get( "sv_maxclients", "20", CVAR_SERVERINFO | CVAR_LATCH );  // NERVE - SMF - changed to 20 from 8
 	sv_maxRate = Cvar_Get( "sv_maxRate", "0",  CVAR_SERVERINFO );

--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -32,8 +32,9 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
+
 #include "server.h"
-#include "common/Assert.h"
 #include "CryptoChallenge.h"
 #include "framework/Rcon.h"
 
@@ -53,7 +54,8 @@ cvar_t         *sv_privatePassword; // password for the privateClient slots
 cvar_t         *sv_allowDownload;
 cvar_t         *sv_maxclients;
 
-cvar_t         *sv_privateClients; // number of clients reserved for password
+Cvar::Range<Cvar::Cvar<int>> sv_privateClients("sv_privateClients",
+    "number of password-protected client slots", CVAR_SERVERINFO, 0, 0, MAX_CLIENTS);
 cvar_t         *sv_hostname;
 cvar_t         *sv_statsURL;
 cvar_t         *sv_master[ MAX_MASTER_SERVERS ]; // master server IP addresses
@@ -575,7 +577,7 @@ void SVC_Info( netadr_t from, const Cmd::Args& args )
 	int botCount = 0;
 	int count = 0;
 
-	for ( int i = sv_privateClients->integer; i < sv_maxclients->integer; i++ )
+	for ( int i = sv_privateClients.Get(); i < sv_maxclients->integer; i++ )
 	{
 		if ( svs.clients[ i ].state >= clientState_t::CS_CONNECTED )
 		{
@@ -634,7 +636,7 @@ void SVC_Info( netadr_t from, const Cmd::Args& args )
 	info_map["mapname"] = sv_mapname->string;
 	info_map["clients"] = std::to_string( count );
 	info_map["bots"] = std::to_string( botCount );
-	info_map["sv_maxclients"] = std::to_string( sv_maxclients->integer - sv_privateClients->integer );
+	info_map["sv_maxclients"] = std::to_string( std::max( 0, sv_maxclients->integer - sv_privateClients.Get() ) );
 	info_map["pure"] = std::to_string( sv_pure->integer );
 
 	if ( sv_statsURL->string[0] )


### PR DESCRIPTION
- Avoid potential crashes with out of bounds value of `sv_privateClients`.
- Implement my suggestion [here](https://github.com/Unvanquished/Unvanquished/issues/1028#issuecomment-335695254) for server stats in the presence of private slot users. Namely, the difference between the number of current clients and the max should be the number of open public slots. For comparison, #40 proposes max clients = max(number of public slots, number of clients).
- Actually prevent users without the right password from occupying the private slots (fixes #41).