### PR TITLE
gl_shader: clean-up some useless macro boilerplate

### DIFF
--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -811,24 +811,19 @@ public:
 		return 0;
 	}
 
-	void EnableMacro()
+	void SetMacro( bool enable )
 	{
 		int bit = GetBit();
 
-		if ( !_shader->IsMacroSet( bit ) )
+		if ( enable && !_shader->IsMacroSet( bit ) )
 		{
 			_shader->AddMacroBit( bit );
 		}
-	}
-
-	void DisableMacro()
-	{
-		int bit = GetBit();
-
-		if ( _shader->IsMacroSet( bit ) )
+		else if ( !enable && _shader->IsMacroSet( bit ) )
 		{
 			_shader->DelMacroBit( bit );
 		}
+		// else do nothing because already enabled/disabled
 	}
 
 public:
@@ -867,26 +862,9 @@ public:
 		return ATTR_BONE_FACTORS;
 	}
 
-	void EnableVertexSkinning()
-	{
-		EnableMacro();
-	}
-
-	void DisableVertexSkinning()
-	{
-		DisableMacro();
-	}
-
 	void SetVertexSkinning( bool enable )
 	{
-		if ( enable )
-		{
-			EnableVertexSkinning();
-		}
-		else
-		{
-			DisableVertexSkinning();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -912,26 +890,9 @@ public:
 	bool     HasConflictingMacros( size_t permutation, const std::vector< GLCompileMacro * > &macros ) const;
 	uint32_t GetRequiredVertexAttributes() const;
 
-	void EnableVertexAnimation()
-	{
-		EnableMacro();
-	}
-
-	void DisableVertexAnimation()
-	{
-		DisableMacro();
-	}
-
 	void SetVertexAnimation( bool enable )
 	{
-		if ( enable )
-		{
-			EnableVertexAnimation();
-		}
-		else
-		{
-			DisableVertexAnimation();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -959,26 +920,9 @@ public:
 		return ATTR_QTANGENT;
 	}
 
-	void EnableVertexSprite()
-	{
-		EnableMacro();
-	}
-
-	void DisableVertexSprite()
-	{
-		DisableMacro();
-	}
-
 	void SetVertexSprite( bool enable )
 	{
-		if ( enable )
-		{
-			EnableVertexSprite();
-		}
-		else
-		{
-			DisableVertexSprite();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -1007,26 +951,9 @@ public:
 		return ATTR_QTANGENT;
 	}
 
-	void EnableTCGenEnvironment()
-	{
-		EnableMacro();
-	}
-
-	void DisableTCGenEnvironment()
-	{
-		DisableMacro();
-	}
-
 	void SetTCGenEnvironment( bool enable )
 	{
-		if ( enable )
-		{
-			EnableMacro();
-		}
-		else
-		{
-			DisableMacro();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -1050,26 +977,9 @@ public:
 		return EGLCompileMacro::USE_TCGEN_LIGHTMAP;
 	}
 
-	void EnableTCGenLightmap()
-	{
-		EnableMacro();
-	}
-
-	void DisableTCGenLightmap()
-	{
-		DisableMacro();
-	}
-
 	void SetTCGenLightmap( bool enable )
 	{
-		if ( enable )
-		{
-			EnableMacro();
-		}
-		else
-		{
-			DisableMacro();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -1092,26 +1002,9 @@ public:
 		return EGLCompileMacro::USE_PARALLAX_MAPPING;
 	}
 
-	void EnableParallaxMapping()
-	{
-		EnableMacro();
-	}
-
-	void DisableParallaxMapping()
-	{
-		DisableMacro();
-	}
-
 	void SetParallaxMapping( bool enable )
 	{
-		if ( enable )
-		{
-			EnableMacro();
-		}
-		else
-		{
-			DisableMacro();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -1134,26 +1027,9 @@ public:
 		return EGLCompileMacro::USE_REFLECTIVE_SPECULAR;
 	}
 
-	void EnableReflectiveSpecular()
-	{
-		EnableMacro();
-	}
-
-	void DisableReflectiveSpecular()
-	{
-		DisableMacro();
-	}
-
 	void SetReflectiveSpecular( bool enable )
 	{
-		if ( enable )
-		{
-			EnableMacro();
-		}
-		else
-		{
-			DisableMacro();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -1176,26 +1052,9 @@ public:
 		return EGLCompileMacro::LIGHT_DIRECTIONAL;
 	}
 
-	void EnableMacro_LIGHT_DIRECTIONAL()
-	{
-		EnableMacro();
-	}
-
-	void DisableMacro_LIGHT_DIRECTIONAL()
-	{
-		DisableMacro();
-	}
-
 	void SetMacro_LIGHT_DIRECTIONAL( bool enable )
 	{
-		if ( enable )
-		{
-			EnableMacro();
-		}
-		else
-		{
-			DisableMacro();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -1218,26 +1077,9 @@ public:
 		return EGLCompileMacro::USE_SHADOWING;
 	}
 
-	void EnableShadowing()
-	{
-		EnableMacro();
-	}
-
-	void DisableShadowing()
-	{
-		DisableMacro();
-	}
-
 	void SetShadowing( bool enable )
 	{
-		if ( enable )
-		{
-			EnableMacro();
-		}
-		else
-		{
-			DisableMacro();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -1261,26 +1103,9 @@ public:
 		return EGLCompileMacro::USE_DEPTH_FADE;
 	}
 
-	void EnableDepthFade()
-	{
-		EnableMacro();
-	}
-
-	void DisableDepthFade()
-	{
-		DisableMacro();
-	}
-
 	void SetDepthFade( bool enable )
 	{
-		if ( enable )
-		{
-			EnableMacro();
-		}
-		else
-		{
-			DisableMacro();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -1303,26 +1128,9 @@ public:
 		return USE_PHYSICAL_SHADING;
 	}
 
-	void EnableMacro_USE_PHYSICAL_SHADING()
-	{
-		EnableMacro();
-	}
-
-	void DisableMacro_USE_PHYSICAL_SHADING()
-	{
-		DisableMacro();
-	}
-
 	void SetPhysicalShading( bool enable )
 	{
-		if ( enable )
-		{
-			EnableMacro();
-		}
-		else
-		{
-			DisableMacro();
-		}
+		SetMacro( enable );
 	}
 };
 
@@ -1345,26 +1153,9 @@ public:
 		return USE_ALPHA_TESTING;
 	}
 
-	void EnableAlphaTesting()
-	{
-		EnableMacro();
-	}
-
-	void DisableAlphaTesting()
-	{
-		DisableMacro();
-	}
-
 	void SetAlphaTesting(bool enable)
 	{
-		if (enable)
-		{
-			EnableMacro();
-		}
-		else
-		{
-			DisableMacro();
-		}
+		SetMacro( enable );
 	}
 };
 

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1850,13 +1850,13 @@ static void RB_SetupLightForLighting( trRefLight_t *light )
 
 							GL_PushMatrix();
 
-							gl_genericShader->DisableVertexSkinning();
-							gl_genericShader->DisableVertexAnimation();
-							gl_genericShader->DisableTCGenEnvironment();
-							gl_genericShader->DisableVertexSprite();
-							gl_genericShader->DisableTCGenLightmap();
-							gl_genericShader->DisableDepthFade();
-							gl_genericShader->DisableAlphaTesting();
+							gl_genericShader->SetVertexSkinning( false );
+							gl_genericShader->SetVertexAnimation( false );
+							gl_genericShader->SetTCGenEnvironment( false );
+							gl_genericShader->SetVertexSprite( false );
+							gl_genericShader->SetTCGenLightmap( false );
+							gl_genericShader->SetDepthFade( false );
+							gl_genericShader->SetAlphaTesting( false );
 							gl_genericShader->BindProgram( 0 );
 
 							// set uniforms
@@ -2718,13 +2718,13 @@ void RB_RunVisTests( )
 		Tess_UpdateVBOs( );
 		GL_VertexAttribsState( ATTR_POSITION );
 
-		gl_genericShader->DisableVertexSkinning();
-		gl_genericShader->DisableVertexAnimation();
-		gl_genericShader->DisableVertexSprite();
-		gl_genericShader->DisableTCGenEnvironment();
-		gl_genericShader->DisableTCGenLightmap();
-		gl_genericShader->DisableDepthFade();
-		gl_genericShader->DisableAlphaTesting();
+		gl_genericShader->SetVertexSkinning( false );
+		gl_genericShader->SetVertexAnimation( false );
+		gl_genericShader->SetVertexSprite( false );
+		gl_genericShader->SetTCGenEnvironment( false );
+		gl_genericShader->SetTCGenLightmap( false );
+		gl_genericShader->SetDepthFade( false );
+		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
@@ -3245,13 +3245,13 @@ static void RB_RenderDebugUtils()
 		static const vec3_t minSize = { -2, -2, -2 };
 		static const vec3_t maxSize = { 2,  2,  2 };
 
-		gl_genericShader->DisableVertexSkinning();
-		gl_genericShader->DisableVertexAnimation();
-		gl_genericShader->DisableVertexSprite();
-		gl_genericShader->DisableTCGenEnvironment();
-		gl_genericShader->DisableTCGenLightmap();
-		gl_genericShader->DisableDepthFade();
-		gl_genericShader->DisableAlphaTesting();
+		gl_genericShader->SetVertexSkinning( false );
+		gl_genericShader->SetVertexAnimation( false );
+		gl_genericShader->SetVertexSprite( false );
+		gl_genericShader->SetTCGenEnvironment( false );
+		gl_genericShader->SetTCGenLightmap( false );
+		gl_genericShader->SetDepthFade( false );
+		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
@@ -3406,13 +3406,13 @@ static void RB_RenderDebugUtils()
 		static const vec3_t mins = { -1, -1, -1 };
 		static const vec3_t maxs = { 1, 1, 1 };
 
-		gl_genericShader->DisableVertexSkinning();
-		gl_genericShader->DisableVertexAnimation();
-		gl_genericShader->DisableVertexSprite();
-		gl_genericShader->DisableTCGenEnvironment();
-		gl_genericShader->DisableTCGenLightmap();
-		gl_genericShader->DisableDepthFade();
-		gl_genericShader->DisableAlphaTesting();
+		gl_genericShader->SetVertexSkinning( false );
+		gl_genericShader->SetVertexAnimation( false );
+		gl_genericShader->SetVertexSprite( false );
+		gl_genericShader->SetTCGenEnvironment( false );
+		gl_genericShader->SetTCGenLightmap( false );
+		gl_genericShader->SetDepthFade( false );
+		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
@@ -3531,13 +3531,13 @@ static void RB_RenderDebugUtils()
 		static const vec3_t mins = { -1, -1, -1 };
 		static const vec3_t maxs = { 1, 1, 1 };
 
-		gl_genericShader->DisableVertexSkinning();
-		gl_genericShader->DisableVertexAnimation();
-		gl_genericShader->DisableVertexSprite();
-		gl_genericShader->DisableTCGenEnvironment();
-		gl_genericShader->DisableTCGenLightmap();
-		gl_genericShader->DisableDepthFade();
-		gl_genericShader->DisableAlphaTesting();
+		gl_genericShader->SetVertexSkinning( false );
+		gl_genericShader->SetVertexAnimation( false );
+		gl_genericShader->SetVertexSprite( false );
+		gl_genericShader->SetTCGenEnvironment( false );
+		gl_genericShader->SetTCGenLightmap( false );
+		gl_genericShader->SetDepthFade( false );
+		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
@@ -3608,13 +3608,13 @@ static void RB_RenderDebugUtils()
 		static refSkeleton_t skeleton;
 		refSkeleton_t        *skel;
 
-		gl_genericShader->DisableVertexSkinning();
-		gl_genericShader->DisableVertexAnimation();
-		gl_genericShader->DisableVertexSprite();
-		gl_genericShader->DisableTCGenEnvironment();
-		gl_genericShader->DisableTCGenLightmap();
-		gl_genericShader->DisableDepthFade();
-		gl_genericShader->DisableAlphaTesting();
+		gl_genericShader->SetVertexSkinning( false );
+		gl_genericShader->SetVertexAnimation( false );
+		gl_genericShader->SetVertexSprite( false );
+		gl_genericShader->SetTCGenEnvironment( false );
+		gl_genericShader->SetTCGenLightmap( false );
+		gl_genericShader->SetDepthFade( false );
+		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_Cull( cullType_t::CT_TWO_SIDED );
@@ -3837,13 +3837,13 @@ static void RB_RenderDebugUtils()
 		matrix_t      ortho;
 		vec4_t        quadVerts[ 4 ];
 
-		gl_genericShader->DisableVertexSkinning();
-		gl_genericShader->DisableVertexAnimation();
-		gl_genericShader->DisableVertexSprite();
-		gl_genericShader->DisableTCGenEnvironment();
-		gl_genericShader->DisableTCGenLightmap();
-		gl_genericShader->DisableDepthFade();
-		gl_genericShader->DisableAlphaTesting();
+		gl_genericShader->SetVertexSkinning( false );
+		gl_genericShader->SetVertexAnimation( false );
+		gl_genericShader->SetVertexSprite( false );
+		gl_genericShader->SetTCGenEnvironment( false );
+		gl_genericShader->SetTCGenLightmap( false );
+		gl_genericShader->SetDepthFade( false );
+		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
@@ -3953,13 +3953,13 @@ static void RB_RenderDebugUtils()
 			cubemapProbe_t *cubeProbeNearest;
 			cubemapProbe_t *cubeProbeSecondNearest;
 
-			gl_genericShader->DisableVertexSkinning();
-			gl_genericShader->DisableVertexAnimation();
-			gl_genericShader->DisableVertexSprite();
-			gl_genericShader->DisableTCGenEnvironment();
-			gl_genericShader->DisableTCGenLightmap();
-			gl_genericShader->DisableDepthFade();
-			gl_genericShader->DisableAlphaTesting();
+			gl_genericShader->SetVertexSkinning( false );
+			gl_genericShader->SetVertexAnimation( false );
+			gl_genericShader->SetVertexSprite( false );
+			gl_genericShader->SetTCGenEnvironment( false );
+			gl_genericShader->SetTCGenLightmap( false );
+			gl_genericShader->SetDepthFade( false );
+			gl_genericShader->SetAlphaTesting( false );
 			gl_genericShader->BindProgram( 0 );
 
 			//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
@@ -4029,13 +4029,13 @@ static void RB_RenderDebugUtils()
 
 		GLimp_LogComment( "--- r_showLightGrid > 0: Rendering light grid\n" );
 
-		gl_genericShader->DisableVertexSkinning();
-		gl_genericShader->DisableVertexAnimation();
-		gl_genericShader->DisableVertexSprite();
-		gl_genericShader->DisableTCGenEnvironment();
-		gl_genericShader->DisableTCGenLightmap();
-		gl_genericShader->DisableDepthFade();
-		gl_genericShader->DisableAlphaTesting();
+		gl_genericShader->SetVertexSkinning( false );
+		gl_genericShader->SetVertexAnimation( false );
+		gl_genericShader->SetVertexSprite( false );
+		gl_genericShader->SetTCGenEnvironment( false );
+		gl_genericShader->SetTCGenLightmap( false );
+		gl_genericShader->SetDepthFade( false );
+		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
@@ -4126,13 +4126,13 @@ static void RB_RenderDebugUtils()
 			return;
 		}
 
-		gl_genericShader->DisableVertexSkinning();
-		gl_genericShader->DisableVertexAnimation();
-		gl_genericShader->DisableVertexSprite();
-		gl_genericShader->DisableTCGenEnvironment();
-		gl_genericShader->DisableTCGenLightmap();
-		gl_genericShader->DisableDepthFade();
-		gl_genericShader->DisableAlphaTesting();
+		gl_genericShader->SetVertexSkinning( false );
+		gl_genericShader->SetVertexAnimation( false );
+		gl_genericShader->SetVertexSprite( false );
+		gl_genericShader->SetTCGenEnvironment( false );
+		gl_genericShader->SetTCGenLightmap( false );
+		gl_genericShader->SetDepthFade( false );
+		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		// set uniforms
@@ -4414,13 +4414,13 @@ static void RB_RenderDebugUtils()
 			return;
 		}
 
-		gl_genericShader->DisableVertexSkinning();
-		gl_genericShader->DisableVertexAnimation();
-		gl_genericShader->DisableVertexSprite();
-		gl_genericShader->DisableTCGenEnvironment();
-		gl_genericShader->DisableTCGenLightmap();
-		gl_genericShader->DisableDepthFade();
-		gl_genericShader->DisableAlphaTesting();
+		gl_genericShader->SetVertexSkinning( false );
+		gl_genericShader->SetVertexAnimation( false );
+		gl_genericShader->SetVertexSprite( false );
+		gl_genericShader->SetTCGenEnvironment( false );
+		gl_genericShader->SetTCGenLightmap( false );
+		gl_genericShader->SetDepthFade( false );
+		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
@@ -4509,13 +4509,13 @@ void DebugDrawBegin( debugDrawMode_t mode, float size ) {
 			break;
 	}
 
-	gl_genericShader->DisableVertexSkinning();
-	gl_genericShader->DisableVertexAnimation();
-	gl_genericShader->DisableVertexSprite();
-	gl_genericShader->DisableTCGenEnvironment();
-	gl_genericShader->DisableTCGenLightmap();
-	gl_genericShader->DisableDepthFade();
-	gl_genericShader->DisableAlphaTesting();
+	gl_genericShader->SetVertexSkinning( false );
+	gl_genericShader->SetVertexAnimation( false );
+	gl_genericShader->SetVertexSprite( false );
+	gl_genericShader->SetTCGenEnvironment( false );
+	gl_genericShader->SetTCGenLightmap( false );
+	gl_genericShader->SetDepthFade( false );
+	gl_genericShader->SetAlphaTesting( false );
 	gl_genericShader->BindProgram( 0 );
 
 	GL_State( GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA );
@@ -4824,13 +4824,13 @@ void RE_StretchRaw( int x, int y, int w, int h, int cols, int rows, const byte *
 	glVertexAttrib4f( ATTR_INDEX_QTANGENT, 0.0f, 0.0f, 0.0f, 1.0f );
 	glVertexAttrib4f( ATTR_INDEX_COLOR, tr.identityLight, tr.identityLight, tr.identityLight, 1 );
 
-	gl_genericShader->DisableVertexSkinning();
-	gl_genericShader->DisableVertexAnimation();
-	gl_genericShader->DisableVertexSprite();
-	gl_genericShader->DisableTCGenEnvironment();
-	gl_genericShader->DisableTCGenLightmap();
-	gl_genericShader->DisableDepthFade();
-	gl_genericShader->DisableAlphaTesting();
+	gl_genericShader->SetVertexSkinning( false );
+	gl_genericShader->SetVertexAnimation( false );
+	gl_genericShader->SetVertexSprite( false );
+	gl_genericShader->SetTCGenEnvironment( false );
+	gl_genericShader->SetTCGenLightmap( false );
+	gl_genericShader->SetDepthFade( false );
+	gl_genericShader->SetAlphaTesting( false );
 	gl_genericShader->BindProgram( 0 );
 
 	// set uniforms
@@ -5740,13 +5740,13 @@ void RB_ShowImages()
 
 	glFinish();
 
-	gl_genericShader->DisableVertexSkinning();
-	gl_genericShader->DisableVertexAnimation();
-	gl_genericShader->DisableVertexSprite();
-	gl_genericShader->DisableTCGenEnvironment();
-	gl_genericShader->DisableTCGenLightmap();
-	gl_genericShader->DisableDepthFade();
-	gl_genericShader->DisableAlphaTesting();
+	gl_genericShader->SetVertexSkinning( false );
+	gl_genericShader->SetVertexAnimation( false );
+	gl_genericShader->SetVertexSprite( false );
+	gl_genericShader->SetTCGenEnvironment( false );
+	gl_genericShader->SetTCGenLightmap( false );
+	gl_genericShader->SetDepthFade( false );
+	gl_genericShader->SetAlphaTesting( false );
 	gl_genericShader->BindProgram( 0 );
 
 	GL_Cull( cullType_t::CT_TWO_SIDED );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -432,10 +432,10 @@ static void DrawTris()
 	gl_genericShader->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
 	gl_genericShader->SetVertexAnimation( tess.vboVertexAnimation );
 	gl_genericShader->SetVertexSprite( tess.vboVertexSprite );
-	gl_genericShader->DisableTCGenEnvironment();
-	gl_genericShader->DisableTCGenLightmap();
-	gl_genericShader->DisableDepthFade();
-	gl_genericShader->DisableAlphaTesting();
+	gl_genericShader->SetTCGenEnvironment( false );
+	gl_genericShader->SetTCGenLightmap( false );
+	gl_genericShader->SetDepthFade( false );
+	gl_genericShader->SetAlphaTesting( false );
 
 	if( tess.surfaceShader->stages[0] ) {
 		deform = tess.surfaceShader->stages[0]->deformIndex;
@@ -1313,8 +1313,8 @@ static void Render_depthFill(int stage)
 	gl_genericShader->SetTCGenEnvironment(pStage->tcGen_Environment);
 	gl_genericShader->SetTCGenLightmap(pStage->tcGen_Lightmap);
 	gl_genericShader->SetAlphaTesting(alphaBits != 0);
-	gl_genericShader->DisableDepthFade();
-	gl_genericShader->DisableVertexSprite();
+	gl_genericShader->SetDepthFade( false );
+	gl_genericShader->SetVertexSprite( false );
 	gl_genericShader->BindProgram(pStage->deformIndex);
 
 	// set uniforms
@@ -2215,10 +2215,10 @@ static void Render_heatHaze( int stage )
 	gl_heatHazeShader->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
 	gl_heatHazeShader->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
 	if( tess.surfaceShader->autoSpriteMode ) {
-		gl_heatHazeShader->EnableVertexSprite();
+		gl_heatHazeShader->SetVertexSprite( true );
 		tess.vboVertexSprite = true;
 	} else {
-		gl_heatHazeShader->DisableVertexSprite();
+		gl_heatHazeShader->SetVertexSprite( false );
 		tess.vboVertexSprite = false;
 	}
 


### PR DESCRIPTION
clean-up some useless macro boilerplate, because it's easier to debug code that has less code