### PR TITLE
R_FindCubeImage: avoid the boring “Failed to open” on skybox format try

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1619,7 +1619,7 @@ Finds and returns an image loader for a given basename,
 tells the extra prefix that may be required to load the image.
 =================
 */
-int R_FindImageLoader( char *baseName, const char **prefix ) {
+static int R_FindImageLoader( const char *baseName, const char **prefix ) {
 	const FS::PakInfo* bestPak = nullptr;
 	int i;
 
@@ -1658,8 +1658,10 @@ int R_FindImageLoader( char *baseName, const char **prefix ) {
 	return bestLoader;
 }
 
-int R_FindImageLoader( char *baseName ) {
-	const char *prefix; // not used but required by R_FindImageLoader
+static int R_FindImageLoader( const char *baseName ) {
+	// not used but required by R_FindImageLoader
+	const char *prefix;
+
 	return R_FindImageLoader( baseName, &prefix );
 }
 
@@ -2012,18 +2014,16 @@ image_t        *R_FindCubeImage( const char *imageName, int bits, filterType_t f
 		}
 	}
 
-	const char *cubeMapName;
 	char cubeMapBaseName[ MAX_QPATH ];
-
-	COM_StripExtension3( buffer, cubeMapBaseName, MAX_QPATH );
+	COM_StripExtension3( buffer, cubeMapBaseName, sizeof( cubeMapBaseName ) );
 
 	for ( i = 0; i < numCubeMapLoaders; i++ )
 	{
-		cubeMapName = va( "%s.%s", cubeMapBaseName, cubeMapLoaders[ i ].ext );
-		if( R_FindImageLoader( (char*) cubeMapName ) >= 0 )
+		std::string cubeMapName = Str::Format( "%s.%s", cubeMapBaseName, cubeMapLoaders[ i ].ext );
+		if( R_FindImageLoader( cubeMapName.c_str() ) >= 0 )
 		{
 			Log::Debug( "found %s cube map '%s'", cubeMapLoaders[ i ].ext, cubeMapBaseName );
-			cubeMapLoaders[ i ].ImageLoader( cubeMapName, pic, &width, &height, &numLayers, &numMips, &bits, 0 );
+			cubeMapLoaders[ i ].ImageLoader( cubeMapName.c_str(), pic, &width, &height, &numLayers, &numMips, &bits, 0 );
 			if( numLayers == 6 && pic[0] ) {
 				numPicsToFree = 1;
 				goto createCubeImage;

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1663,6 +1663,11 @@ int R_FindImageLoader( char *baseName, const char **prefix ) {
 	return bestLoader;
 }
 
+int R_FindImageLoader( char *baseName ) {
+	const char *prefix; // not used but required by R_FindImageLoader
+	return R_FindImageLoader( baseName, &prefix );
+}
+
 /*
 =================
 R_LoadImage

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1658,7 +1658,7 @@ static int R_FindImageLoader( const char *baseName, const char **prefix ) {
 	return bestLoader;
 }
 
-static int R_FindImageLoader( const char *baseName ) {
+int R_FindImageLoader( const char *baseName ) {
 	// not used but required by R_FindImageLoader
 	const char *prefix;
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3150,6 +3150,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	void    R_InitImages();
 	void    R_ShutdownImages();
 
+	int R_FindImageLoader( const char *baseName );
 	image_t *R_FindImageFile( const char *name, int bits, filterType_t filterType, wrapType_t wrapType );
 	image_t *R_FindCubeImage( const char *name, int bits, filterType_t filterType, wrapType_t wrapType );
 


### PR DESCRIPTION
This is to avoid those boring, false-positive debug messages:

```
Debug: Failed to open 'env/shared_vega_src/sky' for reading: No such file or directory
Debug: Failed to open 'env/shared_vega_src/sky' for reading: No such file or directory
```

Note that the `R_FindImageLoader` code (first two commits) is the one I first pushed in #159.
If first worked on `R_FindImageLoader` for the need of the removal of this debug message, but working on Xonotic stuff was more exciting. :stuck_out_tongue: 

This is better to merge this first, as the image commits will be together, and then the dpMaterial PR would just be 1 commit.