### PR TITLE
do not abort shader on “unknown general shader parameter” warning

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -3684,7 +3684,8 @@ static bool ParseShader( const char *_text )
 		else
 		{
 			Log::Warn("unknown general shader parameter '%s' in '%s'", token, shader.name );
-			return false;
+			SkipRestOfLine( text );
+			continue;
 		}
 	}
 


### PR DESCRIPTION
There is two possibilites:

- if it's a warning, it does not have to return;
- if it has to return, it's not a warning but an error.

After some testing it appeared it's a warning
so we just have to ignore the whole line and
let the parser read the next line.

It's very useful to ignore unknown dp* and xon* keywords
from darkplaces and xonotic when loading maps from them
for example.

It will help any project wanting to port existing game to
Dæmon to have a better partial support more quickly: this
kind of project would appreciate to be able to focusing on
implementing the ones required for gameplay while not having
any urge to implement the ones that are only needed for
eye candy.