### PR TITLE
ParseStage: do not overwrite alpha channel with rgbGen const, fix #120

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -2081,7 +2081,9 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 				vec3_t color;
 
 				ParseVector( text, 3, color );
-				stage->constantColor = Color::Adapt( color );
+				stage->constantColor.SetRed( 255 * color[0] );
+				stage->constantColor.SetGreen( 255 * color[1] );
+				stage->constantColor.SetBlue( 255 * color[2] );
 
 				stage->rgbGen = colorGen_t::CGEN_CONST;
 			}


### PR DESCRIPTION
I hope that it does the same thing the `ColorAdaptor` line did but without modifying alpha channel:

https://github.com/DaemonEngine/Daemon/blob/714566b0db058094eb86090420d3c31b955f929a/src/common/Color.h#L126-L128

[![fixedbug](https://dl.illwieckz.net/b/unvanquished/bugs/maps/station15/waterbug/unvanquished_2019-03-10_233447_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/maps/station15/waterbug/unvanquished_2019-03-10_233447_000.jpg)

[![fixedbug](https://dl.illwieckz.net/b/unvanquished/bugs/maps/station15/waterbug/unvanquished_2019-03-10_235500_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/maps/station15/waterbug/unvanquished_2019-03-10_235500_000.jpg)

[![fixedbug](https://dl.illwieckz.net/b/unvanquished/bugs/maps/station15/waterbug/unvanquished_2019-03-10_235509_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/maps/station15/waterbug/unvanquished_2019-03-10_235509_000.jpg)

[![fixedbug](https://dl.illwieckz.net/b/unvanquished/bugs/maps/station15/waterbug/unvanquished_2019-03-10_235528_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/maps/station15/waterbug/unvanquished_2019-03-10_235528_000.jpg)

Note that I also tested the alternative to edit the `Color.h` code to not reset alpha channel instead and it visually looks the same:

[![fixedbug](https://dl.illwieckz.net/b/unvanquished/bugs/maps/station15/waterbug/unvanquished_2019-03-11_000935_000.jpg)](https://dl.illwieckz.net/b/unvanquished/bugs/maps/station15/waterbug/unvanquished_2019-03-11_000935_000.jpg)

So this must fix #120.