### PR TITLE
map meta lookup: only check for map in packs starting with “map-” prefix, fix #285

### DIFF
--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -637,9 +637,22 @@ void FS_LoadBasePak()
 
 void FS_LoadAllMapMetadata()
 {
+	const std::string pak_map_prefix("map-");
+
 	for (const auto& pak: FS::GetAvailableMapPaks()) {
 		try {
-			FS::PakPath::LoadPakPrefix(pak, va("meta/%s/", pak.name.substr(4).c_str()));
+			// If pak name is long enough to have “map-” prefix,
+			// and pak name without ”map-” prefix is not empty string.
+			if (pak.name.length() > pak_map_prefix.length())
+			{
+				// If pak name starts with “map-” prefix
+				if (Str::IsPrefix(pak_map_prefix, pak.name))
+				{
+					// FIXME: This looks to be game-specific,
+					// not all games use “meta/” mechanism.
+					FS::PakPath::LoadPakPrefix(pak, va("meta/%s/", pak.name.substr(pak_map_prefix.length()).c_str()));
+				}
+			}
 		} catch (std::system_error&) {} // ignore and move on
 	}
 }


### PR DESCRIPTION
Map meta lookup: only check for map in packs starting with `map-` prefix, fix #285.

- don't look for map in packs whose name is too small to have a map-prefix
- don't look for map in packs not starting with `map-` prefix
- don't look for map in packs with empty string after `map-` prefix

---

- fix #285 bug
- may speedup map listing

Note: looking for stuff in `meta/` looks to be game-specific.


