### PR TITLE
Remove unused AES256 decryption

### DIFF
--- a/src/engine/framework/Crypto.cpp
+++ b/src/engine/framework/Crypto.cpp
@@ -289,8 +289,6 @@ bool Aes256Encrypt( Data plain_text, const Data& key, Data& output )
     output.resize( plain_text.size(), 0 );
     nettle_aes256_encrypt( &ctx, plain_text.size(),
         output.data(), plain_text.data() );
-    nettle_aes256_decrypt( &ctx, plain_text.size(),
-        plain_text.data(), output.data() );
     return true;
 }
 


### PR DESCRIPTION
As we encrypt `plain_text` with `key` and write result to `output`,
there is no reason to decrypt `output` and rewrite `plain_text`.

Fixes https://github.com/DaemonEngine/Daemon/issues/305