### PR TITLE
renderer: fix infuriating grey line

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -722,10 +722,7 @@ std::string     GLShaderManager::BuildGPUShaderText( Str::StringRef mainShaderNa
 	AddDefine( env, "MAX_REF_LIGHTS", MAX_REF_LIGHTS );
 	AddDefine( env, "TILE_SIZE", TILE_SIZE );
 
-	float fbufWidthScale = 1.0f / glConfig.vidWidth;
-	float fbufHeightScale = 1.0f / glConfig.vidHeight;
-
-	AddDefine( env, "r_FBufScale", fbufWidthScale, fbufHeightScale );
+	AddDefine( env, "r_FBufSize", glConfig.vidWidth, glConfig.vidHeight );
 
 	AddDefine( env, "r_tileStep", glState.tileStep[ 0 ], glState.tileStep[ 1 ] );
 

--- a/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
+++ b/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
@@ -34,7 +34,7 @@ DECLARE_OUTPUT(vec4)
 void	main()
 {
 	// calculate the screen texcoord in the 0.0 to 1.0 range
-	vec2 st = gl_FragCoord.st * r_FBufScale;
+	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	vec4 original = clamp(texture2D(u_CurrentMap, st), 0.0, 1.0);
 

--- a/src/engine/renderer/glsl_source/contrast_fp.glsl
+++ b/src/engine/renderer/glsl_source/contrast_fp.glsl
@@ -42,14 +42,13 @@ vec4 f(vec4 color) {
 
 void	main()
 {
-	vec2 scale = r_FBufScale;
-	vec2 st = gl_FragCoord.st;
-
 	// calculate the screen texcoord in the 0.0 to 1.0 range
-	st *= r_FBufScale;
+	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	// multiply with 4 because the FBO is only 1/4th of the screen resolution
 	st *= vec2(4.0, 4.0);
+
+	vec2 scale = 1 / r_FBufSize;
 
 	// perform a box filter for the downsample
 	vec4 color = f(texture2D(u_ColorMap, st + vec2(-1.0, -1.0) * scale));

--- a/src/engine/renderer/glsl_source/depthtile1_fp.glsl
+++ b/src/engine/renderer/glsl_source/depthtile1_fp.glsl
@@ -39,7 +39,7 @@ IN(flat) vec3 unprojectionParams;
 
 uniform vec3 u_zFar;
 
-const vec2 pixelScale = r_FBufScale;
+const vec2 pixelScale = 1 / r_FBufSize;
 
 DECLARE_OUTPUT(vec4)
 

--- a/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
@@ -40,7 +40,7 @@ out vec4 outputColor;
 void	main()
 {
 	// calculate the screen texcoord in the 0.0 to 1.0 range
-	vec2 st = gl_FragCoord.st * r_FBufScale;
+	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	// reconstruct vertex position in world space
 	float depth = texture2D(u_DepthMap, st).r;

--- a/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
@@ -129,7 +129,7 @@ vec3 RandomVec3(vec2 uv)
 
 	dir = normalize(vec3(cos(angle), sin(angle), r));
 #else
-	// dir = texture2D(u_NoiseMap, gl_FragCoord.st * r_FBufScale).rgb;
+	// dir = texture2D(u_NoiseMap, gl_FragCoord.st / r_FBufSize).rgb;
 	dir = normalize(2.0 * (texture2D(u_RandomMap, uv).xyz - 0.5));
 #endif
 
@@ -357,7 +357,7 @@ vec4 PCF(vec3 Pworld, float filterWidth, float samples, out vec4 clipMoments)
 	{
 		for(int j = 0; j < samples; j++)
 		{
-			vec3 rand = RandomVec3(gl_FragCoord.st * r_FBufScale + vec2(i, j)) * filterWidth;
+			vec3 rand = RandomVec3(gl_FragCoord.st / r_FBufSize + vec2(i, j)) * filterWidth;
 			// rand.z = 0;
 			// rand = normalize(rand) * filterWidth;
 
@@ -420,7 +420,7 @@ vec4 PCF(vec4 shadowVert, float filterWidth, float samples, out vec4 clipMoments
 	{
 		for(int j = 0; j < samples; j++)
 		{
-			vec3 rand = RandomVec3(gl_FragCoord.st * r_FBufScale + vec2(i, j)) * filterWidth;
+			vec3 rand = RandomVec3(gl_FragCoord.st / r_FBufSize + vec2(i, j)) * filterWidth;
 			// rand = vec3(0.0, 0.0, 1.0);
 			// rand.z = 0;
 			// rand = normalize(rand);// * filterWidth;
@@ -484,7 +484,7 @@ vec4 PCF(vec4 incidentRay, float filterWidth, float samples, out vec4 clipMoment
 	{
 		for(int j = 0; j < samples; j++)
 		{
-			vec3 rand = RandomVec3(gl_FragCoord.st * r_FBufScale + vec2(i, j)) * filterWidth;
+			vec3 rand = RandomVec3(gl_FragCoord.st / r_FBufSize + vec2(i, j)) * filterWidth;
 			// rand.z = 0;
 			// rand = normalize(rand) * filterWidth;
 
@@ -750,7 +750,7 @@ void	main()
 {
 #if 0
 	// create random noise vector
-	vec3 rand = RandomVec3(gl_FragCoord.st * r_FBufScale);
+	vec3 rand = RandomVec3(gl_FragCoord.st / r_FBufSize);
 
 	outputColor = vec4(rand * 0.5 + 0.5, 1.0);
 	return;

--- a/src/engine/renderer/glsl_source/fxaa_fp.glsl
+++ b/src/engine/renderer/glsl_source/fxaa_fp.glsl
@@ -47,12 +47,12 @@ out vec4 outputColor;
 void	main()
 {
 	outputColor = FxaaPixelShader(
-		gl_FragCoord.xy * r_FBufScale, //pos
+		gl_FragCoord.xy / r_FBufSize, //pos
 		vec4(0.0), //not used
 		u_ColorMap, //tex
 		u_ColorMap, //not used
 		u_ColorMap, //not used
-		r_FBufScale, //fxaaQualityRcpFrame
+		1 / r_FBufSize, //fxaaQualityRcpFrame
 		vec4(0.0), //not used
 		vec4(0.0), //not used
 		vec4(0.0), //not used

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -48,7 +48,7 @@ void	main()
 #endif
 
 #if defined(USE_DEPTH_FADE) || defined(USE_VERTEX_SPRITE)
-	float depth = texture2D(u_DepthMap, gl_FragCoord.xy * r_FBufScale).x;
+	float depth = texture2D(u_DepthMap, gl_FragCoord.xy / r_FBufSize).x;
 	float fadeDepth = 0.5 * var_FadeDepth.x / var_FadeDepth.y + 0.5;
 	color.a *= smoothstep(gl_FragCoord.z, fadeDepth, depth);
 #endif

--- a/src/engine/renderer/glsl_source/heatHaze_fp.glsl
+++ b/src/engine/renderer/glsl_source/heatHaze_fp.glsl
@@ -38,7 +38,7 @@ void	main()
 	vec3 normal = NormalInTangentSpace(var_TexCoords);
 
 	// calculate the screen texcoord in the 0.0 to 1.0 range
-	vec2 st = gl_FragCoord.st * r_FBufScale;
+	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	// offset by the scaled normal and clamp it to 0.0 - 1.0
 	st += normal.xy * var_Deform;

--- a/src/engine/renderer/glsl_source/lightVolume_omni_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightVolume_omni_fp.glsl
@@ -50,7 +50,7 @@ DECLARE_OUTPUT(vec4)
 void	main()
 {
 	// calculate the screen texcoord in the 0.0 to 1.0 range
-	vec2 st = gl_FragCoord.st * r_FBufScale;
+	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	// reconstruct vertex position in world space
 	float depth = texture2D(u_DepthMap, st).r;

--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -87,7 +87,7 @@ void	main()
 	}
 
 	// calculate the screen texcoord in the 0.0 to 1.0 range
-	vec2 texScreen = gl_FragCoord.st * r_FBufScale;
+	vec2 texScreen = gl_FragCoord.st / r_FBufSize;
 	vec2 texNormal = var_TexCoords;
 
 #if defined(USE_PARALLAX_MAPPING)

--- a/src/engine/renderer/glsl_source/motionblur_fp.glsl
+++ b/src/engine/renderer/glsl_source/motionblur_fp.glsl
@@ -35,11 +35,10 @@ out vec4 outputColor;
 
 void	main()
 {
-	vec2 st = gl_FragCoord.st;
 	vec4 color = vec4( 0.0 );
 
 	// calculate the screen texcoord in the 0.0 to 1.0 range
-	st *= r_FBufScale;
+	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	float depth = texture2D( u_DepthMap, st ).r;
 

--- a/src/engine/renderer/glsl_source/portal_fp.glsl
+++ b/src/engine/renderer/glsl_source/portal_fp.glsl
@@ -33,7 +33,7 @@ DECLARE_OUTPUT(vec4)
 void	main()
 {
 	// calculate the screen texcoord in the 0.0 to 1.0 range
-	vec2 st = gl_FragCoord.st * r_FBufScale;
+	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	vec4 color = texture2D(u_CurrentMap, st);
 	color *= var_Color;

--- a/src/engine/renderer/glsl_source/screen_fp.glsl
+++ b/src/engine/renderer/glsl_source/screen_fp.glsl
@@ -31,7 +31,7 @@ DECLARE_OUTPUT(vec4)
 void	main()
 {
 	// calculate the screen texcoord in the 0.0 to 1.0 range
-	vec2 st = gl_FragCoord.st * r_FBufScale;
+	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	vec4 color = texture2D(u_CurrentMap, st);
 	color *= var_Color;

--- a/src/engine/renderer/glsl_source/ssao_fp.glsl
+++ b/src/engine/renderer/glsl_source/ssao_fp.glsl
@@ -29,7 +29,7 @@ DECLARE_OUTPUT(vec4)
 
 uniform vec3 u_zFar;
 
-const vec2 pixelScale = r_FBufScale;
+const vec2 pixelScale = 1 / r_FBufSize;
 const float haloCutoff = 15.0;
 
 float depthToZ(float depth) {

--- a/src/engine/renderer/glsl_source/volumetricFog_fp.glsl
+++ b/src/engine/renderer/glsl_source/volumetricFog_fp.glsl
@@ -51,7 +51,7 @@ float DecodeDepth(vec4 color)
 void	main()
 {
 	// calculate the screen texcoord in the 0.0 to 1.0 range
-	vec2 st = gl_FragCoord.st * r_FBufScale;
+	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	// calculate fog volume depth
 	float fogDepth;


### PR DESCRIPTION
Maybe I'm a wizard, then.

I've noticed that if the bug is not in SSAO neither FXAA code, using both makes worst artifacts than only one of those. I also noticed that ticking FXAA on and off (the later not requiring an engine restart), I was seeing the screen being more streched with on than off, in real time.

Here is with  and without fxaa (while ssao is enabled):

[![with ssao, without fxaa](https://dl.illwieckz.net/b/daemon/bugs/boggy-lines/unvanquished_2020-02-09_122221_000.png)](https://dl.illwieckz.net/b/daemon/bugs/boggy-lines/unvanquished_2020-02-09_122221_000.png)

[![with ssao, with fxaa](https://dl.illwieckz.net/b/daemon/bugs/boggy-lines/unvanquished_2020-02-09_122226_000.png)](https://dl.illwieckz.net/b/daemon/bugs/boggy-lines/unvanquished_2020-02-09_122226_000.png)

Those screenshots can also be [seen there with a nice slider](https://imgsli.com/MTE5MTg).

So, I've noticed that the only common code in both shaders was something like that:

```
gl_FragCoord.st * r_FBufScale;
```

Which is the computation for the pixel size.

I then thought: _“maybe those floats in `r_FBufScale` (a `vec2`) have rounding errors”_, I then modified them in shader the arbitrary way and I was able to produce garbage based on vertical and horizontal lines the same way:

[![garbage with lines](https://dl.illwieckz.net/b/daemon/bugs/boggy-lines/unvanquished_2020-02-09_123041_000.png)](https://dl.illwieckz.net/b/daemon/bugs/boggy-lines/unvanquished_2020-02-09_123041_000.png)

I then thought: _“wait, those floats are passed from c++ to glsl, those floats are just the quotient of 1 by ints, we can pass them as int instead and translate multiplication by division”_, I tried, it seems to work.

So, this is expected to fix https://github.com/Unvanquished/Unvanquished/issues/858

On my side it does:

[![no more boggy lines](https://dl.illwieckz.net/b/daemon/bugs/boggy-lines/unvanquished_2020-02-09_140119_000.png)](https://dl.illwieckz.net/b/daemon/bugs/boggy-lines/unvanquished_2020-02-09_140119_000.png)