### PR TITLE
Travis/matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 sudo: required
 
-language:
-  - cpp
-
-os:
-  - linux
-  - osx
-
+language: cpp
 cache: ccache
 
-compiler:
-  - gcc
-  - clang
+matrix:
+  include:
+    - name: "Linux build using gcc"
+      os: linux
+      compiler: gcc
+    - name: "Linux build using clang"
+      os: linux
+      compiler: clang
+    - name: "osx build"
+      os: osx
+      compiler: clang
+    # osx links gcc to clang; so skip
 
 #Prepare dependency installation
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,14 @@ sudo: required
 language: cpp
 cache: ccache
 
+addons:
+  apt:
+    update: true
+  homebrew:
+    packages:
+    - ninja
+    - ccache
+
 matrix:
   include:
     - name: "Linux build using gcc"
@@ -16,13 +24,6 @@ matrix:
       compiler: clang
     # osx links gcc to clang; so skip
 
-#Prepare dependency installation
-before_install:
-  - |
-    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      sudo apt-get -qq update
-    fi
-
 install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
       sudo apt-get -y -q --no-install-recommends install
@@ -33,11 +34,8 @@ install:
         libfreetype6-dev libglew-dev libopenal-dev
         liblua5.2-dev;
     fi
-  - |
-    if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      sudo apt-get -y -q --no-install-recommends install ninja-build
-    elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      brew install ninja
+  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+      sudo apt-get -y -q --no-install-recommends install ninja-build;
     fi
   - |
     # workarounds to make ccache work
@@ -45,7 +43,6 @@ install:
       sudo ln -s $(which ccache) /usr/lib/ccache/clang
       sudo ln -s $(which ccache) /usr/lib/ccache/clang++
     elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      brew install ccache
       export PATH="/usr/local/opt/ccache/libexec:$PATH"
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,8 @@ before_script:
   - export CXXFLAGS="$CXXFLAGS -D__extern_always_inline=inline"
 
 script:
-  - cmake -DUSE_WERROR=1 -DBE_VERBOSE=1 -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DUSE_DEBUG_OPTIMIZE=0 ..
+  - cmake -DUSE_PRECOMPILED_HEADER=0
+    -DUSE_WERROR=1 -DBE_VERBOSE=1 -G "Ninja" -DCMAKE_BUILD_TYPE=Debug -DUSE_DEBUG_OPTIMIZE=0 ..
   - cmake --build . -- -j8
 
 before_cache:


### PR DESCRIPTION
based on feedback by @slipher this skips the osc+gcc build
and tries to reduce homebrew install time by using the travis homebrew plugin, hoping that it will skip the updates as indicated by the [documentation](https://docs.travis-ci.com/user/installing-dependencies/#installing-packages-on-os-x)