### PR TITLE
revamp cubemap code and fix quake3 skybox with small bottom face, fix #142

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1959,6 +1959,30 @@ static void R_Rotate( byte *in, int width, int height, int degrees )
 }
 
 /*
+========
+R_Resize
+
+wrapper for ResampleTexture to help to resize a texture in place like this:
+pic = R_Resize( pic, width, height, newWidth, newHeight );
+
+please not resize normalmap with this, use ResampleTexture directly instead
+
+========
+*/
+
+byte *R_Resize( byte *in, int width, int height, int newWidth, int newHeight )
+{
+
+	byte *out;
+
+	out = (byte*) ri.Z_Malloc( newWidth * newHeight * 4 );
+	ResampleTexture( (unsigned int*) in, width, height, (unsigned int*) out, newWidth, newHeight, false );
+	ri.Free( in );
+
+	return out;
+}
+
+/*
 ===============
 R_FindCubeImage
 


### PR DESCRIPTION
## Skybox code revamp

The skybox code was very ugly with 10 gotos and buggy behavior, for example it would not attempt to load any multifile skybox if a single-file skybox was successfully loaded but had invalid content.

Also, the code was inefficient, for example it was doing the image rotation operation for every face even if the rotation has an angle of 0°, hence allocating a new image, copying all the pixels in the new image et. for nothing.

## Irregular skybox fixing

Some quake3 skyboxes were shipped with a smaller bottom face, for example a `16×16` bottom face while other faces were `512×512` that was probably a trick to save file size when textures were stored losslessly in a tga and bandwith was low as voice modems.

To fix this, a new `R_Resize` function is added to `tr_image.cpp` that is just a wrapper to `ResampleTexture` that makes in-place resizing easier.

The faces are resized to the size of a square that has for width and height the greater width and height found in any face. This way it would not only fix the quake3 skyboxes with smaller bottom faces, but also non-square skyboxes.

A warning is displayed so the user is encouraged to fix the skybox because 1. we workaround something that is broken, 2. user may is likely to have access to tools with resize algorithms that produce better looking results.

In any way, those kind of small bottom faces were likely to not be seen, that's also why they were downscaled at first.

