### PR TITLE
crypto: Add casts to fix compile errors.

### DIFF
--- a/src/engine/framework/Crypto.cpp
+++ b/src/engine/framework/Crypto.cpp
@@ -154,9 +154,9 @@ Data Base64Encode( const Data& input )
 
     Data output( BASE64_ENCODE_LENGTH( input.size() ) + BASE64_ENCODE_FINAL_LENGTH );
     int encoded_bytes = nettle_base64_encode_update(
-        &ctx, output.data(), input.size(), input.data()
+        &ctx, reinterpret_cast<char*>(output.data()), input.size(), input.data()
     );
-    encoded_bytes += nettle_base64_encode_final( &ctx, output.data() + encoded_bytes );
+    encoded_bytes += nettle_base64_encode_final( &ctx, reinterpret_cast<char*>(output.data()) + encoded_bytes );
     output.erase( output.begin() + encoded_bytes, output.end() );
     return output;
 }
@@ -176,7 +176,7 @@ bool Base64Decode( const Data& input, Data& output )
     Data temp( BASE64_DECODE_LENGTH( input.size() ) );
     std::size_t decoded_bytes = 0;
     if ( !nettle_base64_decode_update( &ctx, &decoded_bytes, temp.data(),
-                                       input.size(), input.data() ) )
+                                       input.size(), reinterpret_cast<const char*>(input.data()) ) )
     {
         return false;
     }


### PR DESCRIPTION
[ 69%] Building CXX object daemon_build/CMakeFiles/engine-lib.dir/src/engine/framework/Crypto.cpp.o
/home/modi/unv/Unvanquished/daemon/src/engine/framework/Crypto.cpp: In function ‘Crypto::Data Crypto::Encoding::Base64Encode(const Data&)’:
/home/modi/unv/Unvanquished/daemon/src/engine/framework/Crypto.cpp:157:26: error: invalid conversion from ‘unsigned char*’ to ‘char*’ [-fpermissive]
         &ctx, output.data(), input.size(), input.data()
               ~~~~~~~~~~~^~
In file included from /home/modi/unv/Unvanquished/daemon/src/engine/framework/Crypto.cpp:34:0:
/usr/include/nettle/base64.h:98:1: note:   initializing argument 2 of ‘size_t nettle_base64_encode_update(base64_encode_ctx*, char*, size_t, const uint8_t*)’
 base64_encode_update(struct base64_encode_ctx *ctx,
 ^
/home/modi/unv/Unvanquished/daemon/src/engine/framework/Crypto.cpp:159:70: error: invalid conversion from ‘unsigned char*’ to ‘char*’ [-fpermissive]
     encoded_bytes += nettle_base64_encode_final( &ctx, output.data() + encoded_bytes );
                                                        ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
In file included from /home/modi/unv/Unvanquished/daemon/src/engine/framework/Crypto.cpp:34:0:
/usr/include/nettle/base64.h:106:1: note:   initializing argument 2 of ‘size_t nettle_base64_encode_final(base64_encode_ctx*, char*)’
 base64_encode_final(struct base64_encode_ctx *ctx,
 ^
/home/modi/unv/Unvanquished/daemon/src/engine/framework/Crypto.cpp: In function ‘bool Crypto::Encoding::Base64Decode(const Data&, Crypto::Data&)’:
/home/modi/unv/Unvanquished/daemon/src/engine/framework/Crypto.cpp:179:64: error: invalid conversion from ‘const unsigned char*’ to ‘const char*’ [-fpermissive]
                                        input.size(), input.data() ) )
                                                      ~~~~~~~~~~^~
In file included from /home/modi/unv/Unvanquished/daemon/src/engine/framework/Crypto.cpp:34:0:
/usr/include/nettle/base64.h:158:1: note:   initializing argument 5 of ‘int nettle_base64_decode_update(base64_decode_ctx*, size_t*, uint8_t*, size_t, const char*)’
 base64_decode_update(struct base64_decode_ctx *ctx,
 ^
make[2]: *** [daemon_build/CMakeFiles/engine-lib.dir/build.make:879: daemon_build/CMakeFiles/engine-lib.dir/src/engine/framework/Crypto.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:879: daemon_build/CMakeFiles/engine-lib.dir/all] Error 2
make: *** [Makefile:84: all] Error 2