### PR TITLE
Implement CVAR_LATCH for new cvars

### DIFF
--- a/src/common/Cvar.h
+++ b/src/common/Cvar.h
@@ -46,6 +46,7 @@ namespace Cvar {
         TEMPORARY  = BIT(8), // The cvar is temporary and is not to be archived (overrides archive flags)
         CHEAT      = BIT(9), // The cvar is a cheat and should stay at its default value on pure servers.
         USER_ARCHIVE = BIT(14), // The cvar is saved to the configuration file at user request
+        LATCH      = BIT(15), // The cvar's value can be changed only after a cgame restart. Intentionally different from CVAR_LATCH.
     };
 
     // Internal to the Cvar system

--- a/src/common/Cvar.h
+++ b/src/common/Cvar.h
@@ -46,7 +46,8 @@ namespace Cvar {
         TEMPORARY  = BIT(8), // The cvar is temporary and is not to be archived (overrides archive flags)
         CHEAT      = BIT(9), // The cvar is a cheat and should stay at its default value on pure servers.
         USER_ARCHIVE = BIT(14), // The cvar is saved to the configuration file at user request
-        LATCH      = BIT(15), // The cvar's value can be changed only after a cgame restart. Intentionally different from CVAR_LATCH.
+        LATCH      = BIT(15), // The cvar's value can be changed only after a cgame restart.
+                              // Different value from CVAR_LATCH since a separate implementation is used.
     };
 
     // Internal to the Cvar system

--- a/src/common/Cvar.h
+++ b/src/common/Cvar.h
@@ -281,9 +281,11 @@ namespace Cvar {
 
     template<typename T>
     OnValueChangedResult Cvar<T>::OnValueChanged(Str::StringRef text) {
-        if (Parse(text, value)) {
-            OnValueChangedResult validationResult = Validate(value);
+        T newValue;
+        if (Parse(text, newValue)) {
+            OnValueChangedResult validationResult = Validate(newValue);
             if (validationResult.success) {
+                value = std::move(newValue);
                 return OnValueChangedResult{true, GetDescription()};
             } else {
                 return validationResult;

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2666,6 +2666,8 @@ void CL_StartHunkUsers()
 		return;
 	}
 
+	Cvar::SetLatchedValues();
+
 	if ( !cls.rendererStarted && CL_InitRenderer() )
 	{
 		cls.rendererStarted = true;

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2930,7 +2930,6 @@ void CL_Init()
 	Cvar_Get( "name", UNNAMED_PLAYER, CVAR_USERINFO | CVAR_ARCHIVE );
 	cl_rate = Cvar_Get( "rate", "25000", CVAR_USERINFO | CVAR_ARCHIVE );
 	Cvar_Get( "snaps", "40", CVAR_USERINFO  );
-//  Cvar_Get ("sex", "male", CVAR_USERINFO  );
 
 	Cvar_Get( "password", "", CVAR_USERINFO );
 

--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -329,6 +329,7 @@ namespace Cvar {
 
             if (proxy && cvar->proxy) {
                 Log::Warn("Cvar %s cannot be registered twice", name.c_str());
+                return false;
             }
 
             // Register the cvar with the previous user_created value

--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -119,7 +119,6 @@ namespace Cvar {
 
         if (not var.name) {
             var.name = CopyString(name.c_str());
-            var.index = -1;
             var.modificationCount = -1;
         }
 

--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -279,7 +279,7 @@ namespace Cvar {
 
                 if (result.success) {
                     if (cvar->flags & LATCH && value != cvar->value) {
-                        ChangeCvarDescription(cvarName, cvar, Str::Format("%s^* - latched value \"%s^*\"", result.description, value));
+                        ChangeCvarDescription(cvarName, cvar, Str::Format("%s - latched value \"%s^*\"", result.description, value));
                         OnValueChangedResult undo = cvar->proxy->OnValueChanged(cvar->value);
                         ASSERT(undo.success);
                         if (setLatchedValuesCalled) {

--- a/src/engine/framework/CvarSystem.h
+++ b/src/engine/framework/CvarSystem.h
@@ -88,6 +88,8 @@ namespace Cvar {
     void SetValueCProxy(const std::string& cvarName, const std::string& value);
 
     void SetCheatsAllowed(bool allowed);
+    // Use the stored values for new-style cvars with LATCH flag
+    void SetLatchedValues();
     void Shutdown();
 
     //Kept as a reference for cvar flags
@@ -98,7 +100,7 @@ namespace Cvar {
     // Remove eventually
     //CVAR_UNSAFE, not sure <- no support for now
     //CVAR_USER_CREATED is kept for now but not really needed
-    //CVAR_LATCH, CVAR_SHADER, CVAR_INIT are not longer supported, will be implemented by the proxy
+    //CVAR_INIT is no longer supported, will be implemented by the proxy
 
     //CVAR_NORESTART is not used will be killed
     //CVAR_TEMP seems useless, don't put the CVAR_ARCHIVE and CVAR_CHEAT

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -597,25 +597,22 @@ static void NORETURN Com_Crash_f()
 
 void Com_SetRecommended()
 {
-	cvar_t   *r_highQualityVideo; //, *com_recommended;
+	cvar_t   *r_highQualityVideo;
 	bool goodVideo;
 
 	// will use this for recommended settings as well.. do i outside the lower check so it gets done even with command line stuff
 	r_highQualityVideo = Cvar_Get( "r_highQualityVideo", "1", 0 );
-	//com_recommended = Cvar_Get("com_recommended", "-1", 0);
 	goodVideo = ( r_highQualityVideo && r_highQualityVideo->integer );
 
 	if ( goodVideo )
 	{
 		Log::Notice( "Found high quality video and slow CPU\n" );
 		Cmd::BufferCommandText("preset preset_fast.cfg");
-		Cvar_Set( "com_recommended", "2" );
 	}
 	else
 	{
 		Log::Notice( "Found low quality video and slow CPU\n" );
 		Cmd::BufferCommandText("preset preset_fastest.cfg");
-		Cvar_Set( "com_recommended", "3" );
 	}
 }
 

--- a/src/engine/qcommon/cvar.h
+++ b/src/engine/qcommon/cvar.h
@@ -58,18 +58,6 @@ struct cvar_t
 	int modificationCount; // incremented each time the cvar is changed
 	float value; // atof( string )
 	int integer; // atoi( string )
-
-    int index; //for vmCvar_t
-
-	/**
-	 * indicate whether the cvar won't be archived, even if it's an ARCHIVE flagged cvar.
-	 * this allows us to keep ARCHIVE cvars unwritten to autogen until a user changes them
-	 */
-	bool transient;
-
-	cvar_t *next;
-
-	cvar_t *hashNext;
 };
 
 /**

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -52,7 +52,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_measureOverdraw;
 
-	cvar_t      *r_inGameVideo;
 	cvar_t      *r_fastsky;
 	cvar_t      *r_drawSun;
 
@@ -1119,7 +1118,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_zfar = ri.Cvar_Get( "r_zfar", "0", CVAR_CHEAT );
 		r_ignoreGLErrors = ri.Cvar_Get( "r_ignoreGLErrors", "1", 0 );
 		r_fastsky = ri.Cvar_Get( "r_fastsky", "0", 0 );
-		r_inGameVideo = ri.Cvar_Get( "r_inGameVideo", "1", CVAR_ARCHIVE );
 		r_drawSun = ri.Cvar_Get( "r_drawSun", "0", 0 );
 		r_finish = ri.Cvar_Get( "r_finish", "0", CVAR_CHEAT );
 		r_textureMode = ri.Cvar_Get( "r_textureMode", "GL_LINEAR_MIPMAP_LINEAR", CVAR_ARCHIVE );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2789,7 +2789,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_ambientScale;
 	extern cvar_t *r_lightScale;
 
-	extern cvar_t *r_inGameVideo; // controls whether in game video should be draw
 	extern cvar_t *r_fastsky; // controls whether sky should be cleared or drawn
 	extern cvar_t *r_drawSun; // controls drawing of sun quad
 	extern cvar_t *r_dynamicLight; // dynamic lights enabled/disabled

--- a/src/engine/sys/sdl_input.cpp
+++ b/src/engine/sys/sdl_input.cpp
@@ -62,7 +62,6 @@ static cvar_t       *in_joystickUseAnalog = nullptr;
 static cvar_t       *in_gameControllerTriggerDeadzone = nullptr;
 
 static cvar_t *in_gameController = nullptr;
-static cvar_t *in_gameControllerAvailable = nullptr;
 static cvar_t *in_gameControllerDebug = nullptr;
 
 static SDL_Window *window = nullptr;
@@ -1252,7 +1251,6 @@ void IN_Init( void *windowData )
 	in_gameControllerTriggerDeadzone = Cvar_Get( "in_gameControllerTriggerDeadzone", "0.5", 0);
 
 	in_gameController = Cvar_Get( "in_gameController", "1", CVAR_TEMP );
-	in_gameControllerAvailable = Cvar_Get( "in_gameControllerAvailable", "0", CVAR_ROM );
 	in_gameControllerDebug = Cvar_Get( "in_gameControllerDebug", "0", CVAR_TEMP );
 	SDL_StartTextInput();
 	mouseAvailable = ( in_mouse->value != 0 );


### PR DESCRIPTION
To do before merging: Prevent `The change will take effect after restart` messages from being printed when the cvars are set from command line/configs.