### PR TITLE
renderer: revive liquid shader (currently disabled because it is broken)

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -584,6 +584,11 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_normalMapping", 1 );
 	}
 
+	if ( r_liquidMapping->integer )
+	{
+		AddDefine( str, "r_liquidMapping", 1 );
+	}
+
 	if ( r_specularMapping->integer )
 	{
 		AddDefine( str, "r_specularMapping", 1 );

--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -111,9 +111,15 @@ void	main()
 	vec4 reflectColor;
 	vec4 color;
 
+#if defined(r_liquidMapping)
 	refractColor = texture2D(u_CurrentMap, texScreen).rgb;
 	reflectColor.rgb = texture2D(u_PortalMap, texScreen).rgb;
 	reflectColor.a = 1.0;
+#else // !r_liquidMapping
+	// dummy fallback color
+	refractColor = vec3(0.7, 0.7, 0.7);
+	reflectColor = vec4(0.7, 0.7, 0.7, 1.0);
+#endif // !r_liquidMapping
 
 	color.rgb = mix(refractColor, reflectColor.rgb, fresnel);
 	color.a = 1.0;

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4716,6 +4716,7 @@ static void RB_RenderView( bool depthPass )
 
 	if ( backEnd.viewParms.portalLevel > 0 )
 	{
+		if ( r_liquidMapping->integer )
 		{
 			// capture current color buffer
 			// liquid shader will then bind tr.portalRenderImage

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4716,14 +4716,16 @@ static void RB_RenderView( bool depthPass )
 
 	if ( backEnd.viewParms.portalLevel > 0 )
 	{
-#if !defined( GLSL_COMPILE_STARTUP_ONLY )
 		{
 			// capture current color buffer
+			// liquid shader will then bind tr.portalRenderImage
+			// as u_PortalMap to be read by liquid glsl
+			// FIXME: it does not work
 			GL_SelectTexture( 0 );
 			GL_Bind( tr.portalRenderImage );
 			glCopyTexSubImage2D( GL_TEXTURE_2D, 0, 0, 0, 0, 0, tr.portalRenderImage->uploadWidth, tr.portalRenderImage->uploadHeight );
 		}
-#endif
+
 		backEnd.pc.c_portals++;
 	}
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -166,6 +166,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_deluxeMapping;
 	cvar_t      *r_normalScale;
 	cvar_t      *r_normalMapping;
+	cvar_t      *r_liquidMapping;
 	cvar_t      *r_highQualityNormalMapping;
 	cvar_t      *r_parallaxDepthScale;
 	cvar_t      *r_parallaxMapping;
@@ -1199,6 +1200,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_normalScale = ri.Cvar_Get( "r_normalScale", "1.0", CVAR_ARCHIVE );
 		r_normalMapping = ri.Cvar_Get( "r_normalMapping", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_highQualityNormalMapping = ri.Cvar_Get( "r_highQualityNormalMapping", "0",  CVAR_LATCH );
+		r_liquidMapping = ri.Cvar_Get( "r_liquidMapping", "0", CVAR_LATCH );
 		r_parallaxDepthScale = ri.Cvar_Get( "r_parallaxDepthScale", "0.03", CVAR_CHEAT );
 		r_parallaxMapping = ri.Cvar_Get( "r_parallaxMapping", "0", 0 );
 		r_glowMapping = ri.Cvar_Get( "r_glowMapping", "1", CVAR_LATCH );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2857,6 +2857,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_normalScale;
 	extern cvar_t *r_normalMapping;
 	extern cvar_t *r_highQualityNormalMapping;
+	extern cvar_t *r_liquidMapping;
 	extern cvar_t *r_parallaxDepthScale;
 	extern cvar_t *r_parallaxMapping;
 	extern cvar_t *r_glowMapping;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2545,7 +2545,6 @@ static void Render_liquid( int stage )
 
 		// FIXME: if there is both, embedded heightmap in normalmap is used instead of standalone heightmap
 		if ( !hasHeightMapInNormalMap )
-		else
 		{
 			GL_BindToTMU( 15, pStage->bundle[ TB_HEIGHTMAP ].image[ 0 ] );
 		}

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -106,9 +106,9 @@ static void GLSL_InitGPUShadersOrError()
 	// debug utils
 	gl_shaderManager.load( gl_debugShadowMapShader );
 
-#if !defined( GLSL_COMPILE_STARTUP_ONLY )
-
 	gl_shaderManager.load( gl_liquidShader );
+
+#if !defined( GLSL_COMPILE_STARTUP_ONLY )
 
 	gl_shaderManager.load( gl_volumetricFogShader );
 
@@ -2462,7 +2462,6 @@ static void Render_heatHaze( int stage )
 	GL_CheckErrors();
 }
 
-#if !defined( GLSL_COMPILE_STARTUP_ONLY )
 static void Render_liquid( int stage )
 {
 	vec3_t        viewOrigin;
@@ -2576,9 +2575,6 @@ static void Render_liquid( int stage )
 
 	GL_CheckErrors();
 }
-#else
-static void Render_liquid(int){}
-#endif
 
 static void Render_fog()
 {


### PR DESCRIPTION
By making this code live again, we make easier to not introduce bugs in this code.

A cvar is available for adventurous people to debug the feature, named `r_liquidMapping`, disabled by default.

The specular code is refactored against the one in `computeLight` library.