### PR TITLE
implement pre-collapsed shader stage, fix #216

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1089,7 +1089,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		bool        tcGen_Environment;
 		bool        tcGen_Lightmap;
 
-		bool            disableImplicitLightmap;
+		bool implicitLightmap;
 
 		Color::Color32Bit constantColor; // for CGEN_CONST and AGEN_CONST
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1222,8 +1222,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		float          portalRange; // distance to fog out at
 		bool       isPortal;
 
-		int            collapseTextureEnv; // 0, GL_MODULATE, GL_ADD (FIXME: put in stage)
-
 		cullType_t     cullType; // CT_FRONT_SIDED, CT_BACK_SIDED, or CT_TWO_SIDED
 		bool       polygonOffset; // set for decals and other items that must be offset
 		float          polygonOffsetValue;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1004,6 +1004,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	{
 	  TB_COLORMAP,
 	  TB_DIFFUSEMAP = TB_COLORMAP,
+	  TB_REFLECTIONMAP = TB_COLORMAP,
 	  TB_NORMALMAP,
 	  TB_SPECULARMAP,
 	  TB_MATERIALMAP = TB_SPECULARMAP,
@@ -1054,6 +1055,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	enum class collapseType_t
 	{
 	  COLLAPSE_none,
+	  COLLAPSE_generic, // used before we know it's another one
 	  COLLAPSE_lighting_PHONG,
 	  COLLAPSE_lighting_PBR,
 	  COLLAPSE_reflection_CB,
@@ -1062,6 +1064,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	struct shaderStage_t
 	{
 		stageType_t     type;
+
+		collapseType_t collapseType;
 
 		bool        active;
 
@@ -1218,8 +1222,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		float          portalRange; // distance to fog out at
 		bool       isPortal;
 
-		collapseType_t lightingCollapseType;
-		collapseType_t reflectCollapseType;
 		int            collapseTextureEnv; // 0, GL_MODULATE, GL_ADD (FIXME: put in stage)
 
 		cullType_t     cullType; // CT_FRONT_SIDED, CT_BACK_SIDED, or CT_TWO_SIDED

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1129,7 +1129,7 @@ static void Render_lightMapping( int stage )
 
 	GL_State( stateBits );
 
-	bool noLightMap = pStage->disableImplicitLightmap
+	bool noLightMap = !pStage->implicitLightmap
 		&& (tess.surfaceShader->surfaceFlags & SURF_NOLIGHTMAP)
 		&& !(tess.numSurfaceStages > 0 && tess.surfaceStages[0]->rgbGen == colorGen_t::CGEN_VERTEX);
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -699,15 +699,6 @@ static void Render_generic( int stage )
 	GL_CheckErrors();
 }
 
-static bool hasMaterialMapping( shader_t *shader ) {
-  switch( shader->lightingCollapseType ) {
-  case collapseType_t::COLLAPSE_lighting_PBR:
-    return true;
-  default:
-    return false;
-  }
-}
-
 static void Render_vertexLighting_DBS_entity( int stage )
 {
 	vec3_t        viewOrigin;
@@ -725,7 +716,7 @@ static void Render_vertexLighting_DBS_entity( int stage )
 	bool parallaxMapping = r_parallaxMapping->integer && tess.surfaceShader->parallax && !tess.surfaceShader->noParallax && heightMapInNormalMap;
 	bool specularMapping = r_specularMapping->integer && ( pStage->bundle[ TB_SPECULARMAP ].image[ 0 ] );
 	bool glowMapping = r_glowMapping->integer && ( pStage->bundle[ TB_GLOWMAP ].image[ 0 ] != nullptr );
-	bool materialMapping = hasMaterialMapping( tess.surfaceShader );
+	bool materialMapping = pStage->collapseType == collapseType_t::COLLAPSE_lighting_PBR;
 
 	// choose right shader program ----------------------------------
 	gl_vertexLightingShader_DBS_entity->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4025,11 +4025,23 @@ static bool ParseShader( const char *_text )
 			continue;
 		}
 		// reflectionMapBlended <image>
-		else if ( !Q_stricmp( token, "reflectionMapBlended" )
-			|| ( *r_dpMaterial && !Q_stricmp( token, "dpreflectcube" ) ) )
+		else if ( !Q_stricmp( token, "reflectionMapBlended" ) )
 		{
 			ParseReflectionMapBlended( &stages[ s ], text );
 			s++;
+			continue;
+		}
+		else if ( !Q_stricmp( token, "dpreflectcube" ) )
+		{
+			if ( *r_dpMaterial )
+			{
+				ParseReflectionMapBlended( &stages[ s ], text, TB_COLORMAP );
+				s++;
+			}
+			else
+			{
+				Log::Warn("disabled DarkPlaces shader parameter '%s' in '%s'", token, shader.name );
+			}
 			continue;
 		}
 		// lightFalloffImage <image>

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -2298,11 +2298,7 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 				continue;
 			}
 
-			if ( !Q_stricmp( token, "colorMap" ) )
-			{
-				stage->type = stageType_t::ST_COLORMAP;
-			}
-			else if ( !Q_stricmp( token, "diffuseMap" ) )
+			if ( !Q_stricmp( token, "diffuseMap" ) )
 			{
 				Log::Warn("deprecated XreaL stage parameter '%s' in shader '%s', better use it in place of 'map' keyword and pack related textures within the same stage", token, shader.name );
 				stage->type = stageType_t::ST_DIFFUSEMAP;


### PR DESCRIPTION
This is my attempt to implement pre-collapsed shader stages, as defined in #216.
This will allow to use more than one collapsed (multi-texture) stage per shader.

Historical syntax (Doom3-like) with collapsing heuristic is still there.