### PR TITLE
pass DAEMON_DIR back to nacl vm build

### DIFF
--- a/cmake/DaemonGame.cmake
+++ b/cmake/DaemonGame.cmake
@@ -81,6 +81,7 @@ function(GAMEMODULE)
                 CMAKE_ARGS
                     -DFORK=2
                     -DCMAKE_TOOLCHAIN_FILE=${Daemon_SOURCE_DIR}/cmake/toolchain-pnacl.cmake
+                    -DDAEMON_DIR=${Daemon_SOURCE_DIR}
                     -DDEPS_DIR=${DEPS_DIR}
                     -DBUILD_GAME_NACL_NEXE=${BUILD_GAME_NACL_NEXE}
                     -DBUILD_GAME_NACL=1


### PR DESCRIPTION
for some reason some nacl vm related build steps are driven by the engine cmake
configuration, hence when the engine is not built as a submodule, the cmake script
has to tell the vm build process where the engine source tree is.