### PR TITLE
server: 64 bytes are not enough to fit a pak name, client already expects 256, fix #167

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -168,7 +168,7 @@ struct client_t
 	char           name[ MAX_NAME_LENGTH ]; // extracted from userinfo, high bits masked
 
 	// downloading
-	char          downloadName[ MAX_QPATH ]; // if not empty string, we are downloading
+	char          downloadName[ MAX_OSPATH ]; // if not empty string, we are downloading
 	FS::File*     download; // file being downloaded
 	int           downloadSize; // total bytes (can't use EOF because of paks)
 	int           downloadCount; // bytes sent

--- a/src/engine/server/sv_ccmds.cpp
+++ b/src/engine/server/sv_ccmds.cpp
@@ -140,7 +140,7 @@ static void SV_MapRestart_f()
 	if ( sv_maxclients->modified )
 	{
 		char mapname[ MAX_QPATH ];
-		char pakname[ MAX_QPATH ];
+		char pakname[ MAX_OSPATH ];
 
 		Log::Notice( "sv_maxclients variable change — restarting.\n" );
 		// restart the map the slow way


### PR DESCRIPTION
See #167,  `downloadName` is set to `256` in client but `64` in server, and in anyway, 64 is not large enough.

https://github.com/DaemonEngine/Daemon/blob/9322bda72627da2846310f5e4f624449b22122bf/src/engine/qcommon/q_shared.h#L199-L200
https://github.com/DaemonEngine/Daemon/blob/9322bda72627da2846310f5e4f624449b22122bf/src/engine/client/client.h#L344
https://github.com/DaemonEngine/Daemon/blob/9322bda72627da2846310f5e4f624449b22122bf/src/engine/server/server.h#L171
https://github.com/DaemonEngine/Daemon/blob/9322bda72627da2846310f5e4f624449b22122bf/src/engine/server/sv_ccmds.cpp#L143
