### PR TITLE
R_UploadImage: detect heightmap in normalmap alphachanel

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1361,6 +1361,27 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips,
 		ri.Hunk_FreeTempMemory( scaledBuffer );
 	}
 
+	// detect heightmap in normalmap alpha channel and enable it
+	// if not already enabled by explicit shader keyword
+	if ( image->bits & IF_NORMALMAP )
+	{
+		if ( ! ( image->bits & IF_DISPLACEMAP ) )
+		{
+			switch ( image->internalFormat )
+			{
+				case GL_RGBA:
+				case GL_RGBA8:
+				case GL_RGBA16:
+				case GL_RGBA16F:
+				case GL_RGBA32F:
+				case GL_RGBA32UI:
+				case GL_COMPRESSED_RGBA_S3TC_DXT3_EXT:
+				case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
+					image->bits |= IF_DISPLACEMAP;
+			}
+		}
+	}
+
 	GL_Unbind( image );
 }
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1442,6 +1442,12 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer )
 		return false;
 	}
 
+	// enable parallax if an heightmap is found
+	if ( stage->bundle[ 0 ].image[ 0 ]->bits & IF_DISPLACEMAP )
+	{
+		shader.parallax = true;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
detect heightmap in normalmap alpha channel and enable parallax for the given shader

this makes removes the need of an explicit shader keyword telling the engine there is an heightmap embedded in normalmap: if there is an alpha channel in normalmap there is an eightmap, else there is only a normalmap

was experimented first in #159