### PR TITLE
HTTP download enhancements

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -2544,7 +2544,7 @@ bool ParsePakName(const char* begin, const char* end, std::string& name, std::st
 	} else if (Str::IsSuffix(PAK_DIR_EXT, begin)) {
 		end -= strlen(PAK_DIR_EXT);
 	} else {
-		ASSERT_UNREACHABLE();
+		return false;
 	}
 
 	nameStart = std::find(std::reverse_iterator<const char*>(end), std::reverse_iterator<const char*>(begin), '/').base();

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -158,8 +158,8 @@ namespace Path {
 	std::string Build(Str::StringRef base, Str::StringRef path);
 
 	// Get the directory portion of a path:
-	// a/b/c => a/b/
-	// a/b/ => a/
+	// a/b/c => a/b
+	// a/b/ => a
 	// a => ""
 	std::string DirName(Str::StringRef path);
 

--- a/src/common/Log.cpp
+++ b/src/common/Log.cpp
@@ -101,7 +101,7 @@ namespace Log {
         }
     }
 
-    static const int debugTargets = (1 << GRAPHICAL_CONSOLE) | (1 << TTY_CONSOLE);
+    static const int debugTargets = (1 << GRAPHICAL_CONSOLE) | (1 << TTY_CONSOLE) | (1 << LOGFILE);
     static const int verboseTargets = (1 << GRAPHICAL_CONSOLE) | (1 << TTY_CONSOLE) | (1 << LOGFILE);
     static const int noticeTargets = (1 << GRAPHICAL_CONSOLE) | (1 << TTY_CONSOLE) | (1 << LOGFILE);
     static const int warnTargets = (1 << GRAPHICAL_CONSOLE) | (1 << TTY_CONSOLE) | (1 << LOGFILE);

--- a/src/engine/client/cl_download.cpp
+++ b/src/engine/client/cl_download.cpp
@@ -37,6 +37,7 @@ Maryland 20850 USA.
 #include "client.h"
 
 Log::Logger downloadLogger("client.pakDownload", "", Log::Level::NOTICE);
+Cvar::Cvar<int> cl_downloadCount("cl_downloadCount", "bytes of a file downloaded", Cvar::NONE, 0);
 
 /*
 =====================
@@ -130,7 +131,7 @@ static void CL_BeginDownload( const char *localName, const char *remoteName )
 	// Set so UI gets access to it
 	Cvar_Set( "cl_downloadName", remoteName );
 	Cvar_Set( "cl_downloadSize", "0" );
-	Cvar_Set( "cl_downloadCount", "0" );
+	cl_downloadCount.Set(0);
 	Cvar_SetValue( "cl_downloadTime", cls.realtime );
 
 	clc.downloadBlock = 0; // Starting new file
@@ -487,7 +488,7 @@ void CL_ParseDownload( msg_t *msg )
 	clc.downloadCount += size;
 
 	// So UI gets access to it
-	Cvar_SetValue( "cl_downloadCount", clc.downloadCount );
+	cl_downloadCount.Set(clc.downloadCount);
 
 	if ( !size )
 	{

--- a/src/engine/client/cl_download.cpp
+++ b/src/engine/client/cl_download.cpp
@@ -36,7 +36,7 @@ Maryland 20850 USA.
 
 #include "client.h"
 
-static Log::Logger downloadLogger("client.pakDownload");
+Log::Logger downloadLogger("client.pakDownload", "", Log::Level::NOTICE);
 
 /*
 =====================

--- a/src/engine/client/dl_main.cpp
+++ b/src/engine/client/dl_main.cpp
@@ -42,6 +42,8 @@ Maryland 20850 USA.
 #include "qcommon/q_shared.h"
 #include "qcommon/qcommon.h"
 
+extern Log::Logger downloadLogger; // cl_download.cpp
+
 // initialize once
 static int   dl_initialized = 0;
 
@@ -83,7 +85,7 @@ void DL_InitDownload()
 
 	dl_multi = curl_multi_init();
 
-	Log::Debug( "Client download subsystem initialized" );
+	downloadLogger.Debug( "Client download subsystem initialized" );
 	dl_initialized = 1;
 }
 
@@ -133,7 +135,7 @@ int DL_BeginDownload( const char *localName, const char *remoteName )
 
 	if ( !localName || !remoteName )
 	{
-		Log::Debug( "Empty download URL or empty local file name" );
+		downloadLogger.Notice( "Empty download URL or empty local file name" );
 		return 0;
 	}
 
@@ -141,7 +143,7 @@ int DL_BeginDownload( const char *localName, const char *remoteName )
 
 	if ( !dl_file )
 	{
-		Log::Warn( "DL_BeginDownload unable to open '%s' for writing\n", localName );
+		downloadLogger.Notice( "DL_BeginDownload unable to open '%s' for writing", localName );
 		return 0;
 	}
 
@@ -177,7 +179,7 @@ dlStatus_t DL_DownloadLoop()
 
 	if ( !dl_request )
 	{
-		Log::Debug( "DL_DownloadLoop: unexpected call with dl_request == NULL" );
+		downloadLogger.Warn( "DL_DownloadLoop: unexpected call with dl_request == NULL" );
 		return dlStatus_t::DL_DONE;
 	}
 
@@ -219,7 +221,7 @@ dlStatus_t DL_DownloadLoop()
 
 	if ( err )
 	{
-		Log::Debug( "DL_DownloadLoop: request terminated with failure status '%s'", err );
+		downloadLogger.Notice( "DL_DownloadLoop: request terminated with failure status '%s'", err );
 		return dlStatus_t::DL_FAILED;
 	}
 


### PR DESCRIPTION
Refactor the HTTP download code with better handling of libcurl errors.
Introduce the PAKSERVER file security feature (see the comments in dl_main.cpp for explanation).

Reviewers may prefer to look at the combined (as opposed to per-commit) diffs for dl_main.cpp as I moved some stuff around multiple times.

Before merging, we should get everyone running a server with HTTP downloads enabled to add the PAKSERVER file.