### PR TITLE
Remove need for our patch to Detour (see #130)

### DIFF
--- a/src/engine/botlib/bot_api.h
+++ b/src/engine/botlib/bot_api.h
@@ -33,6 +33,7 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 
 #include "bot_types.h"
 
+void BotInit();
 bool     BotSetupNav( const botClass_t *botClass, qhandle_t *navHandle );
 void         BotShutdownNav();
 

--- a/src/engine/botlib/bot_load.cpp
+++ b/src/engine/botlib/bot_load.cpp
@@ -31,6 +31,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 ===========================================================================
 */
 
+#include "common/Common.h"
+
+#include "DetourAssert.h"
+
 #include "bot_local.h"
 #include "nav.h"
 
@@ -39,6 +43,27 @@ NavData_t BotNavData[ MAX_NAV_DATA ];
 
 LinearAllocator alloc( 1024 * 1024 * 16 );
 FastLZCompressor comp;
+
+// Recast uses NDEBUG to determine whether assertions are enabled.
+// Make sure this is in sync with DEBUG_BUILD
+#if defined(DEBUG_BUILD) != !defined(NDEBUG)
+#error
+#endif
+
+#ifdef DEBUG_BUILD
+static void FailAssertion(const char* expression, const char* file, int line)
+{
+	DAEMON_ASSERT_CALLSITE_HELPER(
+		file, "Detour assert", line, , , false, Str::Format("\"%s\" is false", expression));
+}
+#endif
+
+void BotInit()
+{
+#ifdef DEBUG_BUILD
+	dtAssertFailSetCustom(FailAssertion);
+#endif
+}
 
 void BotSaveOffMeshConnections( NavData_t *nav )
 {

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -43,6 +43,7 @@ Maryland 20850 USA.
 #include "CryptoChallenge.h"
 #include "common/Defs.h"
 #include "qcommon/sys.h"
+#include "botlib/bot_api.h"
 
 /*
 ===============
@@ -603,6 +604,7 @@ Only called at main exe startup, not for each game
 void SV_Init()
 {
 	SV_AddOperatorCommands();
+	BotInit();
 
 	// serverinfo vars
 	Cvar_Get( "timelimit", "0", CVAR_SERVERINFO );

--- a/srclibs.cmake
+++ b/srclibs.cmake
@@ -7,6 +7,7 @@ set(DETOURLIST
     ${LIB_DIR}/recastnavigation/DebugUtils/Source/DebugDraw.cpp
     ${LIB_DIR}/recastnavigation/Detour/Source/DetourAlloc.cpp
     ${LIB_DIR}/recastnavigation/Detour/Include/DetourAssert.h
+    ${LIB_DIR}/recastnavigation/Detour/Source/DetourAssert.cpp
     ${LIB_DIR}/recastnavigation/Detour/Source/DetourCommon.cpp
     ${LIB_DIR}/recastnavigation/DebugUtils/Source/DetourDebugDraw.cpp
     ${LIB_DIR}/recastnavigation/Detour/Source/DetourNavMesh.cpp


### PR DESCRIPTION
I imported the current master of the official repository as the 'upstream' branch in our fork, and pointed the submodule reference to that. I plan to rename the current `master` branch to `obsolete/daemonassert` after that.

But maybe instead of all that, it would be better to revert the one commit in our repository that's different, and merge all the commits from upstream into our master branch. WDYT?