### PR TITLE
use only one texCoords per surface

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1410,7 +1410,7 @@ void GLShader::SetRequiredVertexPointers()
 
 GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	GLShader( "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
-	u_ColorTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_ViewOrigin( this ),
 	u_ViewUp( this ),
 	u_AlphaThreshold( this ),
@@ -1446,10 +1446,7 @@ void GLShader_generic::SetShaderProgramUniforms( shaderProgram_t *shaderProgram 
 
 GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 	GLShader( "lightMapping", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT | ATTR_COLOR, manager ),
-	u_DiffuseTextureMatrix( this ),
-	u_NormalTextureMatrix( this ),
-	u_SpecularTextureMatrix( this ),
-	u_GlowTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_SpecularExponent( this ),
 	u_ColorModulate( this ),
 	u_Color( this ),
@@ -1500,10 +1497,7 @@ void GLShader_lightMapping::SetShaderProgramUniforms( shaderProgram_t *shaderPro
 
 GLShader_vertexLighting_DBS_entity::GLShader_vertexLighting_DBS_entity( GLShaderManager *manager ) :
 	GLShader( "vertexLighting_DBS_entity", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
-	u_DiffuseTextureMatrix( this ),
-	u_NormalTextureMatrix( this ),
-	u_SpecularTextureMatrix( this ),
-	u_GlowTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_SpecularExponent( this ),
 	u_AlphaThreshold( this ),
 	u_ViewOrigin( this ),
@@ -1564,10 +1558,7 @@ GLShader_vertexLighting_DBS_world::GLShader_vertexLighting_DBS_world( GLShaderMa
 	          ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT | ATTR_COLOR,
 		  manager
 	        ),
-	u_DiffuseTextureMatrix( this ),
-	u_NormalTextureMatrix( this ),
-	u_SpecularTextureMatrix( this ),
-	u_GlowTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_SpecularExponent( this ),
 	u_ColorModulate( this ),
 	u_Color( this ),
@@ -1619,9 +1610,7 @@ void GLShader_vertexLighting_DBS_world::SetShaderProgramUniforms( shaderProgram_
 
 GLShader_forwardLighting_omniXYZ::GLShader_forwardLighting_omniXYZ( GLShaderManager *manager ):
 	GLShader("forwardLighting_omniXYZ", "forwardLighting", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager),
-	u_DiffuseTextureMatrix( this ),
-	u_NormalTextureMatrix( this ),
-	u_SpecularTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_SpecularExponent( this ),
 	u_AlphaThreshold( this ),
 	u_ColorModulate( this ),
@@ -1679,9 +1668,7 @@ void GLShader_forwardLighting_omniXYZ::SetShaderProgramUniforms( shaderProgram_t
 
 GLShader_forwardLighting_projXYZ::GLShader_forwardLighting_projXYZ( GLShaderManager *manager ):
 	GLShader("forwardLighting_projXYZ", "forwardLighting", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager),
-	u_DiffuseTextureMatrix( this ),
-	u_NormalTextureMatrix( this ),
-	u_SpecularTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_SpecularExponent( this ),
 	u_AlphaThreshold( this ),
 	u_ColorModulate( this ),
@@ -1741,9 +1728,7 @@ void GLShader_forwardLighting_projXYZ::SetShaderProgramUniforms( shaderProgram_t
 
 GLShader_forwardLighting_directionalSun::GLShader_forwardLighting_directionalSun( GLShaderManager *manager ):
 	GLShader("forwardLighting_directionalSun", "forwardLighting", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager),
-	u_DiffuseTextureMatrix( this ),
-	u_NormalTextureMatrix( this ),
-	u_SpecularTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_SpecularExponent( this ),
 	u_AlphaThreshold( this ),
 	u_ColorModulate( this ),
@@ -1812,7 +1797,7 @@ void GLShader_forwardLighting_directionalSun::SetShaderProgramUniforms( shaderPr
 
 GLShader_shadowFill::GLShader_shadowFill( GLShaderManager *manager ) :
 	GLShader( "shadowFill", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
-	u_ColorTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_ViewOrigin( this ),
 	u_AlphaThreshold( this ),
 	u_LightOrigin( this ),
@@ -1841,7 +1826,7 @@ void GLShader_shadowFill::SetShaderProgramUniforms( shaderProgram_t *shaderProgr
 
 GLShader_reflection::GLShader_reflection( GLShaderManager *manager ):
 	GLShader("reflection", "reflection_CB", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
-	u_NormalTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_ViewOrigin( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
@@ -1941,7 +1926,7 @@ void GLShader_fogGlobal::SetShaderProgramUniforms( shaderProgram_t *shaderProgra
 
 GLShader_heatHaze::GLShader_heatHaze( GLShaderManager *manager ) :
 	GLShader( "heatHaze", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
-	u_NormalTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_ViewOrigin( this ),
 	u_ViewUp( this ),
 	u_DeformMagnitude( this ),
@@ -2015,7 +2000,7 @@ void GLShader_contrast::SetShaderProgramUniforms( shaderProgram_t *shaderProgram
 GLShader_cameraEffects::GLShader_cameraEffects( GLShaderManager *manager ) :
 	GLShader( "cameraEffects", ATTR_POSITION | ATTR_TEXCOORD, manager ),
 	u_ColorModulate( this ),
-	u_ColorTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
 	u_DeformMagnitude( this ),
 	u_InverseGamma( this )
@@ -2103,7 +2088,7 @@ void GLShader_lightVolume_omni::SetShaderProgramUniforms( shaderProgram_t *shade
 
 GLShader_liquid::GLShader_liquid( GLShaderManager *manager ) :
 	GLShader( "liquid", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
-	u_NormalTextureMatrix( this ),
+	u_TextureMatrix( this ),
 	u_ViewOrigin( this ),
 	u_RefractionIndex( this ),
 	u_ModelMatrix( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1185,76 +1185,16 @@ public:
 	}
 };
 
-class u_ColorTextureMatrix :
+class u_TextureMatrix :
 	GLUniformMatrix4f
 {
 public:
-	u_ColorTextureMatrix( GLShader *shader ) :
-		GLUniformMatrix4f( shader, "u_ColorTextureMatrix" )
+	u_TextureMatrix( GLShader *shader ) :
+		GLUniformMatrix4f( shader, "u_TextureMatrix" )
 	{
 	}
 
-	void SetUniform_ColorTextureMatrix( const matrix_t m )
-	{
-		this->SetValue( GL_FALSE, m );
-	}
-};
-
-class u_DiffuseTextureMatrix :
-	GLUniformMatrix4f
-{
-public:
-	u_DiffuseTextureMatrix( GLShader *shader ) :
-		GLUniformMatrix4f( shader, "u_DiffuseTextureMatrix" )
-	{
-	}
-
-	void SetUniform_DiffuseTextureMatrix( const matrix_t m )
-	{
-		this->SetValue( GL_FALSE, m );
-	}
-};
-
-class u_NormalTextureMatrix :
-	GLUniformMatrix4f
-{
-public:
-	u_NormalTextureMatrix( GLShader *shader ) :
-		GLUniformMatrix4f( shader, "u_NormalTextureMatrix" )
-	{
-	}
-
-	void SetUniform_NormalTextureMatrix( const matrix_t m )
-	{
-		this->SetValue( GL_FALSE, m );
-	}
-};
-
-class u_SpecularTextureMatrix :
-	GLUniformMatrix4f
-{
-public:
-	u_SpecularTextureMatrix( GLShader *shader ) :
-		GLUniformMatrix4f( shader, "u_SpecularTextureMatrix" )
-	{
-	}
-
-	void SetUniform_SpecularTextureMatrix( const matrix_t m )
-	{
-		this->SetValue( GL_FALSE, m );
-	}
-};
-
-class u_GlowTextureMatrix :
-	GLUniformMatrix4f
-{
-public:
-	u_GlowTextureMatrix( GLShader *shader ) :
-		GLUniformMatrix4f( shader, "u_GlowTextureMatrix" )
-	{
-	}
-
-	void SetUniform_GlowTextureMatrix( const matrix_t m )
+	void SetUniform_TextureMatrix( const matrix_t m )
 	{
 		this->SetValue( GL_FALSE, m );
 	}
@@ -2180,7 +2120,7 @@ class u_Lights :
 
 class GLShader_generic :
 	public GLShader,
-	public u_ColorTextureMatrix,
+	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_ViewUp,
 	public u_AlphaThreshold,
@@ -2209,10 +2149,7 @@ public:
 
 class GLShader_lightMapping :
 	public GLShader,
-	public u_DiffuseTextureMatrix,
-	public u_NormalTextureMatrix,
-	public u_SpecularTextureMatrix,
-	public u_GlowTextureMatrix,
+	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_ColorModulate,
 	public u_Color,
@@ -2241,10 +2178,7 @@ public:
 
 class GLShader_vertexLighting_DBS_entity :
 	public GLShader,
-	public u_DiffuseTextureMatrix,
-	public u_NormalTextureMatrix,
-	public u_SpecularTextureMatrix,
-	public u_GlowTextureMatrix,
+	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_AlphaThreshold,
 	public u_ViewOrigin,
@@ -2278,10 +2212,7 @@ public:
 
 class GLShader_vertexLighting_DBS_world :
 	public GLShader,
-	public u_DiffuseTextureMatrix,
-	public u_NormalTextureMatrix,
-	public u_SpecularTextureMatrix,
-	public u_GlowTextureMatrix,
+	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_ColorModulate,
 	public u_Color,
@@ -2312,9 +2243,7 @@ public:
 
 class GLShader_forwardLighting_omniXYZ :
 	public GLShader,
-	public u_DiffuseTextureMatrix,
-	public u_NormalTextureMatrix,
-	public u_SpecularTextureMatrix,
+	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_AlphaThreshold,
 	public u_ColorModulate,
@@ -2352,9 +2281,7 @@ public:
 
 class GLShader_forwardLighting_projXYZ :
 	public GLShader,
-	public u_DiffuseTextureMatrix,
-	public u_NormalTextureMatrix,
-	public u_SpecularTextureMatrix,
+	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_AlphaThreshold,
 	public u_ColorModulate,
@@ -2393,9 +2320,7 @@ public:
 
 class GLShader_forwardLighting_directionalSun :
 	public GLShader,
-	public u_DiffuseTextureMatrix,
-	public u_NormalTextureMatrix,
-	public u_SpecularTextureMatrix,
+	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_AlphaThreshold,
 	public u_ColorModulate,
@@ -2436,7 +2361,7 @@ public:
 
 class GLShader_shadowFill :
 	public GLShader,
-	public u_ColorTextureMatrix,
+	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_AlphaThreshold,
 	public u_LightOrigin,
@@ -2459,7 +2384,7 @@ public:
 
 class GLShader_reflection :
 	public GLShader,
-	public u_NormalTextureMatrix,
+	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
@@ -2534,7 +2459,7 @@ public:
 
 class GLShader_heatHaze :
 	public GLShader,
-	public u_NormalTextureMatrix,
+	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_ViewUp,
 	public u_DeformMagnitude,
@@ -2591,7 +2516,7 @@ public:
 class GLShader_cameraEffects :
 	public GLShader,
 	public u_ColorModulate,
-	public u_ColorTextureMatrix,
+	public u_TextureMatrix,
 	public u_ModelViewProjectionMatrix,
 	public u_DeformMagnitude,
 	public u_InverseGamma
@@ -2662,7 +2587,7 @@ public:
 
 class GLShader_liquid :
 	public GLShader,
-	public u_NormalTextureMatrix,
+	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_RefractionIndex,
 	public u_ModelMatrix,

--- a/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
+++ b/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
@@ -27,7 +27,7 @@ uniform sampler3D u_ColorMap;
 uniform vec4      u_ColorModulate;
 uniform float     u_InverseGamma;
 
-IN(smooth) vec2		var_Tex;
+IN(smooth) vec2		var_TexCoords;
 
 DECLARE_OUTPUT(vec4)
 

--- a/src/engine/renderer/glsl_source/cameraEffects_vp.glsl
+++ b/src/engine/renderer/glsl_source/cameraEffects_vp.glsl
@@ -26,14 +26,14 @@ IN vec3 		attr_Position;
 IN vec2 		attr_TexCoord0;
 
 uniform mat4		u_ModelViewProjectionMatrix;
-uniform mat4		u_ColorTextureMatrix;
+uniform mat4		u_TextureMatrix;
 
-OUT(smooth) vec2	var_Tex;
+OUT(smooth) vec2	var_TexCoords;
 
 void	main()
 {
 	// transform vertex position into homogenous clip-space
 	gl_Position = u_ModelViewProjectionMatrix * vec4(attr_Position, 1.0);
 
-	var_Tex = (u_ColorTextureMatrix * vec4(attr_TexCoord0, 0.0, 1.0)).st;
+	var_TexCoords = (u_TextureMatrix * vec4(attr_TexCoord0, 0.0, 1.0)).st;
 }

--- a/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
@@ -25,14 +25,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 uniform sampler2D	u_ColorMap;
 
 IN(smooth) vec3		var_Position;
-IN(smooth) vec2		var_Tex;
+IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec4		var_Color;
 
 DECLARE_OUTPUT(vec4)
 
 void	main()
 {
-	vec4 color = texture2D(u_ColorMap, var_Tex);
+	vec4 color = texture2D(u_ColorMap, var_TexCoords);
 
 	color *= var_Color;
 	outputColor = color;

--- a/src/engine/renderer/glsl_source/fogQuake3_vp.glsl
+++ b/src/engine/renderer/glsl_source/fogQuake3_vp.glsl
@@ -36,7 +36,7 @@ uniform vec4		u_FogDepthVector;
 uniform float		u_FogEyeT;
 
 OUT(smooth) vec3	var_Position;
-OUT(smooth) vec2	var_Tex;
+OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) vec4	var_Color;
 
 void DeformVertex( inout vec4 pos,
@@ -96,7 +96,7 @@ void	main()
 		}
 	}
 
-	var_Tex = vec2(s, t);
+	var_TexCoords = vec2(s, t);
 
 	var_Color = color;
 }

--- a/src/engine/renderer/glsl_source/forwardLighting_vp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_vp.glsl
@@ -22,23 +22,18 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* forwardLighting_vp.glsl */
 
-uniform mat4		u_DiffuseTextureMatrix;
-uniform mat4		u_NormalTextureMatrix;
-uniform mat4		u_SpecularTextureMatrix;
-
-uniform vec4		u_ColorModulate;
-uniform vec4		u_Color;
-
+uniform mat4		u_TextureMatrix;
 uniform mat4		u_LightAttenuationMatrix;
 uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
+uniform vec4		u_ColorModulate;
+uniform vec4		u_Color;
+
 uniform float		u_Time;
 
 OUT(smooth) vec3	var_Position;
-OUT(smooth) vec2	var_TexDiffuse;
-OUT(smooth) vec2	var_TexNormal;
-OUT(smooth) vec2	var_TexSpecular;
+OUT(smooth) vec2	var_TexCoords;
 
 OUT(smooth) vec4	var_TexAttenuation;
 
@@ -86,13 +81,7 @@ void	main()
 	var_TexAttenuation = u_LightAttenuationMatrix * position;
 
 	// transform diffusemap texcoords
-	var_TexDiffuse = (u_DiffuseTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
-
-	// transform normalmap texcoords
-	var_TexNormal = (u_NormalTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
-
-	// transform specularmap texture coords
-	var_TexSpecular = (u_SpecularTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
+	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
 
 	var_Color = color;
 }

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 uniform sampler2D	u_ColorMap;
 uniform float		u_AlphaThreshold;
 
-IN(smooth) vec2		var_Tex;
+IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec4		var_Color;
 
 #if defined(USE_DEPTH_FADE) || defined(USE_VERTEX_SPRITE)
@@ -37,7 +37,7 @@ DECLARE_OUTPUT(vec4)
 
 void	main()
 {
-	vec4 color = texture2D(u_ColorMap, var_Tex);
+	vec4 color = texture2D(u_ColorMap, var_TexCoords);
 
 #if defined(USE_ALPHA_TESTING)
 	if( abs(color.a + u_AlphaThreshold) <= 1.0 )

--- a/src/engine/renderer/glsl_source/generic_vp.glsl
+++ b/src/engine/renderer/glsl_source/generic_vp.glsl
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* generic_vp.glsl */
 
-uniform mat4		u_ColorTextureMatrix;
+uniform mat4		u_TextureMatrix;
 #if !defined(USE_VERTEX_SPRITE)
 uniform vec3		u_ViewOrigin;
 #endif
@@ -44,7 +44,7 @@ uniform float           u_DepthScale;
 OUT(smooth) vec2	var_FadeDepth;
 #endif
 
-OUT(smooth) vec2	var_Tex;
+OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) vec4	var_Color;
 
 void DeformVertex( inout vec4 pos,
@@ -84,12 +84,12 @@ void	main()
 
 		vec3 reflected = LB.normal * 2.0 * d - viewer;
 
-		var_Tex = 0.5 + vec2(0.5, -0.5) * reflected.yz;
+		var_TexCoords = 0.5 + vec2(0.5, -0.5) * reflected.yz;
 	}
 #elif defined(USE_TCGEN_LIGHTMAP)
-	var_Tex = (u_ColorTextureMatrix * vec4(lmCoord, 0.0, 1.0)).xy;
+	var_TexCoords = (u_TextureMatrix * vec4(lmCoord, 0.0, 1.0)).xy;
 #else
-	var_Tex = (u_ColorTextureMatrix * vec4(texCoord, 0.0, 1.0)).xy;
+	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).xy;
 #endif
 
 #if defined(USE_DEPTH_FADE) || defined(USE_VERTEX_SPRITE)

--- a/src/engine/renderer/glsl_source/heatHaze_fp.glsl
+++ b/src/engine/renderer/glsl_source/heatHaze_fp.glsl
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 uniform sampler2D	u_CurrentMap;
 uniform float		u_AlphaThreshold;
 
-IN(smooth) vec2		var_TexNormal;
+IN(smooth) vec2		var_TexCoords;
 IN(smooth) float	var_Deform;
 
 DECLARE_OUTPUT(vec4)
@@ -35,7 +35,7 @@ void	main()
 	vec4 color;
 
 	// compute normal in tangent space from normalmap
-	vec3 N = NormalInTangentSpace(var_TexNormal);
+	vec3 N = NormalInTangentSpace(var_TexCoords);
 
 	// calculate the screen texcoord in the 0.0 to 1.0 range
 	vec2 st = gl_FragCoord.st * r_FBufScale;

--- a/src/engine/renderer/glsl_source/heatHaze_vp.glsl
+++ b/src/engine/renderer/glsl_source/heatHaze_vp.glsl
@@ -24,14 +24,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 uniform float		u_Time;
 
-uniform mat4		u_NormalTextureMatrix;
+uniform mat4		u_TextureMatrix;
 uniform mat4		u_ProjectionMatrixTranspose;
 uniform mat4		u_ModelViewMatrixTranspose;
 uniform mat4		u_ModelViewProjectionMatrix;
 
 uniform float		u_DeformMagnitude;
 
-OUT(smooth) vec2	var_TexNormal;
+OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) float	var_Deform;
 
 void DeformVertex( inout vec4 pos,
@@ -66,7 +66,7 @@ void	main()
 	deformVec.z = dot(u_ModelViewMatrixTranspose[2], position);
 
 	// transform normalmap texcoords
-	var_TexNormal = (u_NormalTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
+	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
 
 	d1 = dot(u_ProjectionMatrixTranspose[0],  deformVec);
 	d2 = dot(u_ProjectionMatrixTranspose[3],  deformVec);

--- a/src/engine/renderer/glsl_source/lightMapping_vp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_vp.glsl
@@ -22,10 +22,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* lightMapping_vp.glsl */
 
-uniform mat4		u_DiffuseTextureMatrix;
-uniform mat4		u_NormalTextureMatrix;
-uniform mat4		u_SpecularTextureMatrix;
-uniform mat4		u_GlowTextureMatrix;
+uniform mat4		u_TextureMatrix;
 uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
@@ -35,10 +32,7 @@ uniform vec4		u_ColorModulate;
 uniform vec4		u_Color;
 
 OUT(smooth) vec3	var_Position;
-OUT(smooth) vec2	var_TexDiffuse;
-OUT(smooth) vec2	var_TexGlow;
-OUT(smooth) vec2	var_TexNormal;
-OUT(smooth) vec2	var_TexSpecular;
+OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) vec2	var_TexLight;
 OUT(smooth) vec3	var_Tangent;
 OUT(smooth) vec3	var_Binormal;
@@ -72,17 +66,9 @@ void	main()
 	gl_Position = u_ModelViewProjectionMatrix * position;
 
 	// transform diffusemap texcoords
-	var_TexDiffuse = (u_DiffuseTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
+	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
+
 	var_TexLight = lmCoord;
-
-	// transform normalmap texcoords
-	var_TexNormal = (u_NormalTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
-
-	// transform specularmap texcoords
-	var_TexSpecular = (u_SpecularTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
-
-	// transform glowmap texcoords
-	var_TexGlow = (u_GlowTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
 
 	var_Position = position.xyz;
 

--- a/src/engine/renderer/glsl_source/lightVolume_omni_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightVolume_omni_fp.glsl
@@ -43,7 +43,6 @@ uniform float       u_LightScale;
 uniform mat4		u_LightAttenuationMatrix;
 uniform mat4		u_UnprojectMatrix;
 
-IN(smooth) vec2		var_TexDiffuse;
 IN(smooth) vec3		var_TexAttenXYZ;
 
 DECLARE_OUTPUT(vec4)

--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -43,7 +43,7 @@ uniform vec3            u_LightGridOrigin;
 uniform vec3            u_LightGridScale;
 
 IN(smooth) vec3		var_Position;
-IN(smooth) vec2		var_TexNormal;
+IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec3		var_Tangent;
 IN(smooth) vec3		var_Binormal;
 IN(smooth) vec3		var_Normal;
@@ -90,7 +90,7 @@ void	main()
 
 	// calculate the screen texcoord in the 0.0 to 1.0 range
 	vec2 texScreen = gl_FragCoord.st * r_FBufScale;
-	vec2 texNormal = var_TexNormal;
+	vec2 texNormal = var_TexCoords;
 
 #if defined(USE_PARALLAX_MAPPING)
 	// ray intersect in view direction

--- a/src/engine/renderer/glsl_source/liquid_vp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_vp.glsl
@@ -28,12 +28,12 @@ IN vec3			attr_Tangent;
 IN vec3			attr_Binormal;
 IN vec3			attr_Normal;
 
-uniform mat4		u_NormalTextureMatrix;
+uniform mat4		u_TextureMatrix;
 uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
 OUT(smooth) vec3	var_Position;
-OUT(smooth) vec2	var_TexNormal;
+OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) vec3	var_Tangent;
 OUT(smooth) vec3	var_Binormal;
 OUT(smooth) vec3	var_Normal;
@@ -47,7 +47,7 @@ void	main()
 	var_Position = (u_ModelMatrix * vec4(attr_Position, 1.0)).xyz;
 
 	// transform normalmap texcoords
-	var_TexNormal = (u_NormalTextureMatrix * vec4(attr_TexCoord0, 0.0, 1.0)).st;
+	var_TexCoords = (u_TextureMatrix * vec4(attr_TexCoord0, 0.0, 1.0)).st;
 
 	var_Tangent.xyz = (u_ModelMatrix * vec4(attr_Tangent, 0.0)).xyz;
 	var_Binormal.xyz = (u_ModelMatrix * vec4(attr_Binormal, 0.0)).xyz;

--- a/src/engine/renderer/glsl_source/reflection_CB_fp.glsl
+++ b/src/engine/renderer/glsl_source/reflection_CB_fp.glsl
@@ -27,7 +27,7 @@ uniform vec3		u_ViewOrigin;
 uniform mat4		u_ModelMatrix;
 
 IN(smooth) vec3		var_Position;
-IN(smooth) vec2		var_TexNormal;
+IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec4		var_Tangent;
 IN(smooth) vec4		var_Binormal;
 IN(smooth) vec4		var_Normal;
@@ -41,7 +41,7 @@ void	main()
 
 	mat3 tangentToWorldMatrix = mat3(var_Tangent.xyz, var_Binormal.xyz, var_Normal.xyz);
 
-	vec2 texNormal = var_TexNormal;
+	vec2 texNormal = var_TexCoords;
 
 #if defined(USE_PARALLAX_MAPPING)
 	// compute texcoords offset from heightmap

--- a/src/engine/renderer/glsl_source/reflection_CB_vp.glsl
+++ b/src/engine/renderer/glsl_source/reflection_CB_vp.glsl
@@ -22,14 +22,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* reflection_CB_vp.glsl */
 
-uniform mat4		u_NormalTextureMatrix;
+uniform mat4		u_TextureMatrix;
 uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
 uniform float		u_Time;
 
 OUT(smooth) vec3	var_Position;
-OUT(smooth) vec2	var_TexNormal;
+OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) vec4	var_Tangent;
 OUT(smooth) vec4	var_Binormal;
 OUT(smooth) vec4	var_Normal;
@@ -66,6 +66,6 @@ void	main()
 	var_Normal.xyz = (u_ModelMatrix * vec4(LB.normal, 0.0)).xyz;
 
 	// transform normalmap texcoords
-	var_TexNormal = (u_NormalTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
+	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
 }
 

--- a/src/engine/renderer/glsl_source/shadowFill_fp.glsl
+++ b/src/engine/renderer/glsl_source/shadowFill_fp.glsl
@@ -28,7 +28,7 @@ uniform vec3		u_LightOrigin;
 uniform float		u_LightRadius;
 
 IN(smooth) vec3		var_Position;
-IN(smooth) vec2		var_Tex;
+IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec4		var_Color;
 
 DECLARE_OUTPUT(vec4)
@@ -63,7 +63,7 @@ vec4 ShadowDepthToEVSM(float depth)
 
 void	main()
 {
-	vec4 color = texture2D(u_ColorMap, var_Tex);
+	vec4 color = texture2D(u_ColorMap, var_TexCoords);
 
 	if( abs(color.a + u_AlphaThreshold) <= 1.0 )
 	{

--- a/src/engine/renderer/glsl_source/shadowFill_vp.glsl
+++ b/src/engine/renderer/glsl_source/shadowFill_vp.glsl
@@ -24,14 +24,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 uniform vec4		u_Color;
 
-uniform mat4		u_ColorTextureMatrix;
+uniform mat4		u_TextureMatrix;
 uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
 uniform float		u_Time;
 
 OUT(smooth) vec3	var_Position;
-OUT(smooth) vec2	var_Tex;
+OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) vec4	var_Color;
 
 void DeformVertex( inout vec4 pos,
@@ -66,7 +66,7 @@ void	main()
 #endif
 
 	// transform texcoords
-	var_Tex = (u_ColorTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
+	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
 
 	// assign color
 	var_Color = u_Color;

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_vp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_vp.glsl
@@ -22,23 +22,17 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* vertexLighting_DBS_entity_vp.glsl */
 
-uniform mat4		u_DiffuseTextureMatrix;
-uniform mat4		u_NormalTextureMatrix;
-uniform mat4		u_SpecularTextureMatrix;
-uniform mat4		u_GlowTextureMatrix;
+uniform mat4		u_TextureMatrix;
 uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
 uniform float		u_Time;
 
 OUT(smooth) vec3	var_Position;
-OUT(smooth) vec2	var_TexDiffuse;
+OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) vec4	var_Color;
-OUT(smooth) vec2	var_TexNormal;
-OUT(smooth) vec2	var_TexSpecular;
 OUT(smooth) vec3	var_Tangent;
 OUT(smooth) vec3	var_Binormal;
-OUT(smooth) vec2	var_TexGlow;
 
 OUT(smooth) vec3	var_Normal;
 
@@ -74,15 +68,6 @@ void	main()
 	var_Normal.xyz = (u_ModelMatrix * vec4(LB.normal, 0.0)).xyz;
 
 	// transform diffusemap texcoords
-	var_TexDiffuse = (u_DiffuseTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
+	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
 	var_Color = color;
-
-	// transform normalmap texcoords
-	var_TexNormal = (u_NormalTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
-
-	// transform specularmap texture coords
-	var_TexSpecular = (u_SpecularTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
-
-	// transform glowmap texcoords
-	var_TexGlow = (u_GlowTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
 }

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
@@ -37,12 +37,9 @@ uniform vec3            u_LightGridScale;
 uniform vec3		u_ViewOrigin;
 
 IN(smooth) vec3		var_Position;
-IN(smooth) vec2		var_TexDiffuse;
-IN(smooth) vec2		var_TexGlow;
+IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec4		var_Color;
 
-IN(smooth) vec2		var_TexNormal;
-IN(smooth) vec2		var_TexSpecular;
 IN(smooth) vec3		var_Tangent;
 IN(smooth) vec3		var_Binormal;
 
@@ -72,8 +69,7 @@ void ReadLightGrid(in vec3 pos, out vec3 lgtDir,
 
 void	main()
 {
-	vec2 texDiffuse = var_TexDiffuse;
-	vec2 texGlow = var_TexGlow;
+	vec2 texCoords = var_TexCoords;
 
 	// compute view direction in world space
 	vec3 viewDir = normalize(u_ViewOrigin - var_Position);
@@ -84,21 +80,15 @@ void	main()
 	ReadLightGrid( (var_Position - u_LightGridOrigin) * u_LightGridScale,
 		       L, ambCol, dirCol);
 
-	vec2 texNormal = var_TexNormal;
-	vec2 texSpecular = var_TexSpecular;
-
 #if defined(USE_PARALLAX_MAPPING)
 	// compute texcoords offset from heightmap
-	vec2 texOffset = ParallaxTexOffset(texNormal, viewDir, tangentToWorldMatrix);
+	vec2 texOffset = ParallaxTexOffset(texCoords, viewDir, tangentToWorldMatrix);
 
-	texDiffuse += texOffset;
-	texGlow += texOffset;
-	texNormal += texOffset;
-	texSpecular += texOffset;
+	texCoords += texOffset;
 #endif // USE_PARALLAX_MAPPING
 
 	// compute the diffuse term
-	vec4 diffuse = texture2D(u_DiffuseMap, texDiffuse) * var_Color;
+	vec4 diffuse = texture2D(u_DiffuseMap, texCoords) * var_Color;
 
 	if( abs(diffuse.a + u_AlphaThreshold) <= 1.0 )
 	{
@@ -106,10 +96,10 @@ void	main()
 		return;
 	}
 
-	vec4 specular = texture2D(u_SpecularMap, texSpecular);
+	vec4 specular = texture2D(u_SpecularMap, texCoords);
 
 	// compute normal in world space from normalmap
-	vec3 N = NormalInWorldSpace(texNormal, tangentToWorldMatrix);
+	vec3 N = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
 
 	// compute final color
 	vec4 color = vec4( ambCol * diffuse.xyz, diffuse.a );
@@ -118,7 +108,7 @@ void	main()
 	computeDLights( var_Position, N, viewDir, diffuse, specular, color );
 
 #if defined(r_glowMapping)
-	color.rgb += texture2D(u_GlowMap, texGlow).rgb;
+	color.rgb += texture2D(u_GlowMap, texCoords).rgb;
 #endif // r_glowMapping
 
 	outputColor = color;

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_world_vp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_world_vp.glsl
@@ -22,10 +22,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* vertexLighting_DBS_world_vp.glsl */
 
-uniform mat4		u_DiffuseTextureMatrix;
-uniform mat4		u_NormalTextureMatrix;
-uniform mat4		u_SpecularTextureMatrix;
-uniform mat4		u_GlowTextureMatrix;
+uniform mat4		u_TextureMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
 uniform float		u_Time;
@@ -34,12 +31,9 @@ uniform vec4		u_ColorModulate;
 uniform vec4		u_Color;
 
 OUT(smooth) vec3	var_Position;
-OUT(smooth) vec2	var_TexDiffuse;
-OUT(smooth) vec2	var_TexGlow;
+OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) vec4	var_Color;
 
-OUT(smooth) vec2	var_TexNormal;
-OUT(smooth) vec2	var_TexSpecular;
 OUT(smooth) vec3	var_Tangent;
 OUT(smooth) vec3	var_Binormal;
 
@@ -75,22 +69,13 @@ void	main()
 	var_Position = position.xyz;
 
 	// transform diffusemap texcoords
-	var_TexDiffuse = (u_DiffuseTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
+	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
 
 	// assign color
 	var_Color = color;
-	
-	// transform normalmap texcoords
-	var_TexNormal = (u_NormalTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
-
-	// transform specularmap texture coords
-	var_TexSpecular = (u_SpecularTextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
 	
 	var_Tangent = LB.tangent;
 	var_Binormal = LB.binormal;
 
 	var_Normal = LB.normal;
-
-	// transform glowmap texture coords
-	var_TexGlow = ( u_GlowTextureMatrix * vec4(texCoord, 0.0, 1.0) ).st;
 }

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1869,7 +1869,7 @@ static void RB_SetupLightForLighting( trRefLight_t *light )
 
 							// bind u_ColorMap
 							GL_BindToTMU( 0, tr.whiteImage );
-							gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+							gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 							gl_genericShader->SetUniform_ModelViewProjectionMatrix( light->shadowMatrices[ frustumIndex ] );
 
@@ -2737,7 +2737,7 @@ void RB_RunVisTests( )
 
 		// bind u_ColorMap
 		GL_BindToTMU( 0, tr.whiteImage );
-		gl_genericShader->SetUniform_ColorTextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
+		gl_genericShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
 
 		GL_State( GLS_DEPTHTEST_DISABLE | GLS_COLORMASK_BITS );
 		glBeginQuery( GL_SAMPLES_PASSED, testState->hQueryRef );
@@ -3265,7 +3265,7 @@ static void RB_RenderDebugUtils()
 
 		// bind u_ColorMap
 		GL_BindToTMU( 0, tr.whiteImage );
-		gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+		gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 		ia = nullptr;
 		Color::Color lightColor;
@@ -3425,7 +3425,7 @@ static void RB_RenderDebugUtils()
 
 		// bind u_ColorMap
 		GL_BindToTMU( 0, tr.whiteImage );
-		gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+		gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 		for ( iaCount = 0, ia = &backEnd.viewParms.interactions[ 0 ]; iaCount < backEnd.viewParms.numInteractions; ia++, iaCount++ )
 		{
@@ -3550,7 +3550,7 @@ static void RB_RenderDebugUtils()
 
 		// bind u_ColorMap
 		GL_BindToTMU( 0, tr.whiteImage );
-		gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+		gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 		ent = backEnd.refdef.entities;
 
@@ -3632,7 +3632,7 @@ static void RB_RenderDebugUtils()
 #else
 		GL_BindToTMU( 0, tr.whiteImage );
 #endif
-		gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+		gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 		ent = backEnd.refdef.entities;
 
@@ -3855,7 +3855,7 @@ static void RB_RenderDebugUtils()
 
 		// bind u_ColorMap
 		GL_BindToTMU( 0, tr.whiteImage );
-		gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+		gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 		// set 2D virtual screen size
 		GL_PushMatrix();
@@ -3980,7 +3980,7 @@ static void RB_RenderDebugUtils()
 
 			// bind u_ColorMap
 			GL_BindToTMU( 0, tr.whiteImage );
-			gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+			gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 			GL_CheckErrors();
 
@@ -4056,7 +4056,7 @@ static void RB_RenderDebugUtils()
 
 		// bind u_ColorMap
 		GL_BindToTMU( 0, tr.whiteImage );
-		gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+		gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 		GL_CheckErrors();
 
@@ -4141,7 +4141,7 @@ static void RB_RenderDebugUtils()
 
 		// bind u_ColorMap
 		GL_BindToTMU( 0, tr.whiteImage );
-		gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+		gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 		GL_CheckErrors();
 
@@ -4236,7 +4236,7 @@ static void RB_RenderDebugUtils()
 
 					// bind u_ColorMap
 					GL_BindToTMU( 0, tr.whiteImage );
-					gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+					gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 					gl_genericShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 
@@ -4438,7 +4438,7 @@ static void RB_RenderDebugUtils()
 
 		// bind u_ColorMap
 		GL_BindToTMU( 0, tr.whiteImage );
-		gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+		gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 		GL_CheckErrors();
 
@@ -4530,7 +4530,7 @@ void DebugDrawBegin( debugDrawMode_t mode, float size ) {
 
 	// bind u_ColorMap
 	GL_BindToTMU( 0, tr.whiteImage );
-	gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+	gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 	// render in world space
 	backEnd.orientation = backEnd.viewParms.world;
@@ -4842,7 +4842,7 @@ void RE_StretchRaw( int x, int y, int w, int h, int cols, int rows, const byte *
 
 	// bind u_ColorMap
 	GL_BindToTMU( 0, tr.scratchImage[ client ] );
-	gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+	gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 	// if the scratchImage isn't in the format we want, specify it as a new texture
 	if ( cols != tr.scratchImage[ client ]->width || rows != tr.scratchImage[ client ]->height )
@@ -5754,7 +5754,7 @@ void RB_ShowImages()
 	// set uniforms
 	//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 	gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
-	gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+	gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 
 	GL_SelectTexture( 0 );
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -479,7 +479,7 @@ static void DrawTris()
 
 	// bind u_ColorMap
 	GL_BindToTMU( 0, tr.whiteImage );
-	gl_genericShader->SetUniform_ColorTextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
+	gl_genericShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
 	gl_genericShader->SetRequiredVertexPointers();
 
 	glDepthRange( 0, 0 );
@@ -678,7 +678,7 @@ static void Render_generic( int stage )
 	// bind u_ColorMap
 	GL_SelectTexture( 0 );
 	BindAnimatedImage( &pStage->bundle[ TB_COLORMAP ] );
-	gl_genericShader->SetUniform_ColorTextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
+	gl_genericShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
 
 	if ( hasDepthFade )
 	{
@@ -801,7 +801,7 @@ static void Render_vertexLighting_DBS_entity( int stage )
 
 	// bind u_DiffuseMap
 	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-	gl_vertexLightingShader_DBS_entity->SetUniform_DiffuseTextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	gl_vertexLightingShader_DBS_entity->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 
 	if ( normalMapping || heightMapInNormalMap )
 	{
@@ -815,8 +815,6 @@ static void Render_vertexLighting_DBS_entity( int stage )
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
-
-	gl_vertexLightingShader_DBS_entity->SetUniform_NormalTextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
 
 	if ( specularMapping )
 	{
@@ -832,8 +830,6 @@ static void Render_vertexLighting_DBS_entity( int stage )
 	{
 		GL_BindToTMU( 2, tr.blackImage );
 	}
-
-	gl_vertexLightingShader_DBS_entity->SetUniform_SpecularTextureMatrix( tess.svars.texMatrices[ TB_SPECULARMAP ] );
 
 	if ( tr.cubeHashTable != nullptr )
 	{
@@ -922,12 +918,8 @@ static void Render_vertexLighting_DBS_entity( int stage )
 	if ( glowMapping )
 	{
 		GL_BindToTMU( 5, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
-
-		gl_vertexLightingShader_DBS_entity->SetUniform_GlowTextureMatrix( tess.svars.texMatrices[ TB_GLOWMAP ] );
 	} else {
 		GL_BindToTMU( 5, tr.blackImage );
-
-		gl_vertexLightingShader_DBS_entity->SetUniform_GlowTextureMatrix( tess.svars.texMatrices[ TB_GLOWMAP ] );
 	}
 
 	if ( tr.lightGrid1Image && tr.lightGrid2Image ) {
@@ -1053,7 +1045,7 @@ static void Render_vertexLighting_DBS_world( int stage )
 
 	// bind u_DiffuseMap
 	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-	gl_vertexLightingShader_DBS_world->SetUniform_DiffuseTextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	gl_vertexLightingShader_DBS_world->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 
 	if ( normalMapping || heightMapInNormalMap )
 	{
@@ -1067,8 +1059,6 @@ static void Render_vertexLighting_DBS_world( int stage )
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
-
-	gl_vertexLightingShader_DBS_world->SetUniform_NormalTextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
 
 	if ( specularMapping )
 	{
@@ -1085,8 +1075,6 @@ static void Render_vertexLighting_DBS_world( int stage )
 		GL_BindToTMU( 2, tr.blackImage );
 	}
 
-	gl_vertexLightingShader_DBS_world->SetUniform_SpecularTextureMatrix( tess.svars.texMatrices[ TB_SPECULARMAP ] );
-
 	if ( tr.lightGrid1Image && tr.lightGrid2Image ) {
 		GL_BindToTMU( 6, tr.lightGrid1Image );
 		GL_BindToTMU( 7, tr.lightGrid2Image );
@@ -1095,12 +1083,8 @@ static void Render_vertexLighting_DBS_world( int stage )
 	if ( glowMapping )
 	{
 		GL_BindToTMU( 3, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
-
-		gl_vertexLightingShader_DBS_world->SetUniform_GlowTextureMatrix( tess.svars.texMatrices[ TB_GLOWMAP ] );
 	} else {
 		GL_BindToTMU( 3, tr.blackImage );
-
-		gl_vertexLightingShader_DBS_world->SetUniform_GlowTextureMatrix( tess.svars.texMatrices[ TB_GLOWMAP ] );
 	}
 
 	gl_vertexLightingShader_DBS_world->SetRequiredVertexPointers();
@@ -1223,7 +1207,7 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 	else
 	{
 		GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-		gl_lightMappingShader->SetUniform_DiffuseTextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+		gl_lightMappingShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 	}
 
 	// bind u_NormalMap
@@ -1239,8 +1223,6 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 		GL_BindToTMU( 1, tr.flatImage );
 	}
 
-	gl_lightMappingShader->SetUniform_NormalTextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
-
 	if ( specularMapping )
 	{
 		// bind u_SpecularMap
@@ -1255,8 +1237,6 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 	{
 		GL_BindToTMU( 2, tr.blackImage );
 	}
-
-	gl_lightMappingShader->SetUniform_SpecularTextureMatrix( tess.svars.texMatrices[ TB_SPECULARMAP ] );
 
 	// bind u_DeluxeMap
 	if ( deluxeMapping )
@@ -1282,12 +1262,8 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 	if ( glowMapping )
 	{
 		GL_BindToTMU( 5, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
-
-		gl_lightMappingShader->SetUniform_GlowTextureMatrix( tess.svars.texMatrices[ TB_GLOWMAP ] );
 	} else {
 		GL_BindToTMU( 5, tr.blackImage );
-
-		gl_lightMappingShader->SetUniform_GlowTextureMatrix( tess.svars.texMatrices[ TB_GLOWMAP ] );
 	}
 
 	gl_lightMappingShader->SetRequiredVertexPointers();
@@ -1360,13 +1336,13 @@ static void Render_depthFill(int stage)
 	if ( alphaBits != 0 )
 	{
 		GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-		gl_genericShader->SetUniform_ColorTextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+		gl_genericShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 	}
 	else
 	{
 		//GL_Bind(tr.defaultImage);
 		GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-		gl_genericShader->SetUniform_ColorTextureMatrix( matrixIdentity );
+		gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 	}
 
 	gl_genericShader->SetRequiredVertexPointers();
@@ -1435,7 +1411,7 @@ static void Render_shadowFill( int stage )
 	if ( ( pStage->stateBits & GLS_ATEST_BITS ) != 0 )
 	{
 		GL_BindToTMU( 0, pStage->bundle[ TB_COLORMAP ].image[ 0 ] );
-		gl_shadowFillShader->SetUniform_ColorTextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
+		gl_shadowFillShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
 	}
 	else
 	{
@@ -1578,7 +1554,7 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *diffuseStage,
 
 	// bind u_DiffuseMap
 	GL_BindToTMU( 0, diffuseStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-	gl_forwardLightingShader_omniXYZ->SetUniform_DiffuseTextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	gl_forwardLightingShader_omniXYZ->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 
 	if ( normalMapping || heightMapInNormalMap )
 	{
@@ -1592,8 +1568,6 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *diffuseStage,
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
-
-	gl_forwardLightingShader_omniXYZ->SetUniform_NormalTextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
 
 	if ( specularMapping )
 	{
@@ -1609,8 +1583,6 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *diffuseStage,
 	{
 		GL_BindToTMU( 2, tr.blackImage );
 	}
-
-	gl_forwardLightingShader_omniXYZ->SetUniform_SpecularTextureMatrix( tess.svars.texMatrices[ TB_SPECULARMAP ] );
 
 	// bind u_AttenuationMapXY
 	GL_SelectTexture( 3 );
@@ -1769,7 +1741,7 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *diffuseStage,
 
 	// bind u_DiffuseMap
 	GL_BindToTMU( 0, diffuseStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-	gl_forwardLightingShader_projXYZ->SetUniform_DiffuseTextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	gl_forwardLightingShader_projXYZ->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 
 	if ( normalMapping || heightMapInNormalMap )
 	{
@@ -1783,8 +1755,6 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *diffuseStage,
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
-
-	gl_forwardLightingShader_projXYZ->SetUniform_NormalTextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
 
 	if ( specularMapping )
 	{
@@ -1800,8 +1770,6 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *diffuseStage,
 	{
 		GL_BindToTMU( 2, tr.blackImage );
 	}
-
-	gl_forwardLightingShader_projXYZ->SetUniform_SpecularTextureMatrix( tess.svars.texMatrices[ TB_SPECULARMAP ] );
 
 	// bind u_AttenuationMapXY
 	GL_SelectTexture( 3 );
@@ -1962,7 +1930,7 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *diffuseStage,
 
 	// bind u_DiffuseMap
 	GL_BindToTMU( 0, diffuseStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-	gl_forwardLightingShader_directionalSun->SetUniform_DiffuseTextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	gl_forwardLightingShader_directionalSun->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 
 	if ( normalMapping || heightMapInNormalMap )
 	{
@@ -1976,8 +1944,6 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *diffuseStage,
 	{
 		GL_BindToTMU( 1, tr.flatImage );
 	}
-
-	gl_forwardLightingShader_directionalSun->SetUniform_NormalTextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
 
 	if ( specularMapping )
 	{
@@ -1993,8 +1959,6 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *diffuseStage,
 	{
 		GL_BindToTMU( 2, tr.blackImage );
 	}
-
-	gl_forwardLightingShader_directionalSun->SetUniform_SpecularTextureMatrix( tess.svars.texMatrices[ TB_SPECULARMAP ] );
 
 	// bind u_ShadowMap
 	if ( shadowCompare )
@@ -2093,7 +2057,7 @@ static void Render_reflection_CB( int stage )
 		GL_BindToTMU( 1, tr.flatImage );
 	}
 
-	gl_reflectionShader->SetUniform_NormalTextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
+	gl_reflectionShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
 
 	// bind u_depthScale u_parallaxOffsetBias
 	if ( parallaxMapping )
@@ -2274,7 +2238,7 @@ static void Render_heatHaze( int stage )
 		// bind u_NormalMap
 		GL_BindToTMU( 0, pStage->bundle[ TB_COLORMAP ].image[ 0 ] );
 
-		gl_heatHazeShader->SetUniform_NormalTextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
+		gl_heatHazeShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
 
 		// bind u_NormalFormat
 		gl_heatHazeShader->SetUniform_NormalFormat( tess.surfaceShader->normalFormat );
@@ -2363,7 +2327,7 @@ static void Render_liquid( int stage )
 		gl_liquidShader->SetUniform_NormalFormat( tess.surfaceShader->normalFormat );
 	}
 
-	gl_liquidShader->SetUniform_NormalTextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
+	gl_liquidShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
 
 	Tess_DrawElements();
 


### PR DESCRIPTION
The extra compute and boilerplate code seem useless and it already ended in bugs when parallax offset was applied to diffuse, normal, specular but nor glow map, and I would find stupid to add more boilerplate when height map will be implemented.

Diffuse/normal/specular/glow/height maps are component of the same material, so there is no reason to handle their coordinates separately.

Doing this would also avoid the need for a lot of `ifdef` code when normal/specular/glow/parallax support is disabled.

And well, that extra code seems useless even when they are enabled.

It unify the symbol names to `var_TexCoords`.

Alongside the `var_TexDiffuse`, `var_TexNormal`, `var_TexSpecular`, `var_TexGlow` there was some occurrence of `var_Tex`.

Some comments in already rewritten code told that Tr3b had issue with some driver/hardware suffered from "too much var" issue when passed from vp to fp shaders, leading him to abuse some variables,
see 72268b, even if I have not faced this issue with hardware that is so old the game is unplayable, this is an even better way to reduce the number of variables passed from vp to fp.

For multimap material (diffuse/normal/specular/glow), the `texCoords` used is the diffuse one.

Note that we already computed the parallax `texOffset` from diffuse coords only, and applied it to other maps as it would be stupid and inefficient to compute the parallax `texOffset` on each normal/specular/glow coords.
