### PR TITLE
renderer: make dpMaterials collapsed shader from the start, including non-shader images

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -3628,7 +3628,7 @@ static void R_LoadShaders( lump_t *l )
 
 	for ( i = 0; i < count; i++ )
 	{
-		Log::Debug("shader: '%s'", out[ i ].shader );
+		Log::Debug("loading shader: '%s'", out[ i ].shader );
 
 		out[ i ].surfaceFlags = LittleLong( out[ i ].surfaceFlags );
 		out[ i ].contentFlags = LittleLong( out[ i ].contentFlags );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1072,6 +1072,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 
 		bool        active;
 
+		bool            dpMaterial;
+
 		textureBundle_t bundle[ MAX_TEXTURE_BUNDLES ];
 
 		expression_t    ifExp;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5416,6 +5416,8 @@ shader_t       *R_FindShader( const char *name, shaderType_t type,
 	// choosing filter based on the NOMIP flag seems strange,
 	// maybe it should be changed to type == SHADER_2D
 	if( !(bits & RSF_NOMIP) ) {
+		LoadExtraMaps( &stages[ 0 ], fileName );
+
 		image = R_FindImageFile( fileName, bits, filterType_t::FT_DEFAULT,
 					 wrapTypeEnum_t::WT_REPEAT );
 	} else {

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1689,13 +1689,13 @@ struct extraMapParser_t
 	int bundleIndex;
 };
 
-static const extraMapParser_t extraMapParsers[] =
+static const extraMapParser_t dpExtraMapParsers[] =
 {
-	{ "norm",    "normal map",     ParseNormalMap,     TB_NORMALMAP, },
-	{ "bump",    "height map",     ParseHeightMap,     TB_HEIGHTMAP, },
-	{ "gloss",   "specular map",   ParseSpecularMap,   TB_SPECULARMAP, },
-	{ "glow",    "glow map",       ParseGlowMap,       TB_GLOWMAP, },
-	{ "luma",    "glow map",       ParseGlowMap,       TB_GLOWMAP, },
+	{ "_norm",    "normal map",     ParseNormalMap,     TB_NORMALMAP, },
+	{ "_bump",    "height map",     ParseHeightMap,     TB_HEIGHTMAP, },
+	{ "_gloss",   "specular map",   ParseSpecularMap,   TB_SPECULARMAP, },
+	{ "_glow",    "glow map",       ParseGlowMap,       TB_GLOWMAP, },
+	{ "_luma",    "glow map",       ParseGlowMap,       TB_GLOWMAP, },
 };
 
 /*
@@ -1809,9 +1809,9 @@ void LoadExtraMaps( shaderStage_t *stage, const char *colorMapName )
 
 		COM_StripExtension3( colorMapName, colorMapBaseName, sizeof( colorMapBaseName ) );
 
-		for ( const extraMapParser_t parser: extraMapParsers )
+		for ( const extraMapParser_t parser: dpExtraMapParsers )
 		{
-			std::string extraMapName = Str::Format( "%s_%s", colorMapBaseName, parser.suffix );
+			std::string extraMapName = Str::Format( "%s%s", colorMapBaseName, parser.suffix );
 			if( R_FindImageLoader( extraMapName.c_str() ) >= 0 )
 			{
 				foundExtraMap = true;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4322,16 +4322,8 @@ static void CollapseStages()
 		return;
 	}
 
-	// FIXME: heightStage is only used by dpMaterial Darkplaces compatibility layer
-	// that still uses to-be-collapsed standalone stages,
-	// this code will be dead when the dpMaterial feature
-	// will be ported to the pre-collapsed stage layout
-	// and this heightMap collapsing code would have to be deleted:
-	// https://github.com/DaemonEngine/Daemon/pull/252#pullrequestreview-336919745
-
 	int diffuseStage = -1;
 	int normalStage = -1;
-	int heightStage = -1;
 	int specularStage = -1;
 	int physicalStage = -1;
 	int reflectionStage = -1;
@@ -4380,17 +4372,6 @@ static void CollapseStages()
 			else
 			{
 				normalStage = i;
-			}
-		}
-		else if ( stages[ i ].type == stageType_t::ST_HEIGHTMAP )
-		{
-			if ( heightStage != -1 )
-			{
-				Log::Warn( "more than one height map stage in shader '%s'", shader.name );
-			}
-			else
-			{
-				heightStage = i;
 			}
 		}
 		else if ( stages[ i ].type == stageType_t::ST_SPECULARMAP )
@@ -4495,7 +4476,6 @@ static void CollapseStages()
 	if ( diffuseStage != -1
 		&& ( specularStage != -1
 			|| normalStage != -1
-			|| heightStage != -1
 			|| physicalStage != -1
 			|| lightStage != -1
 			|| glowStage != -1 ) )
@@ -4535,14 +4515,6 @@ static void CollapseStages()
 				stages[ diffuseStage ].heightMapInNormalMap = stages[ normalStage ].heightMapInNormalMap;
 				// disable since it's merged
 				stages[ normalStage ].active = false;
-			}
-
-			if ( heightStage != -1 )
-			{
-				// merge with diffuse stage
-				stages[ diffuseStage ].bundle[ TB_HEIGHTMAP ] = stages[ heightStage ].bundle[ TB_COLORMAP ];
-				// disable since it's merged
-				stages[ heightStage ].active = false;
 			}
 
 			if ( specularStage != -1 )

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1820,7 +1820,7 @@ void LoadExtraMaps( shaderStage_t *stage, const char *colorMapName )
 				const char *name = extraMapName.c_str();
 				parser.parser( stage, &name, parser.bundleIndex );
 
-				if ( Q_stricmp( "norm", parser.suffix ) == 0 )
+				if ( parser.bundleIndex == TB_NORMALMAP )
 				{
 					// Xonotic uses -Y (DirectX) while this engine uses Y (OpenGL)
 					stage->normalScale[ 0 ] = 1;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4655,7 +4655,7 @@ static void CollapseStages()
 				}
 				// if there is a custom light stage, keep the glow stage uncollapsed
 				// and make sure the diffuse stage precedes the light stage
-				// and the light stage (known to exist because of implicitLightMap==false) precedes the glow stage
+				// and the light stage (known to exist because of implicitLightmap == false) precedes the glow stage
 				else
 				{
 					ASSERT_GE(lightStage, 0);


### PR DESCRIPTION
- now useless very ugly `FindMapInStage` is now dropped
- now useless heightmap collapsing code is now dropped
- extra maps loading for non-shader images is now enabled

as DarkPlaces only supports one kind of lightmap blend operation we can blindly collapse lightmap stages in darkplaces pre-collapsed stages.

So, shader parsing and rendering must be faster, and code is cleaner.

Next step is to merge cube Reflection with lightMapping glsl shader, a lot of code will disappear and bugs with it.