### PR TITLE
Drop support of OS file handles in gamelogic

### DIFF
--- a/src/common/IPC/CommonSyscalls.h
+++ b/src/common/IPC/CommonSyscalls.h
@@ -246,14 +246,14 @@ namespace VM {
 
     enum EngineFileSystemMessages {
         FS_INITIALIZE,
-        FS_HOMEPATH_OPENMODE,
+        FS_HOMEPATH_OPENMODE, // TODO(0.52) remove
         FS_HOMEPATH_FILEEXISTS,
         FS_HOMEPATH_TIMESTAMP,
         FS_HOMEPATH_MOVEFILE,
         FS_HOMEPATH_DELETEFILE,
         FS_HOMEPATH_LISTFILES,
         FS_HOMEPATH_LISTFILESRECURSIVE,
-        FS_PAKPATH_OPEN,
+        FS_PAKPATH_OPEN, // TODO(0.52) remove
         FS_PAKPATH_TIMESTAMP,
         FS_PAKPATH_LOADPAK
     };
@@ -264,7 +264,7 @@ namespace VM {
     >;
     using FSHomePathOpenModeMsg = IPC::SyncMessage<
         IPC::Message<IPC::Id<FILESYSTEM, FS_HOMEPATH_OPENMODE>, std::string, uint32_t>,
-        IPC::Reply<Util::optional<IPC::OwnedFileHandle>>
+        IPC::Reply<>
     >;
     using FSHomePathFileExistsMsg = IPC::SyncMessage<
         IPC::Message<IPC::Id<FILESYSTEM, FS_HOMEPATH_FILEEXISTS>, std::string>,
@@ -292,7 +292,7 @@ namespace VM {
     >;
     using FSPakPathOpenMsg = IPC::SyncMessage<
         IPC::Message<IPC::Id<FILESYSTEM, FS_PAKPATH_OPEN>, uint32_t, std::string>,
-        IPC::Reply<Util::optional<IPC::OwnedFileHandle>>
+        IPC::Reply<>
     >;
     using FSPakPathTimestampMsg = IPC::SyncMessage<
         IPC::Message<IPC::Id<FILESYSTEM, FS_PAKPATH_TIMESTAMP>, uint32_t, std::string>,

--- a/src/common/IPC/Primitives.cpp
+++ b/src/common/IPC/Primitives.cpp
@@ -171,12 +171,6 @@ FileHandle FileHandle::FromDesc(const FileDesc& desc)
 #endif
 }
 
-OwnedFileHandle::~OwnedFileHandle()
-{
-	if (handle)
-		close(handle.GetHandle());
-}
-
 void Socket::Close()
 {
 	if (Sys::IsValidHandle(handle))

--- a/src/common/IPC/Primitives.h
+++ b/src/common/IPC/Primitives.h
@@ -70,42 +70,6 @@ namespace IPC {
 		FileOpenMode mode;
 	};
 
-	// Same as FileHandle except the fd is closed on destruction
-	class OwnedFileHandle {
-	public:
-		OwnedFileHandle() = default;
-		OwnedFileHandle(int fd, FileOpenMode mode) : handle(fd, mode) {}
-		OwnedFileHandle(OwnedFileHandle&& other) : handle(other.handle) {
-			other.handle = FileHandle();
-		}
-		OwnedFileHandle& operator=(OwnedFileHandle&& other) {
-			std::swap(handle, other.handle);
-			return *this;
-		}
-		~OwnedFileHandle();
-		explicit operator bool() const {
-			return bool(handle);
-		}
-
-		FileDesc GetDesc() const {
-			return handle.GetDesc();
-		}
-		static OwnedFileHandle FromDesc(const FileDesc& desc) {
-			OwnedFileHandle out;
-			out.handle = FileHandle::FromDesc(desc);
-			return out;
-		}
-
-		int GetHandle() {
-			int fd = handle.GetHandle();
-			handle = FileHandle();
-			return fd;
-		}
-
-	private:
-		FileHandle handle;
-	};
-
 	// Message-based socket through which data and handles can be passed.
 	class Socket {
 	public:
@@ -214,16 +178,6 @@ namespace Util {
 		static IPC::FileHandle Read(Reader& stream)
 		{
 			return IPC::FileHandle::FromDesc(stream.ReadHandle());
-		}
-	};
-	template<> struct SerializeTraits<IPC::OwnedFileHandle> {
-		static void Write(Writer& stream, const IPC::OwnedFileHandle& value)
-		{
-			stream.WriteHandle(value.GetDesc());
-		}
-		static IPC::OwnedFileHandle Read(Reader& stream)
-		{
-			return IPC::OwnedFileHandle::FromDesc(stream.ReadHandle());
 		}
 	};
 	template<> struct SerializeTraits<IPC::SharedMemory> {

--- a/src/engine/botlib/bot_load.cpp
+++ b/src/engine/botlib/bot_load.cpp
@@ -128,7 +128,7 @@ void BotLoadOffMeshConnections( const char *filename, NavData_t *nav )
 
 	Cvar_VariableStringBuffer( "mapname", mapname, sizeof( mapname ) );
 	Com_sprintf( filePath, sizeof( filePath ), "maps/%s-%s.navcon", mapname, filename );
-	FS_FOpenFileRead( filePath, &f, true );
+	FS_FOpenFileRead( filePath, &f );
 
 	if ( !f )
 	{
@@ -189,7 +189,7 @@ bool BotLoadNavMesh( const char *filename, NavData_t &nav )
 	Com_sprintf( filePath, sizeof( filePath ), "maps/%s-%s.navMesh", mapname, filename );
 	Log::Notice( " loading navigation mesh file '%s'...", filePath );
 
-	int len = FS_FOpenFileRead( filePath, &f, true );
+	int len = FS_FOpenFileRead( filePath, &f );
 
 	if ( !f )
 	{

--- a/src/engine/client/cin_ogm.cpp
+++ b/src/engine/client/cin_ogm.cpp
@@ -528,7 +528,7 @@ int Cin_OGM_Init( const char *filename )
 
 	memset( &g_ogm, 0, sizeof( cin_ogm_t ) );
 
-	FS_FOpenFileRead( filename, &g_ogm.ogmFile, true );
+	FS_FOpenFileRead( filename, &g_ogm.ogmFile );
 
 	if ( !g_ogm.ogmFile )
 	{

--- a/src/engine/client/cl_avi.cpp
+++ b/src/engine/client/cl_avi.cpp
@@ -562,7 +562,7 @@ bool CL_CloseAVI()
 	// Write index
 
 	// Open the temp index file
-	if ( ( indexSize = FS_FOpenFileRead( idxFileName, &afd.idxF, true ) ) <= 0 )
+	if ( ( indexSize = FS_FOpenFileRead( idxFileName, &afd.idxF ) ) <= 0 )
 	{
 		FS_FCloseFile( afd.f );
 		return false;

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -624,7 +624,7 @@ class DemoPlayCmd: public Cmd::StaticCmd {
                     Com_sprintf(name, sizeof(name), "demos/%s.dm_%d", arg, prot_ver);
                 }
 
-                FS_FOpenFileRead(name, &clc.demofile, true);
+                FS_FOpenFileRead(name, &clc.demofile);
                 prot_ver++;
             }
 
@@ -1422,7 +1422,7 @@ static void CL_LoadRSAKeys()
 
 	Log::Notice( "Loading RSA keys from %s" , fileName );
 
-	len = FS_FOpenFileRead( fileName, &f, true );
+	len = FS_FOpenFileRead( fileName, &f );
 
 	if ( !f || len < 1 )
 	{
@@ -2611,7 +2611,7 @@ bool CL_InitRenderer()
 	// filehandle is unused but forces FS_FOpenFileRead() to heed purecheck because it does not when filehandle is nullptr
 	if ( cl_consoleFont->string[0] )
 	{
-		if ( FS_FOpenFileRead( cl_consoleFont->string, &f, false ) >= 0 )
+		if ( FS_FOpenFileRead( cl_consoleFont->string, &f ) >= 0 )
 		{
 			if ( cl_consoleFontScaling->value == 0 )
 			{

--- a/src/engine/framework/CommonVMServices.cpp
+++ b/src/engine/framework/CommonVMServices.cpp
@@ -249,9 +249,9 @@ namespace VM {
                 break;
 
             case QVM_COMMON_FS_FOPEN_FILE:
-                IPC::HandleMsg<FSFOpenFileMsg>(channel, std::move(reader), [this](const std::string& filename, bool open, int fsMode, int& success, int& handle) {
+                IPC::HandleMsg<FSFOpenFileMsg>(channel, std::move(reader), [this](const std::string& filename, bool open, int fsMode, int& length, int& handle) {
                     fsMode_t mode = static_cast<fsMode_t>(fsMode);
-                    success = FS_Game_FOpenFileByMode(filename.c_str(), open ? &handle : nullptr, mode);
+                    length = FS_Game_FOpenFileByMode(filename.c_str(), open ? &handle : nullptr, mode);
                 });
                 break;
 

--- a/src/engine/null/null_renderer.cpp
+++ b/src/engine/null/null_renderer.cpp
@@ -40,11 +40,11 @@ Maryland 20850 USA.
 void RE_Shutdown( bool ) { }
 qhandle_t RE_RegisterModel( const char *name )
 {
-	return FS_FOpenFileRead( name, nullptr, false );
+	return FS_FOpenFileRead( name, nullptr );
 }
 qhandle_t RE_RegisterSkin( const char *name )
 {
-	return FS_FOpenFileRead( name, nullptr, false );
+	return FS_FOpenFileRead( name, nullptr );
 }
 qhandle_t RE_RegisterShader( const char *, RegisterShaderFlags_t )
 {

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -87,7 +87,7 @@ bool FS_FileExists(const char* path)
 	return FS::PakPath::FileExists(path) || FS::HomePath::FileExists(path);
 }
 
-int FS_FOpenFileRead(const char* path, fileHandle_t* handle, bool)
+int FS_FOpenFileRead(const char* path, fileHandle_t* handle)
 {
 	if (!handle)
 		return FS_FileExists(path);
@@ -202,7 +202,7 @@ int FS_Game_FOpenFileByMode(const char* path, fileHandle_t* handle, fsMode_t mod
 	switch (mode) {
 	case fsMode_t::FS_READ:
 		if (FS::PakPath::FileExists(path))
-			return FS_FOpenFileRead(path, handle, false);
+			return FS_FOpenFileRead(path, handle);
 		else {
 			int size = FS_SV_FOpenFileRead(FS::Path::Build("game", path).c_str(), handle);
 			return (!handle || *handle) ? size : -1;
@@ -427,7 +427,7 @@ void FS_WriteFile(const char* path, const void* buffer, int size)
 int FS_ReadFile(const char* path, void** buffer)
 {
 	fileHandle_t handle;
-	int length = FS_FOpenFileRead(path, &handle, true);
+	int length = FS_FOpenFileRead(path, &handle);
 
 	if (length < 0) {
 		if (buffer)

--- a/src/engine/qcommon/parse.cpp
+++ b/src/engine/qcommon/parse.cpp
@@ -1143,7 +1143,7 @@ static script_t *Parse_LoadScriptFile( const char *filename )
 	void         *buffer;
 	script_t     *script;
 
-	length = FS_FOpenFileRead( filename, &fp, false );
+	length = FS_FOpenFileRead( filename, &fp );
 
 	if ( !fp ) { return nullptr; }
 

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -379,7 +379,7 @@ fileHandle_t FS_FOpenFileWriteViaTemporary( const char *qpath );
 
 fileHandle_t FS_SV_FOpenFileWrite( const char *filename );
 void         FS_SV_Rename( const char *from, const char *to );
-int          FS_FOpenFileRead( const char *qpath, fileHandle_t *file, bool uniqueFILE );
+int          FS_FOpenFileRead( const char *qpath, fileHandle_t *file );
 
 /*
 if uniqueFILE is true, then a new FILE will be fopened even if the file

--- a/src/engine/qcommon/translation.cpp
+++ b/src/engine/qcommon/translation.cpp
@@ -82,7 +82,7 @@ public:
 		end = buffer + BUFFER_SIZE - putBack;
 		setg( end, end, end );
 
-		FS_FOpenFileRead( filename.c_str(), &fileHandle, false );
+		FS_FOpenFileRead( filename.c_str(), &fileHandle );
 	}
 
 	~DaemonInputbuf()

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -229,7 +229,7 @@ struct refimport_t
 	int ( *FS_FTell )( fileHandle_t f );
 	int ( *FS_Read )( void *buffer, int len, fileHandle_t f );
 	int ( *FS_FCloseFile )( fileHandle_t f );
-	int ( *FS_FOpenFileRead )( const char *qpath, fileHandle_t *file, bool uniqueFILE );
+	int ( *FS_FOpenFileRead )( const char *qpath, fileHandle_t *file );
 
 	// cinematic stuff
 	void ( *CIN_UploadCinematic )( int handle );

--- a/src/shared/CommonProxies.cpp
+++ b/src/shared/CommonProxies.cpp
@@ -522,11 +522,11 @@ void trap_SendConsoleCommand(const char *text)
 
 int trap_FS_FOpenFile(const char *qpath, fileHandle_t *f, fsMode_t mode)
 {
-	int ret, handle;
-	VM::SendMsg<VM::FSFOpenFileMsg>(qpath, f != nullptr, Util::ordinal(mode), ret, handle);
+	int length, handle;
+	VM::SendMsg<VM::FSFOpenFileMsg>(qpath, f != nullptr, Util::ordinal(mode), length, handle);
 	if (f)
 		*f = handle;
-	return ret;
+	return length;
 }
 
 int trap_FS_Read(void *buffer, int len, fileHandle_t f)


### PR DESCRIPTION
To make WebAssembly migration easier by getting rid of IPC calls which aren't purely sending bytes.

The feature is currently not used anywhere. There is one bit of code in the cgame which depends on PakPath::ReadFile, but that turns out not to be used also...