### PR TITLE
renderer: make R_UploadImage set IF_ALPHA if alpha channel

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1332,22 +1332,17 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips,
 		ri.Hunk_FreeTempMemory( scaledBuffer );
 	}
 
-	// detect heightmap in normalmap alpha channel and enable it
-	// if not already enabled by explicit shader keyword
-	if ( image->bits & IF_NORMALMAP )
+	switch ( image->internalFormat )
 	{
-		switch ( image->internalFormat )
-		{
-			case GL_RGBA:
-			case GL_RGBA8:
-			case GL_RGBA16:
-			case GL_RGBA16F:
-			case GL_RGBA32F:
-			case GL_RGBA32UI:
-			case GL_COMPRESSED_RGBA_S3TC_DXT3_EXT:
-			case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
-				image->bits |= IF_HEIGHTMAP;
-		}
+		case GL_RGBA:
+		case GL_RGBA8:
+		case GL_RGBA16:
+		case GL_RGBA16F:
+		case GL_RGBA32F:
+		case GL_RGBA32UI:
+		case GL_COMPRESSED_RGBA_S3TC_DXT3_EXT:
+		case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
+			image->bits |= IF_ALPHA;
 	}
 
 	GL_Unbind( image );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -526,8 +526,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	  IF_LIGHTMAP = BIT( 13 ),
 	  IF_RGBA16 = BIT( 14 ),
 	  IF_RGBE = BIT( 15 ),
-	  IF_ALPHATEST = BIT( 16 ),
-	  IF_HEIGHTMAP = BIT( 17 ),
+	  IF_ALPHATEST = BIT( 16 ), // FIXME: this is unused
+	  IF_ALPHA = BIT( 17 ),
 	  IF_NOLIGHTSCALE = BIT( 18 ),
 	  IF_BC1 = BIT( 19 ),
 	  IF_BC2 = BIT( 20 ),

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1438,7 +1438,7 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 
 	if ( stage->stateBits & ( GLS_ATEST_BITS ) )
 	{
-		imageBits |= IF_ALPHATEST;
+		imageBits |= IF_ALPHATEST; // FIXME: this is unused
 	}
 
 	if ( stage->overrideFilterType )
@@ -1477,13 +1477,11 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 	// tell renderer to enable parallax mapping since an heightmap is found
 	// also tell renderer to not abuse normalmap alpha channel because it's an heightmap
 	// https://github.com/DaemonEngine/Daemon/issues/183#issuecomment-473691252
-	if ( stage->bundle[ bundleIndex ].image[ 0 ]->bits & IF_HEIGHTMAP )
+	if ( stage->bundle[ bundleIndex ].image[ 0 ]->bits & IF_NORMALMAP
+		&& stage->bundle[ bundleIndex ].image[ 0 ]->bits & IF_ALPHA )
 	{
-		if ( stage->bundle[ bundleIndex ].image[ 0 ]->bits & IF_NORMALMAP )
-		{
-			Log::Debug("found heightmap embedded in normalmap '%s'", buffer);
-			stage->heightMapInNormalMap = true;
-		}
+		Log::Debug("found heightmap embedded in normalmap '%s'", buffer);
+		stage->heightMapInNormalMap = true;
 	}
 
 	return true;


### PR DESCRIPTION
drop specific `IF_HEIGHTMAP` that was only set with heightmap in normal map alpha channel
but not with loose heightmaps.

also mark `IF_ALPHATEST` as unused.

`IF_NORMALMAP` is used in many places so it has to be kept.