### PR TITLE
tr_shader: color map after diffuse map keeps light map explicitely ordered

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4159,7 +4159,11 @@ static void CollapseStages()
 
 	for ( int i = 0; i < MAX_SHADER_STAGES; i++ )
 	{
-		if ( stages[ i ].type == stageType_t::ST_DIFFUSEMAP )
+		if ( !stages[ i ].active )
+		{
+			continue;
+		}
+		else if ( stages[ i ].type == stageType_t::ST_DIFFUSEMAP )
 		{
 			if ( diffuseStage != -1 )
 			{


### PR DESCRIPTION
I'm not sure this is a good idea: keep color map after diffuse map ordered after lightmap, some maybe mistake, others may be legacy addition map (glow map).

because of the bad design of the `*Map` material stuff there it's hard to raise a warning when people mistakenly put color maps after diffuse map, meaning a proper collapsing code paints the lightmap before the color maps overriding them, we can see an example of bad material like this in hangar28 map by tvezet:

```c
textures/hangar28_pk02/sand_stone
{
	qer_editorimage textures/shared_pk02_src/sand01_d
	
	q3map_nonplanar
	q3map_shadeangle 170
	q3map_lightmapmergable
	
	diffuseMap          textures/shared_pk02_src/sand01_d
	normalMap           textures/shared_pk02_src/sand01_n
	specularMap         textures/shared_pk02_src/sand01_s
    
	{
		map textures/shared_pk02_src/rock01_d	// Primary
		rgbGen identity
	}
	{
		map textures/shared_pk02_src/sand01_d	// Secondary
		blendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA
		//alphaFunc GE128
		rgbGen identity
		alphaGen vertex
		
	}
	{
		map $lightmap
		blendFunc GL_DST_COLOR GL_ZERO
		rgbGen identity
	}
}
```

We see a collapsable diffuse stage then two color maps in a terrain blending pattern then a lightmap. In such case lightmap must be disabled in collapsable diffuse stage to be sure the explicit lightmap stage is painted over the terrain map. One would say, “why take care of such monstruosity?” the problem is that legacy addition map just looks the same for a parser point of view, for example our medistation material has a legacy addition map:

```c
models/buildables/medistat/medistat
{
	qer_editorImage models/buildables/medistat/medistat_d
	diffuseMap models/buildables/medistat/medistat_d
	normalMap models/buildables/medistat/medistat_n
	{
		stage specularMap
		map models/buildables/medistat/medistat_s
		specularExponentMin 10
		specularExponentMax 25
	}
	{
		map models/buildables/medistat/medistat_a
		blendfunc add
	}
}
```

Hopefully there is no explicit lightmap stage so we are lucky and lightmap is already painted before the addition map, but add an explicit lightmap stage with a custom filtering and then you get bugs. Note that those materials may be rewritten to use the `glowMap` keyword to avoid one rendering stage but that's out of topic.

In some case the legacy addition maps can't use the `glowMap` keyword, especially when there is more than one and/or they have specific effects. See that `drill` example:

```c
models/buildables/drill/drill
{
	qer_editorImage models/buildables/drill/drill_d
	diffuseMap models/buildables/drill/drill_d
	normalMap models/buildables/drill/drill_n
	specularMap models/buildables/drill/drill_s
	// white lamp on top
	{
		map models/buildables/drill/drill_top_a
		blendfunc add
		rgbGen    wave sin 1 .85 .5 .08
	}
	// small yellow lamps around
	{
		map models/buildables/drill/drill_around_a
		blendfunc add
		rgb       .85 .85 .85
	}

	when destroyed models/buildables/drill/drill_dead
}
```

In this example there is no explicit lightmap stage, but if there was we have to make sure they are ordered well. Note that I haven't found yet unproper legacy addition map with bad placed light stage, and by luck the light stage is implicitely painted before the legacy addition map hence it's already rendered properly when lightmap stage is implicit.

Not merging this code would keep the hangar28 bug obvious to mappers which is not bad. I want to be sure there is no legit case for such pattern. If there is no legit case for such pattern (i.e. colormap that is not an addition map after collapsable diffuse stage with explicit lightmap stage), there is no need to merge that. Map would have to be fixed in any way.

Note that this commit also adds a test for stages being active when iterating them to detect their kind, this minor change can be merged in any way and I will extract it as a standalone commit.