### PR TITLE
null default sound sample

### DIFF
--- a/src/engine/audio/Sample.cpp
+++ b/src/engine/audio/Sample.cpp
@@ -70,7 +70,7 @@ namespace Audio {
 
     // Implementation of the sample storage
 
-    static const char errorSampleName[] = "sound/feedback/hit.wav";
+    static const char errorSampleName[] = "sound/null";
     static std::shared_ptr<Sample> errorSample = nullptr;
     bool initialized = false;
 

--- a/src/engine/audio/SoundCodec.cpp
+++ b/src/engine/audio/SoundCodec.cpp
@@ -102,7 +102,7 @@ AudioData LoadSoundCodec(std::string filename)
 		return AudioData();
 	}
 
-	audioLogs.Debug("Sound file %s not found.", filename);
+	audioLogs.Warn("Sound file %s not found.", filename);
 	return AudioData();
 
 }


### PR DESCRIPTION
Use `null.wav` as default sound sample instead of `sound/feedback/hit/wav`.

When loading a map with an ambient (looping) sound missing, player just hear an horribly annoying endless `tick tick tick tick` sound. Having a warning or notice in console saying the sound is missing must be enough. No need for a sound feedback.