### PR TITLE
WIP: set a minimum amount of lighting

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -579,6 +579,11 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_showLightTiles", 1 );
 	}
 
+	if ( r_floorLight->integer )
+	{
+		AddDefine( str, "r_floorLight", 1 );
+	}
+
 	if ( r_normalMapping->integer )
 	{
 		AddDefine( str, "r_normalMapping", 1 );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -159,6 +159,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_offsetFactor;
 	cvar_t      *r_offsetUnits;
 
+	cvar_t      *r_floorLight;
+
 	cvar_t      *r_specularExponentMin;
 	cvar_t      *r_specularExponentMax;
 	cvar_t      *r_specularScale;
@@ -1190,6 +1192,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_clear = ri.Cvar_Get( "r_clear", "0", CVAR_CHEAT );
 		r_offsetFactor = ri.Cvar_Get( "r_offsetFactor", "-1", CVAR_CHEAT );
 		r_offsetUnits = ri.Cvar_Get( "r_offsetUnits", "-2", CVAR_CHEAT );
+
+		r_floorLight = ri.Cvar_Get( "r_floorLight", "0", CVAR_LATCH );
 
 		r_specularExponentMin = ri.Cvar_Get( "r_specularExponentMin", "0", CVAR_CHEAT );
 		r_specularExponentMax = ri.Cvar_Get( "r_specularExponentMax", "16", CVAR_CHEAT );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2849,6 +2849,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_offsetFactor;
 	extern cvar_t *r_offsetUnits;
 
+	extern cvar_t *r_floorLight;
+
 	extern cvar_t *r_specularExponentMin;
 	extern cvar_t *r_specularExponentMax;
 	extern cvar_t *r_specularScale;


### PR DESCRIPTION
The last time I updated [The Dark Mod](http://www.thedarkmod.com/main/), I got a bug: there was no lighting. But I noticed everything was still visible. So I discovered that this stealth game that rely a lot on darky zones never have pure dark zones:

[![no light](https://dl.illwieckz.net/b/thedarkmod/bugs/no-light/training_mission_2019-02-03_02.07.17.jpg)](https://dl.illwieckz.net/b/thedarkmod/bugs/no-light/training_mission_2019-02-03_02.07.17.jpg)

[![no light](https://dl.illwieckz.net/b/thedarkmod/bugs/no-light/training_mission_2019-02-03_02.09.46.jpg)](https://dl.illwieckz.net/b/thedarkmod/bugs/no-light/training_mission_2019-02-03_02.09.46.jpg)

[![no light](https://dl.illwieckz.net/b/thedarkmod/bugs/no-light/training_mission_2019-02-03_02.14.36.jpg)](https://dl.illwieckz.net/b/thedarkmod/bugs/no-light/training_mission_2019-02-03_02.14.36.jpg)

I remembered the usual complain about the Unvanquished game being too darky, and I thought the idea was nice and I wanted the feature in Dæmon too.

Then I was yet another time annoyed by the ugly darky blotches of our non-sRGB lightmaps. And then the light came to my mind. If there is no pure dark zones, there can't be dark blotches.

Dark blotches came from the fact the current color curve does not have so much steps in the dark part, hence the shadows coming from average grey to pure black in one step.

So I implemented this hack. For every shadow color component between `0` and `0.18`, rescale it between `0.06` and `0.18`. The `0.06` value was chosen the empirical way by testing with some maps suffering a lot from the bug, and some other maps to ensure nothing wrong occurs. The `0.18` value was arbitrarily chosen without much thinking.

I really have no idea about the way to name this feature. Currently, the cvar is named `r_floorLight`, I highly recommend yourself to try this.

It's an easy hack to greatly improve the looking of our maps. sRGB lightmaps will tamper the need for such hack for good looking purpose, but since it's a good feature to always keep a minimum amount of light, it may be good to keep the feature and just adjust the numbers for the sRGB curve.

Note: it looks less good in thumbnails because the dark stuff being less contrasted, but it looks better in game this way:

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190038_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190038_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190100_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190100_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190234_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190234_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190257_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190257_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190403_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190403_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190425_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190425_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190701_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190701_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190723_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190723_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190830_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190830_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190847_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190847_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_191519_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_191519_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_191545_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_191545_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_191841_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_191841_000.jpg)

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_191905_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_191905_000.jpg)

There is one issue though, the usual "black" texture hack does not work anymore:

[![floorlight](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190440_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/floorlight/unvanquished_2019-04-07_190440_000.jpg)