### PR TITLE
tell a surface belongs to the bsp, properly select the renderer

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -828,6 +828,7 @@ static void RB_RenderDrawSurfaces( shaderSort_t fromSort, shaderSort_t toSort,
 	shader_t      *shader, *oldShader;
 	int           lightmapNum, oldLightmapNum;
 	int           fogNum, oldFogNum;
+	bool          bspSurface;
 	bool      depthRange, oldDepthRange;
 	int           i;
 	drawSurf_t    *drawSurf;
@@ -854,6 +855,7 @@ static void RB_RenderDrawSurfaces( shaderSort_t fromSort, shaderSort_t toSort,
 		shader = drawSurf->shader;
 		lightmapNum = drawSurf->lightmapNum();
 		fogNum = drawSurf->fogNum();
+		bspSurface = drawSurf->bspSurface;
 
 		if( entity == &tr.worldEntity ) {
 			if( !( drawSurfFilter & DRAWSURFACES_WORLD ) )
@@ -888,7 +890,7 @@ static void RB_RenderDrawSurfaces( shaderSort_t fromSort, shaderSort_t toSort,
 				Tess_End();
 			}
 
-			Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, lightmapNum, fogNum );
+			Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, lightmapNum, fogNum, bspSurface );
 
 			oldShader = shader;
 			oldLightmapNum = lightmapNum;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1595,6 +1595,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		surfaceType_t *surface; // any of surface*_t
 		shader_t      *shader;
 		uint64_t      sort;
+		bool          bspSurface;
 
 		inline int index() const {
 			return int( ( sort & SORT_INDEX_MASK ) );
@@ -3002,7 +3003,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 
 	void           R_AddPolygonSurfaces();
 
-	void           R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, int fogNum );
+	void           R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, int fogNum, bool bspSurface = false );
 
 	void           R_LocalNormalToWorld( const vec3_t local, vec3_t world );
 	void           R_LocalPointToWorld( const vec3_t local, vec3_t world );
@@ -3295,6 +3296,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		bool    skipVBO;
 		int16_t     lightmapNum;
 		int16_t     fogNum;
+		bool        bspSurface;
 
 		uint32_t    numIndexes;
 		uint32_t    numVertexes;
@@ -3342,7 +3344,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	                 bool skipTangentSpaces,
 	                 bool skipVBO,
 	                 int lightmapNum,
-	                 int     fogNum );
+	                 int fogNum,
+	                 bool bspSurface = false );
 
 // *INDENT-ON*
 	void Tess_End();

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1947,7 +1947,7 @@ int R_SpriteFogNum( trRefEntity_t *ent )
 R_AddDrawSurf
 =================
 */
-void R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, int fogNum )
+void R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, int fogNum, bool bspSurface )
 {
 	int        index;
 	drawSurf_t *drawSurf;
@@ -1961,6 +1961,7 @@ void R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, i
 	drawSurf->entity = tr.currentEntity;
 	drawSurf->surface = surface;
 	drawSurf->shader = shader;
+	drawSurf->bspSurface = bspSurface;
 
 	int entityNum;
 
@@ -1983,7 +1984,7 @@ void R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, i
 	tr.refdef.numDrawSurfs++;
 
 	if ( shader->depthShader != nullptr ) {
-		R_AddDrawSurf( surface, shader->depthShader, 0, 0 );
+		R_AddDrawSurf( surface, shader->depthShader, 0, 0, bspSurface );
 	}
 }
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -3056,18 +3056,21 @@ void Tess_StageIteratorGeneric()
 					{
 						if ( r_precomputedLighting->integer || r_vertexLighting->integer )
 						{
-							if ( !r_vertexLighting->integer && tess.lightmapNum >= 0 && tess.lightmapNum <= tr.lightmaps.currentElements )
+
+							if ( tess.bspSurface )
 							{
-								Render_lightMapping( stage );
-							}
-							else if ( backEnd.currentEntity != &tr.worldEntity )
-							{
-								// FIXME: This can be reached if r_vertexLighting == 0 and tess.lightmapNum is invalid which doesn't seem right
-								Render_vertexLighting_DBS_entity( stage );
+								if ( !r_vertexLighting->integer && tess.lightmapNum >= 0 && tess.lightmapNum <= tr.lightmaps.currentElements )
+								{
+									Render_lightMapping( stage );
+								}
+								else
+								{
+									Render_vertexLighting_DBS_world( stage );
+								}
 							}
 							else
 							{
-								Render_vertexLighting_DBS_world( stage );
+								Render_vertexLighting_DBS_entity( stage );
 							}
 						}
 						else

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -505,7 +505,8 @@ void Tess_Begin( void ( *stageIteratorFunc )(),
                  bool skipTangentSpaces,
                  bool skipVBO,
                  int lightmapNum,
-                 int fogNum )
+                 int fogNum,
+                 bool bspSurface )
 {
 	shader_t *state;
 
@@ -534,7 +535,6 @@ void Tess_Begin( void ( *stageIteratorFunc )(),
 		tess.surfaceStages = nullptr;
 		Tess_MapVBOs( false );
 	}
-
 
 	bool isSky = ( state != nullptr && state->isSky != false );
 
@@ -569,6 +569,7 @@ void Tess_Begin( void ( *stageIteratorFunc )(),
 	tess.skipVBO = skipVBO;
 	tess.lightmapNum = lightmapNum;
 	tess.fogNum = fogNum;
+	tess.bspSurface = bspSurface;
 
 	if ( r_logFile->integer )
 	{

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -49,7 +49,7 @@ void Tess_EndBegin()
 {
 	Tess_End();
 	Tess_Begin( tess.stageIteratorFunc, tess.stageIteratorFunc2, tess.surfaceShader, tess.lightShader, tess.skipTangentSpaces, tess.skipVBO,
-	            tess.lightmapNum, tess.fogNum );
+	            tess.lightmapNum, tess.fogNum, tess.bspSurface );
 }
 
 /*
@@ -113,7 +113,7 @@ void Tess_CheckOverflow( int verts, int indexes )
 	}
 
 	Tess_Begin( tess.stageIteratorFunc, tess.stageIteratorFunc2, tess.surfaceShader, tess.lightShader, tess.skipTangentSpaces, tess.skipVBO,
-	            tess.lightmapNum, tess.fogNum );
+	            tess.lightmapNum, tess.fogNum, tess.bspSurface );
 }
 
 /*

--- a/src/engine/renderer/tr_world.cpp
+++ b/src/engine/renderer/tr_world.cpp
@@ -296,7 +296,7 @@ static bool R_AddWorldSurface( bspSurface_t *surf, int fogIndex, int planeBits )
 		return true;
 	}
 
-	R_AddDrawSurf( surf->data, surf->shader, surf->lightmapNum, fogIndex );
+	R_AddDrawSurf( surf->data, surf->shader, surf->lightmapNum, fogIndex, true );
 	return true;
 }
 


### PR DESCRIPTION
See #302 for explanations about the issue it fixes.

If I color in red what is rendered by `vertexLighting_DBS_entity_fp.glsl`, in green what is rendered by `vertexLighting_DBS_world_fp.glsl` and in blue what is rendered by `lightMapping_fp.glsl`, I get this:

While world vertex lighting is disabled:

[![bsp surface](https://dl.illwieckz.net/b/daemon/bugs/map-entities-as-models/unvanquished_2020-04-11_085656_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/map-entities-as-models/unvanquished_2020-04-11_085656_000.jpg)

While world vertex lighting is enabled:

[![bsp surface](https://dl.illwieckz.net/b/daemon/bugs/map-entities-as-models/unvanquished_2020-04-11_085727_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/map-entities-as-models/unvanquished_2020-04-11_085727_000.jpg)

Everything looks fine now, bsp non-world models are not anymore rendered as entities.

There is still cases where surfaces are lightmapped while vertex world lighting is enabled, but that looks to be the bug described in #296.