### PR TITLE
do not crash the engine when using cubemaps

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -6347,6 +6347,14 @@ void R_BuildCubeMaps()
 	size_t tics = 0;
 	int nextTicCount = 0;
 
+	// Early abort if a BSP is not loaded yet since
+	// the buildcubemaps command can be called from
+	// everywhere including the main menu.
+	if ( tr.world == nullptr )
+	{
+		return;
+	}
+
 	startTime = ri.Milliseconds();
 
 	memset( &rf, 0, sizeof( refdef_t ) );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -726,8 +726,6 @@ static void Render_lightMapping( int stage )
 	&& (tess.surfaceShader->surfaceFlags & SURF_NOLIGHTMAP)
 	&& !(tess.numSurfaceStages > 0 && tess.surfaceStages[0]->rgbGen == colorGen_t::CGEN_VERTEX);
 
-	bool isWorldEntity = backEnd.currentEntity == &tr.worldEntity;
-
 	uint32_t stateBits = pStage->stateBits;
 
 	if ( enableLightMapping && r_showLightMaps->integer )
@@ -949,6 +947,8 @@ static void Render_lightMapping( int stage )
 	{
 		cubemapProbe_t *cubeProbeNearest;
 		cubemapProbe_t *cubeProbeSecondNearest;
+
+		bool isWorldEntity = backEnd.currentEntity == &tr.worldEntity;
 
 		if ( backEnd.currentEntity && !isWorldEntity )
 		{


### PR DESCRIPTION
The cubemap feature and reflective specular thing is not working, anyway, this PR makes sure the engine does not crash when the cubemaps are generated:

1. do not attempt to generate cubemaps (`buildcubemaps` command) when no map is loaded (for example in main menu);
2. always load a `whiteCubeImage` when cubemap pointers are null and do more tests for this.

Note that the renderer attempts to use cubemaps while they are built so maybe the extra tests for null pointers are only required until they all are build successfully, but I have no proof there would not be a bug somewhere trying to bind `nullptr` as image in some other scenario.