### PR TITLE
Cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ if(NOT DAEMON_EXTERNAL_APP)
         set(BUILD_GAME_NACL_NEXE 0)
     endif()
     option(BUILD_TTY_CLIENT "Build Daemon headless client" 1)
-    option(BUILD_DUMMPY_APP "Build the dummy app for daemon" 0)
+    option(BUILD_DUMMY_APP "Build the dummy app for daemon" 0)
 
     set(NACL_RUNTIME_PATH "" CACHE STRING "Directory containing the NaCl binaries")
 
@@ -703,7 +703,7 @@ if (NOT NACL)
     set_property(TARGET engine-lib APPEND PROPERTY COMPILE_OPTIONS ${WARNINGS})
     ADD_PRECOMPILED_HEADER(engine-lib)
 
-    if(BUILD_DUMMPY_APP)
+    if (BUILD_DUMMY_APP)
         AddApplication(
             Target dummyapp
             ExecutableName dummyapp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,23 @@ option(USE_DEBUG_OPTIMIZE "Try to optimize the debug build" 1)
 option(USE_PRECOMPILED_HEADER "Improve build times by using a precompiled header" 1)
 option(USE_ADDRESS_SANITIZER "Try to use the address sanitizer" 0)
 option(BE_VERBOSE "Tell the compiler to report all warnings" 0)
-option( USE_STATIC_LIBS "Tries to use static libs where possible. Only works for Linux" 0 )
+option(USE_STATIC_LIBS "Tries to use static libs where possible. Only works for Linux" 0)
+
+# Game VM modules are built with a recursive invocation of CMake, by which all the configuration
+# options are lost, except ones we explicitly choose to pass.
+set(DEFAULT_NACL_VM_INHERITED_OPTIONS
+    BE_VERBOSE
+    BUILD_CGAME
+    BUILD_SGAME
+    CMAKE_BUILD_TYPE
+    USE_PEDANTIC
+    USE_PRECOMPILED_HEADER
+    USE_WERROR
+)
+set(NACL_VM_INHERITED_OPTIONS "${DEFAULT_NACL_VM_INHERITED_OPTIONS}" CACHE STRING
+    "Semicolon-separated list of options for which NaCl game VMs should use the same value as the other binaries")
+mark_as_advanced(NACL_VM_INHERITED_OPTIONS)
+
 if (BE_VERBOSE)
     set(WARNMODE "no-error=")
 else()

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -340,4 +340,9 @@ if (APPLE)
 endif()
 
 # Configuration specific definitions
-set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:DEBUG_BUILD>)
+
+# This stupid trick to define THIS_IS_NOT_A_DEBUG_BUILD (rather than nothing) in the non-debug case
+# is so that it doesn't break the hacky gcc/clang PCH code which reads all the definitions
+# and prefixes "-D" to them.
+set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS
+             $<$<NOT:$<CONFIG:Debug>>:THIS_IS_NOT_A_>DEBUG_BUILD)

--- a/cmake/DaemonGame.cmake
+++ b/cmake/DaemonGame.cmake
@@ -69,6 +69,11 @@ function(GAMEMODULE)
             set(FORK 1 PARENT_SCOPE)
             include(ExternalProject)
             set(vm nacl-vms)
+            set(inherited_option_args)
+            foreach(inherited_option ${NACL_VM_INHERITED_OPTIONS})
+                set(inherited_option_args ${inherited_option_args}
+                    "-D${inherited_option}=${${inherited_option}}")
+            endforeach(inherited_option)
             ExternalProject_Add(${vm}
                 SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
                 BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${vm}
@@ -76,10 +81,7 @@ function(GAMEMODULE)
                 CMAKE_ARGS
                     -DFORK=2
                     -DCMAKE_TOOLCHAIN_FILE=${Daemon_SOURCE_DIR}/cmake/toolchain-pnacl.cmake
-                    -DCMAKE_BUILD_TYPE=$<CONFIG>
                     -DDEPS_DIR=${DEPS_DIR}
-                    -DBUILD_CGAME=${BUILD_CGAME}
-                    -DBUILD_SGAME=${BUILD_SGAME}
                     -DBUILD_GAME_NACL_NEXE=${BUILD_GAME_NACL_NEXE}
                     -DBUILD_GAME_NACL=1
                     -DBUILD_GAME_NATIVE_DLL=0
@@ -87,6 +89,7 @@ function(GAMEMODULE)
                     -DBUILD_CLIENT=0
                     -DBUILD_TTY_CLIENT=0
                     -DBUILD_SERVER=0
+                    ${inherited_option_args}
                 INSTALL_COMMAND ""
             )
             ExternalProject_Add_Step(${vm} forcebuild


### PR DESCRIPTION
Pass more flags to the nacl vms build (such as build type and use pch), and fix the bug in pch generation introduced by using a generator expression for DEBUG_BUILD.