### PR TITLE
WIP: glsl/normal: use ifdef for normal z reconstruction

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1456,12 +1456,12 @@ GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 	u_ModelViewProjectionMatrix( this ),
 	u_ParallaxDepthScale( this ),
 	u_ParallaxOffsetBias( this ),
-	u_HeightMapInNormalMap( this ),
 	u_NormalFormat( this ),
 	u_numLights( this ),
 	u_Lights( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_DELUXE_MAPPING( this ),
+	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_PARALLAX_MAPPING( this ),
 	GLCompileMacro_USE_PHYSICAL_SHADING( this )
 {
@@ -1507,7 +1507,6 @@ GLShader_vertexLighting_DBS_entity::GLShader_vertexLighting_DBS_entity( GLShader
 	u_VertexInterpolation( this ),
 	u_ParallaxDepthScale( this ),
 	u_ParallaxOffsetBias( this ),
-	u_HeightMapInNormalMap( this ),
 	u_NormalFormat( this ),
 	u_EnvironmentInterpolation( this ),
 	u_LightGridOrigin( this ),
@@ -1517,6 +1516,7 @@ GLShader_vertexLighting_DBS_entity::GLShader_vertexLighting_DBS_entity( GLShader
 	GLDeformStage( this ),
 	GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
+	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_PARALLAX_MAPPING( this ),
 	GLCompileMacro_USE_REFLECTIVE_SPECULAR( this ),
 	GLCompileMacro_USE_PHYSICAL_SHADING( this )
@@ -1568,7 +1568,6 @@ GLShader_vertexLighting_DBS_world::GLShader_vertexLighting_DBS_world( GLShaderMa
 	u_ModelViewProjectionMatrix( this ),
 	u_ParallaxDepthScale( this ),
 	u_ParallaxOffsetBias( this ),
-	u_HeightMapInNormalMap( this ),
 	u_NormalFormat( this ),
 	u_LightWrapAround( this ),
 	u_LightGridOrigin( this ),
@@ -1576,6 +1575,7 @@ GLShader_vertexLighting_DBS_world::GLShader_vertexLighting_DBS_world( GLShaderMa
 	u_numLights( this ),
 	u_Lights( this ),
 	GLDeformStage( this ),
+	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_PARALLAX_MAPPING( this ),
 	GLCompileMacro_USE_PHYSICAL_SHADING( this )
 {
@@ -1630,11 +1630,11 @@ GLShader_forwardLighting_omniXYZ::GLShader_forwardLighting_omniXYZ( GLShaderMana
 	u_VertexInterpolation( this ),
 	u_ParallaxDepthScale( this ),
 	u_ParallaxOffsetBias( this ),
-	u_HeightMapInNormalMap( this ),
 	u_NormalFormat( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
+	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_PARALLAX_MAPPING( this ),
 	GLCompileMacro_USE_SHADOWING( this )
 {
@@ -1689,11 +1689,11 @@ GLShader_forwardLighting_projXYZ::GLShader_forwardLighting_projXYZ( GLShaderMana
 	u_VertexInterpolation( this ),
 	u_ParallaxDepthScale( this ),
 	u_ParallaxOffsetBias( this ),
-	u_HeightMapInNormalMap( this ),
 	u_NormalFormat( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
+	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_PARALLAX_MAPPING( this ),
 	GLCompileMacro_USE_SHADOWING( this )
 {
@@ -1751,11 +1751,11 @@ GLShader_forwardLighting_directionalSun::GLShader_forwardLighting_directionalSun
 	u_VertexInterpolation( this ),
 	u_ParallaxDepthScale( this ),
 	u_ParallaxOffsetBias( this ),
-	u_HeightMapInNormalMap( this ),
 	u_NormalFormat( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
+	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_PARALLAX_MAPPING( this ),
 	GLCompileMacro_USE_SHADOWING( this )
 {
@@ -1833,13 +1833,13 @@ GLShader_reflection::GLShader_reflection( GLShaderManager *manager ):
 	u_Bones( this ),
 	u_ParallaxDepthScale( this ),
 	u_ParallaxOffsetBias( this ),
-	u_HeightMapInNormalMap( this ),
 	u_NormalScale( this ),
 	u_NormalFormat( this ),
 	u_VertexInterpolation( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
+	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_PARALLAX_MAPPING( this )
 {
 }
@@ -2099,7 +2099,6 @@ GLShader_liquid::GLShader_liquid( GLShaderManager *manager ) :
 	u_FresnelBias( this ),
 	u_ParallaxDepthScale( this ),
 	u_ParallaxOffsetBias( this ),
-	u_HeightMapInNormalMap( this ),
 	u_NormalScale( this ),
 	u_NormalFormat( this ),
 	u_FogDensity( this ),
@@ -2107,6 +2106,7 @@ GLShader_liquid::GLShader_liquid( GLShaderManager *manager ) :
 	u_SpecularExponent( this ),
 	u_LightGridOrigin( this ),
 	u_LightGridScale( this ),
+	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_PARALLAX_MAPPING( this )
 {
 }

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -784,6 +784,7 @@ protected:
 	  USE_TCGEN_ENVIRONMENT,
 	  USE_TCGEN_LIGHTMAP,
 	  USE_DELUXE_MAPPING,
+	  USE_HEIGHTMAP_IN_NORMALMAP,
 	  USE_PARALLAX_MAPPING,
 	  USE_REFLECTIVE_SPECULAR,
 	  USE_SHADOWING,
@@ -1004,6 +1005,31 @@ public:
 	}
 
 	void SetDeluxeMapping( bool enable )
+	{
+		SetMacro( enable );
+	}
+};
+
+class GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP :
+	GLCompileMacro
+{
+public:
+	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( GLShader *shader ) :
+		GLCompileMacro( shader )
+	{
+	}
+
+	const char *GetName() const
+	{
+		return "USE_HEIGHTMAP_IN_NORMALMAP";
+	}
+
+	EGLCompileMacro GetType() const
+	{
+		return EGLCompileMacro::USE_HEIGHTMAP_IN_NORMALMAP;
+	}
+
+	void SetHeightMapInNormalMap( bool enable )
 	{
 		SetMacro( enable );
 	}
@@ -1779,21 +1805,6 @@ public:
 	}
 };
 
-class u_HeightMapInNormalMap :
-	GLUniform1i
-{
-public:
-	u_HeightMapInNormalMap( GLShader *shader ) :
-		GLUniform1i( shader, "u_HeightMapInNormalMap" )
-	{
-	}
-
-	void SetUniform_HeightMapInNormalMap( int value )
-	{
-		this->SetValue( value );
-	}
-};
-
 class u_EnvironmentInterpolation :
 	GLUniform1f
 {
@@ -2159,12 +2170,12 @@ class GLShader_lightMapping :
 	public u_ModelViewProjectionMatrix,
 	public u_ParallaxDepthScale,
 	public u_ParallaxOffsetBias,
-	public u_HeightMapInNormalMap,
 	public u_NormalFormat,
 	public u_numLights,
 	public u_Lights,
 	public GLDeformStage,
 	public GLCompileMacro_USE_DELUXE_MAPPING,
+	public GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP,
 	public GLCompileMacro_USE_PARALLAX_MAPPING,
 	public GLCompileMacro_USE_PHYSICAL_SHADING
 {
@@ -2188,7 +2199,6 @@ class GLShader_vertexLighting_DBS_entity :
 	public u_VertexInterpolation,
 	public u_ParallaxDepthScale,
 	public u_ParallaxOffsetBias,
-	public u_HeightMapInNormalMap,
 	public u_NormalFormat,
 	public u_EnvironmentInterpolation,
 	public u_LightGridOrigin,
@@ -2198,6 +2208,7 @@ class GLShader_vertexLighting_DBS_entity :
 	public GLDeformStage,
 	public GLCompileMacro_USE_VERTEX_SKINNING,
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
+	public GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP,
 	public GLCompileMacro_USE_PARALLAX_MAPPING,
 	public GLCompileMacro_USE_REFLECTIVE_SPECULAR,
 	public GLCompileMacro_USE_PHYSICAL_SHADING
@@ -2222,7 +2233,6 @@ class GLShader_vertexLighting_DBS_world :
 	public u_ModelViewProjectionMatrix,
 	public u_ParallaxDepthScale,
 	public u_ParallaxOffsetBias,
-	public u_HeightMapInNormalMap,
 	public u_NormalFormat,
 	public u_LightWrapAround,
 	public u_LightGridOrigin,
@@ -2230,6 +2240,7 @@ class GLShader_vertexLighting_DBS_world :
 	public u_numLights,
 	public u_Lights,
 	public GLDeformStage,
+	public GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP,
 	public GLCompileMacro_USE_PARALLAX_MAPPING,
 	public GLCompileMacro_USE_PHYSICAL_SHADING
 {
@@ -2263,11 +2274,11 @@ class GLShader_forwardLighting_omniXYZ :
 	public u_VertexInterpolation,
 	public u_ParallaxDepthScale,
 	public u_ParallaxOffsetBias,
-	public u_HeightMapInNormalMap,
 	public u_NormalFormat,
 	public GLDeformStage,
 	public GLCompileMacro_USE_VERTEX_SKINNING,
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
+	public GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP,
 	public GLCompileMacro_USE_PARALLAX_MAPPING,
 	public GLCompileMacro_USE_SHADOWING //,
 {
@@ -2302,11 +2313,11 @@ class GLShader_forwardLighting_projXYZ :
 	public u_VertexInterpolation,
 	public u_ParallaxDepthScale,
 	public u_ParallaxOffsetBias,
-	public u_HeightMapInNormalMap,
 	public u_NormalFormat,
 	public GLDeformStage,
 	public GLCompileMacro_USE_VERTEX_SKINNING,
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
+	public GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP,
 	public GLCompileMacro_USE_PARALLAX_MAPPING,
 	public GLCompileMacro_USE_SHADOWING //,
 {
@@ -2343,11 +2354,11 @@ class GLShader_forwardLighting_directionalSun :
 	public u_VertexInterpolation,
 	public u_ParallaxDepthScale,
 	public u_ParallaxOffsetBias,
-	public u_HeightMapInNormalMap,
 	public u_NormalFormat,
 	public GLDeformStage,
 	public GLCompileMacro_USE_VERTEX_SKINNING,
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
+	public GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP,
 	public GLCompileMacro_USE_PARALLAX_MAPPING,
 	public GLCompileMacro_USE_SHADOWING //,
 {
@@ -2391,13 +2402,13 @@ class GLShader_reflection :
 	public u_Bones,
 	public u_ParallaxDepthScale,
 	public u_ParallaxOffsetBias,
-	public u_HeightMapInNormalMap,
 	public u_NormalScale,
 	public u_NormalFormat,
 	public u_VertexInterpolation,
 	public GLDeformStage,
 	public GLCompileMacro_USE_VERTEX_SKINNING,
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
+	public GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP,
 	public GLCompileMacro_USE_PARALLAX_MAPPING
 {
 public:
@@ -2598,7 +2609,6 @@ class GLShader_liquid :
 	public u_FresnelBias,
 	public u_ParallaxDepthScale,
 	public u_ParallaxOffsetBias,
-	public u_HeightMapInNormalMap,
 	public u_NormalScale,
 	public u_NormalFormat,
 	public u_FogDensity,
@@ -2606,6 +2616,7 @@ class GLShader_liquid :
 	public u_SpecularExponent,
 	public u_LightGridOrigin,
 	public u_LightGridScale,
+	public GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP,
 	public GLCompileMacro_USE_PARALLAX_MAPPING
 {
 public:

--- a/src/engine/renderer/glsl_source/reliefMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/reliefMapping_fp.glsl
@@ -63,27 +63,24 @@ vec3 NormalInTangentSpace(vec2 texNormal)
 	vec3 normal;
 
 #if defined(r_normalMapping)
-	if (u_HeightMapInNormalMap == 0)
-	{
-		// the Capcom trick abusing alpha channel of DXT1/5 formats to encode normal map
-		// https://github.com/DaemonEngine/Daemon/issues/183#issuecomment-473691252
-		//
-		// the algorithm also works with normal maps in rgb format without alpha channel
-		// but we still must be sure there is no height map in alpha channel hence the test
-		//
-		// crunch -dxn seems to produce such files, since alpha channel is abused such format
-		// is unsuitable to embed height map, then height map must be distributed as loose file
-		normal = texture2D(u_NormalMap, texNormal).rga;
-		normal.x *= normal.z;
-		normal.xy = 2.0 * normal.xy - 1.0;
-		normal.z = sqrt(1.0 - dot(normal.xy, normal.xy));
-	}
-	else
-	{
-		// alpha channel contains the height map so do not try to restore the normal map from it
-		normal = texture2D(u_NormalMap, texNormal).rgb;
-		normal = 2.0 * normal - 1.0;
-	}
+#if defined(USE_HEIGHTMAP_IN_NORMALMAP)
+	// alpha channel contains the height map so do not try to restore the normal map from it
+	normal = texture2D(u_NormalMap, texNormal).rgb;
+	normal = 2.0 * normal - 1.0;
+#else // !HEIGHTMAP_IN_NORMALMAP
+	// the Capcom trick abusing alpha channel of DXT1/5 formats to encode normal map
+	// https://github.com/DaemonEngine/Daemon/issues/183#issuecomment-473691252
+	//
+	// the algorithm also works with normal maps in rgb format without alpha channel
+	// but we still must be sure there is no height map in alpha channel hence the test
+	//
+	// crunch -dxn seems to produce such files, since alpha channel is abused such format
+	// is unsuitable to embed height map, then height map must be distributed as loose file
+	normal = texture2D(u_NormalMap, texNormal).rga;
+	normal.x *= normal.z;
+	normal.xy = 2.0 * normal.xy - 1.0;
+	normal.z = sqrt(1.0 - dot(normal.xy, normal.xy));
+#endif // HEIGHTMAP_IN_NORMALMAP
 
 	normal = normalFlip(normal);
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -737,6 +737,8 @@ static void Render_vertexLighting_DBS_entity( int stage )
 
 	gl_vertexLightingShader_DBS_entity->SetParallaxMapping( parallaxMapping );
 
+	gl_vertexLightingShader_DBS_entity->SetHeightMapInNormalMap( heightMapInNormalMap );
+
 	gl_vertexLightingShader_DBS_entity->SetReflectiveSpecular( normalMapping && tr.cubeHashTable != nullptr );
 
 	gl_vertexLightingShader_DBS_entity->SetPhysicalShading( materialMapping );
@@ -814,8 +816,6 @@ static void Render_vertexLighting_DBS_entity( int stage )
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
-
-	gl_vertexLightingShader_DBS_entity->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	if ( specularMapping )
 	{
@@ -958,6 +958,8 @@ static void Render_vertexLighting_DBS_world( int stage )
 
 	gl_vertexLightingShader_DBS_world->SetParallaxMapping( parallaxMapping );
 
+	gl_vertexLightingShader_DBS_world->SetHeightMapInNormalMap( heightMapInNormalMap );
+
 	tess.vboVertexSprite = false;
 
 	gl_vertexLightingShader_DBS_world->BindProgram( pStage->deformIndex );
@@ -1060,8 +1062,6 @@ static void Render_vertexLighting_DBS_world( int stage )
 		GL_BindToTMU( 1, tr.flatImage );
 	}
 
-	gl_vertexLightingShader_DBS_world->SetHeightMapInNormalMap( heightMapInNormalMap );
-
 	if ( specularMapping )
 	{
 		// bind u_SpecularMap
@@ -1156,6 +1156,8 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 
 	gl_lightMappingShader->SetParallaxMapping( parallaxMapping );
 
+	gl_lightMappingShader->SetHeightMapInNormalMap( heightMapInNormalMap );
+
 	tess.vboVertexSprite = false;
 
 	gl_lightMappingShader->BindProgram( pStage->deformIndex );
@@ -1223,8 +1225,6 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
-
-	gl_lightMappingShader->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	if ( specularMapping )
 	{
@@ -1449,6 +1449,8 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *diffuseStage,
 	gl_forwardLightingShader_omniXYZ->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
 
 	gl_forwardLightingShader_omniXYZ->SetParallaxMapping( parallaxMapping );
+
+	gl_forwardLightingShader_omniXYZ->SetHeightMapInNormalMap( heightMapInNormalMap );
 	
 	gl_forwardLightingShader_omniXYZ->SetShadowing( shadowCompare );
 
@@ -1571,8 +1573,6 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *diffuseStage,
 		GL_BindToTMU( 1, tr.flatImage );
 	}
 
-	gl_forwardLightingShader_omniXYZ->SetHeightMapInNormalMap( heightMapInNormalMap );
-
 	if ( specularMapping )
 	{
 		// bind u_SpecularMap
@@ -1636,6 +1636,8 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *diffuseStage,
 	gl_forwardLightingShader_projXYZ->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
 
 	gl_forwardLightingShader_projXYZ->SetParallaxMapping( parallaxMapping );
+
+	gl_forwardLightingShader_projXYZ->SetHeightMapInNormalMap( heightMapInNormalMap );
 	
 	gl_forwardLightingShader_projXYZ->SetShadowing( shadowCompare );
 
@@ -1759,8 +1761,6 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *diffuseStage,
 		GL_BindToTMU( 1, tr.flatImage );
 	}
 
-	gl_forwardLightingShader_projXYZ->SetHeightMapInNormalMap( heightMapInNormalMap );
-
 	if ( specularMapping )
 	{
 		// bind u_SpecularMap
@@ -1822,6 +1822,8 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *diffuseStage,
 	gl_forwardLightingShader_directionalSun->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
 
 	gl_forwardLightingShader_directionalSun->SetParallaxMapping( parallaxMapping );
+
+	gl_forwardLightingShader_directionalSun->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	gl_forwardLightingShader_directionalSun->SetShadowing( shadowCompare );
 
@@ -1949,8 +1951,6 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *diffuseStage,
 		GL_BindToTMU( 1, tr.flatImage );
 	}
 
-	gl_forwardLightingShader_directionalSun->SetHeightMapInNormalMap( heightMapInNormalMap );
-
 	if ( specularMapping )
 	{
 		// bind u_SpecularMap
@@ -2019,6 +2019,8 @@ static void Render_reflection_CB( int stage )
 	// choose right shader program ----------------------------------
 	gl_reflectionShader->SetParallaxMapping( parallaxMapping );
 
+	gl_reflectionShader->SetHeightMapInNormalMap( heightMapInNormalMap );
+
 	gl_reflectionShader->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
 	gl_reflectionShader->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
 
@@ -2080,8 +2082,6 @@ static void Render_reflection_CB( int stage )
 
 	// bind u_NormalFormat
 	gl_reflectionShader->SetUniform_NormalFormat( tess.surfaceShader->normalFormat );
-
-	gl_reflectionShader->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	gl_reflectionShader->SetRequiredVertexPointers();
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -796,7 +796,6 @@ static void Render_vertexLighting_DBS_entity( int stage )
 		depthScale *= parallaxDepthScale == 0 ? 1 : parallaxDepthScale;
 		gl_vertexLightingShader_DBS_entity->SetUniform_ParallaxDepthScale( depthScale );
 		gl_vertexLightingShader_DBS_entity->SetUniform_ParallaxOffsetBias( tess.surfaceShader->parallaxOffsetBias );
-		gl_vertexLightingShader_DBS_entity->SetUniform_HeightMapInNormalMap( tess.surfaceShader->heightMapInNormalMap );
 	}
 
 	// bind u_DiffuseMap
@@ -815,6 +814,8 @@ static void Render_vertexLighting_DBS_entity( int stage )
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
+
+	gl_vertexLightingShader_DBS_entity->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	if ( specularMapping )
 	{
@@ -1035,7 +1036,6 @@ static void Render_vertexLighting_DBS_world( int stage )
 		depthScale *= parallaxDepthScale == 0 ? 1 : parallaxDepthScale;
 		gl_vertexLightingShader_DBS_world->SetUniform_ParallaxDepthScale( depthScale );
 		gl_vertexLightingShader_DBS_world->SetUniform_ParallaxOffsetBias( tess.surfaceShader->parallaxOffsetBias );
-		gl_vertexLightingShader_DBS_world->SetUniform_HeightMapInNormalMap( tess.surfaceShader->heightMapInNormalMap );
 	}
 
 	if( tr.world ) {
@@ -1059,6 +1059,8 @@ static void Render_vertexLighting_DBS_world( int stage )
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
+
+	gl_vertexLightingShader_DBS_world->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	if ( specularMapping )
 	{
@@ -1196,7 +1198,6 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 		depthScale *= parallaxDepthScale == 0 ? 1 : parallaxDepthScale;
 		gl_lightMappingShader->SetUniform_ParallaxDepthScale( depthScale );
 		gl_lightMappingShader->SetUniform_ParallaxOffsetBias( tess.surfaceShader->parallaxOffsetBias );
-		gl_lightMappingShader->SetUniform_HeightMapInNormalMap( tess.surfaceShader->heightMapInNormalMap );
 	}
 
 	// bind u_DiffuseMap
@@ -1222,6 +1223,8 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
+
+	gl_lightMappingShader->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	if ( specularMapping )
 	{
@@ -1497,7 +1500,6 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *diffuseStage,
 		depthScale *= parallaxDepthScale == 0 ? 1 : parallaxDepthScale;
 		gl_forwardLightingShader_omniXYZ->SetUniform_ParallaxDepthScale( depthScale );
 		gl_forwardLightingShader_omniXYZ->SetUniform_ParallaxOffsetBias( tess.surfaceShader->parallaxOffsetBias );
-		gl_forwardLightingShader_omniXYZ->SetUniform_HeightMapInNormalMap( tess.surfaceShader->heightMapInNormalMap );
 	}
 
 	// set uniforms
@@ -1568,6 +1570,8 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *diffuseStage,
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
+
+	gl_forwardLightingShader_omniXYZ->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	if ( specularMapping )
 	{
@@ -1683,7 +1687,6 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *diffuseStage,
 		depthScale *= parallaxDepthScale == 0 ? 1 : parallaxDepthScale;
 		gl_forwardLightingShader_projXYZ->SetUniform_ParallaxDepthScale( depthScale );
 		gl_forwardLightingShader_projXYZ->SetUniform_ParallaxOffsetBias( tess.surfaceShader->parallaxOffsetBias );
-		gl_forwardLightingShader_projXYZ->SetUniform_HeightMapInNormalMap( tess.surfaceShader->heightMapInNormalMap );
 	}
 
 	// set uniforms
@@ -1755,6 +1758,8 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *diffuseStage,
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
+
+	gl_forwardLightingShader_projXYZ->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	if ( specularMapping )
 	{
@@ -1868,7 +1873,6 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *diffuseStage,
 		depthScale *= parallaxDepthScale == 0 ? 1 : parallaxDepthScale;
 		gl_forwardLightingShader_directionalSun->SetUniform_ParallaxDepthScale( depthScale );
 		gl_forwardLightingShader_directionalSun->SetUniform_ParallaxOffsetBias( tess.surfaceShader->parallaxOffsetBias );
-		gl_forwardLightingShader_directionalSun->SetUniform_HeightMapInNormalMap( tess.surfaceShader->heightMapInNormalMap );
 	}
 
 	// set uniforms
@@ -1944,6 +1948,8 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *diffuseStage,
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
+
+	gl_forwardLightingShader_directionalSun->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	if ( specularMapping )
 	{
@@ -2070,11 +2076,12 @@ static void Render_reflection_CB( int stage )
 		depthScale *= parallaxDepthScale == 0 ? 1 : parallaxDepthScale;
 		gl_reflectionShader->SetUniform_ParallaxDepthScale( depthScale );
 		gl_reflectionShader->SetUniform_ParallaxOffsetBias( tess.surfaceShader->parallaxOffsetBias );
-		gl_reflectionShader->SetUniform_HeightMapInNormalMap( tess.surfaceShader->heightMapInNormalMap );
 	}
 
 	// bind u_NormalFormat
 	gl_reflectionShader->SetUniform_NormalFormat( tess.surfaceShader->normalFormat );
+
+	gl_reflectionShader->SetHeightMapInNormalMap( heightMapInNormalMap );
 
 	gl_reflectionShader->SetRequiredVertexPointers();
 


### PR DESCRIPTION
**DO NOT MERGE** until the `#ifdef` bug is fixed, see #190.

This is a simple change that makes glsl relying on `#ifdef` instead of an `uniform` to test for the fact the normalmap is embedding heightmap in alpha channel or not. This makes GMA965 able to render parpax default scene with `11` fps instead of `10` (+10%) (unnoticeable on R9 390X).

This is not merged yet because of a nasty bug, it looks like the define is not defined any time as while I move in map, the wrong code is sometime run instead of the expected one:

[![glsl ifdef](https://dl.illwieckz.net/b/daemon/bugs/glsl-ifdef/unvanquished_2019-03-23_203425_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/glsl-ifdef/unvanquished_2019-03-23_203425_000.jpg)

[![glsl ifdef](https://dl.illwieckz.net/b/daemon/bugs/glsl-ifdef/unvanquished_2019-03-23_203429_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/glsl-ifdef/unvanquished_2019-03-23_203429_000.jpg)

The bug is on the wall texture, not on the blooming reactor.

I reproduced the bug on both `radeonsi` (R9 390X) and `i965` (Haswell) drivers, this is likely to not be a driver bug but a bug in dæmon code, the ifdef code is very cryptic and would benefit a lot from a rewrite.

I'm basically pushing this branch so people have code to debug the `#ifdef` bug (#190).