### PR TITLE
cvar: make r_dpMaterial, fs_legacypaks and fs_maxSymlinkDepth latched cvars

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -123,8 +123,8 @@ template<> struct SerializeTraits<FS::LoadedPakInfo> {
 namespace FS {
 
 #ifdef BUILD_ENGINE
-static Cvar::Cvar<bool> fs_legacypaks("fs_legacypaks", "also load pk3s, ignoring version", Cvar::NONE, false);
-static Cvar::Cvar<int> fs_maxSymlinkDepth("fs_maxSymlinkDepth", "max depth of symlinks in zip paks (0 means disabled)", Cvar::NONE, 0);
+static Cvar::Cvar<bool> fs_legacypaks("fs_legacypaks", "also load pk3s, ignoring version", Cvar::LATCH, false);
+static Cvar::Cvar<int> fs_maxSymlinkDepth("fs_maxSymlinkDepth", "max depth of symlinks in zip paks (0 means disabled)", Cvar::LATCH, 0);
 
 bool UseLegacyPaks()
 {

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -50,7 +50,7 @@ static cullType_t    implicitCullType;
 static char          whenTokens[ MAX_STRING_CHARS ];
 
 // DarkPlaces material compatibility
-static Cvar::Cvar<bool> r_dpMaterial("r_dpMaterial", "Enable DarkPlaces material compatibility", Cvar::NONE, false);
+static Cvar::Cvar<bool> r_dpMaterial("r_dpMaterial", "Enable DarkPlaces material compatibility", Cvar::LATCH, false);
 Cvar::Cvar<bool> r_dpBlend("r_dpBlend", "Enable DarkPlaces blend compatibility, process GT0 as GE128", Cvar::NONE, false);
 
 /*


### PR DESCRIPTION
- reimplement latched cvar in new cvar system
- make `r_dpMaterial` a latched cvar
- make `fs_legacypaks` and `fs_maxSymlinkDepth` latched cvars

All I want is to be told to restart when I change those cvars.

Note that:

1. it seems to work
3. @Kangz wrote in ad04f91 that `CVAR_LATCH` is ”not longer supported” and “will be implemented by the proxy” which is not I done (and I don't know what Kangz expected): https://github.com/DaemonEngine/Daemon/blob/ad04f91fb60508d04a894205f728159abf912681/src/engine/framework/CvarSystem.h#L40

So, they may be dragons!