### PR TITLE
load image and sound file with dot in their extension-independent name

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1758,11 +1758,20 @@ static void R_LoadImage( const char **buffer, byte **pic, int *width, int *heigh
 		}
 	}
 
-	// the file isn't there, try again without the extension
-	COM_StripExtension3( token, filename, MAX_QPATH );
-
+	// if the file isn't there, maybe the file path did not have any extension,
+	// and it may be possible the file has a dot in its name that was mistakenly
+	// taken as an extension
 	const char *prefix;
 	int bestLoader = R_FindImageLoader( filename, &prefix );
+
+	if ( *ext && bestLoader == -1 )
+	{
+		// if there is no file with such extension
+		// or there is no codec available for this file format
+		COM_StripExtension3( token, filename, sizeof(filename) );
+
+		bestLoader = R_FindImageLoader( filename, &prefix );
+	}
 
 	if ( bestLoader >= 0 )
 	{


### PR DESCRIPTION
At Quake 3 time it was common to add the .blend suffix to glow maps
so people made files named like:

- textures/something/somename.blend.jpg

If the shader use the full path, the engine will find the file even
if it's shipped in another format, because the engine will look for:

- textures/something/somename.blend.jpg
- textures/something/somename.blend.crn
- textures/something/somename.blend.png
- etc.

But the shader use the extension-independent path, the engine will
not find the file because the .blend suffix will be mistakenly
removed like if it was an extension, and the engine will look for:

- textures/something/somename.jpg
- textures/something/somename.crn
- textures/something/somename.png
- etc.

The engine may either fail to load the file, or load the wrong file
given the somename.blend.jpg file is usually a sidecar for an
existing somename.jpg file.

With this change, the engine tries to load the file by appending
common file extensions before stripping the extension and retrying
with common file extension on stripped name.

Tremulous mappers usually followed Quake 3 methodology, so there is
hundreds or thousands of maps that use .blend picture suffix out
there. It would have been possible to write a workaround for those
special files, but it's far better to make the engine able to fully
support files with dot in their names.

The change is applied to the sound loader as well.