### PR TITLE
WIP: fix heightmap orientation, black is low and white is high

### DIFF
--- a/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
@@ -965,7 +965,7 @@ void	main()
 	Vts = normalize(Vts);
 
 	// size and start position of search in texture space
-	vec2 S = Vts.xy * -u_DepthScale / Vts.z;
+	vec2 S = Vts.xy * u_DepthScale / Vts.z;
 
 	float depth = RayIntersectDisplaceMap(texNormal, S, u_NormalMap);
 

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -63,7 +63,7 @@ void	main()
 	V = normalize(V);
 
 	// size and start position of search in texture space
-	vec2 S = V.xy * -u_DepthScale / V.z;
+	vec2 S = V.xy * u_DepthScale / V.z;
 
 #if 0
 	vec2 texOffset = vec2(0.0);

--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -155,8 +155,8 @@ void	main()
 	// ray intersect in view direction
 
 	// size and start position of search in texture space
-	//vec2 S = V.xy * -u_DepthScale / V.z;
-	vec2 S = V.xy * -0.03 / V.z;
+	//vec2 S = V.xy * u_DepthScale / V.z;
+	vec2 S = V.xy * 0.03 / V.z;
 
 	float depth = RayIntersectDisplaceMap(texNormal, S);
 

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
@@ -100,7 +100,7 @@ void	main()
 	Vts = normalize(Vts);
 
 	// size and start position of search in texture space
-	vec2 S = Vts.xy * -u_DepthScale / Vts.z;
+	vec2 S = Vts.xy * u_DepthScale / Vts.z;
 
 #if 0
 	vec2 texOffset = vec2(0.0);

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
@@ -94,7 +94,7 @@ void	main()
 	Vts = normalize(Vts);
 
 	// size and start position of search in texture space
-	vec2 S = Vts.xy * -u_DepthScale / Vts.z;
+	vec2 S = Vts.xy * u_DepthScale / Vts.z;
 
 #if 0
 	vec2 texOffset = vec2(0.0);


### PR DESCRIPTION
issue found while experimenting with xonotic assets in #159, see also #30, especially https://github.com/DaemonEngine/Daemon/issues/30#issuecomment-466850340

there is only one heightmap standard: black is low and white is high

xreal was doing white is low and black is high for heightmap in alpha channel of normal map but was doing black is low and white is high for heightmap in loose file which does not make sense

in any way daemon seems to have been forked before the addition of shader keywords to support heightmap loose file so only heightmap in alpha channel is supported at this point