### PR TITLE
fix buggy parenthesis in liquid glsl shader

### DIFF
--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -171,7 +171,7 @@ void	main()
 
 	vec3 N = normalize(var_Normal);
 
-	vec3 N2 = texture2D(u_NormalMap, texNormal.st).xyw);
+	vec3 N2 = texture2D(u_NormalMap, texNormal.st).xyw;
 	N2.x *= N2.z;
 	N2.xy = 2.0 * N2.xy - 1.0;
 	N2.z = sqrt(1.0 - dot(N2.xy, N2.xy));


### PR DESCRIPTION
introduced in 86d4352d6aad71d66360403264ff4a22cd77f72d

I still don't know why the shader compiler never complained before today