### PR TITLE
tr_init: make r_normalMapping a latched cvar

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1197,7 +1197,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_specularMapping = ri.Cvar_Get( "r_specularMapping", "1", CVAR_LATCH );
 		r_deluxeMapping = ri.Cvar_Get( "r_deluxeMapping", "1", CVAR_ARCHIVE );
 		r_normalScale = ri.Cvar_Get( "r_normalScale", "1.0", CVAR_ARCHIVE );
-		r_normalMapping = ri.Cvar_Get( "r_normalMapping", "1", CVAR_ARCHIVE );
+		r_normalMapping = ri.Cvar_Get( "r_normalMapping", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_highQualityNormalMapping = ri.Cvar_Get( "r_highQualityNormalMapping", "0",  CVAR_LATCH );
 		r_parallaxDepthScale = ri.Cvar_Get( "r_parallaxDepthScale", "0.03", CVAR_CHEAT );
 		r_parallaxMapping = ri.Cvar_Get( "r_parallaxMapping", "0", 0 );


### PR DESCRIPTION
The glsl code expects this to be defined before compilation.

Not having this a latched cvar means different code is
run when `r_normalMapping` is switched off but `vid_restart`
is not yet called, and when `r_normalMapping` is already off
when vid_restart is called.

The previous code was preventing shader compilation error
to be detected in some scenarii, when `r_normalMapping` was
switched off then switched on before doing `vid_restart`.