### PR TITLE
WIP: cl_main: iterate server query list from Com_EventLoop, fix #284

### DIFF
--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -1287,6 +1287,7 @@ public:
 		if ( message.secure == Rcon::Secure::EncryptedChallenge )
 		{
 			queue.Push(message);
+			Log::Debug( "RconCmd: getchallenge %s", NET_AdrToStringwPort( message.remote ) );
 			Net::OutOfBandPrint(netsrc_t::NS_CLIENT, message.remote, "getchallenge");
 		}
 		else
@@ -1682,6 +1683,7 @@ void CL_CheckForResend()
 	switch ( cls.state )
 	{
 		case connstate_t::CA_CONNECTING:
+			Log::Debug( "CL_CheckForResend: getchallenge %s", NET_AdrToStringwPort( clc.serverAddress ) );
 			Net::OutOfBandPrint( netsrc_t::NS_CLIENT, clc.serverAddress, "getchallenge" );
 			break;
 
@@ -3317,6 +3319,7 @@ int CL_ServerStatus( const char *serverAddress, char *serverStatusString, int ma
 			serverStatus->retrieved = false;
 			serverStatus->time = 0;
 			serverStatus->startTime = Sys_Milliseconds();
+			Log::Debug( "CL_ServerStatus (resend): getstatus %s", serverAddress );
 			Net::OutOfBandPrint( netsrc_t::NS_CLIENT, to, "getstatus" );
 			return false;
 		}
@@ -3330,6 +3333,7 @@ int CL_ServerStatus( const char *serverAddress, char *serverStatusString, int ma
 		serverStatus->retrieved = false;
 		serverStatus->startTime = Sys_Milliseconds();
 		serverStatus->time = 0;
+		Log::Debug( "CL_ServerStatus (retrieved): getstatus %s", serverAddress );
 		Net::OutOfBandPrint( netsrc_t::NS_CLIENT, to, "getstatus" );
 		return false;
 	}
@@ -3784,6 +3788,7 @@ void CL_Ping_f()
 
 	CL_SetServerInfoByAddress( pingptr->adr, nullptr, 0 );
 
+	Log::Debug( "CL_Ping_f: getinfo %s", server );
 	Net::OutOfBandPrint( netsrc_t::NS_CLIENT, to, "getinfo xxx" );
 }
 
@@ -3873,6 +3878,7 @@ bool CL_UpdateVisiblePings_f( int source )
 								memcpy( &cl_pinglist[ j ].adr, &server[ i ].adr, sizeof( netadr_t ) );
 								cl_pinglist[ j ].start = Sys_Milliseconds();
 								cl_pinglist[ j ].time = 0;
+								Log::Debug( "CL_UpdateVisiblePings_f: getinfo %s", NET_AdrToStringwPort( cl_pinglist[ j ].adr ) );
 								Net::OutOfBandPrint( netsrc_t::NS_CLIENT, cl_pinglist[ j ].adr, "getinfo xxx" );
 								slots++;
 								break;
@@ -3986,6 +3992,7 @@ void CL_ServerStatus_f()
 		}
 	}
 
+	Log::Debug( "CL_ServerStatus_f: getstatus %s", server );
 	Net::OutOfBandPrint( netsrc_t::NS_CLIENT, *toptr, "getstatus" );
 
 	serverStatus = CL_GetServerStatus( *toptr );

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -250,6 +250,7 @@ struct ping_t
 	int      start;
 	int      time;
 	char     info[ MAX_INFO_STRING ];
+	bool     toPing;
 };
 
 #define MAX_FEATLABEL_CHARS 32

--- a/src/engine/null/null_client.cpp
+++ b/src/engine/null/null_client.cpp
@@ -57,6 +57,10 @@ void CL_Frame( int )
 {
 }
 
+void CL_IterateServerQueries()
+{
+}
+
 void CL_PacketEvent( const netadr_t& , msg_t*  )
 {
 }

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -432,6 +432,9 @@ void Com_EventLoop()
 
 	while (true)
 	{
+		// send next server query if it's time to
+		CL_IterateServerQueries();
+
 		auto ev = Com_GetEvent();
 
 		// if no more events are available

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -678,8 +678,9 @@ void CL_MouseEvent( int dx, int dy );
 void CL_MousePosEvent( int dx, int dy);
 void CL_FocusEvent( bool focus );
 
-
 void CL_JoystickEvent( int axis, int value );
+
+void CL_IterateServerQueries();
 
 void CL_PacketEvent( const netadr_t& from, msg_t *msg );
 


### PR DESCRIPTION
I modified the behavior of the code to iterate the server query list in the main loop to not be blocking, this was an issue that was annoying me and it would have been worst with a floodLimiter and far worst with more servers.

I added a cvar named `cl_floodLimiter` which is set to `0`. That's because on mobile broadband network, sent packets may be lost if we flood them. I've noticed that on Coucou Networks (_Edit:_ Free Mobile) going under 70ms between each server query leads to packets being lost, so people like me can set it to `100` or other safe value like that.

