### PR TITLE
appveyor: use Visual Studio 2019 and do 32-bit and 64-bit build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,19 +2,14 @@ branches:
   except:
     - debian
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 environment:
+  generator: Visual Studio 16 2019
+  configuration: Debug
   matrix:
-    - COMPILER: msvc
-      COMPILER_VERSION: "15.0" # Visual Studio 2017
-      TARGET: x86
-      GENERATOR: "NMake Makefiles"
-
-matrix:
-  fast_finish: false
-
-configuration: Debug
+    - platform: win32
+    - platform: x64
 
 build:
   parallel: true
@@ -24,6 +19,5 @@ before_build:
 
 build_script:
   - cmd: cmake --version
-  - cmd: call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - cmd: cmake -DUSE_WERROR=1 -DBE_VERBOSE=1 -DUSE_PRECOMPILED_HEADER=0 -G "NMake Makefiles" -DBUILD_GAME_NACL=0 -DCMAKE_BUILD_TYPE=Debug -H. -Bbuild
+  - cmd: cmake -G"%generator%" -A"%platform%" -DUSE_WERROR=1 -DBE_VERBOSE=1 -DUSE_PRECOMPILED_HEADER=0 -DBUILD_GAME_NACL=0 -DCMAKE_BUILD_TYPE="%configuration%" -H. -Bbuild
   - cmd: cmake --build build


### PR DESCRIPTION
use Visual Studio 2019 and do 32-bit and 64-bit build
