### PR TITLE
renderer/tr_shader: introduce engine-agnostic normalFormat material stage keyword

### DIFF
--- a/src/engine/renderer/glsl_source/reliefMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/reliefMapping_fp.glsl
@@ -75,12 +75,23 @@ vec3 NormalInTangentSpace(vec2 texNormal)
 	// take the square root of a negative number here.
 	normal.z = sqrt(max(0, 1.0 - dot(normal.xy, normal.xy)));
 #endif // !USE_HEIGHTMAP_IN_NORMALMAP
-	// HACK: 0 normal Z channel can't be good
+	/* Disable normal map scaling when normal Z scale is set to zero.
+
+	This happens when r_normalScale is set to zero because
+	u_NormalScale.z is premultiplied with r_normalScale. User can
+	disable normal map scaling by setting r_normalScale to zero.
+
+	Normal Z component equal to zero would be wrong anyway.
+	*/
 	if (u_NormalScale.z != 0)
 	{
 		normal *= u_NormalScale;
 	}
 
+	// HACK: the GLSL code is currently assuming
+	// DirectX normal map format (+X -Y +Z)
+	// but engine is assuming the OpenGL way (+X +Y +Z)
+	normal.y *= -1;
 #else // !r_normalMapping
 	// Flat normal map is {0.5, 0.5, 1.0} in [ 0.0, 1.0]
 	// which is stored as {0.0, 0.0, 1.0} in [-1.0, 1.0].

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1140,9 +1140,11 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		bool enableSpecularMapping;
 		bool enableGlowMapping;
 
-		// normalMap channel scale, negative value flips channel
-		bool            hasNormalScale;
-		vec3_t          normalScale;
+		// Normal map scale and format.
+		bool hasNormalFormat;
+		bool hasNormalScale;
+		vec3_t normalFormat;
+		vec3_t normalScale;
 
 		expression_t    normalIntensityExp;
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -579,37 +579,34 @@ void Tess_Begin( void ( *stageIteratorFunc )(),
 	}
 }
 
-/*
-==============
-SetNormalScale
-==============
-*/
-void SetNormalScale( shaderStage_t *pStage, vec3_t normalScale)
+void SetNormalScale( shaderStage_t *pStage, vec3_t normalScale )
 {
-		float normalIntensity = RB_EvalExpression( &pStage->normalIntensityExp, 1 );
+	float normalIntensity = RB_EvalExpression( &pStage->normalIntensityExp, 1.0 );
 
-		normalScale[ 0 ] = 1;
-		normalScale[ 1 ] = 1;
-		normalScale[ 2 ] = 1;
+	for ( int i = 0; i < 3; i++ )
+	{
+		normalScale[ i ] = pStage->normalScale[ i ];
 
-		normalScale[ 0 ] *= normalIntensity;
-		normalScale[ 1 ] *= normalIntensity;
-
-		if ( pStage->hasNormalScale )
+		// Normal intensity is only applied on X and Y.
+		// This behaviour is inherited.
+		if ( i < 2 )
 		{
-			normalScale[ 0 ] *= pStage->normalScale[ 0 ];
-			normalScale[ 1 ] *= pStage->normalScale[ 1 ];
-			normalScale[ 2 ] *= pStage->normalScale[ 2 ];
+			normalScale[ i ] *= normalIntensity;
 		}
+	}
 
-		// NOTE: normalmap with zero Z component is wrong
-		//
-		// since glsl disables normalScale when Z is zero
-		// setting this to zero has side effect to reset
-		// per-stage normalScale
-		//
-		// there is no intention to keep this undefined feature
-		normalScale[ 2 ] *= r_normalScale->value;
+	/* Note: the GLSL code disables normal map scaling when normal Z scale is
+	equal to zero.
+
+	It means normal map scaling is disabled when r_normalScale is set to zero.
+	This is cool enough to be kept as a feature.
+
+	Normal Z component equal to zero would be wrong anyway.
+
+	r_normalScale is only applied on Z.
+	This behaviour is inherited.
+	*/
+	normalScale[ 2 ] *= r_normalScale->value;
 }
 
 // *INDENT-ON*


### PR DESCRIPTION
Introduce engine-agnostic `normalFormat` material stage keyword.

There is already a `normalScale` keyword which allows to revert channel by using a negative value, but this is not a way to describe the _format_ of the file that is loaded. So, people would have to use a negative `normalScale` Y value in their `.shader` file if the normal map file is stored in DirectX way and the engine is computing normal maps the OpenGL way, but a positive Y `normalScale` value if file format and engine format matches.

By introducing the `normalFormat` stage keyword, artist can describe the normal map file format and don't mind about what the engine does. It also means the engine may switch its internal format without having to mind anything, the coder implementing another normal format would know how to convert the normal map file in engine whatever the format, not requiring him to ask artists to edit every existing `.shader` material file.

It was possible to make `normalScale` keyword engine-agnostic but that would be a very bad idea because this keyword exist in other engine of this lineage (idtech3 renderer2, OpenJK…, etc.). Then it's better to keep this keyword behaviour the way it works the same as other engine does.

For making things easier to think of, the engine is currently assuming a default normal map format is OpenGL (+X +Y +Z), because it's easier to multiply every channel with `1.0` by default whatever the channel when there is nothing to do.

For backward-compatibility purposes and to keep compatibility with other engines (idtech3 renderer2, XreaL, ET:Legacy, OpenJK, etc.), the `normalMap`, `normalHeightMap` keywords and `bumpMap` deprecated alias set the normal map format to DirectX one. Historically, the Doom 3 engine is an OpenGL engine using DirectX normal map format convention, and XreaL implemented normal maps in order to be able to load Doom3 formats, then expected DirectX normal maps. Engines like those I just quoted are reusing XreaL material stage keywords like `normalMap` that were Doom3 keywords at first, then are expecting DirectX format. It looks like we would have to live with it.

While the `normalMap` keyword is expecting normal map in the DirectX format because of backward compatibility with historical engines and third-party ones, Dæmon-based games developers are free to encourage the use of normal map using OpenGL format, maybe use contribution guidelines asking for normal map using OpenGL format explicitely. In such case contributors would just have to add the required line to tell the normal map is using OpenGL format.

The material stage keyword syntax is:

OpenGL format:

```
normalMap /textures/castle/brick_n
normalFormat X Y Z
```

DirectX format (`normalFormat` keyword is not required since `nomalMap` keyword already does it):

```
normalMap /textures/castle/brick_n
normalFormat X -Y Z
```

Weird format (like the one used in Vega texture set):

```
normalMap /textures/castle/brick_n
normalFormat -X -Y Z
```

With this work, we may one day change the normal map format used in GLSL code (see #274) without having to mind anything: the material parser is telling the engine which conversion to do, and the assets would not have to be edited if they use the `normalFormat` keyword.

The Vega map and texture set is expected to use the `normalFormat` keyword to fix normal map orientation in upcoming Unvanquished 0.52.

With such design we would be able to add support for alternative material syntax from other games to load normal maps, in such case, the keyword parsing code would just have to set the normal map format this syntax expects. The Darkplaces compatibility layer already does it this way.

Here are the default normal map formats used in engine:

- C++ engine: OpenGL
- XreaL `normalMap` keyword: DirectX
- Darkplaces `_norm` sidecar autoloading: OpenGL
- GLSL renderer as a black box: OpenGL
- GLSL code itself: DirectX (a hack reverts the Y channel on input, we may edit the code to avoid the Y reversion hack)