### PR TITLE
add support for DDS DXT3, fix #82

### DIFF
--- a/src/engine/renderer/tr_image_dds.cpp
+++ b/src/engine/renderer/tr_image_dds.cpp
@@ -277,6 +277,11 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 			blockSize = 8;
 			break;
 
+		case FOURCC_DXT3:
+			*bits |= IF_BC3;
+			blockSize = 16;
+			break;
+
 		case FOURCC_DXT5:
 			*bits |= IF_BC3;
 			blockSize = 16;


### PR DESCRIPTION
DXT5 and DXT3 formats are very close (see that [documentation](https://www.fsdeveloper.com/wiki/index.php?title=DXT_compression_explained)).

The define for DXT3 was already there and code path for DXT5 too hence this code just copypaste the DXT5 switch for DXT3.

DXT3 `dds` files loaded this way look to be rendered the exact same way they would be rendered if they were converted to `tga` by `crunch` at first.

Xonotic has textures using this format.

- Before:
[![DDS DXT3](https://dl.illwieckz.net/b/daemon/bugs/dds-invalid-fourcc/unvanquished_2018-03-11_191901_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/dds-invalid-fourcc/unvanquished_2018-03-11_191901_000.jpg)
- After:
[![DDS DXT3](https://dl.illwieckz.net/b/daemon/bugs/dds-invalid-fourcc/unvanquished_2018-03-11_191959_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/dds-invalid-fourcc/unvanquished_2018-03-11_191959_000.jpg)

- Before:
[![DDS DXT3](https://dl.illwieckz.net/b/daemon/bugs/dds-invalid-fourcc/unvanquished_2018-03-11_192118_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/dds-invalid-fourcc/unvanquished_2018-03-11_192118_000.jpg)
- After:
[![DDS DXT3](https://dl.illwieckz.net/b/daemon/bugs/dds-invalid-fourcc/unvanquished_2018-03-11_192317_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/dds-invalid-fourcc/unvanquished_2018-03-11_192317_000.jpg)

We see in this last texture that transparency is handled. Transparency is probably badly rendered (or not rendered at all on first textures) because of unknown darkplaces-specific shader keywords, if I convert those `dds` textures to `tga` ones it does not look better, so it's not a format parsing issue.