### PR TITLE
quick and cheap parallax for real time lights

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -584,6 +584,11 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_normalMapping", 1 );
 	}
 
+	if ( r_quickLightParallaxMapping->integer )
+	{
+		AddDefine( str, "r_quickLightParallaxMapping", 1 );
+	}
+
 	if ( r_specularMapping->integer )
 	{
 		AddDefine( str, "r_specularMapping", 1 );

--- a/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
@@ -948,7 +948,11 @@ void	main()
 
 #if defined(USE_PARALLAX_MAPPING)
 	// compute texcoords offset from heightmap
+#if defined(r_quickLightParallaxMapping)
 	vec2 texOffset = QuickParallaxTexOffset(texCoords, viewDir, tangentToWorldMatrix);
+#else
+	vec2 texOffset = ParallaxTexOffset(texCoords, viewDir, tangentToWorldMatrix);
+#endif
 
 	texCoords += texOffset;
 #endif // USE_PARALLAX_MAPPING

--- a/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
@@ -948,7 +948,7 @@ void	main()
 
 #if defined(USE_PARALLAX_MAPPING)
 	// compute texcoords offset from heightmap
-	vec2 texOffset = ParallaxTexOffset(texCoords, viewDir, tangentToWorldMatrix);
+	vec2 texOffset = QuickParallaxTexOffset(texCoords, viewDir, tangentToWorldMatrix);
 
 	texCoords += texOffset;
 #endif // USE_PARALLAX_MAPPING

--- a/src/engine/renderer/glsl_source/reliefMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/reliefMapping_fp.glsl
@@ -108,6 +108,23 @@ vec3 NormalInWorldSpace(vec2 texNormal, mat3 tangentToWorldMatrix)
 }
 
 #if defined(USE_PARALLAX_MAPPING)
+// very poor but very fast parallax
+// do not use for something else than real time lights
+vec2 QuickParallaxTexOffset(vec2 rayStartTexCoords, vec3 viewDir, mat3 tangentToWorldMatrix)
+{
+	// compute view direction in tangent space
+	vec3 tangentViewDir = normalize(viewDir * tangentToWorldMatrix);
+
+	vec2 displacement = tangentViewDir.xy * -u_ParallaxDepthScale / tangentViewDir.z;
+
+	float topDepth = 1.0 - u_ParallaxOffsetBias;
+
+	float depth = topDepth - texture2D(u_NormalMap, rayStartTexCoords).a;
+
+	// depthmap value at current texture coordinates
+	return depth * displacement;
+}
+
 // compute texcoords offset from heightmap
 // most of the code doing somewhat the same is likely to be named
 // RayIntersectDisplaceMap in other id tech3-based engines

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -168,6 +168,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_highQualityNormalMapping;
 	cvar_t      *r_parallaxDepthScale;
 	cvar_t      *r_parallaxMapping;
+	cvar_t      *r_quickLightParallaxMapping;
 	cvar_t      *r_glowMapping;
 	cvar_t      *r_reflectionMapping;
 
@@ -1199,6 +1200,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_highQualityNormalMapping = ri.Cvar_Get( "r_highQualityNormalMapping", "0",  CVAR_LATCH );
 		r_parallaxDepthScale = ri.Cvar_Get( "r_parallaxDepthScale", "0.03", CVAR_CHEAT );
 		r_parallaxMapping = ri.Cvar_Get( "r_parallaxMapping", "0", 0 );
+		r_quickLightParallaxMapping = ri.Cvar_Get( "r_quickLightParallaxMapping", "1", CVAR_LATCH );
 		r_glowMapping = ri.Cvar_Get( "r_glowMapping", "1", CVAR_LATCH );
 		r_reflectionMapping = ri.Cvar_Get( "r_reflectionMapping", "0", CVAR_CHEAT );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2853,6 +2853,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_highQualityNormalMapping;
 	extern cvar_t *r_parallaxDepthScale;
 	extern cvar_t *r_parallaxMapping;
+	extern cvar_t *r_quickLightParallaxMapping;
 	extern cvar_t *r_glowMapping;
 	extern cvar_t *r_reflectionMapping;
 


### PR DESCRIPTION
It jumps from 31fps to 95fps on hd1080p (110fps in a common scene) on an R9 390X with flame thrower on an open scene that is known to be far slower than the average, I don't see anything wrong noticeable.

Produces 65fps on 2K on that costly scene (90fps in a common scene) and 36fps on 4K (45fps in common scene).

Note that without flame thrower, I get 200~225fps (hd1080p), 185/225fps (2K), 100/140fps (4K).

Basically this quick parallax is only done to be sure the realtime light is not shifted from the usual lightmapped scene (which is parallaxed with a more efficient algorithm).

I'll post screenshots later.

This hack makes a Dæmon based game performant enough to be releasable with parallax enabled or at least available to the user.