### PR TITLE
Fixing FS::InternalLoadPak to only get timestamp for .dpk files.

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1142,7 +1142,8 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 	// Save the real checksum in the list of loaded paks (empty for directories, not used for legacy paks)
 	loadedPaks.back().realChecksum = realChecksum;
 
-	// Get the timestamp of the pak, but only for directories. Directories don't need timestamp.
+	// Get the timestamp of the pak, but only for dpk files. 
+	// Directories (aka a dpkdir) don't need timestamp.
 	// Fixes Windows bug where calling _wstat64i with trailing slash causes "file not found" error.
 	// For future stat calls on directories, trim the trailing slash (if exists)
 	if (pak.type == pakType_t::PAK_ZIP) {

--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1142,10 +1142,14 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 	// Save the real checksum in the list of loaded paks (empty for directories, not used for legacy paks)
 	loadedPaks.back().realChecksum = realChecksum;
 
-	// Get the timestamp of the pak
-	loadedPaks.back().timestamp = FS::RawPath::FileTimestamp(pak.path, err);
-	if (err)
-		return;
+	// Get the timestamp of the pak, but only for directories. Directories don't need timestamp.
+	// Fixes Windows bug where calling _wstat64i with trailing slash causes "file not found" error.
+	// For future stat calls on directories, trim the trailing slash (if exists)
+	if (pak.type == pakType_t::PAK_ZIP) {
+		loadedPaks.back().timestamp = FS::RawPath::FileTimestamp(pak.path, err);
+		if (err)
+			return;
+	}
 
 	loadedPaks.back().pathPrefix = pathPrefix;
 


### PR DESCRIPTION
No longer attempts to get timestamp for directories.

Fixes bug where my_stat (_wstat64i) was failing on Windows when
trailing slash was present.

In the future, trim trailing slash should work on all platforms.

Not sure if this has unintended consequences (are timestamps _really_ useless for dpkdirs?). Please review.