### PR TITLE
cm: Properly initialize box_model

### DIFF
--- a/src/common/cm/cm_load.cpp
+++ b/src/common/cm/cm_load.cpp
@@ -50,7 +50,7 @@ clipMap_t cm;
 int       c_pointcontents;
 int       c_traces, c_brush_traces, c_patch_traces, c_trisoup_traces;
 
-cmodel_t  box_model;
+cmodel_t  box_model = {};
 cplane_t  *box_planes;
 cbrush_t  *box_brush;
 


### PR DESCRIPTION
If we don't initialize it, it holds garbage values for some of the
fields which cause crashes when accessed.

Fixes #94