### PR TITLE
tr_shader: fix translucency of pre-collapsed shaders

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -2387,7 +2387,8 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			// clear depth mask for blended surfaces
 			if ( !depthMaskExplicit &&
 			     (stage->type == stageType_t::ST_COLORMAP ||
-			      stage->type == stageType_t::ST_DIFFUSEMAP) &&
+			      stage->type == stageType_t::ST_DIFFUSEMAP ||
+			      stage->collapseType != collapseType_t::COLLAPSE_none ) &&
 			     blendSrcBits != 0 && blendDstBits != 0
 			     && !(blendSrcBits == GLS_SRCBLEND_ONE &&
 				  blendDstBits == GLS_DSTBLEND_ZERO) )


### PR DESCRIPTION
While #277 fixed alpha blending of pre-collapsed shaders, I've discovered translucency was still not working on them, while it was working on color maps and diffuse maps. Since a lone diffuse map is processed as a collapsed shader even if it only has one texture, I was surprised to see it working with diffuse map but stopping working as soon I added a specular map or a normal map.

The cause of the bug was a required operation done only when the stage is a diffuse map, so when the next stage was parsed, if it's not a diffuse map, it would change the behavior. Fix is to not test for diffuse map bug for collapsed stage. As said, a lone diffuse map is processed as a collapsed shader any way, so no need to keep an explicit test for it.

[![blended collapsed shader](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-30_114338_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-30_114338_000.jpg)

On the picture above, from farther to closer, the stages are defined this way:

Color map: light map and dynamic light do not apply:
```c
	{
		map textures/test-water_custom_src/water_d
		scroll time * .1, time * .1
		scale .5, .5
		blend blend
	}
```

Diffuse map: light map and dynamic light apply:
```c
	{
		diffuseMap  textures/test-water_custom_src/water_d
		scroll time * .1, time * .1
		scale .5, .5
		blend blend
	}
```

Collapsed shader with light map, normal and specular maps, and dynamic light apply with normal and specular map operation:
```c
	{
		diffuseMap  textures/test-water_custom_src/water_d
		normalMap   textures/test-water_custom_src/water_n
		specularMap textures/test-water_custom_src/water_s
		scroll time * .1, time * .1
		scale .5, .5
		blend blend
	}
```

See also some screenshots from Xonotic, with translucent water flowing, note that the scrolling of the pre-collapsed shader worked from the start:

[![blended collapsed shader](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-30_144404_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-30_144404_000.jpg)

Or stagnant lava:

[![blended collapsed shader](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-30_144514_000.jpg)](https://dl.illwieckz.net/b/daemon/wip/pre-collapsed-shaders/unvanquished_2020-01-30_144514_000.jpg)