### PR TITLE
Write condump output to passed file name

### DIFF
--- a/src/engine/client/cl_console.cpp
+++ b/src/engine/client/cl_console.cpp
@@ -149,7 +149,7 @@ void Con_Dump_f()
 	}
 
 	std::string name = "condump/";
-	if ( argc == 1 )
+	if ( argc == 2 )
 	{
 		name += Cmd_Argv( 1 );
 	}


### PR DESCRIPTION
When we pass arg to /condump command, it should be taken as file
name where command output should be written to.

Now if arg is passed, it is taken as file name. If no arg is passed, file name
is generated by the engine.

Fixes https://github.com/DaemonEngine/Daemon/issues/304