### PR TITLE
Fix range checks for numBorders in CM_AddFacetBevels

### DIFF
--- a/src/common/cm/cm_plane.cpp
+++ b/src/common/cm/cm_plane.cpp
@@ -495,9 +495,10 @@ void CM_AddFacetBevels( cFacet_t *facet )
 
 			if ( i == facet->numBorders )
 			{
-				if ( facet->numBorders > MAX_FACET_BEVELS )
+				if ( facet->numBorders >= MAX_FACET_BEVELS )
 				{
 					Log::Warn( "too many bevels" );
+					continue;
 				}
 
 				facet->borderPlanes[ facet->numBorders ] = CM_FindPlane2( plane, &flipped );
@@ -589,9 +590,10 @@ void CM_AddFacetBevels( cFacet_t *facet )
 
 				if ( i == facet->numBorders )
 				{
-					if ( facet->numBorders > MAX_FACET_BEVELS )
+					if ( facet->numBorders >= MAX_FACET_BEVELS )
 					{
 						Log::Warn( "too many bevels" );
+						continue;
 					}
 
 					facet->borderPlanes[ facet->numBorders ] = CM_FindPlane2( plane, &flipped );
@@ -640,6 +642,10 @@ void CM_AddFacetBevels( cFacet_t *facet )
 	FreeWinding( w );
 
 	// add opposite plane
+	if ( facet->numBorders >= MAX_FACET_BEVELS ) {
+		Sys::Drop( "too many bevels" );
+		return;
+	}
 	facet->borderPlanes[ facet->numBorders ] = facet->surfacePlane;
 	facet->borderNoAdjust[ facet->numBorders ] = false;
 	facet->borderInward[ facet->numBorders ] = true;


### PR DESCRIPTION
With hope to find the cause of #169 I was comparing our code with the one from other engine and my sharp eyes noticed this. This is not the cause of #169, but it may be useful anyway.

Adapted from patch by @zturtleman, he said at that time it was to fix a bug uncovered by Coverity.

See https://github.com/ioquake/ioq3/commit/ee2541efee2eace042303197a1645013d22fcc34
See https://github.com/etlegacy/etlegacy/commit/0fa531a3a958a287d424a6e56198ac14fc3aec5c

@zturtleman for some reason, compared to ioquake3 the etlegacy patch only has 2 fixes on 3, do you know why? Is it an oversight?