### PR TITLE
tr_image: heightmap is not anymore a depthmap

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1685,15 +1685,8 @@ static void R_LoadImage( const char **buffer, byte **pic, int *width, int *heigh
 	char       filename[ MAX_QPATH ];
 	byte       alphaByte;
 
-	// Tr3B: clear alpha of normalmaps for displacement mapping
-	if ( *bits & IF_NORMALMAP )
-	{
-		alphaByte = 0x00;
-	}
-	else
-	{
-		alphaByte = 0xFF;
-	}
+	// missing alpha means fully opaque
+	alphaByte = 0xFF;
 
 	Q_strncpyz( filename, token, sizeof( filename ) );
 


### PR DESCRIPTION
see also #245, 071c7890394f2d05c6c869e87ec696b85b014f3e

- depthmap was a bad design requiring a lot of tricks
- industry uses heightmap that does not require those tricks
- no alpha channel is normalmap means white heightmap means flat heightmap

hence, no trick is required