### PR TITLE
 tr_shade: reduce diff noise between vertex entity, vertex world and lightmap code (and more)

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1478,7 +1478,6 @@ GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 	u_Color( this ),
 	u_AlphaThreshold( this ),
 	u_ViewOrigin( this ),
-	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
 	u_ParallaxDepthScale( this ),
 	u_ParallaxOffsetBias( this ),

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1627,7 +1627,7 @@ void GLShader_vertexLighting_DBS_world::SetShaderProgramUniforms( shaderProgram_
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_DiffuseMap" ), 0 );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_NormalMap" ), 1 );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_MaterialMap" ), 2 );
-	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_GlowMap" ), 3 );
+	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_GlowMap" ), 5 );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_LightGrid1" ), 6 );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_LightGrid2" ), 7 );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_LightTiles" ), 8 );

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2173,7 +2173,6 @@ class GLShader_lightMapping :
 	public u_Color,
 	public u_AlphaThreshold,
 	public u_ViewOrigin,
-	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
 	public u_ParallaxDepthScale,
 	public u_ParallaxOffsetBias,

--- a/src/engine/renderer/glsl_source/lightMapping_vp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_vp.glsl
@@ -34,21 +34,23 @@ uniform vec4		u_Color;
 OUT(smooth) vec3	var_Position;
 OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) vec2	var_TexLight;
+
 OUT(smooth) vec3	var_Tangent;
 OUT(smooth) vec3	var_Binormal;
 OUT(smooth) vec3	var_Normal;
+
 OUT(smooth) vec4	var_Color;
 
 void DeformVertex( inout vec4 pos,
-		   inout vec3 normal,
-		   inout vec2 st,
-		   inout vec4 color,
-		   in    float time);
+		inout vec3 normal,
+		inout vec2 st,
+		inout vec4 color,
+		in    float time);
 
-void	main()
+void main()
 {
-	vec4 position;
 	localBasis LB;
+	vec4 position;
 	vec2 texCoord, lmCoord;
 	vec4 color;
 
@@ -57,24 +59,26 @@ void	main()
 	color = color * u_ColorModulate + u_Color;
 
 	DeformVertex( position,
-		      LB.normal,
-		      texCoord.xy,
-		      color,
-		      u_Time);
+		LB.normal,
+		texCoord,
+		color,
+		u_Time);
 
 	// transform vertex position into homogenous clip-space
 	gl_Position = u_ModelViewProjectionMatrix * position;
 
-	// transform diffusemap texcoords
-	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
-
-	var_TexLight = lmCoord;
-
+	// assign vertex Position
 	var_Position = position.xyz;
 
 	var_Normal = LB.normal;
 	var_Tangent = LB.tangent;
 	var_Binormal = LB.binormal;
 
+	// transform diffusemap texcoords
+	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
+
+	var_TexLight = lmCoord;
+
+	// assign color
 	var_Color = color;
 }

--- a/src/engine/renderer/glsl_source/lightMapping_vp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_vp.glsl
@@ -23,7 +23,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 /* lightMapping_vp.glsl */
 
 uniform mat4		u_TextureMatrix;
-uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
 uniform float		u_Time;

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_vp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_vp.glsl
@@ -30,32 +30,33 @@ uniform float		u_Time;
 
 OUT(smooth) vec3	var_Position;
 OUT(smooth) vec2	var_TexCoords;
-OUT(smooth) vec4	var_Color;
+
 OUT(smooth) vec3	var_Tangent;
 OUT(smooth) vec3	var_Binormal;
-
 OUT(smooth) vec3	var_Normal;
 
+OUT(smooth) vec4	var_Color;
+
 void DeformVertex( inout vec4 pos,
-		   inout vec3 normal,
-		   inout vec2 st,
-		   inout vec4 color,
-		   in    float time);
+		inout vec3 normal,
+		inout vec2 st,
+		inout vec4 color,
+		in    float time);
 
 void	main()
 {
-	vec4 position;
 	localBasis LB;
+	vec4 position;
 	vec2 texCoord, lmCoord;
 	vec4 color;
 
 	VertexFetch( position, LB, color, texCoord, lmCoord);
 
 	DeformVertex( position,
-		      LB.normal,
-		      texCoord,
-		      color,
-		      u_Time);
+		LB.normal,
+		texCoord,
+		color,
+		u_Time);
 
 	// transform vertex position into homogenous clip-space
 	gl_Position = u_ModelViewProjectionMatrix * position;
@@ -63,11 +64,13 @@ void	main()
 	// transform position into world space
 	var_Position = (u_ModelMatrix * position).xyz;
 
-	var_Tangent.xyz = (u_ModelMatrix * vec4(LB.tangent, 0.0)).xyz;
-	var_Binormal.xyz = (u_ModelMatrix * vec4(LB.binormal, 0.0)).xyz;
-	var_Normal.xyz = (u_ModelMatrix * vec4(LB.normal, 0.0)).xyz;
+	var_Tangent = (u_ModelMatrix * vec4(LB.tangent, 0.0)).xyz;
+	var_Binormal = (u_ModelMatrix * vec4(LB.binormal, 0.0)).xyz;
+	var_Normal = (u_ModelMatrix * vec4(LB.normal, 0.0)).xyz;
 
 	// transform diffusemap texcoords
 	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
+
+	// assign color
 	var_Color = color;
 }

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_world_vp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_world_vp.glsl
@@ -32,23 +32,23 @@ uniform vec4		u_Color;
 
 OUT(smooth) vec3	var_Position;
 OUT(smooth) vec2	var_TexCoords;
-OUT(smooth) vec4	var_Color;
 
 OUT(smooth) vec3	var_Tangent;
 OUT(smooth) vec3	var_Binormal;
-
 OUT(smooth) vec3	var_Normal;
 
-void DeformVertex( inout vec4 pos,
-		   inout vec3 normal,
-		   inout vec2 st,
-		   inout vec4 color,
-		   in    float time);
+OUT(smooth) vec4	var_Color;
 
-void	main()
+void DeformVertex( inout vec4 pos,
+		inout vec3 normal,
+		inout vec2 st,
+		inout vec4 color,
+		in    float time);
+
+void main()
 {
-	vec4 position;
 	localBasis LB;
+	vec4 position;
 	vec2 texCoord, lmCoord;
 	vec4 color;
 
@@ -57,10 +57,10 @@ void	main()
 	color = color * u_ColorModulate + u_Color;
 
 	DeformVertex( position,
-		      LB.normal,
-		      texCoord,
-		      color,
-		      u_Time);
+		LB.normal,
+		texCoord,
+		color,
+		u_Time);
 
 	// transform vertex position into homogenous clip-space
 	gl_Position = u_ModelViewProjectionMatrix * position;
@@ -68,14 +68,13 @@ void	main()
 	// assign vertex Position for light grid sampling
 	var_Position = position.xyz;
 
+	var_Normal = LB.normal;	
+	var_Tangent = LB.tangent;
+	var_Binormal = LB.binormal;
+
 	// transform diffusemap texcoords
 	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;
 
 	// assign color
 	var_Color = color;
-	
-	var_Tangent = LB.tangent;
-	var_Binormal = LB.binormal;
-
-	var_Normal = LB.normal;
 }

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1287,8 +1287,6 @@ static void Render_lightMapping( int stage )
 	// u_ViewOrigin
 	gl_lightMappingShader->SetUniform_ViewOrigin( viewOrigin );
 
-	gl_lightMappingShader->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
-
 	gl_lightMappingShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 
 	gl_lightMappingShader->SetUniform_AlphaTest( pStage->stateBits );


### PR DESCRIPTION
This is the huge rewording work I made when I was looking for the fix described in #277.

Basically I had identified that the bug was bound to the `Render_lightMapping()` function as swaping it with `Render_generic()` or `Render_vertexLighting_DBS_world` made the feature working.

But at this point I didn't know if the issue was in those C++ functions, in GLSL fragment code, or in GLSL vertex code.

At the same time, I wanted to do that rewording because it would benefit for many other work: collapsing the cube reflection, perhaps merge this vertex/lightmapping code one day if it does not clutter the code too much, etc. etc.

Three noticeable changes:

- The `Render_lightMapping()` C++ function was using some global variable directly while other code from `Render_vertexLighting_DBS_world()` and `Render_vertexLighting_DBS_entity()` was copying the variable to a local one before using it. Without more knowledge, I thought it was safe to make the lightMapping C++ code copy the variable before using it too. Maybe it may fix bugs (SMP anyone?) while it would be very unlikely to introduce some, and the operation is probably minor on CPU since other code does it by default any time.
- The `Render_vertexLighting_DBS_world()` function was calling `GL_CheckErrors()` two times while others were doing it once, once may be enough.
- The lightMapping code was feeding GLSL with a `u_ModelMatrix` matrix that was unused.

Without this work, I would not be able to fix #277, which was basically what remained different for no explained reason after everything looked the same.