### PR TITLE
tr_shader: do not enable deluxe map on material without normal map

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1154,9 +1154,11 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 
 	GL_State( stateBits );
 
-	bool deluxeMapping = r_deluxeMapping->integer && tr.worldDeluxeMapping && ( pStage->bundle[ TB_NORMALMAP ].image[ 0 ] != nullptr );
-	normalMapping = normalMapping && deluxeMapping;
-	bool heightMapInNormalMap = tess.surfaceShader->heightMapInNormalMap && ( pStage->bundle[ TB_NORMALMAP ].image[ 0 ] != nullptr );
+	bool hasNormalMap = pStage->bundle[ TB_NORMALMAP ].image[ 0 ] != nullptr;
+
+	bool deluxeMapping = r_deluxeMapping->integer && tr.worldDeluxeMapping && hasNormalMap;
+	normalMapping &= deluxeMapping; // && hasNormalMap (done for deluxeMapping)
+	bool heightMapInNormalMap = tess.surfaceShader->heightMapInNormalMap && hasNormalMap;
 	bool parallaxMapping = r_parallaxMapping->integer && tess.surfaceShader->parallax && !tess.surfaceShader->noParallax && heightMapInNormalMap;
 	bool specularMapping = r_specularMapping->integer && ( pStage->bundle[ TB_SPECULARMAP ].image[ 0 ] );
 	bool glowMapping = r_glowMapping->integer && ( pStage->bundle[ TB_GLOWMAP ].image[ 0 ] != nullptr );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1154,8 +1154,8 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 
 	GL_State( stateBits );
 
-	bool deluxeMapping = r_deluxeMapping->integer && tr.worldDeluxeMapping;
-	normalMapping = normalMapping && deluxeMapping && ( pStage->bundle[ TB_NORMALMAP ].image[ 0 ] != nullptr );
+	bool deluxeMapping = r_deluxeMapping->integer && tr.worldDeluxeMapping && ( pStage->bundle[ TB_NORMALMAP ].image[ 0 ] != nullptr );
+	normalMapping = normalMapping && deluxeMapping;
 	bool heightMapInNormalMap = tess.surfaceShader->heightMapInNormalMap && ( pStage->bundle[ TB_NORMALMAP ].image[ 0 ] != nullptr );
 	bool parallaxMapping = r_parallaxMapping->integer && tess.surfaceShader->parallax && !tess.surfaceShader->noParallax && heightMapInNormalMap;
 	bool specularMapping = r_specularMapping->integer && ( pStage->bundle[ TB_SPECULARMAP ].image[ 0 ] );


### PR DESCRIPTION
fix a regression introduced in 3d53075

before regression:  
[![deluxe without normal](https://dl.illwieckz.net/b/daemon/bugs/deluxe-without-normal/unvanquished_2019-03-31_093518_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/deluxe-without-normal/unvanquished_2019-03-31_093518_000.jpg)

after regression:  
[![deluxe without normal](https://dl.illwieckz.net/b/daemon/bugs/deluxe-without-normal/unvanquished_2019-03-31_093634_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/deluxe-without-normal/unvanquished_2019-03-31_093634_000.jpg)

after fix:  
[![deluxe without normal](https://dl.illwieckz.net/b/daemon/bugs/deluxe-without-normal/unvanquished_2019-03-31_094947_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/deluxe-without-normal/unvanquished_2019-03-31_094947_000.jpg)