### PR TITLE
DXT3/BC2 support for .dds, .crn and .ktx file formats

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -129,7 +129,7 @@ float R_ProcessLightmap( byte *pic, int in_padding, int width, int height, int b
 		{
 			R_ColorShiftLightingBytesCompressed( &pic[ j * 8 ], &pic_out[ j * 8 ] );
 		}
-	} else if( bits & IF_BC3 ) {
+	} else if( bits & (IF_BC2 | IF_BC3) ) {
 		for ( j = 0; j < ((width + 3) >> 2) * ((height + 3) >> 2); j++ )
 		{
 			R_ColorShiftLightingBytesCompressed( &pic[ j * 16 ], &pic_out[ j * 16 ] );

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -949,6 +949,11 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips,
 			internalFormat = GL_COMPRESSED_RGB_S3TC_DXT1_EXT;
 			blockSize = 8;
 		}
+		else if ( image->bits & IF_BC2 ) {
+			format = GL_NONE;
+			internalFormat = GL_COMPRESSED_RGBA_S3TC_DXT3_EXT;
+			blockSize = 16;
+		}
 		else if ( image->bits & IF_BC3 ) {
 			format = GL_NONE;
 			internalFormat = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;

--- a/src/engine/renderer/tr_image_crn.cpp
+++ b/src/engine/renderer/tr_image_crn.cpp
@@ -62,6 +62,9 @@ void LoadCRN( const char *name, byte **data, int *width, int *height,
 	case cCRNFmtDXT1:
 		*bits |= IF_BC1;
 		break;
+	case cCRNFmtDXT3:
+		*bits |= IF_BC2;
+		break;
 	case cCRNFmtDXT5:
 		*bits |= IF_BC3;
 		break;

--- a/src/engine/renderer/tr_image_dds.cpp
+++ b/src/engine/renderer/tr_image_dds.cpp
@@ -277,6 +277,11 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 			blockSize = 8;
 			break;
 
+		case FOURCC_DXT3:
+			*bits |= IF_BC2;
+			blockSize = 16;
+			break;
+
 		case FOURCC_DXT5:
 			*bits |= IF_BC3;
 			blockSize = 16;

--- a/src/engine/renderer/tr_image_ktx.cpp
+++ b/src/engine/renderer/tr_image_ktx.cpp
@@ -99,6 +99,9 @@ void LoadKTX( const char *name, byte **data, int *width, int *height,
 	case GL_COMPRESSED_RGB_S3TC_DXT1_EXT:
 		*bits |= IF_BC1;
 		break;
+	case GL_COMPRESSED_RGBA_S3TC_DXT3_EXT:
+		*bits |= IF_BC2;
+		break;
 	case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
 		*bits |= IF_BC3;
 		break;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -531,10 +531,11 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	  IF_DISPLACEMAP = BIT( 17 ),
 	  IF_NOLIGHTSCALE = BIT( 18 ),
 	  IF_BC1 = BIT( 19 ),
-	  IF_BC3 = BIT( 20 ),
-	  IF_BC4 = BIT( 21 ),
-	  IF_BC5 = BIT( 22 ),
-	  IF_RGBA32UI = BIT( 23 )
+	  IF_BC2 = BIT( 20 ),
+	  IF_BC3 = BIT( 21 ),
+	  IF_BC4 = BIT( 22 ),
+	  IF_BC5 = BIT( 23 ),
+	  IF_RGBA32UI = BIT( 24 )
 	};
 
 	enum class filterType_t
@@ -594,7 +595,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		image_t *next;
 	};
 
-	inline bool IsImageCompressed(int bits) { return bits & (IF_BC1 | IF_BC3 | IF_BC4 | IF_BC5); }
+	inline bool IsImageCompressed(int bits) { return bits & (IF_BC1 | IF_BC2 | IF_BC3 | IF_BC4 | IF_BC5); }
 
 	struct FBO_t
 	{


### PR DESCRIPTION
This should enable DXT3/BC2 support for the daemon engine (see issue #82 ).