### PR TITLE
Fix attack3, drop useitem, reorder command array, ref Unvanquished#1182, Unvanquished #544

### DIFF
--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -1810,9 +1810,9 @@ union OpaquePlayerState {
 //                          10
 //                          11
 //                          12
-//                          13
+// BUTTON_DECONSTRUCT       13 // defined in gamelogic
 #define BUTTON_RALLY        14
-#define BUTTON_DODGE        15
+//                          15
 
 #define MOVE_RUN          120 // if forwardmove or rightmove are >= MOVE_RUN,
 // then BUTTON_WALKING should be set

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -1794,8 +1794,8 @@ union OpaquePlayerState {
 #define USERCMD_BUTTONS     16 // bits allocated for buttons (multiple of 8)
 
 #define BUTTON_ATTACK       0
-#define BUTTON_TALK         1  // disables actions
-#define BUTTON_USE_HOLDABLE 2
+#define BUTTON_ATTACK2      1
+#define BUTTON_ATTACK3      2
 #define BUTTON_GESTURE      3
 #define BUTTON_WALKING      4  // walking can't just be inferred from MOVE_RUN
                                // because a key pressed late in the frame will
@@ -1804,9 +1804,9 @@ union OpaquePlayerState {
                                // and won't generate footsteps
 #define BUTTON_SPRINT       5
 #define BUTTON_ACTIVATE     6
-#define BUTTON_ANY          7  // if any key is pressed
-#define BUTTON_ATTACK2      8
-//                          9
+//                          7
+#define BUTTON_ANY          8  // if any key is pressed
+#define BUTTON_TALK         9  // disables actions
 //                          10
 //                          11
 //                          12


### PR DESCRIPTION
Counterpart to https://github.com/Unvanquished/Unvanquished/pull/1182

Fix `attack3`, drop `useitem`, reorder command array, ref Unvanquished#1182, Unvanquished #544

See https://github.com/Unvanquished/Unvanquished/issues/1180
See https://github.com/Unvanquished/Unvanquished/issues/544