### PR TITLE
Change Light Grid format to store full light direction vectors, fix #291

### DIFF
--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -52,28 +52,14 @@ void ReadLightGrid(in vec3 pos, out vec3 lightDir,
 		   out vec3 ambientColor, out vec3 lightColor) {
 	vec4 texel1 = texture3D(u_LightGrid1, pos);
 	vec4 texel2 = texture3D(u_LightGrid2, pos);
-	float ambientLuminance, lightLuminance;
 
-	texel1.xyz = (texel1.xyz * 255.0 - 128.0) / 127.0;
-	texel2.xyzw = texel2.xyzw - 0.5;
+	float ambientScale = 2.0 * texel1.a;
+	float directedScale = 2.0 - ambientScale;
+	ambientColor = ambientScale * texel1.rgb;
+	lightColor = directedScale * texel1.rgb;
 
-	lightDir = normalize(texel1.xyz);
-
-	lightLuminance = 2.0 * length(texel1.xyz) * texel1.w;
-	ambientLuminance = 2.0 * texel1.w - lightLuminance;
-
-	// YCoCg decode chrominance
-	ambientColor.g = ambientLuminance + texel2.x;
-	ambientLuminance = ambientLuminance - texel2.x;
-	ambientColor.r = ambientLuminance + texel2.y;
-	ambientColor.b = ambientLuminance - texel2.y;
-
-	lightColor.g = lightLuminance + texel2.z;
-	lightLuminance = lightLuminance - texel2.z;
-	lightColor.r = lightLuminance + texel2.w;
-	lightColor.b = lightLuminance - texel2.w;
+	lightDir = normalize( texel2.rgb - (128.0 / 255.0) );
 }
-
 
 void	main()
 {

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_entity_fp.glsl
@@ -54,19 +54,12 @@ void ReadLightGrid(in vec3 pos, out vec3 lightDir,
 	vec4 texel1 = texture3D(u_LightGrid1, pos);
 	vec4 texel2 = texture3D(u_LightGrid2, pos);
 
-	ambientColor = texel1.rgb;
-	lightColor = texel2.rgb;
+	float ambientScale = 2.0 * texel1.a;
+	float directedScale = 2.0 - ambientScale;
+	ambientColor = ambientScale * texel1.rgb;
+	lightColor = directedScale * texel1.rgb;
 
-	lightDir.x = (255.0 * texel1.a - 128.0) / 127.0;
-	lightDir.y = (255.0 * texel2.a - 128.0) / 127.0;
-	lightDir.z = 1.0 - abs(lightDir.x) - abs(lightDir.y);
-
-	vec2 signs = 2.0 * step(0.0, lightDir.xy) - vec2(1.0);
-	if(lightDir.z < 0.0) {
-		lightDir.xy = signs * (vec2(1.0) - abs(lightDir.yx));
-	}
-
-	lightDir = normalize(lightDir);
+	lightDir = normalize( texel2.rgb - (128.0 / 255.0) );
 }
 
 void	main()

--- a/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
+++ b/src/engine/renderer/glsl_source/vertexLighting_DBS_world_fp.glsl
@@ -48,19 +48,12 @@ void ReadLightGrid(in vec3 pos, out vec3 lightDir,
 	vec4 texel1 = texture3D(u_LightGrid1, pos);
 	vec4 texel2 = texture3D(u_LightGrid2, pos);
 
-	ambientColor = texel1.rgb;
-	lightColor = texel2.rgb;
+	float ambientScale = 2.0 * texel1.a;
+	float directedScale = 2.0 - ambientScale;
+	ambientColor = ambientScale * texel1.rgb;
+	lightColor = directedScale * texel1.rgb;
 
-	lightDir.x = (255.0 * texel1.a - 128.0) / 127.0;
-	lightDir.y = (255.0 * texel2.a - 128.0) / 127.0;
-	lightDir.z = 1.0 - abs(lightDir.x) - abs(lightDir.y);
-
-	vec2 signs = 2.0 * step(0.0, lightDir.xy) - vec2(1.0);
-	if(lightDir.z < 0.0) {
-		lightDir.xy = signs * (vec2(1.0) - abs(lightDir.yx));
-	}
-
-	lightDir = normalize(lightDir);
+	lightDir = normalize( texel2.rgb - (128.0 / 255.0) );
 }
 
 void	main()

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -3947,14 +3947,14 @@ void R_LoadLightGrid( lump_t *l )
 		gridPoint2 = (bspGridPoint2_t *) (gridPoint1 + w->numLightGridPoints);
 
 		// default some white light from above
-		gridPoint1->ambient[ 0 ] = 32;
-		gridPoint1->ambient[ 1 ] = 32;
-		gridPoint1->ambient[ 2 ] = 32;
-		gridPoint2->directed[ 0 ] = 96;
-		gridPoint2->directed[ 1 ] = 96;
-		gridPoint2->directed[ 2 ] = 96;
-		gridPoint1->lightVecX = 128;
-		gridPoint2->lightVecY = 128;
+		gridPoint1->color[ 0 ] = 64;
+		gridPoint1->color[ 1 ] = 64;
+		gridPoint1->color[ 2 ] = 64;
+		gridPoint1->ambientPart = 128;
+		gridPoint2->direction[ 0 ] = floatToSnorm8(0.0f);
+		gridPoint2->direction[ 1 ] = floatToSnorm8(0.0f);
+		gridPoint2->direction[ 2 ] = floatToSnorm8(1.0f);
+		gridPoint2->unused = 0;
 
 		w->lightGridData1 = gridPoint1;
 		w->lightGridData2 = gridPoint2;
@@ -4029,52 +4029,15 @@ void R_LoadLightGrid( lump_t *l )
 		direction[ 2 ] = cos( lng );
 
 		// Pack data into an bspGridPoint
-		gridPoint1->ambient[ 0 ] = floatToUnorm8( ambientColor[ 0 ] );
-		gridPoint1->ambient[ 1 ] = floatToUnorm8( ambientColor[ 1 ] );
-		gridPoint1->ambient[ 2 ] = floatToUnorm8( ambientColor[ 2 ] );
-		gridPoint2->directed[ 0 ] = floatToUnorm8( directedColor[ 0 ] );
-		gridPoint2->directed[ 1 ] = floatToUnorm8( directedColor[ 1 ] );
-		gridPoint2->directed[ 2 ] = floatToUnorm8( directedColor[ 2 ] );
+		gridPoint1->color[ 0 ] = floatToUnorm8( 0.5f * (ambientColor[ 0 ] + directedColor[ 0 ]) );
+		gridPoint1->color[ 1 ] = floatToUnorm8( 0.5f * (ambientColor[ 1 ] + directedColor[ 1 ]) );
+		gridPoint1->color[ 2 ] = floatToUnorm8( 0.5f * (ambientColor[ 2 ] + directedColor[ 2 ]) );
+		gridPoint1->ambientPart = floatToUnorm8( VectorLength(ambientColor) / (VectorLength(ambientColor) + VectorLength(directedColor)) );
 
-		// Light direction vectors have to be stored in two bytes:
-		// First the vector is projected onto a unit octahedron, that means |x| + |y| + |z| = 1,
-		// then it is projected onto the x/y plane. The magnitude of z can be reconstructed by
-		// the above identity, but not the sign.
-		// Fortunately the identity implies |x| + |y| <= 1, so all vectors fall within a diamond
-		// shape within the unit square that covers exactly half of the area:
-		//
-		//           +-----+-----+
-		//           |    /|\    |
-		//           |   /#|#\   |
-		//           |  /##|##\  |
-		//           | /###|###\ |
-		//           |/####|####\|
-		//           +-----+-----+
-		//           |\####|####/|
-		//           | \###|###/ |
-		//           |  \##|##/  |
-		//           |   \#|#/   |
-		//           |    \|/    |
-		//           +-----+-----+
-		//
-		// If z >= 0, we keep just the x,y coordinates in the diamond, otherwise the point
-		// is flipped across the nearest diamond edge into one of the outer triangles.
-
-		// The interpolation in this format behaves quite good except when interpolating
-		// two points that are in different outer triangles.
-
-		scale = fabsf( direction[ 0 ] ) + fabsf( direction[ 1 ] ) + fabsf( direction[ 2 ] );
-		if( scale > 0.0f ) {
-			VectorScale( direction, 1.0f / scale, direction );
-			if( direction[ 2 ] < 0.0f ) {
-				float X = direction[ 0 ];
-				float Y = direction[ 1 ];
-				direction[ 0 ] = copysignf( 1.0f - fabs( Y ), X );
-				direction[ 1 ] = copysignf( 1.0f - fabs( X ), Y );
-			}
-		}
-		gridPoint1->lightVecX = 128 + floatToSnorm8( direction[ 0 ] );
-		gridPoint2->lightVecY = 128 + floatToSnorm8( direction[ 1 ] );
+		gridPoint2->direction[0] = 128 + floatToSnorm8( direction[ 0 ] );
+		gridPoint2->direction[1] = 128 + floatToSnorm8( direction[ 1 ] );
+		gridPoint2->direction[2] = 128 + floatToSnorm8( direction[ 2 ] );
+		gridPoint2->unused = 0;
 	}
 
 	// fill in gridpoints with zero light (samples in walls) to avoid
@@ -4095,9 +4058,9 @@ void R_LoadLightGrid( lump_t *l )
 				from[ 0 ] = i - 1;
 				to[ 0 ] = i + 1;
 
-				if( gridPoint1->ambient[ 0 ] ||
-				    gridPoint1->ambient[ 1 ] ||
-				    gridPoint1->ambient[ 2 ] )
+				if( gridPoint1->color[ 0 ] ||
+				    gridPoint1->color[ 1 ] ||
+				    gridPoint1->color[ 2 ] )
 					continue;
 
 				scale = R_InterpolateLightGrid( w, from, to, factors,
@@ -4110,14 +4073,16 @@ void R_LoadLightGrid( lump_t *l )
 					VectorScale( directedColor, scale, directedColor );
 					VectorScale( direction, scale, direction );
 
-					gridPoint1->ambient[ 0 ] = floatToUnorm8( ambientColor[ 0 ] );
-					gridPoint1->ambient[ 1 ] = floatToUnorm8( ambientColor[ 1 ] );
-					gridPoint1->ambient[ 2 ] = floatToUnorm8( ambientColor[ 2 ] );
-					gridPoint1->lightVecX = 128 + floatToSnorm8( direction[ 0 ] );
-					gridPoint2->directed[ 0 ] = floatToUnorm8( directedColor[ 0 ] );
-					gridPoint2->directed[ 1 ] = floatToUnorm8( directedColor[ 1 ] );
-					gridPoint2->directed[ 2 ] = floatToUnorm8( directedColor[ 2 ] );
-					gridPoint2->lightVecY = 128 + floatToSnorm8( direction[ 1 ] );
+
+					gridPoint1->color[0] = floatToUnorm8(0.5f * (ambientColor[0] + directedColor[0]));
+					gridPoint1->color[1] = floatToUnorm8(0.5f * (ambientColor[1] + directedColor[1]));
+					gridPoint1->color[2] = floatToUnorm8(0.5f * (ambientColor[2] + directedColor[2]));
+					gridPoint1->ambientPart = floatToUnorm8(VectorLength(ambientColor) / (VectorLength(ambientColor) + VectorLength(directedColor)));
+
+					gridPoint2->direction[0] = 128 + floatToSnorm8(direction[0]);
+					gridPoint2->direction[1] = 128 + floatToSnorm8(direction[1]);
+					gridPoint2->direction[2] = 128 + floatToSnorm8(direction[2]);
+					gridPoint2->unused = 0;
 				}
 			}
 		}

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1934,20 +1934,18 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		decal_t *decals;
 	};
 
-	// The light direction vector is stored as the x/y coordinates
-	// of the vector projected on an unit octahedron. To disambiguate
-	// the upper and lower half of the octahedron, the four lower
-	// triangles of the octahedron are flipped into the outer corners
-	// of the unit square.
+	// The ambient and directional colors are packed into four bytes, the color[3] is the
+	// average of the ambient and directional colors and the ambientPart factor is the
+	// proportion of ambient light in the total light
 	struct bspGridPoint1_t
 	{
-		byte  ambient[3];
-		byte  lightVecX;
+		byte  color[3];
+		byte  ambientPart;
 	};
 	struct bspGridPoint2_t
 	{
-		byte  directed[3];
-		byte  lightVecY;
+		byte  direction[3];
+		byte  unused;
 	};
 
 // ydnar: optimization
@@ -3426,7 +3424,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	void     R_SetupEntityLighting( const trRefdef_t *refdef, trRefEntity_t *ent, vec3_t forcedOrigin );
 	float R_InterpolateLightGrid( world_t *w, int from[3], int to[3],
 				      float *factors[3], vec3_t ambientLight,
-				      vec3_t directedLight, vec2_t lightDir );
+				      vec3_t directedLight, vec3_t lightDir );
 	int      R_LightForPoint( vec3_t point, vec3_t ambientLight, vec3_t directedLight, vec3_t lightDir );
 	void     R_TessLight( const trRefLight_t *light, const Color::Color& color );
 


### PR DESCRIPTION
> The ambient and directional colors are packed into 4 bytes, the packing method assumes that the ambient and directional colors are similar, but that is usually the case.

Patch by @gimhael. Please send much love to him.

Our engine is great again.