### PR TITLE
prevent some false-positive errors to be raised on optional files or file formats

### DIFF
--- a/src/engine/renderer/tr_animation.cpp
+++ b/src/engine/renderer/tr_animation.cpp
@@ -518,6 +518,14 @@ qhandle_t RE_RegisterAnimation( const char *name )
 	// make sure the render thread is stopped
 	R_SyncRenderThread();
 
+	// do not try to load file for iqm animation name in the form of
+	//   models/players/level0/level0.iqm:stand
+	// since we know it's not a file and it's already loaded
+	if ( strcasestr( name, ".iqm:" ) )
+	{
+		return 0;
+	}
+
 	// load and parse the .md5anim file
 	int bufferLen = ri.FS_ReadFile( name, ( void ** ) &buffer );
 

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1660,8 +1660,17 @@ static void R_LoadImage( const char **buffer, byte **pic, int *width, int *heigh
 		{
 			if ( !Q_stricmp( ext, imageLoaders[ i ].ext ) )
 			{
-				// load
-				imageLoaders[ i ].ImageLoader( filename, pic, width, height, numLayers, numMips, bits, alphaByte );
+				// do not complain on missing file if extension is hardcoded to a wrong one
+				// since file can exist with another extension and it will tested right after
+				// that, and by the way if there is no alternative an error will be raised
+				// because of missing texture so we don't have to let the ImageLoader says
+				// it failed to read the file using this filename
+				if (FS_FileExists( filename ))
+				{
+					// load
+					imageLoaders[ i ].ImageLoader( filename, pic, width, height, numLayers, numMips, bits, alphaByte );
+				}
+				// we still have to break because a loader was found, so we can strip the extension
 				break;
 			}
 		}

--- a/src/engine/renderer/tr_model.cpp
+++ b/src/engine/renderer/tr_model.cpp
@@ -171,6 +171,7 @@ qhandle_t RE_RegisterModel( const char *name )
 		}
 	}
 
+	bool isOptional = false;
 	for ( lod = MD3_MAX_LODS - 1; lod >= 0; lod-- )
 	{
 		char filename[ 1024 ];
@@ -188,9 +189,17 @@ qhandle_t RE_RegisterModel( const char *name )
 
 			sprintf( namebuf, "_%d.md3", lod );
 			strcat( filename, namebuf );
+			isOptional = true;
 		}
 
 		filename[ strlen( filename ) - 1 ] = '3';  // try MD3 first
+
+		// LoD are optionals
+		if (isOptional && !ri.FS_FileExists( filename ))
+		{
+			continue;
+		}
+
 		ri.FS_ReadFile( filename, ( void ** ) &buffer );
 
 		loadmodel = mod;


### PR DESCRIPTION
- do not try to load iqm animation names as files, they are not files!
- do not complain on missing LoD md3 models, fix #52
- do not complain on missing texture with hardcoded extension since other extensions will be tried
