### PR TITLE
make missing shader image a warning

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5201,7 +5201,7 @@ shader_t       *R_FindShader( const char *name, shaderType_t type,
 
 	if ( !image )
 	{
-		Log::Debug("Couldn't find image file for shader %s", name );
+		Log::Warn("Couldn't find image file for shader %s", name );
 		shader.defaultShader = true;
 		return FinishShader();
 	}


### PR DESCRIPTION
I was toying with some maps, I was surprised to see many textures missing without any warning telling me what was wrong. It's better to make this a warning.