### PR TITLE
glsl/lightmapping: fix terrain alpha blending for collapsed materials

### DIFF
--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -61,6 +61,8 @@ void	main()
 	// compute the diffuse term
 	vec4 diffuse = texture2D(u_DiffuseMap, texCoords);
 
+	diffuse *= var_Color;
+
 	if( abs(diffuse.a + u_AlphaThreshold) <= 1.0 )
 	{
 		discard;

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -61,6 +61,7 @@ void	main()
 	// compute the diffuse term
 	vec4 diffuse = texture2D(u_DiffuseMap, texCoords);
 
+	// vertex blend operation like: alphaGen vertex
 	diffuse *= var_Color;
 
 	if( abs(diffuse.a + u_AlphaThreshold) <= 1.0 )

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
@@ -95,6 +95,7 @@ void	main()
 	// compute the diffuse term
 	vec4 diffuse = texture2D(u_DiffuseMap, texCoords);
 
+	// vertex blend operation like: alphaGen vertex
 	diffuse *= var_Color;
 
 	if( abs(diffuse.a + u_AlphaThreshold) <= 1.0 )

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
@@ -89,6 +89,7 @@ void	main()
 	// compute the diffuse term
 	vec4 diffuse = texture2D(u_DiffuseMap, texCoords);
 
+	// vertex blend operation like: alphaGen vertex
 	diffuse *= var_Color;
 
 	if( abs(diffuse.a + u_AlphaThreshold) <= 1.0 )


### PR DESCRIPTION
It is now possible to do:

```c
textures/hangar28_pk02/stone_sand
{
	qer_editorimage   textures/shared_pk02_src/rock01_d
	q3map_nonplanar
	q3map_shadeangle 170
	q3map_lightmapmergable
	
	{
		// Primary
		diffuseMap      textures/shared_pk02_src/rock01_d
		normalMap       textures/shared_pk02_src/rock01_n
		specularMap     textures/shared_pk02_src/rock01_s
		rgbGen identity
	}
	{
		// Secondary
		diffuseMap      textures/shared_pk02_src/sand01_d
		normalMap       textures/shared_pk02_src/sand01_n
		specularMap     textures/shared_pk02_src/sand01_s
		blendFunc blend
		alphaGen vertex
	}
}
```

Before:

[![flat shader with terrain alpha blending](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-31_221624_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-31_221624_000.jpg)

After:

[![pre collapsed shader with terrain alpha blending](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-28_064641_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-28_064641_000.jpg)

[![pre collapsed shader with terrain alpha blending](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-28_064900_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-28_064900_000.jpg)