### PR TITLE
glsl: deduplicate RayIntersectDisplaceMap

### DIFF
--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -51,60 +51,6 @@ IN(smooth) vec3		var_Normal;
 
 DECLARE_OUTPUT(vec4)
 
-#if defined(USE_PARALLAX_MAPPING)
-float RayIntersectDisplaceMap(vec2 dp, vec2 ds)
-{
-	const int linearSearchSteps = 16;
-	const int binarySearchSteps = 6;
-
-	float depthStep = 1.0 / float(linearSearchSteps);
-
-	// current size of search window
-	float size = depthStep;
-
-	// current depth position
-	float depth = 0.0;
-
-	// best match found (starts with last position 1.0)
-	float bestDepth = 1.0;
-
-	// search front to back for first point inside object
-	for(int i = 0; i < linearSearchSteps - 1; ++i)
-	{
-		depth += size;
-
-		vec4 t = texture2D(u_NormalMap, dp + ds * depth);
-
-		if(bestDepth > 0.996)		// if no depth found yet
-			if(depth >= t.w)
-				bestDepth = depth;	// store best depth
-	}
-
-	depth = bestDepth;
-
-	// recurse around first point (depth) for closest match
-	for(int i = 0; i < binarySearchSteps; ++i)
-	{
-		size *= 0.5;
-
-		vec4 t = texture2D(u_NormalMap, dp + ds * depth);
-
-		if(depth >= t.w)
-#ifdef RM_DOUBLEDEPTH
-			if(depth <= t.z)
-#endif
-			{
-				bestDepth = depth;
-				depth -= 2.0 * size;
-			}
-
-		depth += size;
-	}
-
-	return bestDepth;
-}
-#endif
-
 void ReadLightGrid(in vec3 pos, out vec3 lgtDir,
 		   out vec3 ambCol, out vec3 lgtCol ) {
 	vec4 texel1 = texture3D(u_LightGrid1, pos);
@@ -158,7 +104,7 @@ void	main()
 	//vec2 S = V.xy * -u_DepthScale / V.z;
 	vec2 S = V.xy * -0.03 / V.z;
 
-	float depth = RayIntersectDisplaceMap(texNormal, S);
+	float depth = RayIntersectDisplaceMap(texNormal, S, u_NormalMap);
 
 	// compute texcoords offset
 	vec2 texOffset = S * depth;


### PR DESCRIPTION
`RayIntersectDisplaceMap` is already defined in `reliefMapping_fp.glsl`, doing the exact same thing:

https://github.com/DaemonEngine/Daemon/blob/9322bda72627da2846310f5e4f624449b22122bf/src/engine/renderer/glsl_source/reliefMapping_fp.glsl#L203-L253