### PR TITLE
define dtAssert and rcAssert as DAEMON_ASSERT

### DIFF
--- a/src/common/Assert.h
+++ b/src/common/Assert.h
@@ -148,6 +148,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         Str::Format("\"%s >= %s\" bound: %s, actual: %s", #a, #b, AssertDetail::Printable(a), AssertDetail::Printable(b)) \
     );
 
+/*
+ * Reuse DAEMON_ASSERT in Detour and Recast
+ */
+#define dtAssert DAEMON_ASSERT
+#define rcAssert DAEMON_ASSERT
+
 #if !defined(DAEMON_SKIP_ASSERT_SHORTHANDS)
     #define ASSERT DAEMON_ASSERT
     #define ASSERT_EQ DAEMON_ASSERT_EQ


### PR DESCRIPTION
The idea is to define `dtAssert` and `rcAssert` as `DAEMON_ASSERT` and to patch Detour/Recast to reuse those definitions if already defined. If it works and if it's OK, I'll try to upstream the Detour/Recast patch so we can drop our custom _recastnavigation_ fork.

See https://github.com/Unvanquished/recastnavigation/pull/1