### PR TITLE
DarkPlaces only supports one alphaFunc operation, GE128

### DIFF
--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1243,7 +1243,27 @@ public:
 
 		switch( stateBits & GLS_ATEST_BITS ) {
 			case GLS_ATEST_GT_0:
-				value = 1.0f;
+				if ( *r_dpBlend )
+				{
+					// DarkPlaces only supports one alphaFunc operation:
+					//   https://gitlab.com/xonotic/darkplaces/blob/324a5329d33ef90df59e6488abce6433d90ac04c/model_shared.c#L1875-1876
+					// Which is GE128:
+					//   https://gitlab.com/xonotic/darkplaces/blob/0ea8f691e05ea968bb8940942197fa627966ff99/render.h#L95
+					// Because of that, people may silently introduce regressions in their textures
+					// designed for GT0 by compressing them using a lossy picture format like Jpg.
+					// Xonotic texture known to trigger this bug:
+					//   models/desertfactory/textures/shaders/grass01
+					// Using GE128 instead would hide Jpeg artifacts while not breaking that much
+					// non-DarkPlaces GT0.
+					// No one operation other than GT0 an GE128 was found in whole Xonotic corpus,
+					// so if there is other operations used in third party maps, they were broken
+					// on DarkPlaces and will work there.
+					value = 0.5f;
+				}
+				else
+				{
+					value = 1.0f;
+				}
 				break;
 			case GLS_ATEST_LT_128:
 				value = -1.5f;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2765,6 +2765,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_ignore; // used for debugging anything
 	extern cvar_t *r_verbose; // used for verbose debug spew
 
+	extern Cvar::Cvar<bool> r_dpBlend;
+
 	extern cvar_t *r_znear; // near Z clip plane
 	extern cvar_t *r_zfar;
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -51,6 +51,7 @@ static char          whenTokens[ MAX_STRING_CHARS ];
 
 // DarkPlaces material compatibility
 static Cvar::Cvar<bool> r_dpMaterial("r_dpMaterial", "Enable DarkPlaces material compatibility", Cvar::NONE, false);
+Cvar::Cvar<bool> r_dpBlend("r_dpBlend", "Enable DarkPlaces blend compatibility, process GT0 as GE128", Cvar::NONE, false);
 
 /*
 ================
@@ -859,7 +860,20 @@ static unsigned NameToAFunc( const char *funcname )
 {
 	if ( !Q_stricmp( funcname, "GT0" ) )
 	{
-		return GLS_ATEST_GT_0;
+		if ( *r_dpBlend )
+		{
+			// DarkPlaces only supports one alphaFunc operation: GE128
+			Log::Warn("alphaFunc 'GT0' will be replaced by 'GE128' in shader '%s' because r_dpBlend compatibility layer is enabled", shader.name );
+			return GLS_ATEST_GE_128;
+		}
+		else
+		{
+			if ( *r_dpMaterial )
+			{
+				Log::Warn("alphaFunc 'GT0' will not be replaced by 'GE128' in shader '%s' because r_dpBlend compatibility layer is disabled", shader.name );
+			}
+			return GLS_ATEST_GT_0;
+		}
 	}
 	else if ( !Q_stricmp( funcname, "LT128" ) )
 	{


### PR DESCRIPTION
DarkPlaces only supports one alphaFunc operation:

https://gitlab.com/xonotic/darkplaces/blob/324a5329d33ef90df59e6488abce6433d90ac04c/model_shared.c#L1875-1876

Which is GE128:

https://gitlab.com/xonotic/darkplaces/blob/0ea8f691e05ea968bb8940942197fa627966ff99/render.h#L95

Because of that people may silently introduce regressions in their textures
designed for GT0 by compressing them using a lossy picture format like Jpg.
Xonotic texture known to trigger this bug:

    models/desertfactory/textures/shaders/grass01

Using GE128 instead would hide Jpeg artifacts while not breaking that much
non-Darkplaces GT0.

No one operation other than GT0 an GE128 was found in whole Xonotic corpus,
so if there is other operations used in third party maps, they were broken
on Darkplaces and will work there.

Xonotic assets were fixed to make sure any idTech 3 renderers display the Xonotic
textures the same way Darkplaces displays them by telling renderer to use GE128
operator:

- https://gitlab.com/xonotic/xonotic-maps.pk3dir/merge_requests/140
- https://gitlab.com/xonotic/xonotic-data.pk3dir/merge_requests/753
- https://gitlab.com/xonotic/xonotic-nexcompat.pk3dir/merge_requests/2

But there is thousands of third party maps around there, so the workaround
is required.

Hopefully in case of legit GT0, a GE128 is not that bad, for example with
the grass texture quoted above, it would just be thinner.

Things may be less good in some case, when only the dark frame is expected
to be discarded but there is some dark pixels to keep (typically a road sign).