### PR TITLE
gl_shader: also checksum engine constants to invalidate the shader on cvar change

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -842,7 +842,7 @@ void GLShaderManager::InitShader( GLShader *shader )
 
 	shader->_vertexShaderText = BuildGPUShaderText( shader->GetMainShaderName(), vertexInlines, GL_VERTEX_SHADER );
 	shader->_fragmentShaderText = BuildGPUShaderText( shader->GetMainShaderName(), fragmentInlines, GL_FRAGMENT_SHADER );
-	std::string combinedShaderText= shader->_vertexShaderText + shader->_fragmentShaderText;
+	std::string combinedShaderText = GLEngineConstants.getText() + shader->_vertexShaderText + shader->_fragmentShaderText;
 
 	shader->_checkSum = Com_BlockChecksum( combinedShaderText.c_str(), combinedShaderText.length() );
 }


### PR DESCRIPTION
That's an issue I'm facing since a long time, with problems appearing randomly… Last time I got it was when I was working on #193 and this time it was fully reproducible.

The cached binary shader is expected to be invalidated (then rebuilt) when the content of the shader source change. This is done by computing a checksum at shader compile time and comparing it lately.

Unfortunately, the checksum operation was not checksuming against the header that defines constants like `r_normalMapping`, only the content of the `.glsl` file and some macro. Because of that the shaders where not recompiled when such cvar were modified.

This fixes the issue by concatenating the constant header to the text that is sent to the checksum operation.