### PR TITLE
debugging: implement r_showNormalMaps and r_showMaterialMaps

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -558,6 +558,11 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_showNormalMaps", 1 );
 	}
 
+	if ( r_showMaterialMaps->integer )
+	{
+		AddDefine( str, "r_showMaterialMaps", 1 );
+	}
+
 	if ( glConfig2.vboVertexSkinningAvailable )
 	{
 		AddDefine( str, "r_VertexSkinning", 1 );

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -544,13 +544,19 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_precomputedLighting", 1 );
 
 	if ( r_showLightMaps->integer )
-		AddDefine( str, "r_showLightMaps", r_showLightMaps->integer );
+	{
+		AddDefine( str, "r_showLightMaps", 1 );
+	}
 
 	if ( r_showDeluxeMaps->integer )
-		AddDefine( str, "r_showDeluxeMaps", r_showDeluxeMaps->integer );
+	{
+		AddDefine( str, "r_showDeluxeMaps", 1 );
+	}
 
-	if ( r_showEntityNormals->integer )
-		AddDefine( str, "r_showEntityNormals", r_showEntityNormals->integer );
+	if ( r_showNormalMaps->integer )
+	{
+		AddDefine( str, "r_showNormalMaps", 1 );
+	}
 
 	if ( glConfig2.vboVertexSkinningAvailable )
 	{

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -111,5 +111,7 @@ void	main()
 	// convert normal to [0,1] color space
 	normal = normal * 0.5 + 0.5;
 	outputColor = vec4(normal, 1.0);
+#elif defined(r_showMaterialMaps)
+	outputColor = material;
 #endif
 }

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -102,9 +102,14 @@ void	main()
 
 	outputColor = color;
 
+// Debugging
 #if defined(r_showLightMaps)
 	outputColor = texture2D(u_LightMap, var_TexLight);
 #elif defined(r_showDeluxeMaps)
 	outputColor = texture2D(u_DeluxeMap, var_TexLight);
+#elif defined(r_showNormalMaps)
+	// convert normal to [0,1] color space
+	normal = normal * 0.5 + 0.5;
+	outputColor = vec4(normal, 1.0);
 #endif
 }

--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -156,4 +156,10 @@ void	main()
 	computeLight(lightDir, normal, viewDir, lightColor, diffuse, reflectColor, color);
 
 	outputColor = color;
+
+#if defined(r_showNormalMaps)
+	// convert normal to [0,1] color space
+	normal = normal * 0.5 + 0.5;
+	outputColor = vec4(normal, 1.0);
+#endif
 }

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
@@ -97,16 +97,16 @@ void	main()
 #if defined(USE_REFLECTIVE_SPECULAR)
 	// not implemented for PBR yet
 
-	vec4 specBase = texture2D(u_MaterialMap, texCoords).rgba;
+	vec4 material = texture2D(u_MaterialMap, texCoords).rgba;
 
 	vec4 envColor0 = textureCube(u_EnvironmentMap0, reflect(-viewDir, normal)).rgba;
 	vec4 envColor1 = textureCube(u_EnvironmentMap1, reflect(-viewDir, normal)).rgba;
 
-	specBase.rgb *= mix(envColor0, envColor1, u_EnvironmentInterpolation).rgb;
+	material.rgb *= mix(envColor0, envColor1, u_EnvironmentInterpolation).rgb;
 
 #else // USE_REFLECTIVE_SPECULAR
 	// simple Blinn-Phong
-	vec4 specBase = texture2D(u_MaterialMap, texCoords).rgba;
+	vec4 material = texture2D(u_MaterialMap, texCoords).rgba;
 
 #endif // USE_REFLECTIVE_SPECULAR
 
@@ -127,9 +127,9 @@ void	main()
 
 	// compute final color
 	vec4 color = vec4(ambCol * r_AmbientScale * diffuse.xyz, diffuse.a);
-	computeLight( L, normal, viewDir, lgtCol, diffuse, specBase, color );
+	computeLight( L, normal, viewDir, lgtCol, diffuse, material, color );
 
-	computeDLights( var_Position, normal, viewDir, diffuse, specBase, color );
+	computeDLights( var_Position, normal, viewDir, diffuse, material, color );
 
 #if defined(r_RimLighting)
 	color.rgb += 0.7 * emission;

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
@@ -146,5 +146,7 @@ void	main()
 	// convert normal to [0,1] color space
 	normal = normal * 0.5 + 0.5;
 	outputColor = vec4(normal, 1.0);
+#elif defined(r_showMaterialMaps)
+	outputColor = material;
 #endif
 }

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
@@ -142,7 +142,7 @@ void	main()
 	outputColor = color;
 
 // Debugging
-#if defined(r_showEntityNormals)
+#if defined(r_showNormalMaps)
 	// convert normal to [0,1] color space
 	normal = normal * 0.5 + 0.5;
 	outputColor = vec4(normal, 1.0);

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
@@ -118,5 +118,7 @@ void	main()
 	// convert normal to [0,1] color space
 	normal = normal * 0.5 + 0.5;
 	outputColor = vec4(normal, 1.0);
+#elif defined(r_showMaterialMaps)
+	outputColor = material;
 #endif
 }

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
@@ -112,4 +112,11 @@ void	main()
 #endif // r_glowMapping
 
 	outputColor = color;
+
+// Debugging
+#if defined(r_showNormalMaps)
+	// convert normal to [0,1] color space
+	normal = normal * 0.5 + 0.5;
+	outputColor = vec4(normal, 1.0);
+#endif
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -227,7 +227,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_showBatches;
 	cvar_t      *r_showLightMaps;
 	cvar_t      *r_showDeluxeMaps;
-	cvar_t      *r_showEntityNormals;
+	cvar_t      *r_showNormalMaps;
 	cvar_t      *r_showAreaPortals;
 	cvar_t      *r_showCubeProbes;
 	cvar_t      *r_showBspNodes;
@@ -1304,7 +1304,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_showBatches = ri.Cvar_Get( "r_showBatches", "0", CVAR_CHEAT );
 		r_showLightMaps = ri.Cvar_Get( "r_showLightMaps", "0", CVAR_CHEAT | CVAR_LATCH );
 		r_showDeluxeMaps = ri.Cvar_Get( "r_showDeluxeMaps", "0", CVAR_CHEAT | CVAR_LATCH );
-		r_showEntityNormals = ri.Cvar_Get( "r_showEntityNormals", "0", CVAR_CHEAT | CVAR_LATCH );
+		r_showNormalMaps = ri.Cvar_Get( "r_showNormalMaps", "0", CVAR_CHEAT | CVAR_LATCH );
 		r_showAreaPortals = ri.Cvar_Get( "r_showAreaPortals", "0", CVAR_CHEAT );
 		r_showCubeProbes = ri.Cvar_Get( "r_showCubeProbes", "0", CVAR_CHEAT );
 		r_showBspNodes = ri.Cvar_Get( "r_showBspNodes", "0", CVAR_CHEAT );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -228,6 +228,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_showLightMaps;
 	cvar_t      *r_showDeluxeMaps;
 	cvar_t      *r_showNormalMaps;
+	cvar_t      *r_showMaterialMaps;
 	cvar_t      *r_showAreaPortals;
 	cvar_t      *r_showCubeProbes;
 	cvar_t      *r_showBspNodes;
@@ -1305,6 +1306,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_showLightMaps = ri.Cvar_Get( "r_showLightMaps", "0", CVAR_CHEAT | CVAR_LATCH );
 		r_showDeluxeMaps = ri.Cvar_Get( "r_showDeluxeMaps", "0", CVAR_CHEAT | CVAR_LATCH );
 		r_showNormalMaps = ri.Cvar_Get( "r_showNormalMaps", "0", CVAR_CHEAT | CVAR_LATCH );
+		r_showMaterialMaps = ri.Cvar_Get( "r_showMaterialMaps", "0", CVAR_CHEAT | CVAR_LATCH );
 		r_showAreaPortals = ri.Cvar_Get( "r_showAreaPortals", "0", CVAR_CHEAT );
 		r_showCubeProbes = ri.Cvar_Get( "r_showCubeProbes", "0", CVAR_CHEAT );
 		r_showBspNodes = ri.Cvar_Get( "r_showBspNodes", "0", CVAR_CHEAT );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2955,6 +2955,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_showLightMaps; // render lightmaps only
 	extern cvar_t *r_showDeluxeMaps;
 	extern cvar_t *r_showNormalMaps;
+	extern cvar_t *r_showMaterialMaps;
 	extern cvar_t *r_showAreaPortals;
 	extern cvar_t *r_showCubeProbes;
 	extern cvar_t *r_showBspNodes;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2954,7 +2954,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_showBatches;
 	extern cvar_t *r_showLightMaps; // render lightmaps only
 	extern cvar_t *r_showDeluxeMaps;
-	extern cvar_t *r_showEntityNormals;
+	extern cvar_t *r_showNormalMaps;
 	extern cvar_t *r_showAreaPortals;
 	extern cvar_t *r_showCubeProbes;
 	extern cvar_t *r_showBspNodes;


### PR DESCRIPTION
 implement `r_showNormalMaps`

`r_showEntityNormals` is dropped, in any way, `vertexLighting_DBS_entity`
and `vertexLighting_DBS_world` glsl are asking for merge

also beautify some code for other `r_show*` cvar

also introduce `r_showMaterialMaps` to debug specular and physical maps.