### PR TITLE
appveyor: also test Visual Studio 2017 and investigate NMake generator as we support them

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,19 +5,14 @@ branches:
 environment:
   configuration: Debug
   matrix:
+    # see 96d5c1f3ed77b09c64ce7c3c7cbd37c70456b3db
+    # for NMake template
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       generator: Visual Studio 16 2019
       platform: x64
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      generator: NMake Makefiles
-      # -Aplatform is not supported by CMake's NMake Makefiles generator and produces an error
-      VCVARSBAT: vcvars64.bat
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      generator: Visual Studio 16 2019
-      platform: win32
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       generator: Visual Studio 15 2017
-      platform: x64
+      platform: win32
 
 build:
   parallel: true
@@ -30,9 +25,6 @@ build_script:
   # double line break: line break
   - cmd: >
       cmake --version
-
-      if "%generator%"=="NMake Makefiles"
-      call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\%VCVARSBAT%"
 
       set cmake=cmake
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -22,6 +22,15 @@ before_build:
   - git submodule update --init --recursive
 
 build_script:
-  - cmd: cmake --version
-  - cmd: cmake -G"%generator%" -A"%platform%" -DUSE_WERROR=1 -DBE_VERBOSE=1 -DUSE_PRECOMPILED_HEADER=0 -DBUILD_GAME_NACL=0 -DCMAKE_BUILD_TYPE="%configuration%" -S. -Bbuild
-  - cmd: cmake --build build
+  # simple line break: space
+  # double line break: line break
+  - cmd: >
+      cmake --version
+
+      cmake -G"%generator%" -A"%platform%"
+      -DUSE_WERROR=1 -DBE_VERBOSE=1
+      -DUSE_PRECOMPILED_HEADER=0 -DBUILD_GAME_NACL=0
+      -DCMAKE_BUILD_TYPE="%configuration%"
+      -S. -Bbuild
+
+      cmake --build build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,14 +2,18 @@ branches:
   except:
     - debian
 
-image: Visual Studio 2019
-
 environment:
-  generator: Visual Studio 16 2019
   configuration: Debug
   matrix:
-    - platform: win32
-    - platform: x64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      generator: Visual Studio 16 2019
+      platform: x64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      generator: Visual Studio 16 2019
+      platform: win32
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      generator: Visual Studio 15 2017
+      platform: x64
 
 build:
   parallel: true

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -23,5 +23,5 @@ before_build:
 
 build_script:
   - cmd: cmake --version
-  - cmd: cmake -G"%generator%" -A"%platform%" -DUSE_WERROR=1 -DBE_VERBOSE=1 -DUSE_PRECOMPILED_HEADER=0 -DBUILD_GAME_NACL=0 -DCMAKE_BUILD_TYPE="%configuration%" -H. -Bbuild
+  - cmd: cmake -G"%generator%" -A"%platform%" -DUSE_WERROR=1 -DBE_VERBOSE=1 -DUSE_PRECOMPILED_HEADER=0 -DBUILD_GAME_NACL=0 -DCMAKE_BUILD_TYPE="%configuration%" -S. -Bbuild
   - cmd: cmake --build build

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,10 @@ environment:
       generator: Visual Studio 16 2019
       platform: x64
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      generator: NMake Makefiles
+      # -Aplatform is not supported by CMake's NMake Makefiles generator and produces an error
+      VCVARSBAT: vcvars64.bat
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       generator: Visual Studio 16 2019
       platform: win32
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
@@ -27,7 +31,15 @@ build_script:
   - cmd: >
       cmake --version
 
-      cmake -G"%generator%" -A"%platform%"
+      if "%generator%"=="NMake Makefiles"
+      call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\%VCVARSBAT%"
+
+      set cmake=cmake
+
+      if not "x%generator:Visual Studio=%"=="x%generator%"
+      set cmake=%cmake% -A"%platform%"
+
+      %cmake% -G"%generator%"
       -DUSE_WERROR=1 -DBE_VERBOSE=1
       -DUSE_PRECOMPILED_HEADER=0 -DBUILD_GAME_NACL=0
       -DCMAKE_BUILD_TYPE="%configuration%"


### PR DESCRIPTION
README says the minimum supported VS is VS2017 so it's better to test it

Unvanquished uses `NMake Makefiles` generator so it's better to test it