### PR TITLE
Remove old compiler workarounds

### DIFF
--- a/src/common/Color.h
+++ b/src/common/Color.h
@@ -165,7 +165,6 @@ public:
 		: red( r ), green( g ), blue( b ), alpha( a )
 	{}
 
-#ifdef HAS_EXPLICIT_DEFAULT
     // Default constructor, all components set to zero
     CONSTEXPR_FUNCTION BasicColor() NOEXCEPT = default;
 
@@ -173,11 +172,6 @@ public:
 	CONSTEXPR_FUNCTION BasicColor( BasicColor&& ) NOEXCEPT = default;
     BasicColor& operator=( const BasicColor& ) NOEXCEPT = default;
     BasicColor& operator=( BasicColor&& ) NOEXCEPT = default;
-#else
-    BasicColor()
-        : red( 0 ), green( 0 ), blue( 0 ), alpha( 0 )
-    {}
-#endif
 
 	template<class T, class = std::enable_if<T::is_color>>
 		BasicColor( const T& adaptor ) :
@@ -381,16 +375,7 @@ public:
 	/*
 	 * Constructs an invalid token
 	 */
-#ifdef HAS_EXPLICIT_DEFAULT
 	Token() = default;
-#else
-    Token()
-        : begin( nullptr ),
-          end( nullptr ),
-          type( INVALID )
-    {}
-#endif
-
 
 	/*
 	 * Constructs a token with the given type and range

--- a/src/common/Command.h
+++ b/src/common/Command.h
@@ -183,8 +183,8 @@ namespace Cmd {
             LambdaCmd(std::string name, std::string description, RunFn run, CompleteFn complete = NoopComplete);
             LambdaCmd(std::string name, int flags, std::string description, RunFn run, CompleteFn complete = NoopComplete);
 
-            void Run(const Args& args) const OVERRIDE;
-            CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE;
+            void Run(const Args& args) const override;
+            CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override;
 
         private:
             RunFn run;

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -110,11 +110,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS
 #endif
 
-#ifdef __cplusplus
 #include <new>
 #if defined(__GLIBCXX__) && (__GLIBCXX__ == 20110325 || __GLIBCXX__ == 20110627 || __GLIBCXX__ == 20111026 || __GLIBCXX__ == 20120301 || __GLIBCXX__ == 20130412)
 #define LIBSTDCXX_BROKEN_CXX11
-#endif
 #endif
 
 // Support for explicitly defaulted functions
@@ -200,11 +198,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Compat macros
 #define QDECL
-#if defined(_MSC_VER) && !defined(__cplusplus)
-#define INLINE __inline
-#else
 #define INLINE inline
-#endif
 #define Q_EXPORT DLLEXPORT
 
 // Uses SD-6 Feature Test Recommendations

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -156,7 +156,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define BREAKPOINT() __debugbreak()
 #define NOEXCEPT noexcept
 #define NOEXCEPT_IF(x) noexcept(x)
-#define NOEXCEPT_EXPR(x) false // TODO: Find out why this is defined to false?
+#define NOEXCEPT_EXPR(x) noexcept(x)
 #define CONSTEXPR constexpr
 #define ATTRIBUTE_NO_SANITIZE_ADDRESS
 

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -183,7 +183,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Compat macros
 #define QDECL
 #define INLINE inline
-#define Q_EXPORT DLLEXPORT
 
 // Uses SD-6 Feature Test Recommendations
 #ifdef __cpp_constexpr

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -101,9 +101,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS
 #endif
 
-// Support for explicitly defaulted functions
-#define HAS_EXPLICIT_DEFAULT
-
 // Microsoft Visual C++
 #elif defined( _MSC_VER )
 
@@ -160,7 +157,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define NOEXCEPT noexcept
 #define NOEXCEPT_IF(x) noexcept(x)
 #define NOEXCEPT_EXPR(x) false // TODO: Find out why this is defined to false?
-#define HAS_EXPLICIT_DEFAULT
 #define CONSTEXPR constexpr
 #define ATTRIBUTE_NO_SANITIZE_ADDRESS
 

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -79,15 +79,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #error "Implement BREAKPOINT on your platform"
 #endif
 
-// override and final keywords
-#if __clang__ || (__GNUC__ * 100 + __GNUC_MINOR__) >= 407
-#define OVERRIDE override
-#define FINAL final
-#else
-#define OVERRIDE
-#define FINAL
-#endif
-
 // noexcept keyword, this should be used on all move constructors and move
 // assignments so that containers move objects instead of copying them.
 #define NOEXCEPT noexcept
@@ -171,8 +162,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DLLEXPORT __declspec(dllexport)
 #define DLLIMPORT __declspec(dllimport)
 #define BREAKPOINT() __debugbreak()
-#define OVERRIDE override
-#define FINAL final
 #define NOEXCEPT noexcept
 #define NOEXCEPT_IF(x) noexcept(x)
 #define NOEXCEPT_EXPR(x) false // TODO: Find out why this is defined to false?

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -175,23 +175,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define BREAKPOINT() __debugbreak()
 #define OVERRIDE override
 #define FINAL final
-// VS2015 supports this
-#if _MSC_VER >= 1900
 #define NOEXCEPT noexcept
 #define NOEXCEPT_IF(x) noexcept(x)
-#define NOEXCEPT_EXPR(x) false
+#define NOEXCEPT_EXPR(x) false // TODO: Find out why this is defined to false?
 #define HAS_EXPLICIT_DEFAULT
 #define CONSTEXPR constexpr
-#else
-#define NOEXCEPT
-#define NOEXCEPT_IF(x)
-#define NOEXCEPT_EXPR(x) false
-// Work around lack of C99 support
-#define __func__ __FUNCTION__
-// Work around lack of constexpr
-#define CONSTEXPR const
-#endif
-
 #define ATTRIBUTE_NO_SANITIZE_ADDRESS
 
 // Other compilers, unsupported

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -101,11 +101,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS
 #endif
 
-#include <new>
-#if defined(__GLIBCXX__) && (__GLIBCXX__ == 20110325 || __GLIBCXX__ == 20110627 || __GLIBCXX__ == 20111026 || __GLIBCXX__ == 20120301 || __GLIBCXX__ == 20130412)
-#define LIBSTDCXX_BROKEN_CXX11
-#endif
-
 // Support for explicitly defaulted functions
 #define HAS_EXPLICIT_DEFAULT
 

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -110,10 +110,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS
 #endif
 
-// GCC 4.6 has incomplete support for C++11
-#if !defined(__clang__) && __GNUC__ * 100 + __GNUC_MINOR__ <= 407
-#define GCC_BROKEN_CXX11
-#endif
 #ifdef __cplusplus
 #include <new>
 #if defined(__GLIBCXX__) && (__GLIBCXX__ == 20110325 || __GLIBCXX__ == 20110627 || __GLIBCXX__ == 20111026 || __GLIBCXX__ == 20120301 || __GLIBCXX__ == 20130412)

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -222,14 +222,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 #if defined(_MSC_VER) //UNREACHABLE
 	#define UNREACHABLE() __assume(0)
-// both gcc, clang and icc defines __GNUC__, so the order is important
-#elif defined(__INTEL_COMPILER)
-	#define UNREACHABLE() __builtin_unreachable()
-#elif defined(__clang__)
-	#if __has_builtin(__builtin_unreachable)
-		#define UNREACHABLE() __builtin_unreachable()
-	#endif
-#elif (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
+// All of gcc, clang and icc define __GNUC__
+#elif defined(__GNUC__)
 	#define UNREACHABLE() __builtin_unreachable()
 #else // UNREACHABLE
 	#define UNREACHABLE()

--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1089,11 +1089,7 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 			if (*it == PAK_DEPS_FILE)
 				hasDeps = true;
 			else if (!Str::IsSuffix("/", *it) && Str::IsPrefix(pathPrefix, *it)) {
-#ifdef LIBSTDCXX_BROKEN_CXX11
-				fileMap.insert({*it, std::pair<uint32_t, offset_t>(loadedPaks.size() - 1, 0)});
-#else
 				fileMap.emplace(*it, std::pair<uint32_t, offset_t>(loadedPaks.size() - 1, 0));
-#endif
 			}
 			it.increment(err);
 			if (err)
@@ -1135,11 +1131,7 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 				depsOffset = offset;
 				return;
 			}
-#ifdef LIBSTDCXX_BROKEN_CXX11
-			fileMap.insert({filename, std::pair<uint32_t, offset_t>(loadedPaks.size() - 1, offset)});
-#else
 			fileMap.emplace(filename, std::pair<uint32_t, offset_t>(loadedPaks.size() - 1, offset));
-#endif
 		}, err);
 		if (err)
 			return;
@@ -1718,11 +1710,7 @@ DirectoryRange ListFiles(Str::StringRef path, std::error_code& err)
 {
 	std::string dirPath = path;
 	if (!dirPath.empty() && dirPath.back() == '/')
-#ifdef LIBSTDCXX_BROKEN_CXX11
-		dirPath.resize(dirPath.size() - 1);
-#else
 		dirPath.pop_back();
-#endif
 
 #ifdef _WIN32
 	WIN32_FIND_DATAW findData;

--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -289,11 +289,11 @@ inline intptr_t my_pread(int fd, void* buf, size_t count, offset_t offset)
 class minizip_category_impl: public std::error_category
 {
 public:
-	virtual const char* name() const NOEXCEPT OVERRIDE FINAL
+	virtual const char* name() const NOEXCEPT override final
 	{
 		return "unzip";
 	}
-	virtual std::string message(int ev) const OVERRIDE FINAL
+	virtual std::string message(int ev) const override final
 	{
 		switch (ev) {
 		case UNZ_OK:
@@ -333,11 +333,11 @@ enum class filesystem_error {
 class filesystem_category_impl: public std::error_category
 {
 public:
-	virtual const char* name() const NOEXCEPT OVERRIDE FINAL
+	virtual const char* name() const NOEXCEPT override final
 	{
 		return "filesystem";
 	}
-	virtual std::string message(int ev) const OVERRIDE FINAL
+	virtual std::string message(int ev) const override final
 	{
 		switch (Util::enum_cast<filesystem_error>(ev)) {
 		case filesystem_error::invalid_filename:

--- a/src/common/Optional.h
+++ b/src/common/Optional.h
@@ -57,25 +57,9 @@ public:
 // Missing type traits
 namespace detail {
 
-// GCC 4.6 is missing some type traits
-#ifdef LIBSTDCXX_BROKEN_CXX11
-using one = char[1];
-using two = char[2];
-template<typename T, typename Arg, typename = decltype(std::declval<T>() = std::declval<Arg>())>
-two& is_assignable_helper(int);
-template<typename T, typename Arg>
-one& is_assignable_helper(...);
-
-template<typename T, typename Arg> struct is_assignable: public std::integral_constant<bool, sizeof(is_assignable_helper<T, Arg>(0)) - 1> {};
-
-template<typename T> struct is_nothrow_move_assignable: public std::integral_constant<bool, NOEXCEPT_EXPR(std::declval<T&>() = std::declval<T>())> {};
-template<typename T> struct is_nothrow_move_constructible: public std::integral_constant<bool, NOEXCEPT_EXPR(T(std::declval<T>()))> {};
-
-#else
 using std::is_assignable;
 using std::is_nothrow_move_assignable;
 using std::is_nothrow_move_constructible;
-#endif
 
 using std::swap;
 template<typename T> struct is_nothrow_swappable: public std::integral_constant<bool, NOEXCEPT_EXPR(swap(std::declval<T&>(), std::declval<T&>()))> {};

--- a/src/common/System.h
+++ b/src/common/System.h
@@ -53,11 +53,7 @@ public:
 	static time_point now() NOEXCEPT;
 };
 #else
-# ifdef LIBSTDCXX_BROKEN_CXX11
-using SteadyClock = std::chrono::monotonic_clock;
-# else
 using SteadyClock = std::chrono::steady_clock;
-# endif
 #endif
 using RealClock = std::chrono::system_clock;
 

--- a/src/common/Util.h
+++ b/src/common/Util.h
@@ -40,19 +40,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Various utilities
 
-// Workaround for broken tuples in GCC 4.6
-#ifdef LIBSTDCXX_BROKEN_CXX11
-namespace std {
-
-template<size_t Index, typename... T>
-typename std::tuple_element<Index, std::tuple<T...>>::type&& get(std::tuple<T...>&& tuple)
-{
-    return static_cast<typename std::tuple_element<Index, std::tuple<T...>>::type&&>(std::get<Index>(tuple));
-}
-
-} // namespace std
-#endif
-
 char     *QDECL PRINTF_LIKE(1) va( const char *format, ... );
 
 namespace Util {

--- a/src/common/Util.h
+++ b/src/common/Util.h
@@ -160,17 +160,10 @@ public:
 	{
 		new(&data) T(std::forward<Args>(args)...);
 	}
-#ifdef GCC_BROKEN_CXX11
-	template<typename Arg> T& assign(Arg&& arg)
-	{
-		return get() = std::forward<Arg>(arg);
-	}
-#else
 	template<typename Arg> decltype(std::declval<T&>() = std::declval<Arg>()) assign(Arg&& arg)
 	{
 		return get() = std::forward<Arg>(arg);
 	}
-#endif
 	void destroy()
 	{
 		get().~T();

--- a/src/engine/audio/Audio.cpp
+++ b/src/engine/audio/Audio.cpp
@@ -502,7 +502,7 @@ namespace Audio {
             ALInfoCmd(): StaticCmd("printALInfo", Cmd::AUDIO, "Prints information about OpenAL") {
             }
 
-            virtual void Run(const Cmd::Args&) const OVERRIDE {
+            virtual void Run(const Cmd::Args&) const override {
                 Print(AL::GetSystemInfo(device, capture));
             }
     };
@@ -513,7 +513,7 @@ namespace Audio {
             ListSamplesCmd(): StaticCmd("listAudioSamples", Cmd::AUDIO, "Lists all the loaded sound samples") {
             }
 
-            virtual void Run(const Cmd::Args&) const OVERRIDE {
+            virtual void Run(const Cmd::Args&) const override {
                 std::vector<std::string> samples = ListSamples();
 
                 std::sort(samples.begin(), samples.end());
@@ -531,7 +531,7 @@ namespace Audio {
             StopSoundsCmd(): StaticCmd("stopSounds", Cmd::AUDIO, "Stops the music and the looping sounds") {
             }
 
-            virtual void Run(const Cmd::Args&) const OVERRIDE {
+            virtual void Run(const Cmd::Args&) const override {
                 ClearAllLoopingSounds();
                 StopMusic();
             }
@@ -543,7 +543,7 @@ namespace Audio {
             StartCaptureTestCmd(): StaticCmd("startSoundCaptureTest", Cmd::AUDIO, "Starts testing the sound capture") {
             }
 
-            virtual void Run(const Cmd::Args&) const OVERRIDE {
+            virtual void Run(const Cmd::Args&) const override {
                 CaptureTestStart();
             }
     };
@@ -554,7 +554,7 @@ namespace Audio {
             StopCaptureTestCmd(): StaticCmd("stopSoundCaptureTest", Cmd::AUDIO, "Stops the testing of the sound capture") {
             }
 
-            virtual void Run(const Cmd::Args&) const OVERRIDE {
+            virtual void Run(const Cmd::Args&) const override {
                 CaptureTestStop();
             }
     };
@@ -566,7 +566,7 @@ namespace Audio {
             PlaySoundCmd(): StaticCmd("playSound", Cmd::AUDIO, "Plays the given sound effects") {
             }
 
-            virtual void Run(const Cmd::Args& args) const OVERRIDE {
+            virtual void Run(const Cmd::Args& args) const override {
                 if (args.Argc() == 1) {
                     PrintUsage(args, "/playSound <file> [<file>…]", "play sound files");
                     return;
@@ -578,7 +578,7 @@ namespace Audio {
                 }
             }
 
-            virtual Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const OVERRIDE {
+            virtual Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const override {
                 if (argNum >= 1) {
                     //TODO have a list of supported extensions somewhere and use that?
                     return FS::PakPath::CompleteFilename(prefix, "", "", true, false);
@@ -595,7 +595,7 @@ namespace Audio {
             PlayMusicCmd(): StaticCmd("playMusic", Cmd::AUDIO, "Plays a music") {
             }
 
-            virtual void Run(const Cmd::Args& args) const OVERRIDE {
+            virtual void Run(const Cmd::Args& args) const override {
                 if (args.Argc() == 2) {
                     StartMusic( args.Argv(1) , "");
                 } else {
@@ -603,7 +603,7 @@ namespace Audio {
                 }
             }
 
-            virtual Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const OVERRIDE {
+            virtual Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const override {
                 if (argNum == 1) {
                     //TODO have a list of supported extensions somewhere and use that?
                     return FS::PakPath::CompleteFilename(prefix, "", "", true, false);
@@ -620,7 +620,7 @@ namespace Audio {
             StopMusicCmd(): StaticCmd("stopMusic", Cmd::AUDIO, "Stops the currently playing music") {
             }
 
-            virtual void Run(const Cmd::Args&) const OVERRIDE {
+            virtual void Run(const Cmd::Args&) const override {
                 StopMusic();
             }
     };

--- a/src/engine/audio/Emitter.cpp
+++ b/src/engine/audio/Emitter.cpp
@@ -352,7 +352,7 @@ namespace Audio {
             TestReverbCmd(): StaticCmd("testReverb", Cmd::AUDIO, "Tests a reverb preset.") {
             }
 
-            virtual void Run(const Cmd::Args& args) const OVERRIDE {
+            virtual void Run(const Cmd::Args& args) const override {
                 if (args.Argc() != 2) {
                     PrintUsage(args, "stop", "stop the test");
                     PrintUsage(args, "[preset name]", "tests the reverb preset.");
@@ -366,7 +366,7 @@ namespace Audio {
                 }
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const override {
                 if (argNum != 1) {
                     return {};
                 }

--- a/src/engine/audio/Emitter.h
+++ b/src/engine/audio/Emitter.h
@@ -77,9 +77,9 @@ namespace Audio {
             EntityEmitter(int entityNum);
             virtual ~EntityEmitter();
 
-            void virtual Update() OVERRIDE;
-            virtual void UpdateSound(Sound& sound) OVERRIDE;
-            virtual void InternalSetupSound(Sound& sound) OVERRIDE;
+            void virtual Update() override;
+            virtual void UpdateSound(Sound& sound) override;
+            virtual void InternalSetupSound(Sound& sound) override;
 
         private:
             int entityNum;
@@ -91,9 +91,9 @@ namespace Audio {
             PositionEmitter(Vec3 position);
             virtual ~PositionEmitter();
 
-            void virtual Update() OVERRIDE;
-            virtual void UpdateSound(Sound& sound) OVERRIDE;
-            virtual void InternalSetupSound(Sound& sound) OVERRIDE;
+            void virtual Update() override;
+            virtual void UpdateSound(Sound& sound) override;
+            virtual void InternalSetupSound(Sound& sound) override;
 
             Vec3 GetPosition() const;
 
@@ -107,9 +107,9 @@ namespace Audio {
             LocalEmitter();
             virtual ~LocalEmitter();
 
-            void virtual Update() OVERRIDE;
-            virtual void UpdateSound(Sound& sound) OVERRIDE;
-            virtual void InternalSetupSound(Sound& sound) OVERRIDE;
+            void virtual Update() override;
+            virtual void UpdateSound(Sound& sound) override;
+            virtual void InternalSetupSound(Sound& sound) override;
     };
 
 }

--- a/src/engine/audio/Sample.h
+++ b/src/engine/audio/Sample.h
@@ -99,10 +99,10 @@ namespace Audio {
     class Sample: public HandledResource<Sample>, public Resource::Resource {
         public:
             explicit Sample(std::string name);
-            virtual ~Sample() OVERRIDE FINAL;
+            virtual ~Sample() override final;
 
-            virtual bool Load() OVERRIDE FINAL;
-            virtual void Cleanup() OVERRIDE FINAL;
+            virtual bool Load() override final;
+            virtual void Cleanup() override final;
 
             AL::Buffer& GetBuffer();
 

--- a/src/engine/audio/Sound.h
+++ b/src/engine/audio/Sound.h
@@ -98,8 +98,8 @@ namespace Audio {
             OneShotSound(std::shared_ptr<Sample> sample);
             virtual ~OneShotSound();
 
-            virtual void SetupSource(AL::Source& source) OVERRIDE;
-            virtual void InternalUpdate() OVERRIDE;
+            virtual void SetupSource(AL::Source& source) override;
+            virtual void InternalUpdate() override;
 
         private:
             std::shared_ptr<Sample> sample;
@@ -113,8 +113,8 @@ namespace Audio {
 
             void FadeOutAndDie();
 
-            virtual void SetupSource(AL::Source& source) OVERRIDE;
-            virtual void InternalUpdate() OVERRIDE;
+            virtual void SetupSource(AL::Source& source) override;
+            virtual void InternalUpdate() override;
 
         private:
             void SetupLoopingSound(AL::Source& source);
@@ -130,8 +130,8 @@ namespace Audio {
             StreamingSound();
             virtual ~StreamingSound();
 
-            virtual void SetupSource(AL::Source& source) OVERRIDE;
-            virtual void InternalUpdate() OVERRIDE;
+            virtual void SetupSource(AL::Source& source) override;
+            virtual void InternalUpdate() override;
 
             void AppendBuffer(AL::Buffer buffer);
             void SetGain(float gain);

--- a/src/engine/botlib/nav.h
+++ b/src/engine/botlib/nav.h
@@ -230,7 +230,7 @@ struct LinearAllocator : public dtTileCacheAlloc
 		resize(cap);
 	}
 
-	~LinearAllocator() OVERRIDE
+	~LinearAllocator() override
 	{
 		free( buffer );
 	}
@@ -246,13 +246,13 @@ struct LinearAllocator : public dtTileCacheAlloc
 		capacity = cap;
 	}
 
-	void reset() OVERRIDE
+	void reset() override
 	{
 		high = dtMax( high, top );
 		top = 0;
 	}
 
-	void* alloc( const size_t size ) OVERRIDE
+	void* alloc( const size_t size ) override
 	{
 		if ( !buffer )
 		{
@@ -269,7 +269,7 @@ struct LinearAllocator : public dtTileCacheAlloc
 		return mem;
 	}
 
-	void free( void* /*ptr*/ ) OVERRIDE { }
+	void free( void* /*ptr*/ ) override { }
 	size_t getHighSize() { return high; }
 };
 #endif

--- a/src/engine/client/cl_console.cpp
+++ b/src/engine/client/cl_console.cpp
@@ -1201,7 +1201,7 @@ class GraphicalTarget : public Log::Target {
 			this->Register(Log::GRAPHICAL_CONSOLE);
 		}
 
-		virtual bool Process(const std::vector<Log::Event>& events) OVERRIDE {
+		virtual bool Process(const std::vector<Log::Event>& events) override {
 			// for some demos we don't want to ever show anything on the console
 			// flush the buffer
 			if ( cl_noprint && cl_noprint->integer )

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -333,7 +333,7 @@ public:
         : Cmd::StaticCmd("demo_record_stop", Cmd::SYSTEM, "Stops recording a demo")
     {}
 
-    void Run(const Cmd::Args&) const OVERRIDE
+    void Run(const Cmd::Args&) const override
     {
         if ( !clc.demorecording )
         {
@@ -353,7 +353,7 @@ public:
         : Cmd::StaticCmd("demo_record", Cmd::SYSTEM, "Begins recording a demo from the current position")
     {}
 
-    void Run(const Cmd::Args& args) const OVERRIDE
+    void Run(const Cmd::Args& args) const override
     {
         if ( args.size() > 2 )
         {
@@ -612,7 +612,7 @@ class DemoPlayCmd: public Cmd::StaticCmd {
         DemoPlayCmd(): Cmd::StaticCmd("demo_play", Cmd::SYSTEM, "Starts playing a demo file") {
         }
 
-        void Run(const Cmd::Args& args) const OVERRIDE {
+        void Run(const Cmd::Args& args) const override {
             if (args.Argc() != 2) {
                 PrintUsage(args, "<demoname>", "starts playing a demo file");
                 return;
@@ -667,7 +667,7 @@ class DemoPlayCmd: public Cmd::StaticCmd {
             clc.firstDemoFrameSkipped = false;
         }
 
-        Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const OVERRIDE {
+        Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const override {
             if (argNum == 1) {
                 return FS::HomePath::CompleteFilename(prefix, "demos", ".dm_" XSTRING(PROTOCOL_VERSION), false, true);
             }
@@ -1335,7 +1335,7 @@ public:
 		StaticCmd("rcon", Cmd::SYSTEM, "Sends a remote console command")
 	{}
 
-	void Run(const Cmd::Args& args) const OVERRIDE
+	void Run(const Cmd::Args& args) const override
 	{
 		if ( cvar_rcon_client_password.Get().empty() )
 		{
@@ -1399,7 +1399,7 @@ public:
 		StaticCmd("rconDiscover", Cmd::SYSTEM, "Sends a request to the server to populate rcon.client cvars")
 	{}
 
-	void Run(const Cmd::Args&) const OVERRIDE
+	void Run(const Cmd::Args&) const override
 	{
 		if ( cls.state < connstate_t::CA_CONNECTED && cvar_rcon_client_destination.Get().empty() )
 		{
@@ -1676,7 +1676,7 @@ public:
                          "Begins recording a video from the current demo")
     {}
 
-    void Run(const Cmd::Args& args) const OVERRIDE
+    void Run(const Cmd::Args& args) const override
     {
         if ( args.size() > 2 )
         {
@@ -1733,7 +1733,7 @@ public:
         : Cmd::StaticCmd("demo_video_stop", Cmd::SYSTEM, "Stops recording a video")
     {}
 
-    void Run(const Cmd::Args&) const OVERRIDE
+    void Run(const Cmd::Args&) const override
     {
         CL_CloseAVI();
     }

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -376,7 +376,7 @@ public:
 	void CGameConsoleLine(const std::string& str);
 
 private:
-	virtual void Syscall(uint32_t id, Util::Reader reader, IPC::Channel& channel) OVERRIDE FINAL;
+	virtual void Syscall(uint32_t id, Util::Reader reader, IPC::Channel& channel) override final;
 	void QVMSyscall(int index, Util::Reader& reader, IPC::Channel& channel);
 
 	std::unique_ptr<VM::CommonVMServices> services;
@@ -384,7 +384,7 @@ private:
     class CmdBuffer: public IPC::CommandBufferHost {
         public:
             CmdBuffer(std::string name);
-            virtual void HandleCommandBufferSyscall(int major, int minor, Util::Reader& reader) OVERRIDE FINAL;
+            virtual void HandleCommandBufferSyscall(int major, int minor, Util::Reader& reader) override final;
     };
 
     CmdBuffer cmdBuffer;

--- a/src/engine/client/key_binding.cpp
+++ b/src/engine/client/key_binding.cpp
@@ -435,7 +435,7 @@ public:
 		StaticCmd("bindlist", Cmd::KEY_BINDING, "Lists all key bindings")
 	{}
 
-	void Run(const Cmd::Args&) const OVERRIDE
+	void Run(const Cmd::Args&) const override
 	{
 		for (auto& kv: keys)
 		{
@@ -505,7 +505,7 @@ public:
 		StaticCmd(name, Cmd::KEY_BINDING, desc), teambind(teambind)
 	{}
 
-	void Run(const Cmd::Args& args) const OVERRIDE
+	void Run(const Cmd::Args& args) const override
 	{
 		if (!IN_IsKeyboardLayoutInfoAvailable()) {
 			deferredBindCommands.push_back(args.EscapedArgs(0));
@@ -549,7 +549,7 @@ public:
 		SetBinding( b, team, args.ConcatArgs( 2 + +teambind ) );
 	}
 
-	Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const OVERRIDE {
+	Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const override {
 		Cmd::CompletionResult res;
 		if (teambind && argNum == 1) {
 			CompleteTeamName(prefix, res);
@@ -571,7 +571,7 @@ public:
 		StaticCmd("editbind", Cmd::KEY_BINDING, "Puts a key binding in the text field for editing")
 	{}
 
-	void Run(const Cmd::Args& args) const OVERRIDE
+	void Run(const Cmd::Args& args) const override
 	{
 		std::u32string buf;
 		int            b;
@@ -631,7 +631,7 @@ public:
 		g_consoleField.SetText( buf );
 	}
 
-	Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const OVERRIDE {
+	Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const override {
 		Cmd::CompletionResult res;
 		CompleteTeamAndKey(argNum, args, prefix, res);
 		return res;
@@ -645,7 +645,7 @@ public:
 		StaticCmd("unbind", Cmd::KEY_BINDING, "Removes a key binding")
 	{}
 
-	void Run(const Cmd::Args& args) const OVERRIDE
+	void Run(const Cmd::Args& args) const override
 	{
 		int b = args.Argc();
 		int team = -1;
@@ -678,7 +678,7 @@ public:
 		SetBinding( key, team, "" );
 	}
 
-	Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const OVERRIDE {
+	Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const override {
 		Cmd::CompletionResult res;
 		CompleteTeamAndKey(argNum, args, prefix, res);
 		return res;
@@ -692,7 +692,7 @@ public:
 		StaticCmd("unbindall", Cmd::KEY_BINDING, "Removes all key bindings")
 	{}
 
-	void Run(const Cmd::Args&) const OVERRIDE
+	void Run(const Cmd::Args&) const override
 	{
 		for (auto& kv : keys)
 		{
@@ -708,7 +708,7 @@ public:
 		StaticCmd("modcase", Cmd::KEY_BINDING, "Conditionally performs an action based on modifier keys")
 	{}
 
-	void Run(const Cmd::Args& args) const OVERRIDE
+	void Run(const Cmd::Args& args) const override
 	{
 		int argc = args.Argc();
 		int index = 0;

--- a/src/engine/framework/BaseCommands.cpp
+++ b/src/engine/framework/BaseCommands.cpp
@@ -47,7 +47,7 @@ namespace Cmd {
             VstrCmd(): StaticCmd("vstr", BASE, "executes a variable command") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 if (args.Argc() != 2) {
                     PrintUsage(args, "<variablename>", "executes a variable command");
                     return;
@@ -57,7 +57,7 @@ namespace Cmd {
                 ExecuteAfter(command, true);
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 Q_UNUSED(args);
 
                 if (argNum == 1) {
@@ -74,7 +74,7 @@ namespace Cmd {
             ExecCmd(Str::StringRef name, bool readHomepath): StaticCmd(name, BASE, "executes a command file"), readHomepath(readHomepath) {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 bool executeSilent = false;
                 bool failSilent = false;
                 bool hasOptions = args.Argc() >= 3 and args.Argv(1).size() >= 2 and args.Argv(1)[0] == '-';
@@ -121,7 +121,7 @@ namespace Cmd {
                 }
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 if (argNum == 1 || (argNum == 2 && Str::IsPrefix("-", args.Argv(1)))) {
                     if (readHomepath)
                         return FS::HomePath::CompleteFilename(prefix, "config", ".cfg", true, false);
@@ -175,7 +175,7 @@ namespace Cmd {
             EchoCmd(): StaticCmd("echo", BASE, "prints to the console") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 std::string res = "";
 
                 for (int i = 1; i < args.Argc(); i++) {
@@ -191,7 +191,7 @@ namespace Cmd {
             RandomCmd(): StaticCmd("random", BASE, "sets a variable to a random integer") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 int min, max;
                 if (args.Argc() != 4 or !Str::ParseInt(min, args.Argv(2)) or !Str::ParseInt(max, args.Argv(3)) or min >= max) {
                     PrintUsage(args, "<variableToSet> <minNumber> <maxNumber>", "sets a variable to a random integer between minNumber and maxNumber");
@@ -204,7 +204,7 @@ namespace Cmd {
                 Cvar::SetValue(cvar, std::to_string(number));
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 Q_UNUSED(args);
 
                 if (argNum == 1) {
@@ -221,7 +221,7 @@ namespace Cmd {
             ConcatCmd(): StaticCmd("concat", BASE, "concatenatas variables") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 if (args.Argc() < 3) {
                     PrintUsage(args, "<variableToSet> <variable1> … <variableN>", "concatenates variable1 to variableN and sets the result to variableToSet");
                     return;
@@ -234,7 +234,7 @@ namespace Cmd {
                 Cvar::SetValue(args.Argv(1), res);
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 Q_UNUSED(args);
 
                 if (argNum >= 1) {
@@ -260,7 +260,7 @@ namespace Cmd {
                 }
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 if  (args.Argc() < 2) {
                     Usage(args);
                     return;
@@ -349,7 +349,7 @@ namespace Cmd {
                 Print("valid operators: + - × * ÷ /");
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 Q_UNUSED(args);
 
                 if (argNum == 1) {
@@ -366,7 +366,7 @@ namespace Cmd {
             IfCmd(): StaticCmd("if", BASE, "conditionally execute commands") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 if (args.Argc() != 5 and args.Argc() != 6) {
                     Usage(args);
                     return;
@@ -442,7 +442,7 @@ namespace Cmd {
                 Print("-- commands are cvar names unless prefixed with / or \\");
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 Q_UNUSED(args);
 
                 if (argNum == 4 or argNum == 5) {
@@ -459,7 +459,7 @@ namespace Cmd {
             ToggleCmd(): Cmd::StaticCmd("toggle", Cmd::BASE, "toggles a cvar between different values") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 if (args.Argc() < 2) {
                     Usage(args);
                     return;
@@ -510,7 +510,7 @@ namespace Cmd {
                 Cvar::SetValue(name, args.Argv(listStart));
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 Q_UNUSED(args);
 
                 if (argNum == 1 or argNum == 2) {
@@ -531,7 +531,7 @@ namespace Cmd {
             CycleCmd(): Cmd::StaticCmd("cycle", Cmd::BASE, "cycles a cvar through numbers") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 int oldValue = 0, start = 0, end = 0;
                 if (args.Argc() < 4 || args.Argc() > 5 ||
                     !Str::ParseInt(oldValue, Cvar::GetValue(args.Argv(1))) ||
@@ -566,7 +566,7 @@ namespace Cmd {
                 Cvar::SetValue(args.Argv(1), va("%i", newValue));
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 Q_UNUSED(args);
 
                 if (argNum == 1) {
@@ -635,7 +635,7 @@ namespace Cmd {
             DelayCmd(): StaticCmd("delay", BASE, "executes a command after a delay") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 int argc = args.Argc();
 
                 if (argc < 3) {
@@ -670,7 +670,7 @@ namespace Cmd {
 
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args&, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args&, Str::StringRef prefix) const override {
                 if (argNum == 1) {
                     return CompleteDelayName(prefix);
                 }
@@ -684,7 +684,7 @@ namespace Cmd {
             UndelayCmd(): StaticCmd("undelay", BASE, "removes named /delay commands") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 if (args.Argc() < 2) {
                     PrintUsage(args, "<name> (command)", "removes all commands with <name> in them.\nif (command) is specified, the removal will be limited only to delays whose commands contain (command).");
                     return;
@@ -704,7 +704,7 @@ namespace Cmd {
                 }
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 Q_UNUSED(args);
 
                 if (argNum == 1) {
@@ -720,7 +720,7 @@ namespace Cmd {
             UndelayAllCmd(): StaticCmd("undelayAll", BASE, "removes all the pending /delay commands") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 Q_UNUSED(args); //TODO
                 delays.clear();
             }
@@ -774,7 +774,7 @@ namespace Cmd {
             AliasProxy(): CmdBase(0) {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 const std::string& name = args.Argv(0);
                 const std::string& parameters = args.EscapedArgs(1);
 
@@ -811,7 +811,7 @@ namespace Cmd {
             AliasCmd(): StaticCmd("alias", BASE, "creates or view an alias") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 if (args.Argc() < 2) {
                     PrintUsage(args, "<name>", "show an alias");
                     PrintUsage(args, "<name> <exec>", "create an alias");
@@ -857,7 +857,7 @@ namespace Cmd {
                 cvar_modifiedFlags |= CVAR_ARCHIVE_BITS;
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 if (argNum == 1) {
                     return CompleteAliasName(prefix);
                 } else if (argNum > 1) {
@@ -874,7 +874,7 @@ namespace Cmd {
             UnaliasCmd(): StaticCmd("unalias", BASE, "deletes an alias") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 if (args.Argc() != 2) {
                     PrintUsage(args, "<name>", "delete an alias");
                     return;
@@ -889,7 +889,7 @@ namespace Cmd {
                 }
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Args& args, Str::StringRef prefix) const override {
                 Q_UNUSED(args);
 
                 if (argNum == 1) {
@@ -906,7 +906,7 @@ namespace Cmd {
             ClearAliasesCmd(): StaticCmd("clearAliases", BASE, "deletes all the aliases") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 Q_UNUSED(args); //TODO
                 RemoveFlaggedCommands(ALIAS);
                 aliases.clear();
@@ -919,7 +919,7 @@ namespace Cmd {
             ListAliasesCmd(): StaticCmd("listAliases", BASE, "lists aliases") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 Q_UNUSED(args); //TODO
                 std::string name;
 

--- a/src/engine/framework/CommandSystem.cpp
+++ b/src/engine/framework/CommandSystem.cpp
@@ -313,7 +313,7 @@ namespace Cmd {
             :StaticCmd(std::move(name), cmdFlags, std::move(description)), showCmdFlags(showCmdFlags) {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 CommandMap& commands = GetCommandMap();
 
                 std::vector<const commandRecord_t*> matches;
@@ -345,7 +345,7 @@ namespace Cmd {
                 Print("%zu commands", matches.size());
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const override {
                 Q_UNUSED(args);
 
                 if (argNum == 1) {

--- a/src/engine/framework/CommandSystem.h
+++ b/src/engine/framework/CommandSystem.h
@@ -111,8 +111,8 @@ namespace Cmd {
 
     class DefaultEnvironment: public Environment {
         public:
-            virtual void Print(Str::StringRef text) OVERRIDE;
-            virtual void ExecuteAfter(Str::StringRef text, bool parseCvars) OVERRIDE;
+            virtual void Print(Str::StringRef text) override;
+            virtual void ExecuteAfter(Str::StringRef text, bool parseCvars) override;
     };
 }
 

--- a/src/engine/framework/CommonVMServices.cpp
+++ b/src/engine/framework/CommonVMServices.cpp
@@ -156,7 +156,7 @@ namespace VM {
                 }
             }
 
-            virtual Cvar::OnValueChangedResult OnValueChanged(Str::StringRef newValue) OVERRIDE {
+            virtual Cvar::OnValueChangedResult OnValueChanged(Str::StringRef newValue) override {
                 Cvar::OnValueChangedResult result;
                 services->GetVM().SendMsg<OnValueChangedMsg>(name, newValue, result.success, result.description);
                 return result;

--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -204,7 +204,7 @@ namespace Cvar {
             CvarCommand() : Cmd::CmdBase(Cmd::CVAR) {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 CvarMap& cvars = GetCvarMap();
                 const std::string& name = args.Argv(0);
                 cvarRecord_t* var = cvars[name];
@@ -537,7 +537,7 @@ namespace Cvar {
             SetCmd(const std::string& name, const std::string& help, int flags): Cmd::StaticCmd(name, Cmd::BASE, help), flags(flags) {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 if (args.Argc() < 2) {
                     PrintUsage(args, "<variable> <value>","");
                     return;
@@ -550,7 +550,7 @@ namespace Cvar {
                 ::Cvar::AddFlags(name, flags);
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const override {
                 if (argNum == 1) {
                     return ::Cvar::Complete(prefix);
                 }
@@ -571,7 +571,7 @@ namespace Cvar {
             ResetCmd(): Cmd::StaticCmd("reset", Cmd::BASE, "resets the named variables") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 int argc = args.Argc();
                 bool clearArchive = true;
 
@@ -599,7 +599,7 @@ namespace Cvar {
                 }
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const override {
                 if (argNum) {
                     return ::Cvar::Complete(prefix);
                 }
@@ -627,7 +627,7 @@ namespace Cvar {
             ListCvars(): Cmd::StaticCmd("listCvars", Cmd::BASE, "lists variables") {
             }
 
-            void Run(const Cmd::Args& args) const OVERRIDE {
+            void Run(const Cmd::Args& args) const override {
                 CvarMap& cvars = GetCvarMap();
 
                 bool raw = false;
@@ -704,7 +704,7 @@ namespace Cvar {
                 Print("%zu cvars", matches.size());
             }
 
-            Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const OVERRIDE {
+            Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const override {
                 int nameIndex = 1;
                 int argc = args.Argc();
 

--- a/src/engine/framework/LogSystem.cpp
+++ b/src/engine/framework/LogSystem.cpp
@@ -96,7 +96,7 @@ namespace Log {
                 this->Register(TTY_CONSOLE);
             }
 
-            virtual bool Process(const std::vector<Log::Event>& events) OVERRIDE {
+            virtual bool Process(const std::vector<Log::Event>& events) override {
                 for (auto& event : events)  {
                     CON_Print(event.text.c_str());
                     CON_Print("\n");
@@ -120,7 +120,7 @@ namespace Log {
                 this->Register(LOGFILE);
             }
 
-            virtual bool Process(const std::vector<Log::Event>& events) OVERRIDE {
+            virtual bool Process(const std::vector<Log::Event>& events) override {
                 //If we have no log file drop the events
                 if (not useLogFile.Get()) {
                     return true;

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -302,7 +302,7 @@ class QuitCmd : public Cmd::StaticCmd {
         QuitCmd(): StaticCmd("quit", Cmd::BASE, "quits the program") {
         }
 
-        void Run(const Cmd::Args& args) const OVERRIDE {
+        void Run(const Cmd::Args& args) const override {
             Quit(args.ConcatArgs(1));
         }
 };

--- a/src/engine/qcommon/cmd.cpp
+++ b/src/engine/qcommon/cmd.cpp
@@ -441,12 +441,12 @@ class ProxyCmd: public Cmd::CmdBase {
 	public:
 		ProxyCmd(): Cmd::CmdBase(Cmd::PROXY_FOR_OLD) {}
 
-		void Run(const Cmd::Args& args) const OVERRIDE {
+		void Run(const Cmd::Args& args) const override {
 			proxyInfo_t proxy = proxies[args.Argv(0)];
 			proxy.cmd();
 		}
 
-		Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const OVERRIDE {
+		Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const override {
 			static char buffer[4096];
 			proxyInfo_t proxy = proxies[args.Argv(0)];
 

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -699,7 +699,7 @@ public:
 	WhichCmd()
 		: Cmd::StaticCmd("which", Cmd::SYSTEM, "shows which pak a file is in") {}
 
-	void Run(const Cmd::Args& args) const OVERRIDE
+	void Run(const Cmd::Args& args) const override
 	{
 		if (args.Argc() != 2) {
 			PrintUsage(args, "<file>", "");
@@ -714,7 +714,7 @@ public:
 			Print("File not found: \"%s\"", filename);
 	}
 
-	Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const OVERRIDE
+	Cmd::CompletionResult Complete(int argNum, const Cmd::Args&, Str::StringRef prefix) const override
 	{
 		if (argNum == 1) {
 			return FS::PakPath::CompleteFilename(prefix, "", "", true, false);
@@ -730,7 +730,7 @@ public:
 	ListPathsCmd()
 		: Cmd::StaticCmd("listPaths", Cmd::SYSTEM, "list filesystem search paths") {}
 
-	void Run(const Cmd::Args&) const OVERRIDE
+	void Run(const Cmd::Args&) const override
 	{
 		Print("Home path: %s", FS::GetHomePath());
 		for (auto& x: FS::PakPath::GetLoadedPaks())
@@ -743,7 +743,7 @@ class DirCmd: public Cmd::StaticCmd {
 public:
 	DirCmd(): Cmd::StaticCmd("dir", Cmd::SYSTEM, "list all files in a given directory with the option to pass a filter") {}
 
-	void Run(const Cmd::Args& args) const OVERRIDE
+	void Run(const Cmd::Args& args) const override
 	{
 		bool filter = false;
 		if (args.Argc() != 2 && args.Argc() != 3) {

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -92,7 +92,6 @@ void ignore_result(T) {}
 #include <wchar.h>
 
 // C++ standard library headers
-#ifdef __cplusplus
 #include <utility>
 #include <functional>
 #include <chrono>
@@ -127,7 +126,6 @@ void ignore_result(T) {}
 #include <valarray>
 #include <sstream>
 #include <iostream>
-#endif // __cplusplus
 
 // vsnprintf is ISO/IEC 9899:1999
 // abstracting this to make it portable

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1549,7 +1549,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	GetRefAPI
 	=====================
 	*/
-	Q_EXPORT refexport_t *GetRefAPI( int apiVersion, refimport_t *rimp )
+	refexport_t *GetRefAPI( int apiVersion, refimport_t *rimp )
 	{
 		static refexport_t re;
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -287,7 +287,7 @@ public:
 	void GameMessageRecieved(int clientNum, const uint8_t *buf, size_t size, int commandTime);
 
 private:
-	virtual void Syscall(uint32_t id, Util::Reader reader, IPC::Channel& channel) OVERRIDE FINAL;
+	virtual void Syscall(uint32_t id, Util::Reader reader, IPC::Channel& channel) override final;
 	void QVMSyscall(int index, Util::Reader& reader, IPC::Channel& channel);
 
 	IPC::SharedMemory shmRegion;

--- a/src/engine/server/sv_ccmds.cpp
+++ b/src/engine/server/sv_ccmds.cpp
@@ -50,7 +50,7 @@ class MapCmd: public Cmd::StaticCmd {
             Cmd::StaticCmd(name, Cmd::SYSTEM, description), cheat(cheat) {
         }
 
-        void Run(const Cmd::Args& args) const OVERRIDE {
+        void Run(const Cmd::Args& args) const override {
             if (args.Argc() < 2) {
                 PrintUsage(args, "<mapname> (layoutname)", "loads a new map");
                 return;
@@ -76,7 +76,7 @@ class MapCmd: public Cmd::StaticCmd {
             SV_SpawnServer(loadedPakInfo->name, mapName);
         }
 
-        Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const OVERRIDE {
+        Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const override {
             if (argNum == 1) {
                 Cmd::CompletionResult out;
                 for (auto& map: FS::GetAvailableMaps()) {
@@ -234,7 +234,7 @@ public:
 		StaticCmd("status", Cmd::SYSTEM, "Shows a table with server and player information")
 	{}
 
-	void Run(const Cmd::Args&) const OVERRIDE
+	void Run(const Cmd::Args&) const override
 	{
 		// make sure server is running
 		if ( !com_sv_running->integer )
@@ -394,7 +394,7 @@ public:
 		StaticCmd("listmaps", Cmd::SYSTEM, "Lists all maps available to the server")
 	{}
 
-	void Run(const Cmd::Args&) const OVERRIDE
+	void Run(const Cmd::Args&) const override
 	{
 		auto maps = FS::GetAvailableMaps();
 

--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -752,7 +752,7 @@ public:
 		: from(from), bufferSize(MAX_MSGLEN - prefix.size() - 1)
 	{}
 
-	virtual void Print(Str::StringRef text) OVERRIDE
+	virtual void Print(Str::StringRef text) override
 	{
 		if (text.size() + buffer.size() > bufferSize - 1)
 		{

--- a/src/shared/CommonProxies.cpp
+++ b/src/shared/CommonProxies.cpp
@@ -182,14 +182,14 @@ class TrapProxyCommand: public Cmd::CmdBase {
     public:
         TrapProxyCommand() : Cmd::CmdBase(0) {
         }
-        virtual void Run(const Cmd::Args& args) const OVERRIDE {
+        virtual void Run(const Cmd::Args& args) const override {
             // Push a pointer to args, it is fine because we remove the pointer before args goes out of scope
             argStack.push_back(&args);
             ConsoleCommand();
             argStack.pop_back();
         }
 
-        Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const OVERRIDE {
+        Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const override {
             static char buffer[4096];
 
             completedPrefix = prefix;
@@ -382,7 +382,7 @@ class VMCvarProxy : public Cvar::CvarProxy {
             Register("");
         }
 
-        virtual Cvar::OnValueChangedResult OnValueChanged(Str::StringRef newValue) OVERRIDE {
+        virtual Cvar::OnValueChangedResult OnValueChanged(Str::StringRef newValue) override {
             value = newValue;
             modificationCount++;
             return Cvar::OnValueChangedResult{true, ""};


### PR DESCRIPTION
According to the minimum supported versions now defined in the README.