### PR TITLE
tr_shader: fix loose texture lighting, fix #289

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5467,7 +5467,7 @@ shader_t       *R_FindShader( const char *name, shaderType_t type,
 				stages[ 0 ].type = stageType_t::ST_DIFFUSEMAP;
 				stages[ 0 ].bundle[ 0 ].image[ 0 ] = image;
 				stages[ 0 ].active = true;
-				stages[ 0 ].rgbGen = colorGen_t::CGEN_VERTEX;
+				stages[ 0 ].rgbGen = colorGen_t::CGEN_IDENTITY;
 				stages[ 0 ].stateBits = implicitStateBits;
 				break;
 			}


### PR DESCRIPTION
Before (light mapping/vertex lighting):

[![wrong colormap blend](https://dl.illwieckz.net/b/daemon/bugs/wrong-colormap-blend/unvanquished_2020-02-13_101512_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/wrong-colormap-blend/unvanquished_2020-02-13_101512_000.jpg)

[![wrong colormap blend](https://dl.illwieckz.net/b/daemon/bugs/wrong-colormap-blend/unvanquished_2020-02-13_101544_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/wrong-colormap-blend/unvanquished_2020-02-13_101544_000.jpg)

After (light mapping/vertex lighting):

[![correct colormap blend](https://dl.illwieckz.net/b/daemon/bugs/wrong-colormap-blend/unvanquished_2020-02-13_101612_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/wrong-colormap-blend/unvanquished_2020-02-13_101612_000.jpg)

[![correct colormap blend](https://dl.illwieckz.net/b/daemon/bugs/wrong-colormap-blend/unvanquished_2020-02-13_101644_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/wrong-colormap-blend/unvanquished_2020-02-13_101644_000.jpg)

Don't mind the weird artifacts visible with vertex lighting, they come from another issue that is not yet tracked down (introduced between `0.50.0` and `0.51.1`).

For some reason the loose textures were set to `DIFFUSEMAP` stageType (that seems correct) while the colorGen was set to `CGEN_VERTEX` (that seems not correct):

https://github.com/DaemonEngine/Daemon/blob/390a2432a748a29a622c9ed3d2796aa0b8d53399/src/engine/renderer/tr_shader.cpp#L5464-L5470

That seems not correct because the rest of the code sets and expects `CGEN_IDENTITY` colorGen for textures with `DIFFUSEMAP` stageType:

https://github.com/DaemonEngine/Daemon/blob/390a2432a748a29a622c9ed3d2796aa0b8d53399/src/engine/renderer/tr_shader.cpp#L1530-L1536

The issue was reproduced on 0.6.0 release and the wrong colorGen was seen in the very first commit of the repository:

https://github.com/DaemonEngine/Daemon/blob/eb73a11506d0cf83cdcf26aa7cc2e26c1f40b5bf/src/engine/rendererGL/tr_shader.c#L5558-L5564

The bug was not visible before because the diffuse map lighting code had blending disabled (that was disabling alpha blending too), the bug was uncovered when alpha blending was enabled for multitexture materials (they use diffuse map lighting code), see #277 (_glsl/lightmapping: fix terrain alpha blending for collapsed materials_).