### PR TITLE
do not migrate legacy homepath when using -homepath arg

### DIFF
--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -485,6 +485,7 @@ void Initialize();
 #else
 std::string DefaultBasePath();
 std::string DefaultHomePath();
+void MigrateHomePath();
 void Initialize(Str::StringRef homePath, Str::StringRef libPath, const std::vector<std::string>& paths);
 #endif
 

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -418,6 +418,7 @@ static void ParseCmdline(int argc, char** argv, cmdlineArgs_t& cmdlineArgs)
 #endif
 
 	bool foundCommands = false;
+	bool foundHomePathCommand = false;
 	for (int i = 1; i < argc; i++) {
 		// A + indicate the start of a command that should be run on startup
 		if (argv[i][0] == '+') {
@@ -489,6 +490,7 @@ static void ParseCmdline(int argc, char** argv, cmdlineArgs_t& cmdlineArgs)
 				Log::Warn("Missing argument for -homepath");
 				continue;
 			}
+			foundHomePathCommand = true;
 			cmdlineArgs.homePath = argv[i + 1];
 			i++;
 		} else if (!strcmp(argv[i], "-resetconfig")) {
@@ -503,6 +505,10 @@ static void ParseCmdline(int argc, char** argv, cmdlineArgs_t& cmdlineArgs)
 			Log::Warn("Ignoring unrecognized parameter \"%s\"", argv[i]);
 			continue;
 		}
+	}
+
+	if (!foundHomePathCommand) {
+		FS::MigrateHomePath();
 	}
 }
 


### PR DESCRIPTION
The bug is obvious:

In #20 (see also #39) I modified `DefaultHomePath()` in `src/common/FileSystem.cpp` to move legacy homepath to XDG's `.local/share/unvanquished` path (or to follow XDG env vars). But `DefaultHomePath()` is called in `cmdlineArgs_t` initialization in `src/engine/framework/System.cpp` and `cmdlineArgs` is initialized in `ParseCmdline()` in `src/engine/framework/System.cpp` _before_ `-homepath` switch is parsed. So, the engine try to do the default homepath move even if an arbitrary homepath is forced by command line. Which is wrong.

This fix is an attempt to fix that this way:

- `DefaultHomePath()` only returns the xdgpath, so `cmdlineArgs` can be initialized without doing the legacy homepath move;
- an `MigrateHomePath()` function was created to do the homepath move (if engine built for linux) to be called by `FS::Initialize()`;
- `MigrateHomePath()` only do the move if `cmdLineArgs.homePath` equals `defaultHomePath` (it means another path was not enforced) so it means the move will not be done if a custom homepath is set.

I'm currently unable to build the engine, so if someone can build and test it would be _very cool_. By the way it does not prevent to have a first look at the code to tell if something is obviously wrong. :stuck_out_tongue: 