### PR TITLE
Don't serialize bools by copying memory

### DIFF
--- a/src/common/Serialize.h
+++ b/src/common/Serialize.h
@@ -220,9 +220,11 @@ namespace Util {
 		size_t handles_pos;
 	};
 
-    // Implementation of the serialization traits for common types and std containers
+	// Implementation of the serialization traits for common types and std containers
 
 	// Simple implementation for POD types
+	// This is only safe to use if every possible byte sequence represents a valid value for the
+	// object. So it cannot be used for bool or a struct containing a bool.
 	template<typename T>
 	struct SerializeTraits<T, typename std::enable_if<std::is_pod<T>::value && !std::is_array<T>::value>::type> {
 		static void Write(Writer& stream, const T& value)
@@ -234,6 +236,19 @@ namespace Util {
 			T value;
 			stream.ReadData(std::addressof(value), sizeof(value));
 			return value;
+		}
+	};
+
+	// bool
+	template<>
+	struct SerializeTraits<bool> {
+		static void Write(Writer& stream, bool value)
+		{
+			stream.Write<uint8_t>(+value);
+		}
+		static bool Read(Reader& stream)
+		{
+			return static_cast<bool>(stream.Read<uint8_t>() & 1);
 		}
 	};
 

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -41,7 +41,47 @@ Maryland 20850 USA.
 
 #define REF_API_VERSION 10
 
-// *INDENT-OFF*
+struct glconfig2_t
+{
+	bool textureCompressionRGTCAvailable;
+
+	bool glCoreProfile;
+
+	int      maxCubeMapTextureSize;
+
+	bool occlusionQueryAvailable;
+	int      occlusionQueryBits;
+
+	char     shadingLanguageVersionString[ MAX_STRING_CHARS ];
+	int      shadingLanguageVersion;
+
+	int      maxVertexUniforms;
+//	int             maxVaryingFloats;
+	int      maxVertexAttribs;
+	bool vboVertexSkinningAvailable;
+	int      maxVertexSkinningBones;
+
+	bool drawBuffersAvailable;
+	bool textureHalfFloatAvailable;
+	bool textureFloatAvailable;
+	bool textureIntegerAvailable;
+	bool textureRGAvailable;
+	bool gpuShader4Available;
+	bool textureGatherAvailable;
+	int      maxDrawBuffers;
+
+	float    maxTextureAnisotropy;
+	bool textureAnisotropyAvailable;
+
+	int      maxRenderbufferSize;
+	int      maxColorAttachments;
+
+	bool getProgramBinaryAvailable;
+	bool bufferStorageAvailable;
+	bool uniformBufferObjectAvailable;
+	bool mapBufferRangeAvailable;
+	bool syncAvailable;
+};
 
 //
 // these are the functions exported by the refresh module

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -39,6 +39,12 @@ Maryland 20850 USA.
 #ifndef __TR_TYPES_H
 #define __TR_TYPES_H
 
+// bool can't be safely deserialized by memcpy
+#pragma push_macro("bool")
+#undef bool
+#define bool DO_NOT_USE_BOOL_IN_IPC_MESSAGE_TYPES
+using bool8_t = uint8_t;
+
 // XreaL BEGIN
 #define MAX_REF_LIGHTS     1024
 #define MAX_REF_ENTITIES   1023 // can't be increased without changing drawsurf bit packing
@@ -168,7 +174,7 @@ struct refEntity_t
 	vec3_t    lightingOrigin; // so multi-part models can be lit identically (RF_LIGHTING_ORIGIN)
 
 	vec3_t    axis[ 3 ]; // rotation vectors
-	bool  nonNormalizedAxes; // axis are not normalized, i.e. they have scale
+	bool8_t  nonNormalizedAxes; // axis are not normalized, i.e. they have scale
 	vec3_t    origin;
 	int       frame;
 
@@ -242,10 +248,10 @@ struct refLight_t
 	vec3_t   projStart;
 	vec3_t   projEnd;
 
-	bool noShadows;
+	bool8_t noShadows;
 	short    noShadowID; // don't cast shadows of all entities with this id
 
-	bool inverseShadows; // don't cast light and draw shadows by darken the scene
+	bool8_t inverseShadows; // don't cast light and draw shadows by darken the scene
 	// this is useful for drawing player shadows with shadow mapping
 };
 
@@ -343,8 +349,8 @@ struct glconfig_t
 	glHardwareType_t     hardwareType;
 
 	textureCompression_t textureCompression;
-	bool             textureEnvAddAvailable;
-	bool             anisotropicAvailable; //----(SA)  added
+	bool8_t             textureEnvAddAvailable;
+	bool8_t             anisotropicAvailable; //----(SA)  added
 	float                maxAnisotropy; //----(SA)  added
 
 	int      vidWidth, vidHeight;
@@ -356,8 +362,10 @@ struct glconfig_t
 
 	// synonymous with "does rendering consume the entire screen?", therefore
 	// a Win32 ICD that used CDS will have this set to TRUE
-	bool isFullscreen;
-	bool smpActive; // dual processor
+	bool8_t isFullscreen;
+	bool8_t smpActive; // dual processor
 };
+
+#pragma pop_macro("bool")
 
 #endif // __TR_TYPES_H

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -360,48 +360,4 @@ struct glconfig_t
 	bool smpActive; // dual processor
 };
 
-// XreaL BEGIN
-struct glconfig2_t
-{
-	bool textureCompressionRGTCAvailable;
-
-	bool glCoreProfile;
-
-	int      maxCubeMapTextureSize;
-
-	bool occlusionQueryAvailable;
-	int      occlusionQueryBits;
-
-	char     shadingLanguageVersionString[ MAX_STRING_CHARS ];
-	int      shadingLanguageVersion;
-
-	int      maxVertexUniforms;
-//	int             maxVaryingFloats;
-	int      maxVertexAttribs;
-	bool vboVertexSkinningAvailable;
-	int      maxVertexSkinningBones;
-
-	bool drawBuffersAvailable;
-	bool textureHalfFloatAvailable;
-	bool textureFloatAvailable;
-	bool textureIntegerAvailable;
-	bool textureRGAvailable;
-	bool gpuShader4Available;
-	bool textureGatherAvailable;
-	int      maxDrawBuffers;
-
-	float    maxTextureAnisotropy;
-	bool textureAnisotropyAvailable;
-
-	int      maxRenderbufferSize;
-	int      maxColorAttachments;
-
-	bool getProgramBinaryAvailable;
-	bool bufferStorageAvailable;
-	bool uniformBufferObjectAvailable;
-	bool mapBufferRangeAvailable;
-	bool syncAvailable;
-};
-// XreaL END
-
 #endif // __TR_TYPES_H


### PR DESCRIPTION
Mostly fixes #148 although there could be a few more `bool`s hiding out in structs.