### PR TITLE
normalMap is another name for bumpMap in blend case too

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1853,7 +1853,7 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			{
 				stage->type = stageType_t::ST_DIFFUSEMAP;
 			}
-			else if ( !Q_stricmp( token, "bumpMap" ) )
+			else if ( !Q_stricmp( token, "normalMap" ) || !Q_stricmp( token, "bumpMap" ) )
 			{
 				stage->type = stageType_t::ST_NORMALMAP;
 			}


### PR DESCRIPTION
everywhere in code normalMap keyword can be used in place of the bumpMap one
except in the blend case, now fixed.

see the original broken code:

```sh
Daemon/src $ grep -r bumpMap
engine/renderer/tr_shader.cpp:			else if ( !Q_stricmp( token, "bumpMap" ) )
engine/renderer/tr_shader.cpp:			else if ( !Q_stricmp( token, "normalMap" ) || !Q_stricmp( token, "bumpMap" ) )
engine/renderer/tr_shader.cpp:		else if ( !Q_stricmp( token, "normalMap" ) || !Q_stricmp( token, "bumpMap" ) )
```

without this, if someones write `blend normalMap` instead of `blend bumpMap`, the engine prints those warning and when affected surface has to be rendered, the engine abort the game and returns to main menu:

```
Warn: unknown blend mode 'normalMap' in shader 'textures/thunder_eX/eX_floor_grate03s', substituting GL_ONE 
Warn: missing parm for blend in shader 'textures/thunder_eX/eX_floor_grate03s' 
Warn: GL_State: invalid dst blend state bits 
```