### PR TITLE
some tr_shade/glsl code cleanup

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1191,6 +1191,21 @@ void GLShaderManager::BindAttribLocations( GLuint program ) const
 	}
 }
 
+// reflective specular not implemented for PBR yet
+bool GLCompileMacro_USE_REFLECTIVE_SPECULAR::HasConflictingMacros( size_t permutation, const std::vector< GLCompileMacro * > &macros ) const
+{
+	for (const GLCompileMacro* macro : macros)
+	{
+		if ( ( permutation & macro->GetBit() ) != 0 && (macro->GetType() == USE_PHYSICAL_SHADING || macro->GetType() == USE_VERTEX_SPRITE) )
+		{
+			//Log::Notice("conflicting macro! canceling '%s' vs. '%s'", GetName(), macro->GetName());
+			return true;
+		}
+	}
+
+	return false;
+}
+
 bool GLCompileMacro_USE_VERTEX_SKINNING::HasConflictingMacros( size_t permutation, const std::vector< GLCompileMacro * > &macros ) const
 {
 	for (const GLCompileMacro* macro : macros)

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1048,6 +1048,8 @@ public:
 		return "USE_REFLECTIVE_SPECULAR";
 	}
 
+	bool HasConflictingMacros(size_t permutation, const std::vector< GLCompileMacro * > &macros) const;
+
 	EGLCompileMacro GetType() const
 	{
 		return EGLCompileMacro::USE_REFLECTIVE_SPECULAR;

--- a/src/engine/renderer/glsl_source/dispersion_C_fp.glsl
+++ b/src/engine/renderer/glsl_source/dispersion_C_fp.glsl
@@ -37,26 +37,26 @@ DECLARE_OUTPUT(vec4)
 void	main()
 {
 	// compute incident ray
-	vec3 I = normalize(var_Position - u_ViewOrigin);
+	vec3 incidentRay = normalize(var_Position - u_ViewOrigin);
 
 	// compute normal
-	vec3 N = normalize(var_Normal);	// FIXME normalize?
+	vec3 normal = normalize(var_Normal);	// FIXME normalize?
 
 	// compute reflection ray
-	vec3 R = reflect(I, N);
+	vec3 reflectionRay = reflect(incidentRay, normal);
 
 	// compute fresnel term
-	float fresnel = u_FresnelBias + pow(1.0 - dot(I, N), u_FresnelPower) * u_FresnelScale;
+	float fresnel = u_FresnelBias + pow(1.0 - dot(incidentRay, normal), u_FresnelPower) * u_FresnelScale;
 
 	// compute reflection color
-	vec3 reflectColor = textureCube(u_ColorMap, R).rgb;
+	vec3 reflectColor = textureCube(u_ColorMap, reflectionRay).rgb;
 
 	// compute refraction color using a refraction ray for each channel
 	vec3 refractColor;
 
-	refractColor.r = textureCube(u_ColorMap, refract(I, N, u_EtaRatio.x)).r;
-	refractColor.g = textureCube(u_ColorMap, refract(I, N, u_EtaRatio.y)).g;
-	refractColor.b = textureCube(u_ColorMap, refract(I, N, u_EtaRatio.z)).b;
+	refractColor.r = textureCube(u_ColorMap, refract(incidentRay, normal, u_EtaRatio.x)).r;
+	refractColor.g = textureCube(u_ColorMap, refract(incidentRay, normal, u_EtaRatio.y)).g;
+	refractColor.b = textureCube(u_ColorMap, refract(incidentRay, normal, u_EtaRatio.z)).b;
 
 	// compute final color
 	vec4 color;

--- a/src/engine/renderer/glsl_source/heatHaze_fp.glsl
+++ b/src/engine/renderer/glsl_source/heatHaze_fp.glsl
@@ -35,13 +35,13 @@ void	main()
 	vec4 color;
 
 	// compute normal in tangent space from normalmap
-	vec3 N = NormalInTangentSpace(var_TexCoords);
+	vec3 normal = NormalInTangentSpace(var_TexCoords);
 
 	// calculate the screen texcoord in the 0.0 to 1.0 range
 	vec2 st = gl_FragCoord.st * r_FBufScale;
 
 	// offset by the scaled normal and clamp it to 0.0 - 1.0
-	st += N.xy * var_Deform;
+	st += normal.xy * var_Deform;
 	st = clamp(st, 0.0, 1.0);
 
 	color = texture2D(u_CurrentMap, st);

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -80,12 +80,7 @@ void	main()
 #if defined(USE_DELUXE_MAPPING)
 	// compute light direction in world space
 	vec4 deluxe = texture2D(u_DeluxeMap, var_TexLight);
-#else // !USE_DELUXE_MAPPING
-	// normal/deluxe mapping is disabled
-	color.xyz += lightColor.xyz * diffuse.xyz;
-#endif // USE_DELUXE_MAPPING
 
-#if defined(USE_DELUXE_MAPPING)
 	vec3 L = 2.0 * deluxe.xyz - 1.0;
 	L = normalize(L);
 
@@ -94,6 +89,9 @@ void	main()
 
 	// compute final color
 	computeLight( L, N, viewDir, lightColor, diffuse, specular, color );
+#else // !USE_DELUXE_MAPPING
+	// normal/deluxe mapping is disabled
+	color.xyz += lightColor.xyz * diffuse.xyz;
 #endif // USE_DELUXE_MAPPING
 
 	computeDLights( var_Position, N, viewDir, diffuse, specular, color );

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -70,7 +70,7 @@ void	main()
 	vec4 specular = texture2D(u_SpecularMap, texCoords);
 
 	// compute normal in world space from normalmap
-	vec3 N = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
+	vec3 normal = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
 
 	// compute light color from world space lightmap
 	vec3 lightColor = texture2D(u_LightMap, var_TexLight).xyz;
@@ -88,13 +88,13 @@ void	main()
 	lightColor /= clamp(dot(normalize(var_Normal), L), 0.004, 1.0);
 
 	// compute final color
-	computeLight( L, N, viewDir, lightColor, diffuse, specular, color );
+	computeLight( L, normal, viewDir, lightColor, diffuse, specular, color );
 #else // !USE_DELUXE_MAPPING
 	// normal/deluxe mapping is disabled
 	color.xyz += lightColor.xyz * diffuse.xyz;
 #endif // USE_DELUXE_MAPPING
 
-	computeDLights( var_Position, N, viewDir, diffuse, specular, color );
+	computeDLights( var_Position, normal, viewDir, diffuse, specular, color );
 
 #if defined(r_glowMapping)
 	color.rgb += texture2D(u_GlowMap, texCoords).rgb;

--- a/src/engine/renderer/glsl_source/lightVolume_omni_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightVolume_omni_fp.glsl
@@ -58,10 +58,10 @@ void	main()
 	P.xyz /= P.w;
 
 	// compute incident ray in world space
-	vec3 R = normalize(P.xyz - u_ViewOrigin);
-	//vec3 R = normalize(u_ViewOrigin - P.xyz);
+	vec3 incidentRay = normalize(P.xyz - u_ViewOrigin);
+	//vec3 incidentRay = normalize(u_ViewOrigin - P.xyz);
 
-	//float traceDistance = dot(P.xyz - (u_ViewOrigin.xyz + R * u_ZNear ), forward);
+	//float traceDistance = dot(P.xyz - (u_ViewOrigin.xyz + incidentRay * u_ZNear ), forward);
 	//traceDistance = clamp(traceDistance, 0.0, 2500.0 ); // Far trace distance
 
 	float traceDistance = distance(P.xyz, u_ViewOrigin);
@@ -79,9 +79,9 @@ void	main()
 
 	for(float tracedDistance = 0.0; tracedDistance < traceDistance; tracedDistance += stepSize)
 	{
-		//vec3 T = P.xyz + (R * stepSize * float(i));
-		//vec3 T = u_ViewOrigin + (R * stepSize * float(i));
-		vec3 T = u_ViewOrigin + (R * tracedDistance);
+		//vec3 T = P.xyz + (incidentRay * stepSize * float(i));
+		//vec3 T = u_ViewOrigin + (incidentRay * stepSize * float(i));
+		vec3 T = u_ViewOrigin + (incidentRay * tracedDistance);
 
 		// compute attenuation
 		vec3 texAttenXYZ		= (u_LightAttenuationMatrix * vec4(T, 1.0)).xyz;

--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -103,17 +103,16 @@ void	main()
 #endif
 
 	// compute normals
-
 	vec3 N = normalize(var_Normal);
 
 	// compute normal in world space from normalmap
-	vec3 N2 = NormalInWorldSpace(texNormal, tangentToWorldMatrix);
+	vec3 normal = NormalInWorldSpace(texNormal, tangentToWorldMatrix);
 
 	// compute fresnel term
-	float fresnel = clamp(u_FresnelBias + pow(1.0 - dot(viewDir, N), u_FresnelPower) *
+	float fresnel = clamp(u_FresnelBias + pow(1.0 - dot(viewDir, normal), u_FresnelPower) *
 			u_FresnelScale, 0.0, 1.0);
 
-	texScreen += u_NormalScale * N2.xy;
+	texScreen += u_NormalScale * normal.xy;
 
 	vec3 refractColor = texture2D(u_CurrentMap, texScreen).rgb;
 	vec3 reflectColor = texture2D(u_PortalMap, texScreen).rgb;
@@ -153,11 +152,11 @@ void	main()
 	vec3 H = normalize(L + viewDir);
 
 	// compute the light term
-	vec3 light = lgtCol * clamp(dot(N2, L), 0.0, 1.0);
+	vec3 light = lgtCol * clamp(dot(normal, L), 0.0, 1.0);
 
 #if defined(r_specularMapping)
 	// compute the specular term
-	vec3 specular = reflectColor * lgtCol * pow(clamp(dot(N2, H), 0.0, 1.0), u_SpecularExponent.x + u_SpecularExponent.y) * r_SpecularScale;
+	vec3 specular = reflectColor * lgtCol * pow(clamp(dot(normal, H), 0.0, 1.0), u_SpecularExponent.x + u_SpecularExponent.y) * r_SpecularScale;
 	color.rgb += specular;
 #endif // r_specularMapping
 

--- a/src/engine/renderer/glsl_source/reflection_CB_fp.glsl
+++ b/src/engine/renderer/glsl_source/reflection_CB_fp.glsl
@@ -51,11 +51,11 @@ void	main()
 #endif // USE_PARALLAX_MAPPING
 
 	// compute normal in tangent space from normal map
-	vec3 N = NormalInWorldSpace(texNormal, tangentToWorldMatrix);
+	vec3 normal = NormalInWorldSpace(texNormal, tangentToWorldMatrix);
 
 	// compute reflection ray
-	vec3 R = reflect(viewDir, N);
+	vec3 reflectionRay = reflect(viewDir, normal);
 
-	outputColor = textureCube(u_ColorMap, R).rgba;
+	outputColor = textureCube(u_ColorMap, reflectionRay).rgba;
 	// outputColor = vec4(1.0, 0.0, 0.0, 1.0);
 }

--- a/src/engine/renderer/glsl_source/refraction_C_fp.glsl
+++ b/src/engine/renderer/glsl_source/refraction_C_fp.glsl
@@ -37,21 +37,21 @@ DECLARE_OUTPUT(vec4)
 void	main()
 {
 	// compute incident ray
-	vec3 I = normalize(var_Position - u_ViewOrigin);
+	vec3 incidentRay = normalize(var_Position - u_ViewOrigin);
 
 	// compute normal
-	vec3 N = normalize(var_Normal);
+	vec3 normal = normalize(var_Normal);
 
 	// compute reflection ray
-	vec3 R = reflect(I, N);
+	vec3 reflectionRay = reflect(incidentRay, normal);
 
 	// compute refraction ray
-	vec3 T = refract(I, N, u_RefractionIndex);
+	vec3 T = refract(incidentRay, N, u_RefractionIndex);
 
 	// compute fresnel term
-	float fresnel = u_FresnelBias + pow(1.0 - dot(I, N), u_FresnelPower) * u_FresnelScale;
+	float fresnel = u_FresnelBias + pow(1.0 - dot(incidentRay, normal), u_FresnelPower) * u_FresnelScale;
 
-	vec3 reflectColor = textureCube(u_ColorMap, R).rgb;
+	vec3 reflectColor = textureCube(u_ColorMap, reflectionRay).rgb;
 	vec3 refractColor = textureCube(u_ColorMap, T).rgb;
 
 	// compute final color

--- a/src/engine/renderer/glsl_source/skybox_fp.glsl
+++ b/src/engine/renderer/glsl_source/skybox_fp.glsl
@@ -32,9 +32,9 @@ DECLARE_OUTPUT(vec4)
 void	main()
 {
 	// compute incident ray
-	vec3 I = normalize(var_Position - u_ViewOrigin);
+	vec3 incidentRay = normalize(var_Position - u_ViewOrigin);
 
-	vec4 color = textureCube(u_ColorMap, I).rgba;
+	vec4 color = textureCube(u_ColorMap, incidentRay).rgba;
 
 	outputColor = color;
 }

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
@@ -92,15 +92,15 @@ void	main()
 #endif // USE_PARALLAX_MAPPING
 
 	// compute normal in world space from normalmap
-	vec3 N = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
+	vec3 normal = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
 
 #if defined(USE_REFLECTIVE_SPECULAR)
 	// not implemented for PBR yet
 
 	vec4 specBase = texture2D(u_SpecularMap, texCoords).rgba;
 
-	vec4 envColor0 = textureCube(u_EnvironmentMap0, reflect(-viewDir, N)).rgba;
-	vec4 envColor1 = textureCube(u_EnvironmentMap1, reflect(-viewDir, N)).rgba;
+	vec4 envColor0 = textureCube(u_EnvironmentMap0, reflect(-viewDir, normal)).rgba;
+	vec4 envColor1 = textureCube(u_EnvironmentMap1, reflect(-viewDir, normal)).rgba;
 
 	specBase.rgb *= mix(envColor0, envColor1, u_EnvironmentInterpolation).rgb;
 
@@ -121,15 +121,15 @@ void	main()
 
 // add Rim Lighting to highlight the edges
 #if defined(r_RimLighting)
-	float rim = pow(1.0 - clamp(dot(N, viewDir), 0.0, 1.0), r_RimExponent);
+	float rim = pow(1.0 - clamp(dot(normal, viewDir), 0.0, 1.0), r_RimExponent);
 	vec3 emission = ambCol * rim * rim * 0.2;
 #endif
 
 	// compute final color
 	vec4 color = vec4(ambCol * r_AmbientScale * diffuse.xyz, diffuse.a);
-	computeLight( L, N, viewDir, lgtCol, diffuse, specBase, color );
+	computeLight( L, normal, viewDir, lgtCol, diffuse, specBase, color );
 
-	computeDLights( var_Position, N, viewDir, diffuse, specBase, color );
+	computeDLights( var_Position, normal, viewDir, diffuse, specBase, color );
 
 #if defined(r_RimLighting)
 	color.rgb += 0.7 * emission;
@@ -144,7 +144,7 @@ void	main()
 // Debugging
 #if defined(r_showEntityNormals)
 	// convert normal to [0,1] color space
-	N = N * 0.5 + 0.5;
-	outputColor = vec4(N, 1.0);
+	normal = normal * 0.5 + 0.5;
+	outputColor = vec4(normal, 1.0);
 #endif
 }

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
@@ -94,8 +94,8 @@ void	main()
 	// compute normal in world space from normalmap
 	vec3 N = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
 
-	// compute the specular term
 #if defined(USE_REFLECTIVE_SPECULAR)
+	// not implemented for PBR yet
 
 	vec4 specBase = texture2D(u_SpecularMap, texCoords).rgba;
 
@@ -104,7 +104,7 @@ void	main()
 
 	specBase.rgb *= mix(envColor0, envColor1, u_EnvironmentInterpolation).rgb;
 
-#else
+#else // USE_REFLECTIVE_SPECULAR
 	// simple Blinn-Phong
 	vec4 specBase = texture2D(u_SpecularMap, texCoords).rgba;
 

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
@@ -99,13 +99,13 @@ void	main()
 	vec4 specular = texture2D(u_SpecularMap, texCoords);
 
 	// compute normal in world space from normalmap
-	vec3 N = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
+	vec3 normal = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
 
 	// compute final color
 	vec4 color = vec4( ambCol * diffuse.xyz, diffuse.a );
-	computeLight( L, N, viewDir, dirCol, diffuse, specular, color );
+	computeLight( L, normal, viewDir, dirCol, diffuse, specular, color );
 
-	computeDLights( var_Position, N, viewDir, diffuse, specular, color );
+	computeDLights( var_Position, normal, viewDir, diffuse, specular, color );
 
 #if defined(r_glowMapping)
 	color.rgb += texture2D(u_GlowMap, texCoords).rgb;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1002,13 +1002,13 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 
 	enum
 	{
-	  TB_COLORMAP = 0,
-	  TB_DIFFUSEMAP = 0,
+	  TB_COLORMAP,
+	  TB_DIFFUSEMAP = TB_COLORMAP,
 	  TB_NORMALMAP,
 	  TB_SPECULARMAP,
 	  TB_MATERIALMAP = TB_SPECULARMAP,
 	  TB_GLOWMAP,
-	  MAX_TEXTURE_BUNDLES = 4
+	  MAX_TEXTURE_BUNDLES
 	};
 
 	struct textureBundle_t

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1054,11 +1054,9 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	enum class collapseType_t
 	{
 	  COLLAPSE_none,
-	  COLLAPSE_genericMulti,
 	  COLLAPSE_lighting_PHONG,
 	  COLLAPSE_lighting_PBR,
 	  COLLAPSE_reflection_CB,
-	  COLLAPSE_color_lightmap
 	};
 
 	struct shaderStage_t

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1238,16 +1238,6 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 		GL_BindToTMU( 2, tr.blackImage );
 	}
 
-	// bind u_DeluxeMap
-	if ( deluxeMapping )
-	{
-		BindDeluxeMap( 4 );
-	}
-	else
-	{
-		GL_BindToTMU( 4, tr.blackImage );
-	}
-
 	// do not paintover lightmap
 	// as a standalone lightmap stage
 	// will do later
@@ -1258,6 +1248,16 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping,
 
 	// bind u_LightMap
 	BindLightMap( 3, whiteLight );
+
+	// bind u_DeluxeMap
+	if ( deluxeMapping )
+	{
+		BindDeluxeMap( 4 );
+	}
+	else
+	{
+		GL_BindToTMU( 4, tr.blackImage );
+	}
 
 	if ( glowMapping )
 	{

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1257,6 +1257,7 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping 
 		GL_BindToTMU( 4, tr.blackImage );
 	}
 
+	// bind u_GlowMap
 	if ( glowMapping )
 	{
 		GL_BindToTMU( 5, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1143,13 +1143,15 @@ static void Render_lightMapping( int stage, bool asColorMap, bool normalMapping 
 		&& !(tess.numSurfaceStages > 0 && tess.surfaceStages[0]->rgbGen == colorGen_t::CGEN_VERTEX);
 
 	bool hasNormalMap = pStage->bundle[ TB_NORMALMAP ].image[ 0 ] != nullptr;
+	bool hasSpecularMap = pStage->bundle[ TB_SPECULARMAP ].image[ 0 ] != nullptr;
+	bool hasGlowMap = pStage->bundle[ TB_GLOWMAP ].image[ 0 ] != nullptr;
 
 	bool deluxeMapping = r_deluxeMapping->integer && tr.worldDeluxeMapping && hasNormalMap;
 	normalMapping &= deluxeMapping; // && hasNormalMap (done for deluxeMapping)
 	bool heightMapInNormalMap = tess.surfaceShader->heightMapInNormalMap && hasNormalMap;
 	bool parallaxMapping = r_parallaxMapping->integer && tess.surfaceShader->parallax && !tess.surfaceShader->noParallax && heightMapInNormalMap;
-	bool specularMapping = r_specularMapping->integer && ( pStage->bundle[ TB_SPECULARMAP ].image[ 0 ] );
-	bool glowMapping = r_glowMapping->integer && ( pStage->bundle[ TB_GLOWMAP ].image[ 0 ] != nullptr );
+	bool specularMapping = r_specularMapping->integer && hasSpecularMap;
+	bool glowMapping = r_glowMapping->integer && hasGlowMap;
 
 	// choose right shader program ----------------------------------
 	GL_BindToTMU( 8, tr.lighttileRenderImage );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2812,6 +2812,7 @@ void Tess_StageIteratorGeneric()
 							}
 							else if ( backEnd.currentEntity != &tr.worldEntity )
 							{
+								// FIXME: This can be reached if r_vertexLighting == 0 and tess.lightmapNum is invalid which doesn't seem right
 								Render_vertexLighting_DBS_entity( stage );
 							}
 							else

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4352,6 +4352,7 @@ static void CollapseStages()
 					ASSERT_GE(lightStage, 0);
 					Log::Debug("found glow map with custom lightmap stage in '%s' shader, not collapsing", shader.name);
 					stages[ glowStage ].type = stageType_t::ST_COLORMAP;
+					// not required since TB_COLORMAP is equal to 0, but the compiler knows how to optimize
 					stages[ glowStage ].bundle[ TB_COLORMAP ] = stages[ glowStage ].bundle[ 0 ];
 
 					// put diffuse stage in the first of the three spots


### PR DESCRIPTION
While I was working on a branch to collapse the reflection cube map stage with the common lightmap one, I did this clean-up.

It makes working on this part of the code easier, but don't have to wait for featural changes to be merged.

Note that one commit makes sure reflective specular is not used whith PBR assets since current reflective specular code is not PBR compatible.