### PR TITLE
polishing: unify the way glsl shaders are written

### DIFF
--- a/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
@@ -934,9 +934,9 @@ void	main()
 
 	// compute light direction in world space
 #if defined(LIGHT_DIRECTIONAL)
-	vec3 L = u_LightDir;
+	vec3 lightDir = u_LightDir;
 #else
-	vec3 L = normalize(u_LightOrigin - var_Position);
+	vec3 lightDir = normalize(u_LightOrigin - var_Position);
 #endif
 
 	vec2 texCoords = var_TexCoords;
@@ -954,16 +954,16 @@ void	main()
 #endif // USE_PARALLAX_MAPPING
 
 	// compute half angle in world space
-	vec3 H = normalize(L + viewDir);
+	vec3 H = normalize(lightDir + viewDir);
 
 	// compute normal in world space from normal map
 	vec3 normal = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
 
 	// compute the light term
 #if defined(r_WrapAroundLighting)
-	float NL = clamp(dot(normal, L) + u_LightWrapAround, 0.0, 1.0) / clamp(1.0 + u_LightWrapAround, 0.0, 1.0);
+	float NL = clamp(dot(normal, lightDir) + u_LightWrapAround, 0.0, 1.0) / clamp(1.0 + u_LightWrapAround, 0.0, 1.0);
 #else
-	float NL = clamp(dot(normal, L), 0.0, 1.0);
+	float NL = clamp(dot(normal, lightDir), 0.0, 1.0);
 #endif
 
 	// compute the diffuse term

--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -48,30 +48,30 @@ IN(smooth) vec3		var_Normal;
 
 DECLARE_OUTPUT(vec4)
 
-void ReadLightGrid(in vec3 pos, out vec3 lgtDir,
-		   out vec3 ambCol, out vec3 lgtCol ) {
+void ReadLightGrid(in vec3 pos, out vec3 lightDir,
+		   out vec3 ambientColor, out vec3 lightColor) {
 	vec4 texel1 = texture3D(u_LightGrid1, pos);
 	vec4 texel2 = texture3D(u_LightGrid2, pos);
-	float ambLum, lgtLum;
+	float ambientLuminance, lightLuminance;
 
 	texel1.xyz = (texel1.xyz * 255.0 - 128.0) / 127.0;
 	texel2.xyzw = texel2.xyzw - 0.5;
 
-	lgtDir = normalize(texel1.xyz);
+	lightDir = normalize(texel1.xyz);
 
-	lgtLum = 2.0 * length(texel1.xyz) * texel1.w;
-	ambLum = 2.0 * texel1.w - lgtLum;
+	lightLuminance = 2.0 * length(texel1.xyz) * texel1.w;
+	ambientLuminance = 2.0 * texel1.w - lightLuminance;
 
 	// YCoCg decode chrominance
-	ambCol.g = ambLum + texel2.x;
-	ambLum   = ambLum - texel2.x;
-	ambCol.r = ambLum + texel2.y;
-	ambCol.b = ambLum - texel2.y;
+	ambientColor.g = ambientLuminance + texel2.x;
+	ambientLuminance = ambientLuminance - texel2.x;
+	ambientColor.r = ambientLuminance + texel2.y;
+	ambientColor.b = ambientLuminance - texel2.y;
 
-	lgtCol.g = lgtLum + texel2.z;
-	lgtLum   = lgtLum - texel2.z;
-	lgtCol.r = lgtLum + texel2.w;
-	lgtCol.b = lgtLum - texel2.w;
+	lightColor.g = lightLuminance + texel2.z;
+	lightLuminance = lightLuminance - texel2.z;
+	lightColor.r = lightLuminance + texel2.w;
+	lightColor.b = lightLuminance - texel2.w;
 }
 
 
@@ -147,8 +147,8 @@ void	main()
 	vec3 ambientColor;
 	vec3 lightColor;
 
-	ReadLightGrid( (var_Position - u_LightGridOrigin) * u_LightGridScale,
-		       lightDir, ambientColor, lightColor );
+	ReadLightGrid((var_Position - u_LightGridOrigin) * u_LightGridScale,
+		       lightDir, ambientColor, lightColor);
 
 	vec4 diffuse = vec4(0.0, 0.0, 0.0, 1.0);
 

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
@@ -26,9 +26,11 @@ uniform sampler2D	u_DiffuseMap;
 uniform sampler2D	u_MaterialMap;
 uniform sampler2D	u_GlowMap;
 
+#if defined(USE_REFLECTIVE_SPECULAR)
 uniform samplerCube	u_EnvironmentMap0;
 uniform samplerCube	u_EnvironmentMap1;
 uniform float		u_EnvironmentInterpolation;
+#endif // USE_REFLECTIVE_SPECULAR
 
 uniform float		u_AlphaThreshold;
 uniform vec3		u_ViewOrigin;
@@ -105,20 +107,15 @@ void	main()
 	vec3 normal = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
 
 	// compute the material term
-#if defined(USE_REFLECTIVE_SPECULAR)
-	// not implemented for PBR yet
-
 	vec4 material = texture2D(u_MaterialMap, texCoords);
 
+#if defined(USE_REFLECTIVE_SPECULAR) && !defined(USE_PHYSICAL_MAPPING)
+	// not implemented for PBR yet
 	vec4 envColor0 = textureCube(u_EnvironmentMap0, reflect(-viewDir, normal));
 	vec4 envColor1 = textureCube(u_EnvironmentMap1, reflect(-viewDir, normal));
 
 	material.rgb *= mix(envColor0, envColor1, u_EnvironmentInterpolation).rgb;
-
-#else // USE_REFLECTIVE_SPECULAR
-	// simple Blinn-Phong
-	vec4 material = texture2D(u_MaterialMap, texCoords);
-#endif // USE_REFLECTIVE_SPECULAR
+#endif // USE_REFLECTIVE_SPECULAR && !USE_PHYSICAL_MAPPING
 
 	// compute final color
 	vec4 color = vec4(ambientColor * r_AmbientScale * diffuse.xyz, diffuse.a);

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
@@ -120,12 +120,6 @@ void	main()
 	vec4 material = texture2D(u_MaterialMap, texCoords);
 #endif // USE_REFLECTIVE_SPECULAR
 
-// add Rim Lighting to highlight the edges
-#if defined(r_RimLighting)
-	float rim = pow(1.0 - clamp(dot(normal, viewDir), 0.0, 1.0), r_RimExponent);
-	vec3 emission = ambientColor * rim * rim * 0.2;
-#endif
-
 	// compute final color
 	vec4 color = vec4(ambientColor * r_AmbientScale * diffuse.xyz, diffuse.a);
 
@@ -133,7 +127,10 @@ void	main()
 
 	computeDLights( var_Position, normal, viewDir, diffuse, material, color );
 
+// add Rim Lighting to highlight the edges
 #if defined(r_RimLighting)
+	float rim = pow(1.0 - clamp(dot(normal, viewDir), 0.0, 1.0), r_RimExponent);
+	vec3 emission = ambientColor * rim * rim * 0.2;
 	color.rgb += 0.7 * emission;
 #endif
 


### PR DESCRIPTION
unify the way glsl shaders are written:

- make easier to compare them while looking for bugs
- make factorisation or merge easier

This is the way I fixed #247

This makes easier to merge vertex entity and vertex world shaders as one, and maybe merge the lightmapping one too, one day. This would be good to avoid duplicates of code living their own life with their own bugs.