### PR TITLE
renderer: factorize and move some computation done every frame for every surface in tr_shade to be done only once in tr_shader

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1094,7 +1094,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		bool        tcGen_Environment;
 		bool        tcGen_Lightmap;
 
-		bool heightMapInNormalMap; // material has normalmap suited for parallax mapping
 		bool implicitLightmap;
 
 		Color::Color32Bit constantColor; // for CGEN_CONST and AGEN_CONST
@@ -1124,6 +1123,22 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		expression_t    fresnelPowerExp;
 		expression_t    fresnelScaleExp;
 		expression_t    fresnelBiasExp;
+
+		// Available textures.
+		bool hasNormalMap;
+		bool hasHeightMap;
+		bool isHeightMapInNormalMap;
+		bool hasMaterialMap;
+		bool isMaterialPhysical;
+		bool hasGlowMap;
+
+		// Available features.
+		bool enableNormalMapping;
+		bool enableDeluxeMapping;
+		bool enableParallaxMapping;
+		bool enablePhysicalMapping;
+		bool enableSpecularMapping;
+		bool enableGlowMapping;
 
 		// normalMap channel scale, negative value flips channel
 		bool            hasNormalScale;
@@ -1212,7 +1227,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		fogPass_t      fogPass; // draw a blended pass, possibly with depth test equals
 		bool       noFog;
 
-		bool       heightMapInNormalMap; // material has normalmap suited for parallax mapping
 		bool       noParallax; // disable parallax for this material even if it's available
 		float      parallaxOffsetBias; // offset the heightmap top relatively to the floor
 		float      parallaxDepthScale; // per-shader parallax depth scale

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2370,7 +2370,7 @@ static void Render_heatHaze( int stage )
 
 	GLimp_LogComment( "--- Render_heatHaze ---\n" );
 
-	bool hasNormalMap = pStage->bundle[ TB_COLORMAP ].image[ 0 ] != nullptr;
+	bool hasNormalMap = pStage->bundle[ TB_NORMALMAP ].image[ 0 ] != nullptr;
 
 	bool normalMapping = r_normalMapping->integer && hasNormalMap;
 
@@ -2435,9 +2435,9 @@ static void Render_heatHaze( int stage )
 	if ( normalMapping )
 	{
 		// bind u_NormalMap
-		GL_BindToTMU( 0, pStage->bundle[ TB_COLORMAP ].image[ 0 ] );
+		GL_BindToTMU( 0, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
 
-		gl_heatHazeShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
+		gl_heatHazeShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
 
 		vec3_t normalScale;
 		SetNormalScale( pStage, normalScale );
@@ -2475,7 +2475,7 @@ static void Render_liquid( int stage )
 
 	GLimp_LogComment( "--- Render_liquid ---\n" );
 
-	bool hasNormalMap = pStage->bundle[ TB_COLORMAP ].image[ 0 ] != nullptr;
+	bool hasNormalMap = pStage->bundle[ TB_NORMALMAP ].image[ 0 ] != nullptr;
 	bool hasHeightMap = pStage->bundle[ TB_HEIGHTMAP ].image[ 0 ] != nullptr;
 
 	bool hasHeightMapInNormalMap = pStage->heightMapInNormalMap && hasNormalMap;
@@ -2556,7 +2556,7 @@ static void Render_liquid( int stage )
 	if ( normalMapping || ( parallaxMapping && hasHeightMapInNormalMap ) )
 	{
 		// bind u_NormalMap
-		GL_BindToTMU( 3, pStage->bundle[ TB_COLORMAP ].image[ 0 ] );
+		GL_BindToTMU( 3, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
 	}
 	else
 	{
@@ -2573,7 +2573,7 @@ static void Render_liquid( int stage )
 		gl_liquidShader->SetUniform_NormalScale( normalScale );
 	}
 
-	gl_liquidShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
+	gl_liquidShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
 
 	Tess_DrawElements();
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -826,42 +826,27 @@ static void Render_vertexLighting_DBS_entity( int stage )
 	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
 	gl_vertexLightingShader_DBS_entity->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 
-	if ( pStage->enableNormalMapping || ( pStage->enableParallaxMapping && pStage->isHeightMapInNormalMap ) )
-	{
-		// bind u_NormalMap
-		GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
-	}
-	else
-	{
-		GL_BindToTMU( 1, tr.flatImage );
-	}
-
 	// bind u_NormalMap
+	GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
+
+	// bind u_NormalScale
 	if ( pStage->enableNormalMapping )
 	{
 		vec3_t normalScale;
 		SetNormalScale( pStage, normalScale );
 
-		// bind u_NormalScale
 		gl_vertexLightingShader_DBS_entity->SetUniform_NormalScale( normalScale );
 	}
 
-	if ( pStage->enablePhysicalMapping || pStage->enableSpecularMapping )
-	{
-		// bind u_MaterialMap
-		GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
+	// bind u_MaterialMap
+	GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
 
-		if ( pStage->enableSpecularMapping )
-		{
-			float specExpMin = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
-			float specExpMax = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
-
-			gl_vertexLightingShader_DBS_entity->SetUniform_SpecularExponent( specExpMin, specExpMax );
-		}
-	}
-	else
+	if ( pStage->enableSpecularMapping )
 	{
-		GL_BindToTMU( 2, tr.blackImage );
+		float specExpMin = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
+		float specExpMax = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
+
+		gl_vertexLightingShader_DBS_entity->SetUniform_SpecularExponent( specExpMin, specExpMax );
 	}
 
 	if ( tr.cubeHashTable != nullptr )
@@ -962,12 +947,7 @@ static void Render_vertexLighting_DBS_entity( int stage )
 	}
 
 	// bind u_GlowMap
-	if ( pStage->enableGlowMapping )
-	{
-		GL_BindToTMU( 5, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
-	} else {
-		GL_BindToTMU( 5, tr.blackImage );
-	}
+	GL_BindToTMU( 5, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
 
 	gl_vertexLightingShader_DBS_entity->SetRequiredVertexPointers();
 
@@ -1087,42 +1067,27 @@ static void Render_vertexLighting_DBS_world( int stage )
 	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
 	gl_vertexLightingShader_DBS_world->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 
-	if ( pStage->enableNormalMapping || ( pStage->enableParallaxMapping && pStage->isHeightMapInNormalMap ) )
-	{
-		// bind u_NormalMap
-		GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
-	}
-	else
-	{
-		GL_BindToTMU( 1, tr.flatImage );
-	}
-
 	// bind u_NormalMap
+	GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
+
+	// bind u_NormalScale
 	if ( pStage->enableNormalMapping )
 	{
 		vec3_t normalScale;
 		SetNormalScale( pStage, normalScale );
 
-		// bind u_NormalScale
 		gl_vertexLightingShader_DBS_world->SetUniform_NormalScale( normalScale );
 	}
 
-	if ( pStage->enablePhysicalMapping || pStage->enableSpecularMapping )
-	{
-		// bind u_MaterialMap
-		GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
+	// bind u_MaterialMap
+	GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
 
-		if ( pStage->enableSpecularMapping )
-		{
-			float specExpMin = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
-			float specExpMax = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
-
-			gl_vertexLightingShader_DBS_world->SetUniform_SpecularExponent( specExpMin, specExpMax );
-		}
-	}
-	else
+	if ( pStage->enableSpecularMapping )
 	{
-		GL_BindToTMU( 2, tr.blackImage );
+		float specExpMin = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
+		float specExpMax = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
+
+		gl_vertexLightingShader_DBS_world->SetUniform_SpecularExponent( specExpMin, specExpMax );
 	}
 
 	if( tr.world )
@@ -1139,12 +1104,7 @@ static void Render_vertexLighting_DBS_world( int stage )
 	}
 
 	// bind u_GlowMap
-	if ( pStage->enableGlowMapping )
-	{
-		GL_BindToTMU( 5, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
-	} else {
-		GL_BindToTMU( 5, tr.blackImage );
-	}
+	GL_BindToTMU( 5, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
 
 	gl_vertexLightingShader_DBS_world->SetRequiredVertexPointers();
 
@@ -1281,42 +1241,27 @@ static void Render_lightMapping( int stage )
 		gl_lightMappingShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 	}
 
-	if ( pStage->enableNormalMapping || ( pStage->enableParallaxMapping && pStage->isHeightMapInNormalMap ) )
-	{
-		// bind u_NormalMap
-		GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
-	}
-	else
-	{
-		GL_BindToTMU( 1, tr.flatImage );
-	}
-
 	// bind u_NormalMap
+	GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
+
+	// bind u_NormalScale
 	if ( pStage->enableNormalMapping )
 	{
 		vec3_t normalScale;
 		SetNormalScale( pStage, normalScale );
 
-		// bind u_NormalScale
 		gl_lightMappingShader->SetUniform_NormalScale( normalScale );
 	}
 
-	if ( pStage->enablePhysicalMapping || pStage->enableSpecularMapping )
-	{
-		// bind u_MaterialMap
-		GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
+	// bind u_MaterialMap
+	GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
 
-		if ( pStage->enableSpecularMapping )
-		{
-			float specExpMin = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
-			float specExpMax = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
-
-			gl_lightMappingShader->SetUniform_SpecularExponent( specExpMin, specExpMax );
-		}
-	}
-	else
+	if ( pStage->enableSpecularMapping )
 	{
-		GL_BindToTMU( 2, tr.blackImage );
+		float specExpMin = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
+		float specExpMax = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
+
+		gl_lightMappingShader->SetUniform_SpecularExponent( specExpMin, specExpMax );
 	}
 
 	// bind u_LightMap
@@ -1333,12 +1278,7 @@ static void Render_lightMapping( int stage )
 	}
 
 	// bind u_GlowMap
-	if ( pStage->enableGlowMapping )
-	{
-		GL_BindToTMU( 5, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
-	} else {
-		GL_BindToTMU( 5, tr.blackImage );
-	}
+	GL_BindToTMU( 5, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
 
 	gl_lightMappingShader->SetRequiredVertexPointers();
 
@@ -1633,39 +1573,28 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *pStage,
 	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
 	gl_forwardLightingShader_omniXYZ->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 
-	if ( pStage->enableNormalMapping || ( pStage->enableParallaxMapping && pStage->isHeightMapInNormalMap ) )
-	{
-		// bind u_NormalMap
-		GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
-	}
-	else
-	{
-		GL_BindToTMU( 1, tr.flatImage );
-	}
+	// bind u_NormalMap
+	GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
 
+	// bind u_NormalScale
 	if ( pStage->enableNormalMapping )
 	{
 		vec3_t normalScale;
 		SetNormalScale( pStage, normalScale );
 
-		// bind u_NormalScale
 		gl_forwardLightingShader_omniXYZ->SetUniform_NormalScale( normalScale );
 	}
 
-	// physical mapping is not implemented
+	// bind u_MaterialMap
+	GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
+
+	// FIXME: physical mapping is not implemented.
 	if ( pStage->enableSpecularMapping )
 	{
-		// bind u_MaterialMap
-		GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
-
 		float minSpec = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
 		float maxSpec = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
 
 		gl_forwardLightingShader_omniXYZ->SetUniform_SpecularExponent( minSpec, maxSpec );
-	}
-	else
-	{
-		GL_BindToTMU( 2, tr.blackImage );
 	}
 
 	// bind u_AttenuationMapXY
@@ -1830,39 +1759,28 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *pStage,
 	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
 	gl_forwardLightingShader_projXYZ->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 
-	if ( pStage->enableNormalMapping || ( pStage->enableParallaxMapping && pStage->isHeightMapInNormalMap ) )
-	{
-		// bind u_NormalMap
-		GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
-	}
-	else
-	{
-		GL_BindToTMU( 1, tr.flatImage );
-	}
+	// bind u_NormalMap
+	GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
 
+	// bind u_NormalScale
 	if ( pStage->enableNormalMapping )
 	{
 		vec3_t normalScale;
 		SetNormalScale( pStage, normalScale );
 
-		// bind u_NormalScale
 		gl_forwardLightingShader_projXYZ->SetUniform_NormalScale( normalScale );
 	}
 
-	// physical mapping is not implemented
+	// bind u_MaterialMap
+	GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
+
+	// FIXME: physical mapping is not implemented.
 	if ( pStage->enableSpecularMapping )
 	{
-		// bind u_MaterialMap
-		GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
-
 		float minSpec = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
 		float maxSpec = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
 
 		gl_forwardLightingShader_projXYZ->SetUniform_SpecularExponent( minSpec, maxSpec );
-	}
-	else
-	{
-		GL_BindToTMU( 2, tr.blackImage );
 	}
 
 	// bind u_AttenuationMapXY
@@ -2029,38 +1947,27 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *pStage, trRef
 	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
 	gl_forwardLightingShader_directionalSun->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 
-	if ( pStage->enableNormalMapping )
-	{
-		// bind u_NormalMap
-		GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
-	}
-	else
-	{
-		GL_BindToTMU( 1, tr.flatImage );
-	}
+	// bind u_NormalMap
+	GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
 
+	// bind u_NormalScale
 	if ( pStage->enableNormalMapping )
 	{
 		vec3_t normalScale;
 		SetNormalScale( pStage, normalScale );
 
-		// bind u_NormalScale
 		gl_forwardLightingShader_directionalSun->SetUniform_NormalScale( normalScale );
 	}
 
-	// physical mapping is not implemented
+	// bind u_MaterialMap
+	GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
+
+	// FIXME: physical mapping is not implemented.
 	if ( pStage->enableSpecularMapping )
 	{
-		// bind u_MaterialMap
-		GL_BindToTMU( 2, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
-
 		float minSpec = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
 		float maxSpec = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
 		gl_forwardLightingShader_directionalSun->SetUniform_SpecularExponent( minSpec, maxSpec );
-	}
-	else
-	{
-		GL_BindToTMU( 2, tr.blackImage );
 	}
 
 	// bind u_ShadowMap
@@ -2148,22 +2055,15 @@ static void Render_reflection_CB( int stage )
 		GL_BindNearestCubeMap( backEnd.viewParms.orientation.origin );
 	}
 
-	if ( pStage->enableNormalMapping || ( pStage->enableParallaxMapping && pStage->isHeightMapInNormalMap ) )
-	{
-		// bind u_NormalMap
-		GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
-	}
-	else
-	{
-		GL_BindToTMU( 1, tr.flatImage );
-	}
+	// bind u_NormalMap
+	GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
 
+	// bind u_NormalScale
 	if ( pStage->enableNormalMapping )
 	{
 		vec3_t normalScale;
 		SetNormalScale( pStage, normalScale );
 
-		// bind u_NormalScale
 		gl_reflectionShader->SetUniform_NormalScale( normalScale );
 	}
 
@@ -2342,11 +2242,11 @@ static void Render_heatHaze( int stage )
 	// draw to background image
 	R_BindFBO( tr.mainFBO[ 1 - backEnd.currentMainFBO ] );
 
+	// bind u_NormalMap
+	GL_BindToTMU( 0, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
+
 	if ( pStage->enableNormalMapping )
 	{
-		// bind u_NormalMap
-		GL_BindToTMU( 0, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
-
 		gl_heatHazeShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_NORMALMAP ] );
 
 		vec3_t normalScale;
@@ -2354,10 +2254,6 @@ static void Render_heatHaze( int stage )
 
 		// bind u_NormalScale
 		gl_heatHazeShader->SetUniform_NormalScale( normalScale );
-	}
-	else
-	{
-		GL_BindToTMU( 0, tr.flatImage );
 	}
 
 	// bind u_CurrentMap
@@ -2415,8 +2311,8 @@ static void Render_liquid( int stage )
 	gl_liquidShader->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
 	gl_liquidShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 
-	// specular component is computed by shader
-	// physical mapping is not implemented
+	// NOTE: specular component is computed by shader.
+	// FIXME: physical mapping is not implemented.
 	if ( pStage->enableSpecularMapping )
 	{
 		float specMin = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
@@ -2452,23 +2348,16 @@ static void Render_liquid( int stage )
 		}
 	}
 
-	if ( pStage->enableNormalMapping || ( pStage->enableParallaxMapping && pStage->isHeightMapInNormalMap ) )
-	{
-		// bind u_NormalMap
-		GL_BindToTMU( 3, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
-	}
-	else
-	{
-		GL_BindToTMU( 3, tr.flatImage );
-	}
+	// bind u_NormalMap
+	GL_BindToTMU( 3, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
 
+	// bind u_NormalScale
 	if ( pStage->enableNormalMapping )
 	{
 		vec3_t normalScale;
 		// FIXME: NormalIntensity default was 0.5
 		SetNormalScale( pStage, normalScale );
 
-		// bind u_NormalScale
 		gl_liquidShader->SetUniform_NormalScale( normalScale );
 	}
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4422,6 +4422,18 @@ static void CollapseStages()
 
 	for ( int i = 0; i < MAX_SHADER_STAGES; i++ )
 	{
+		/* Store hethaze and liquid normal map in normal map slot.
+
+		NOTE: liquidMap may be entirely redesigned in the future
+		to be a variant of diffuseMap (hence supporting all others textures).
+		*/
+		if ( stages[ i ].type == stageType_t::ST_HEATHAZEMAP
+			|| stages[ i ].type == stageType_t::ST_LIQUIDMAP )
+		{
+			stages[ i ].bundle[ TB_NORMALMAP ] = stages[ i ].bundle[ TB_COLORMAP ];
+			stages[ i ].bundle[ TB_COLORMAP ] = {};
+		}
+
 		if ( lightStage != -1 && stages[ i ].collapseType != collapseType_t::COLLAPSE_none )
 		{
 			if ( stages[ i ].dpMaterial )

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4615,6 +4615,13 @@ static void CollapseStages()
 	}
 
 	shader.numStages = numActiveStages;
+
+	// Do some precomputation.
+	for ( int s = 0; s < shader.numStages; s++ )
+	{
+		shaderStage_t *stage = &stages[ s ];
+		// STUB
+	}
 }
 
 // *INDENT-ON*

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4636,6 +4636,22 @@ static void CollapseStages()
 		stage->enablePhysicalMapping = r_physicalMapping->integer && stage->hasMaterialMap && stage->isMaterialPhysical;
 		stage->enableSpecularMapping = r_specularMapping->integer && stage->hasMaterialMap && !stage->isMaterialPhysical;
 		stage->enableGlowMapping = r_glowMapping->integer && stage->hasGlowMap;
+
+		// Bind fallback textures if required.
+		if ( !stage->enableNormalMapping && !( stage->enableParallaxMapping && stage->isHeightMapInNormalMap) )
+		{
+			stage->bundle[ TB_NORMALMAP ].image[ 0 ] = tr.flatImage;
+		}
+
+		if ( !stage->enablePhysicalMapping && !stage->enableSpecularMapping )
+		{
+			stage->bundle[ TB_MATERIALMAP ].image[ 0 ] = tr.blackImage;
+		}
+
+		if ( !stage->enableGlowMapping )
+		{
+			stage->bundle[ TB_GLOWMAP ].image[ 0 ] = tr.blackImage;
+		}
 	}
 }
 


### PR DESCRIPTION
Do a refactorization of some renderer thing, move some computation that are done every frame for every surface in `tr_shade.cpp` to be done only once at map load (or when shader is created) in `tr_shader.cpp`.

This makes also easier to implement some features, pull request #307 (_engine-agnostic normal fomat_) relies heavily on this.

Also deletes 150 lines.