### PR TITLE
renderer: drop r_collapseStages, do not allow to not collapse material stages

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -145,7 +145,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_parallelShadowSplitWeight;
 
 	cvar_t      *r_mode;
-	cvar_t      *r_collapseStages;
 	cvar_t      *r_nobind;
 	cvar_t      *r_singleShader;
 	cvar_t      *r_colorMipLevels;
@@ -1065,7 +1064,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_arb_texture_gather = ri.Cvar_Get( "r_arb_texture_gather", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_arb_gpu_shader5 = ri.Cvar_Get( "r_arb_gpu_shader5", "1", CVAR_CHEAT | CVAR_LATCH );
 
-		r_collapseStages = ri.Cvar_Get( "r_collapseStages", "1", CVAR_LATCH | CVAR_CHEAT );
 		r_picmip = ri.Cvar_Get( "r_picmip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		AssertCvarRange( r_picmip, 0, 3, true );
 		r_colorMipLevels = ri.Cvar_Get( "r_colorMipLevels", "0", CVAR_LATCH );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2838,7 +2838,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_arb_gpu_shader5;
 
 	extern cvar_t *r_nobind; // turns off binding to appropriate textures
-	extern cvar_t *r_collapseStages;
 	extern cvar_t *r_singleShader; // make most world faces use default shader
 	extern cvar_t *r_colorMipLevels; // development aid to see texture mip usage
 	extern cvar_t *r_picmip; // controls picmip values

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4311,11 +4311,6 @@ CollapseMultitexture
 // *INDENT-OFF*
 static void CollapseStages()
 {
-	if ( !r_collapseStages->integer )
-	{
-		return;
-	}
-
 	int diffuseStage = -1;
 	int normalStage = -1;
 	int specularStage = -1;


### PR DESCRIPTION
There is no working rendering path without collapsing anyway.

It's almost dead code, we must _not_ use it.

Dropping this makes easier to do refactorize the engine as we can now assume all materials are collapsed materials in all case.