### PR TITLE
Catch some crn decoding errors

### DIFF
--- a/libs/crunch/crn_decomp.h
+++ b/libs/crunch/crn_decomp.h
@@ -26,6 +26,7 @@
 #endif
 #include <stdarg.h>
 #include <new>  // needed for placement new, _msize, _expand
+#include <exception>
 
 #define CRND_RESTRICT __restrict
 
@@ -130,15 +131,10 @@ void crnd_fail(const char* pExp, const char* pFile, unsigned line);
 
 // File: crnd_assert.h
 namespace crnd {
-void crnd_assert(const char* pExp, const char* pFile, unsigned line);
+class decompression_exception : public std::exception {};
 
-#ifdef NDEBUG
-#define CRND_ASSERT(x) ((void)0)
-#undef CRND_ASSERTS_ENABLED
-#else
-#define CRND_ASSERT(_exp) (void)((!!(_exp)) || (crnd::crnd_assert(#_exp, __FILE__, __LINE__), 0))
-#define CRND_ASSERTS_ENABLED
-#endif
+// HACK: Try to crash less when asked to decode invalid inputs.
+#define CRND_ASSERT(_exp) (!!(_exp) ? (void)0 : throw decompression_exception())
 
 void crnd_trace(const char* pFmt, va_list args);
 void crnd_trace(const char* pFmt, ...);

--- a/src/engine/renderer/tr_image_crn.cpp
+++ b/src/engine/renderer/tr_image_crn.cpp
@@ -93,7 +93,14 @@ bool LoadInMemoryCRN(void* buff, size_t buffLen, byte **data, int *width, int *h
             data[i * ti.m_faces + j] = nextImage;
             nextImage += sizes[i];
         }
-        if (!crnd::crnd_unpack_level(ctx, (void **)&data[i * ti.m_faces], sizes[i], 0, i)) {
+        try {
+            if (!crnd::crnd_unpack_level(ctx, (void **)&data[i * ti.m_faces], sizes[i], 0, i)) {
+                success = false;
+                break;
+            }
+        } catch (const crnd::decompression_exception&) {
+            // Exception added as a hack to try and avoid crashing on files using the old format.
+            // In general though, it seems the crunch library does not try to validate the files and may crash while decoding.
             success = false;
             break;
         }


### PR DESCRIPTION
The crunch library apparently "trusts" all input files to have the correct format, and will crash or cause memory corruption if they don't. So this is a hack to turn the `CRND_ASSERT` statements into runtime exceptions, since some of the assertions will usually trigger if you load a file with the old format. 