### PR TITLE
tr_shader: revamp the stage collapse code

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1043,13 +1043,9 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	  ST_HEATHAZEMAP, // heatHaze post process effect
 	  ST_LIQUIDMAP,
 	  ST_LIGHTMAP,
-	  ST_COLLAPSE_lighting_DB, // diffusemap + bumpmap
-	  ST_COLLAPSE_lighting_DBG, // diffusemap + bumpmap + glowmap
-	  ST_COLLAPSE_lighting_DBS, // diffusemap + bumpmap + specularmap
-	  ST_COLLAPSE_lighting_DBSG, // diffusemap + bumpmap + specularmap + glowmap
-	  ST_COLLAPSE_lighting_DBM, // diffusemap + bumpmap + materialmap
-	  ST_COLLAPSE_lighting_DBMG, // diffusemap + bumpmap + materialmap + glowmap
-	  ST_COLLAPSE_reflection_CB, // color cubemap + bumpmap
+	  ST_COLLAPSE_lighting_PHONG, // diffusemap + opt:normalmap + opt:glowmap + opt:specularmap
+	  ST_COLLAPSE_lighting_PBR,   // diffusemap + opt:normalmap + opt:glowmap + materialmap
+	  ST_COLLAPSE_reflection_CB,  // color cubemap + normalmap
 
 	  // light shader stage types
 	  ST_ATTENUATIONMAP_XY,
@@ -1060,12 +1056,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	{
 	  COLLAPSE_none,
 	  COLLAPSE_genericMulti,
-	  COLLAPSE_lighting_DB,
-	  COLLAPSE_lighting_DBG,
-	  COLLAPSE_lighting_DBS,
-	  COLLAPSE_lighting_DBSG,
-	  COLLAPSE_lighting_DBM,
-	  COLLAPSE_lighting_DBMG,
+	  COLLAPSE_lighting_PHONG,
+	  COLLAPSE_lighting_PBR,
 	  COLLAPSE_reflection_CB,
 	  COLLAPSE_color_lightmap
 	};
@@ -1229,7 +1221,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		float          portalRange; // distance to fog out at
 		bool       isPortal;
 
-		collapseType_t collapseType;
+		collapseType_t lightingCollapseType;
+		collapseType_t reflectCollapseType;
 		int            collapseTextureEnv; // 0, GL_MODULATE, GL_ADD (FIXME: put in stage)
 
 		cullType_t     cullType; // CT_FRONT_SIDED, CT_BACK_SIDED, or CT_TWO_SIDED

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1088,6 +1088,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		bool        tcGen_Environment;
 		bool        tcGen_Lightmap;
 
+		bool            disableImplicitLightmap;
+
 		Color::Color32Bit constantColor; // for CGEN_CONST and AGEN_CONST
 
 		uint32_t        stateBits; // GLS_xxxx mask

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1262,6 +1262,14 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 		GL_BindToTMU( 4, tr.blackImage );
 	}
 
+	// do not paintover lightmap
+	// as a standalone lightmap stage
+	// will do later
+	if ( pStage->disableImplicitLightmap )
+	{
+		whiteLight = true;
+	}
+
 	// bind u_LightMap
 	BindLightMap( 3, whiteLight );
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -700,9 +700,8 @@ static void Render_generic( int stage )
 }
 
 static bool hasMaterialMapping( shader_t *shader ) {
-  switch( shader->collapseType ) {
-  case collapseType_t::COLLAPSE_lighting_DBM:
-  case collapseType_t::COLLAPSE_lighting_DBMG:
+  switch( shader->lightingCollapseType ) {
+  case collapseType_t::COLLAPSE_lighting_PBR:
     return true;
   default:
     return false;
@@ -2807,12 +2806,8 @@ void Tess_StageIteratorGeneric()
 				}
 
 			case stageType_t::ST_DIFFUSEMAP:
-			case stageType_t::ST_COLLAPSE_lighting_DBSG:
-			case stageType_t::ST_COLLAPSE_lighting_DBG:
-			case stageType_t::ST_COLLAPSE_lighting_DB:
-			case stageType_t::ST_COLLAPSE_lighting_DBS:
-			case stageType_t::ST_COLLAPSE_lighting_DBM:
-			case stageType_t::ST_COLLAPSE_lighting_DBMG:
+			case stageType_t::ST_COLLAPSE_lighting_PHONG:
+			case stageType_t::ST_COLLAPSE_lighting_PBR:
 				{
 					{
 						if ( r_precomputedLighting->integer || r_vertexLighting->integer )
@@ -2997,10 +2992,7 @@ void Tess_StageIteratorDepthFill()
 				}
 
 			case stageType_t::ST_DIFFUSEMAP:
-			case stageType_t::ST_COLLAPSE_lighting_DBSG:
-			case stageType_t::ST_COLLAPSE_lighting_DBG:
-			case stageType_t::ST_COLLAPSE_lighting_DB:
-			case stageType_t::ST_COLLAPSE_lighting_DBS:
+			case stageType_t::ST_COLLAPSE_lighting_PHONG:
 				{
 					Render_depthFill( stage );
 					break;
@@ -3080,10 +3072,7 @@ void Tess_StageIteratorShadowFill()
 
 			case stageType_t::ST_LIGHTMAP:
 			case stageType_t::ST_DIFFUSEMAP:
-			case stageType_t::ST_COLLAPSE_lighting_DBSG:
-			case stageType_t::ST_COLLAPSE_lighting_DBG:
-			case stageType_t::ST_COLLAPSE_lighting_DB:
-			case stageType_t::ST_COLLAPSE_lighting_DBS:
+			case stageType_t::ST_COLLAPSE_lighting_PHONG:
 				{
 					Render_shadowFill( stage );
 					break;
@@ -3198,8 +3187,7 @@ void Tess_StageIteratorLighting()
 			switch ( diffuseStage->type )
 			{
 				case stageType_t::ST_DIFFUSEMAP:
-				case stageType_t::ST_COLLAPSE_lighting_DB:
-				case stageType_t::ST_COLLAPSE_lighting_DBS:
+				case stageType_t::ST_COLLAPSE_lighting_PHONG:
 					if ( light->l.rlType == refLightType_t::RL_OMNI )
 					{
 						Render_forwardLighting_DBS_omni( diffuseStage, attenuationXYStage, attenuationZStage, light );

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4154,6 +4154,7 @@ static void CollapseStages()
 	int specularStage = -1;
 	int materialStage = -1;
 	int reflectionStage = -1;
+	int lightStage = -1;
 	int glowStage = -1;
 
 	for ( int i = 0; i < MAX_SHADER_STAGES; i++ )
@@ -4213,6 +4214,17 @@ static void CollapseStages()
 				reflectionStage = i;
 			}
 		}
+		else if ( stages[ i ].type == stageType_t::ST_LIGHTMAP )
+		{
+			if ( lightStage != -1 )
+			{
+				Log::Warn( "more than one light map stage in shader '%s'", shader.name );
+			}
+			else
+			{
+				lightStage = i;
+			}
+		}
 		else if ( stages[ i ].type == stageType_t::ST_GLOWMAP )
 		{
 			if ( glowStage != -1 )
@@ -4249,6 +4261,7 @@ static void CollapseStages()
 		&& ( specularStage != -1
 			|| normalStage != -1
 			|| materialStage != -1
+			|| lightStage != -1
 			|| glowStage != -1 ) )
 	{
 		// note that if uncollapsed diffuseStage had to be merged in another stage
@@ -4295,6 +4308,12 @@ static void CollapseStages()
 				stages[ diffuseStage ].bundle[ TB_MATERIALMAP ] = stages[ materialStage ].bundle[ 0 ];
 				// disable since it's merged
 				stages[ materialStage ].active = false;
+			}
+			if ( lightStage != -1 )
+			{
+				// TODO: investigate how to pass rgbGen/alphaGen to implicit lightmap stage
+				// disable to not paint it over implicit lightmap stage and glow map
+				stages[ lightStage ].active = false;
 			}
 			if ( glowStage != -1 )
 			{


### PR DESCRIPTION
- improve readability
- reduce cpu complexity
- make it extendable
- fix bug when surface with reflectionmap is not normalmapped
- fix lightmap being applied twice and glow map being lightmapped (note: lightmap alphaGen blend not yet supported)
- reduce the lighting stage type count to two: Phong (any combination including diffuse and something that is not material, including specular) and PBR (any combination including diffuse and material)
- fix the bug when a reflection type is applied to shader lighting type