### PR TITLE
Subdirectory support for PAKSERVER checks

### DIFF
--- a/src/engine/client/cl_download.cpp
+++ b/src/engine/client/cl_download.cpp
@@ -389,10 +389,10 @@ void CL_ParseDownload( msg_t *msg )
 			Q_strncpyz( cls.originalDownloadName, cls.downloadName, sizeof( cls.originalDownloadName ) );
 			Q_strncpyz( cls.downloadName, MSG_ReadString( msg ), sizeof( cls.downloadName ) );
 			clc.downloadSize = MSG_ReadLong( msg );
-			clc.downloadFlags = MSG_ReadLong( msg );
+			int basePathLen = MSG_ReadLong( msg );
 
-			downloadLogger.Debug("Server sent us a new WWW DL '%s', size %i, flags %i",
-			                     cls.downloadName, clc.downloadSize, clc.downloadFlags);
+			downloadLogger.Debug("Server sent us a new WWW DL '%s', size %i, prefix len %i",
+			                     cls.downloadName, clc.downloadSize, basePathLen);
 
 			Cvar_SetValue( "cl_downloadSize", clc.downloadSize );
 			clc.bWWWDl = true; // activate wwwdl client loop
@@ -408,7 +408,7 @@ void CL_ParseDownload( msg_t *msg )
 				return;
 			}
 
-			if ( !DL_BeginDownload( cls.downloadTempName, cls.downloadName ) )
+			if ( !DL_BeginDownload( cls.downloadTempName, cls.downloadName, basePathLen ) )
 			{
 				// setting bWWWDl to false after sending the wwwdl fail doesn't work
 				// not sure why, but I suspect we have to eat all remaining block -1 that the server has sent us

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -208,7 +208,6 @@ struct clientConnection_t
 	int          downloadBlock; // block we are waiting for
 	int          downloadCount; // how many bytes we got
 	int          downloadSize; // how many bytes we got
-	int          downloadFlags; // misc download behaviour flags sent by the server
 	char         downloadList[ MAX_INFO_STRING ]; // list of paks we need to download
 
 	// www downloading

--- a/src/engine/client/dl_main.cpp
+++ b/src/engine/client/dl_main.cpp
@@ -295,7 +295,7 @@ inspired from http://www.w3.org/Library/Examples/LoadToFile.c
 setup the download, return once we have a connection
 ===============
 */
-int DL_BeginDownload( const char *localName, const char *remoteName )
+int DL_BeginDownload( const char *localName, const char *remoteName, int basePathLen )
 {
 	DL_StopDownload();
 
@@ -309,12 +309,21 @@ int DL_BeginDownload( const char *localName, const char *remoteName )
 	// anchors, or whatever, but regardless of what comes out, it should do the job of
 	// preventing downloading things that shouldn't be accessed.
 	std::string urlDir = remoteName;
+#if 0 // TODO(0.52) switch on
+	if (basePathLen < 2 || static_cast<size_t>(basePathLen) + 1 >= urlDir.size() || urlDir[basePathLen - 1] != '/') {
+		downloadLogger.Notice("Bad download base path specification");
+		return 0;
+	}
+	urlDir = urlDir.substr(0, basePathLen);
+#else
+	Q_UNUSED(basePathLen);
 	size_t slash = urlDir.rfind('/');
-	if (slash == std::string::npos || slash + 1 == urlDir.size()) {
+	if (slash == 0 || slash == std::string::npos || slash + 1 == urlDir.size()) {
 		downloadLogger.Notice("Bogus download url '%s'", remoteName);
 		return 0;
 	}
 	urlDir = urlDir.substr(0, slash + 1);
+#endif
 
 	downloadLogger.Debug("Checking for PAKSERVER file in %s", urlDir);
 	download.pakserverCheck.emplace(urlDir + PAKSERVER_FILE_NAME);

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -493,16 +493,10 @@ enum class dlStatus_t
   DL_FAILED
 };
 
-int        DL_BeginDownload( const char *localName, const char *remoteName );
+int        DL_BeginDownload( const char *localName, const char *remoteName, int basePathLen );
 dlStatus_t DL_DownloadLoop();
 
 void       DL_Shutdown();
-
-// bitmask
-enum dlFlags_t
-{
-  DL_FLAG_DISCON = 1 << 0, // Obsolete, unused
-};
 
 /*
 ==============================================================

--- a/src/engine/server/sv_client.cpp
+++ b/src/engine/server/sv_client.cpp
@@ -705,7 +705,6 @@ void SV_WriteDownloadToClient( client_t *cl, msg_t *msg )
 	int      rate;
 	int      blockspersnap;
 	char     errorMessage[ 1024 ];
-	int      download_flag;
 
 	const FS::PakInfo* pak;
 	bool success;
@@ -809,9 +808,12 @@ void SV_WriteDownloadToClient( client_t *cl, msg_t *msg )
 					// download URL, size of the download file, download flags
 					MSG_WriteString( msg, cl->downloadURL );
 					MSG_WriteLong( msg, downloadSize );
-					download_flag = 0;
-
-					MSG_WriteLong( msg, download_flag );  // flags
+#if 0 // TODO(0.52) switch on
+					// Base URL length. The base prefix is expected to end with '/'
+					MSG_WriteLong( msg, strlen( sv_wwwBaseURL->string ) + 1 );
+#else
+					MSG_WriteLong( msg, 0 );  // flags
+#endif
 					return;
 				}
 				else


### PR DESCRIPTION
The initial implementation requires the PAKSERVER file to exist in every
directory with downloadable content. This commit makes a change to the
download protocol (to be switched on in the next release) which allows
any prefix of the download URL that ends in '/' to be used as the
directory to check.