### PR TITLE
Disable extension GL_ARB_texture_gather on NVidia GeForce.

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -419,7 +419,7 @@ static std::string GenVersionDeclaration() {
 				       glConfig2.shadingLanguageVersion >= 150 ? (glConfig2.glCoreProfile ? "core" : "compatibility") : "");
 
 	// add supported GLSL extensions
-	addExtension( str, r_arb_texture_gather->integer, 400,
+	addExtension( str, glConfig2.textureGatherAvailable, 400,
 		      GLEW_ARB_texture_gather, "ARB_texture_gather" );
 	addExtension( str, r_ext_gpu_shader4->integer, 130,
 		      GLEW_EXT_gpu_shader4, "EXT_gpu_shader4" );

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -396,6 +396,7 @@ struct glconfig2_t
 	bool textureIntegerAvailable;
 	bool textureRGAvailable;
 	bool gpuShader4Available;
+	bool textureGatherAvailable;
 	int      maxDrawBuffers;
 
 	float    maxTextureAnisotropy;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1069,6 +1069,13 @@ static void GLimp_InitExtensions()
 	// made required in OpenGL 3.0
 	glConfig2.textureRGAvailable = LOAD_CORE_EXTENSION_WITH_CVAR(ARB_texture_rg, r_ext_texture_rg);
 
+	// made required in OpenGL 4.0
+	if( Q_stristr( glConfig.renderer_string, "geforce" ) ) {
+		glConfig2.textureGatherAvailable = false; // disabled on nVidia because some driver versions are bugged
+	} else {
+		glConfig2.textureGatherAvailable = LOAD_EXTENSION_WITH_CVAR(ARB_texture_gather, r_arb_texture_gather);
+	}
+
 	// made required in OpenGL 1.3
 	glConfig.textureCompression = textureCompression_t::TC_NONE;
 	if( GLEW_EXT_texture_compression_s3tc )


### PR DESCRIPTION
Some versions of NVidias OpenGL driver seem to have a bug, and it was just a
performance optimization anyway.

This should fix Unvanquished issue #919.
