### PR TITLE
vertexLighting_DBS_world: fix vertex lighting, use xyz instead of xyx

### DIFF
--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
@@ -74,7 +74,7 @@ void	main()
 	// compute view direction in world space
 	vec3 viewDir = normalize(u_ViewOrigin - var_Position);
 
-	mat3 tangentToWorldMatrix = mat3(var_Tangent.xyz, var_Binormal.xyz, var_Normal.xyx);
+	mat3 tangentToWorldMatrix = mat3(var_Tangent.xyz, var_Binormal.xyz, var_Normal.xyz);
 
 	vec3 L, ambCol, dirCol;
 	ReadLightGrid( (var_Position - u_LightGridOrigin) * u_LightGridScale,


### PR DESCRIPTION
**I FIXED VERTEX LIGHTING**

> _now that's what I call permutation programming_
> -- @Calinou © 2019

**I FIXED VERTEX LIGHTING**

**blame** 4f0a5403621f52fbb2bfdc79f3a3ffdd7cc80304 “Fix vertexlighting world dlights” by @cmf028,
_hiding easter eggs for illwieckz since 20th century_.

**I FIXED VERTEX LIGHTING**

```
\_o< kwaak
kwaak >o_/
_o/* BLAM!
```

**I FIXED VERTEX LIGHTING**

I was just bikeshedding, by renaming accross shaders the variables that contains the same information but named with different names, and then… in my diff tool a line popped as different between `vertexLighting_DBS_world_fp.glsl` and `vertexLighting_DBS_world_fp.glsl`, a line that MUST not be different because it must uses the same boilerplate:

```diff
-	mat3 tangentToWorldMatrix = mat3(var_Tangent.xyz, var_Binormal.xyz, var_Normal.xyz);
+	mat3 tangentToWorldMatrix = mat3(var_Tangent.xyz, var_Binormal.xyz, var_Normal.xyx);
```

Here:
https://github.com/DaemonEngine/Daemon/blob/a361a503cd8efbc5bd3af4025bb752ddf492a4e3/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl#L77

Of course the right way to do it is to use `xyz` this way:

```glsl
	mat3 tangentToWorldMatrix = mat3(var_Tangent.xyz, var_Binormal.xyz, var_Normal.xyz);
```

So, before/after:

[![vertex lighting: broken](https://dl.illwieckz.net/b/daemon/bugs/broken-vertex-texturing/unvanquished_2019-12-17_213855_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/broken-vertex-texturing/unvanquished_2019-12-17_213855_000.jpg)

[![vertex lighting: fixed](https://dl.illwieckz.net/b/daemon/bugs/broken-vertex-texturing/unvanquished_2019-12-17_213952_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/broken-vertex-texturing/unvanquished_2019-12-17_213952_000.jpg)

It also fixes xonotic mapmodels, which are rendered using vertex lighting glsl shader even when the map is rendered with light mapping glsl shader (before/after):

[![vertex lighting: broken](https://dl.illwieckz.net/b/daemon/bugs/broken-vertex-texturing/unvanquished_2019-12-17_215332_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/broken-vertex-texturing/unvanquished_2019-12-17_215332_000.jpg)

[![vertex lighting: fixed](https://dl.illwieckz.net/b/daemon/bugs/broken-vertex-texturing/unvanquished_2019-12-17_215502_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/broken-vertex-texturing/unvanquished_2019-12-17_215502_000.jpg)

Note how the light is not anymore curved by the black hole. I uncurved light around a black hole, where is my nobel prize?

**I FIXED VERTEX LIGHTING**