### PR TITLE
Fix KTX file format support and unify image reader logs

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -218,7 +218,7 @@ void LoadRGBEToFloats( const char *name, float **pic, int *width, int *height )
 
 	if ( !buffer )
 	{
-		Sys::Drop( "LoadRGBE: '%s' not found", name );
+		Sys::Drop( "RGBE image '%s' is not found", name );
 	}
 
 	buf_p = buffer;
@@ -257,22 +257,23 @@ void LoadRGBEToFloats( const char *name, float **pic, int *width, int *height )
 						}
 						else
 						{
-							Log::Warn("LoadRGBE: Expected 'bit_rle_rgbe' found instead '%s'", token );
+							Log::Warn("RGBE image '%s' has expected 'bit_rle_rgbe' but found '%s' instead",
+								name, token );
 						}
 					}
 					else
 					{
-						Log::Warn("LoadRGBE: Expected '-' found instead '%s'", token );
+						Log::Warn("RGBE image '%s' has expected '-' but found '%s' instead", name, token );
 					}
 				}
 				else
 				{
-					Log::Warn("LoadRGBE: Expected '32' found instead '%s'", token );
+					Log::Warn("RGBE image '%s' has expected '32' but found '%s' instead", name, token );
 				}
 			}
 			else
 			{
-				Log::Warn("LoadRGBE: Expected '=' found instead '%s'", token );
+				Log::Warn("RGBE image '%s' has expected '=' but found '%s' instead", name, token );
 			}
 		}
 
@@ -299,17 +300,17 @@ void LoadRGBEToFloats( const char *name, float **pic, int *width, int *height )
 					}
 					else
 					{
-						Log::Warn("LoadRGBE: Expected 'X' found instead '%s'", token );
+						Log::Warn("RGBE image '%s' has expected 'X' but found '%s' instead", name, token );
 					}
 				}
 				else
 				{
-					Log::Warn("LoadRGBE: Expected '+' found instead '%s'", token );
+					Log::Warn("RGBE image '%s' has expected '+' but found '%s' instead", name, token );
 				}
 			}
 			else
 			{
-				Log::Warn("LoadRGBE: Expected 'Y' found instead '%s'", token );
+				Log::Warn("RGBE image '%s' has expected 'Y' but found '%s' instead", name, token );
 			}
 		}
 	}
@@ -336,13 +337,13 @@ void LoadRGBEToFloats( const char *name, float **pic, int *width, int *height )
 	if ( !formatFound )
 	{
 		ri.FS_FreeFile( buffer );
-		Sys::Drop( "LoadRGBE: %s has no format", name );
+		Sys::Drop( "RGBE image '%s' has no format", name );
 	}
 
 	if ( !w || !h )
 	{
 		ri.FS_FreeFile( buffer );
-		Sys::Drop( "LoadRGBE: %s has an invalid image size", name );
+		Sys::Drop( "RGBE image '%s' has an invalid image size", name );
 	}
 
 	*pic = (float*) Com_Allocate( w * h * 3 * sizeof( float ) );

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1390,14 +1390,10 @@ image_t        *R_AllocImage( const char *name, bool linkIntoHashTable )
 static void R_ExportTexture( image_t *image )
 {
 	char path[ 1024 ];
-	int i;
-
-
-	Com_sprintf( path, sizeof( path ), "texexp/%s.ktx",
-		     image->name );
+	Com_sprintf( path, sizeof( path ), "texexp/%s.ktx", image->name );
 
 	// quick and dirty sanitize path name
-	for( i = strlen( path ) - 1; i >= 7; i-- ) {
+	for( size_t i = strlen( path ) - 1; i >= 7; i-- ) {
 		if( !Str::cisalnum( path[ i ] ) && path[ i ] != '.' && path[ i ] != '-' ) {
 			path[ i ] = 'z';
 		}

--- a/src/engine/renderer/tr_image_crn.cpp
+++ b/src/engine/renderer/tr_image_crn.cpp
@@ -128,7 +128,7 @@ void LoadCRN(const char* name, byte **data, int *width, int *height,
             ri.Free(*data);
             *data = nullptr; // This signals failure.
         }
-        Log::Warn("Invalid CRN image: %s", name);
+        Log::Warn("CRN image '%s' has an invalid format", name);
     }
     ri.FS_FreeFile(buff);
 }

--- a/src/engine/renderer/tr_image_dds.cpp
+++ b/src/engine/renderer/tr_image_dds.cpp
@@ -163,7 +163,7 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 
 	if ( strncmp( ( const char * ) buff, "DDS ", 4 ) != 0 )
 	{
-		Log::Warn("R_LoadDDSImage: invalid dds header \"%s\"", name );
+		Log::Warn("DDS image '%s' has invalid DDS id", name );
 		return;
 	}
 
@@ -186,7 +186,7 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 
 	if ( ddsd->dwSize != sizeof( DDSHEADER_t ) || ddsd->ddpfPixelFormat.dwSize != sizeof( DDS_PIXELFORMAT_t ) )
 	{
-		Log::Warn("R_LoadDDSImage: invalid dds header \"%s\"", name );
+		Log::Warn("DDS image '%s' has invalid DDS header", name );
 		return;
 	}
 
@@ -194,7 +194,7 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 
 	if ( *numMips > MAX_TEXTURE_MIPS )
 	{
-		Log::Warn("R_LoadDDSImage: dds image has too many mip levels \"%s\"", name );
+		Log::Warn("DDS image '%s' has too many mip levels (%d > %d)", name, *numMips, MAX_TEXTURE_MIPS );
 		return;
 	}
 
@@ -207,7 +207,8 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 
 		if ( ddsd->dwWidth != ddsd->dwHeight )
 		{
-			Log::Warn("R_LoadDDSImage: invalid dds image \"%s\"", name );
+			Log::Warn("DDS image '%s' is cube map and height (%d) != width (%d)", name,
+				ddsd->dwWidth, ddsd->dwHeight );
 			return;
 		}
 
@@ -218,7 +219,7 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 		if ( *width & ( *width - 1 ) )
 		{
 			//cubes must be a power of two
-			Log::Warn("R_LoadDDSImage: cube images must be power of two \"%s\"", name );
+			Log::Warn("DDS image '%s' is cube map and width (%d) is not power of two", name, *width );
 			return;
 		}
 	}
@@ -232,13 +233,15 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 
 		if ( *numLayers > MAX_TEXTURE_LAYERS )
 		{
-			Log::Warn("R_LoadDDSImage: dds image has too many layers \"%s\"", name );
+			Log::Warn("DDS image '%s' is volume and has too many layers (%d > %d)", name,
+				*numLayers, MAX_TEXTURE_LAYERS );
 			return;
 		}
 
 		if ( *width & ( *width - 1 ) || *height & ( *height - 1 ) || *numLayers & ( *numLayers - 1 ) )
 		{
-			Log::Warn("R_LoadDDSImage: volume images must be power of two \"%s\"", name );
+			Log::Warn("DDS image '%s' is volume and it's values are not power of two: "
+				 "width (%d), height (%d), layers (%d)", name, *width, *height, *numLayers );
 			return;
 		}
 	}
@@ -254,7 +257,8 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 		//except for compressed images!
 		if ( compressed && ( *width & ( *width - 1 ) || *height & ( *height - 1 ) ) )
 		{
-			Log::Warn("R_LoadDDSImage: compressed texture images must be power of two \"%s\"", name );
+			Log::Warn("DDS image '%s' is 2D compressed texture and it's values are not power of two: "
+				"width (%d), height (%d)", name, *width, *height );
 			return;
 		}
 	}
@@ -265,7 +269,7 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 
 		if ( *numLayers != 0 )
 		{
-			Log::Warn("R_LoadDDSImage: compressed volume textures are not supported \"%s\"", name );
+			Log::Warn("DDS image '%s' is unsupported compressed volume texture", name );
 			return;
 		}
 
@@ -300,8 +304,8 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 			break;
 
 		default:
-			Log::Warn("R_LoadDDSImage: unsupported FOURCC 0x%08x, \"%s\"",
-				   ddsd->ddpfPixelFormat.dwFourCC, name );
+			Log::Warn("DDS image '%s' is compressed, but FOURCC 0x%08x is unsupported",
+				name, ddsd->ddpfPixelFormat.dwFourCC );
 			return;
 		}
 		w = *width;
@@ -329,13 +333,14 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 					break;
 
 				default:
-					Log::Warn("R_LoadDDSImage: unsupported RGB bit depth \"%s\"", name );
+					Log::Warn("DDS image '%s' is not compressed, but RGB bit depth (%d) is unsupported", name,
+						ddsd->ddpfPixelFormat.dwRGBBitCount );
 					return;
 			}
 		}
 		else
 		{
-			Log::Warn("R_LoadDDSImage: unsupported DDS image type \"%s\"", name );
+			Log::Warn("DDS image '%s' is not compressed and has unsupported image type", name );
 			return;
 		}
 	}

--- a/src/engine/renderer/tr_image_jpg.cpp
+++ b/src/engine/renderer/tr_image_jpg.cpp
@@ -188,7 +188,7 @@ void LoadJPG( const char *filename, unsigned char **pic, int *width, int *height
 		fclose( jpegfd );
 #endif
 
-		Sys::Drop( "LoadJPG: %s has an invalid image format: %dx%d*4=%d, components: %d", filename,
+		Sys::Drop( "JPG image '%s' has an invalid format: %dx%d*4=%d, components: %d", filename,
 		          cinfo.output_width, cinfo.output_height, pixelcount * 4, cinfo.output_components );
 	}
 

--- a/src/engine/renderer/tr_image_ktx.cpp
+++ b/src/engine/renderer/tr_image_ktx.cpp
@@ -136,24 +136,24 @@ bool LoadInMemoryKTX( const char *name, void *ktxData, size_t ktxSize,
 	auto *hdr{ static_cast<KTX_header_t *>(ktxData) };
 
 	if( !IsValidKTXHeader( hdr, ktxSize ) ) {
-		Log::Warn("KTX texture '%s' is not in KTX format", name);
+		Log::Warn("KTX image '%s' is not in KTX format", name);
 		return false;
 	}
 
 	bool needReverseBytes{false};
 	if( !TryApplyKTXHeaderEndianness( hdr, needReverseBytes ) ) {
-		Log::Warn("KTX texture '%s' has unknown endianness value %u", name,
+		Log::Warn("KTX image '%s' has unknown endianness value '%d'", name,
 		hdr->endianness);
 		return false;
 	}
 
 	if( !IsSupportedKTXFormat( hdr ) ) {
-		Log::Warn("KTX texture '%s' may be valid, but not supported", name);
+		Log::Warn("KTX image '%s' may be valid, but not supported", name);
 		return false;
 	}
 
 	if( !TryParseInternalFormatBits( hdr->glInternalFormat, *bits ) ) {
-		Log::Warn("KTX texture '%s' has unsupported glInternalFormat value %u",
+		Log::Warn("KTX image '%s' has unsupported glInternalFormat value '%d'",
 		name, hdr->glInternalFormat);
 		return false;
 	}
@@ -165,7 +165,7 @@ bool LoadInMemoryKTX( const char *name, void *ktxData, size_t ktxSize,
 
 	byte *firstImageDataPtr{ (byte *)(hdr + 1) + hdr->bytesOfKeyValueData };
 	if ( !IsValidKTXFileStreamPosition( firstImageDataPtr, ktxSize, static_cast<const byte *>(ktxData) ) ) {
-		Log::Warn("KTX texture '%s' has bad bytesOfKeyValueData or texture data", name);
+		Log::Warn("KTX image '%s' has bad bytesOfKeyValueData or texture data", name);
 		return false;
 	}
 	byte *ptr{ firstImageDataPtr };
@@ -187,7 +187,7 @@ bool LoadInMemoryKTX( const char *name, void *ktxData, size_t ktxSize,
 
 	// ptr points to next byte after ktxData buffer end.
 	if ( !IsValidKTXFileStreamPosition( ptr - 1, ktxSize, static_cast<const byte *>(ktxData) ) ) {
-		Log::Warn("KTX texture '%s' has bad header or texture data", name);
+		Log::Warn("KTX image '%s' has bad header or texture data", name);
 		return false;
 	}
 
@@ -741,7 +741,7 @@ void SaveImageKTX( const char *path, image_t *img )
 
 	uint32_t components;
 	if( !ApplyKTXHeaderGlProperties( glInternalFormat, hdr, components ) ) {
-		Log::Warn( "KTX texture '%s' format '%x' is not supported", path, glInternalFormat );
+		Log::Warn( "KTX image '%s' format '%x' is not supported", path, glInternalFormat );
 		return;
 	}
 

--- a/src/engine/renderer/tr_image_ktx.cpp
+++ b/src/engine/renderer/tr_image_ktx.cpp
@@ -179,16 +179,15 @@ bool LoadInMemoryKTX( const char *name, void *ktxData, size_t ktxSize,
 		IsNonArrayCubemapTexture(hdr) ? hdr->numberOfFaces : 1U};
 
 	for(uint32_t i{ 0 }; i < hdr->numberOfMipmapLevels; i++) {
+		if ( !IsValidKTXFileStreamPosition( ptr, ktxSize, static_cast<const byte*>(ktxData) ) ) {
+			Log::Warn("KTX image '%s' has bad header or texture data", name);
+			return false;
+		}
+
 		const uint32_t imageSize{ GetImageSize( ptr, needReverseBytes ) };
 
 		totalImageSize += imageSize * mipmapLevelCoefficient;
 		ptr += sizeof(uint32_t) + imageSize;
-	}
-
-	// ptr points to next byte after ktxData buffer end.
-	if ( !IsValidKTXFileStreamPosition( ptr - 1, ktxSize, static_cast<const byte *>(ktxData) ) ) {
-		Log::Warn("KTX image '%s' has bad header or texture data", name);
-		return false;
 	}
 
 	ptr = firstImageDataPtr;

--- a/src/engine/renderer/tr_image_ktx.cpp
+++ b/src/engine/renderer/tr_image_ktx.cpp
@@ -136,7 +136,7 @@ bool LoadInMemoryKTX( const char *name, void *ktxData, size_t ktxSize,
 	auto *hdr{ static_cast<KTX_header_t *>(ktxData) };
 
 	if( !IsValidKTXHeader( hdr, ktxSize ) ) {
-		Log::Warn("KTX image '%s' is not in KTX format", name);
+		Log::Warn("KTX image '%s' has an invalid format", name);
 		return false;
 	}
 

--- a/src/engine/renderer/tr_image_ktx.cpp
+++ b/src/engine/renderer/tr_image_ktx.cpp
@@ -698,10 +698,10 @@ bool ApplyKTXHeaderGlProperties( uint32_t glInternalFormat, KTX_header_t &hdr, u
 }
 }  // namespace
 
-void LoadKTX( const char *name, byte **data, int *width, int *height,
-	      int *numLayers, int *numMips, int *bits, byte )
+void LoadKTX( const char *name, byte **pic, int *width, int *height,
+			  int *numLayers, int *numMips, int *bits, byte )
 {
-	*data = nullptr;
+	*pic = nullptr;
 	*numLayers = 0;
 
 	void *ktxData{ nullptr };
@@ -709,10 +709,11 @@ void LoadKTX( const char *name, byte **data, int *width, int *height,
 	if (!ktxData) {
 		return;
 	}
-	if ( !LoadInMemoryKTX( name, ktxData, ktxSize, data, width, height, numLayers, numMips, bits ) ) {
-		if (*data) {
-			*data = nullptr; // This signals failure.
+	if ( !LoadInMemoryKTX( name, ktxData, ktxSize, pic, width, height, numLayers, numMips, bits ) ) {
+		if (*pic) {
+			ri.Free(*pic);
 		}
+		*pic = nullptr; // This signals failure.
 	}
 	ri.FS_FreeFile( ktxData );
 }

--- a/src/engine/renderer/tr_image_ktx.cpp
+++ b/src/engine/renderer/tr_image_ktx.cpp
@@ -46,7 +46,7 @@ struct KTX_header_t {
 
 const byte KTX_identifier[12]{ 0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A };
 const uint32_t KTX_endianness{ 0x04030201U };
-const uint32_t KTX_endianness_reverse{ 0x01020304u };
+const uint32_t KTX_endianness_reverse{ 0x01020304U };
 
 bool IsValidKTXHeader( const KTX_header_t *hdr, size_t file_size ) {
 	return hdr && file_size >= sizeof(KTX_header_t) &&
@@ -119,7 +119,7 @@ uint32_t GetImageSize( const byte *ktxPosition, bool needReverseBytes ) {
 	if( needReverseBytes )
 		imageSize = Swap32(imageSize);
 
-	return PAD(imageSize, 4u);
+	return PAD( imageSize, 4U );
 }
 
 bool IsNonArrayCubemapTexture( const KTX_header_t *hdr ) {
@@ -772,16 +772,16 @@ void SaveImageKTX( const char *path, image_t *img )
 			     (GLint *)&mipFilter );
 	if( mipFilter == GL_NEAREST_MIPMAP_NEAREST || mipFilter == GL_NEAREST_MIPMAP_LINEAR ||
 		mipFilter == GL_LINEAR_MIPMAP_NEAREST || mipFilter == GL_LINEAR_MIPMAP_LINEAR ) {
-		mipWidth = std::max(hdr.pixelWidth, 1u);
-		mipHeight = std::max(hdr.pixelHeight, 1u);
-		mipDepth = std::max(hdr.pixelDepth, 1u);
+		mipWidth = std::max(hdr.pixelWidth, 1U);
+		mipHeight = std::max(hdr.pixelHeight, 1U);
+		mipDepth = std::max(hdr.pixelDepth, 1U);
 
 		while( mipWidth > 1 || mipHeight > 1 || mipDepth > 1 ) {
 			hdr.numberOfMipmapLevels++;
 
-			if( mipWidth  > 1 ) mipWidth  >>= 1u;
-			if( mipHeight > 1 ) mipHeight >>= 1u;
-			if( mipDepth  > 1 ) mipDepth  >>= 1u;
+			if( mipWidth  > 1 ) mipWidth  >>= 1U;
+			if( mipHeight > 1 ) mipHeight >>= 1U;
+			if( mipDepth  > 1 ) mipDepth  >>= 1U;
 		}
 	}
 
@@ -789,9 +789,9 @@ void SaveImageKTX( const char *path, image_t *img )
 
 	uint32_t size = 0;
 	int      mipSize;
-	mipWidth = std::max(hdr.pixelWidth, 1u);
-	mipHeight = std::max(hdr.pixelHeight, 1u);
-	mipDepth = std::max(hdr.pixelDepth, 1u);
+	mipWidth = std::max(hdr.pixelWidth, 1U);
+	mipHeight = std::max(hdr.pixelHeight, 1U);
+	mipDepth = std::max(hdr.pixelDepth, 1U);
 	for(uint32_t i = size = 0; i < hdr.numberOfMipmapLevels; i++ ) {
 		size += sizeof(uint32_t);
 		if( !hdr.glFormat ) {
@@ -800,14 +800,14 @@ void SaveImageKTX( const char *path, image_t *img )
 						  &mipSize );
 		} else {
 			mipSize = mipWidth * hdr.glTypeSize * components;
-			mipSize = PAD( mipSize, 4u );
+			mipSize = PAD( mipSize, 4U );
 			mipSize *= mipHeight * mipDepth;
 		}
-		size += hdr.numberOfFaces * PAD( mipSize, 4u );
+		size += hdr.numberOfFaces * PAD( mipSize, 4U );
 
-		if( mipWidth  > 1 ) mipWidth  >>= 1u;
-		if( mipHeight > 1 ) mipHeight >>= 1u;
-		if( mipDepth  > 1 ) mipDepth  >>= 1u;
+		if( mipWidth  > 1 ) mipWidth  >>= 1U;
+		if( mipHeight > 1 ) mipHeight >>= 1U;
+		if( mipDepth  > 1 ) mipDepth  >>= 1U;
 	}
 	
 	byte *data = (byte *)ri.Hunk_AllocateTempMemory( size + sizeof( hdr ) );
@@ -815,9 +815,9 @@ void SaveImageKTX( const char *path, image_t *img )
 	Com_Memcpy( ptr, &hdr, sizeof( hdr ) );
 	ptr += sizeof( hdr );
 
-	mipWidth = std::max(hdr.pixelWidth, 1u);
-	mipHeight = std::max(hdr.pixelHeight, 1u);
-	mipDepth = std::max(hdr.pixelDepth, 1u);
+	mipWidth = std::max(hdr.pixelWidth, 1U);
+	mipHeight = std::max(hdr.pixelHeight, 1U);
+	mipDepth = std::max(hdr.pixelDepth, 1U);
 	for(uint32_t i = 0; i < hdr.numberOfMipmapLevels; i++ ) {
 		if( !hdr.glFormat ) {
 			glGetTexLevelParameteriv( target, i,
@@ -825,10 +825,10 @@ void SaveImageKTX( const char *path, image_t *img )
 						  &mipSize );
 		} else {
 			mipSize = mipWidth * hdr.glTypeSize * components;
-			mipSize = PAD( mipSize, 4u );
+			mipSize = PAD( mipSize, 4U );
 			mipSize *= mipHeight * mipDepth;
 		}
-		*(int32_t *)ptr = PAD( mipSize, 4u );
+		*(int32_t *)ptr = PAD( mipSize, 4U );
 		ptr += sizeof( int32_t );
 
 		for(uint32_t j = 0; j < hdr.numberOfFaces; j++ ) {
@@ -838,12 +838,12 @@ void SaveImageKTX( const char *path, image_t *img )
 				glGetTexImage( target + j, i, hdr.glFormat,
 					       hdr.glType, ptr );
 			}
-			ptr += PAD( mipSize, 4u );
+			ptr += PAD( mipSize, 4U );
 		}
 
-		if( mipWidth  > 1 ) mipWidth  >>= 1u;
-		if( mipHeight > 1 ) mipHeight >>= 1u;
-		if( mipDepth  > 1 ) mipDepth  >>= 1u;
+		if( mipWidth  > 1 ) mipWidth  >>= 1U;
+		if( mipHeight > 1 ) mipHeight >>= 1U;
+		if( mipDepth  > 1 ) mipDepth  >>= 1U;
 	}
 
 	ri.FS_WriteFile( path, data, size + sizeof( hdr ) );

--- a/src/engine/renderer/tr_image_png.cpp
+++ b/src/engine/renderer/tr_image_png.cpp
@@ -78,7 +78,8 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 
 	if ( !png )
 	{
-		Log::Warn("LoadPNG: png_create_write_struct() failed for (%s)", name );
+		Log::Warn("PNG image '%s' has failed png_create_write_struct() [libpng v.'%s']",
+			name, PNG_LIBPNG_VER_STRING );
 		ri.FS_FreeFile( data );
 		return;
 	}
@@ -88,7 +89,8 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 
 	if ( !info )
 	{
-		Log::Warn("LoadPNG: png_create_info_struct() failed for (%s)", name );
+		Log::Warn("PNG image '%s' has failed png_create_info_struct() [libpng v.'%s']",
+			name, PNG_LIBPNG_VER_STRING );
 		ri.FS_FreeFile( data );
 		png_destroy_read_struct( &png, ( png_infopp ) nullptr, ( png_infopp ) nullptr );
 		return;
@@ -102,7 +104,8 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 	if ( setjmp( png_jmpbuf( png ) ) )
 	{
 		// if we get here, we had a problem reading the file
-		Log::Warn("LoadPNG: first exception handler called for (%s)", name );
+		Log::Warn("PNG image '%s' has first exception handler called [libpng v.'%s']",
+			name, PNG_LIBPNG_VER_STRING );
 		ri.FS_FreeFile( data );
 		png_destroy_read_struct( &png, ( png_infopp ) & info, ( png_infopp ) nullptr );
 		return;
@@ -170,7 +173,8 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 	// set a new exception handler
 	if ( setjmp( png_jmpbuf( png ) ) )
 	{
-		Log::Warn("LoadPNG: second exception handler called for (%s)", name );
+		Log::Warn("PNG image '%s' has second exception handler called [libpng v.'%s']",
+			name, PNG_LIBPNG_VER_STRING );
 		ri.Hunk_FreeTempMemory( row_pointers );
 		ri.FS_FreeFile( data );
 		png_destroy_read_struct( &png, ( png_infopp ) & info, ( png_infopp ) nullptr );

--- a/src/engine/renderer/tr_image_tga.cpp
+++ b/src/engine/renderer/tr_image_tga.cpp
@@ -76,19 +76,22 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 	if ( targa_header.image_type != 2 && targa_header.image_type != 10 && targa_header.image_type != 3 )
 	{
 		ri.FS_FreeFile( buffer );
-		Sys::Drop( "LoadTGA: Only type 2 (RGB), 3 (gray), and 10 (RGB) TGA images supported (%s)", name );
+		Sys::Drop( "TGA image '%s' has unsupported image type (%d). "
+			 "Only type 2 (uncompressed RGB), 3 (gray), and 10 (compressed RGB) TGA images supported",
+			 name, targa_header.image_type );
 	}
 
 	if ( targa_header.colormap_type != 0 )
 	{
 		ri.FS_FreeFile( buffer );
-		Sys::Drop( "LoadTGA: colormaps not supported (%s)", name );
+		Sys::Drop( "TGA image '%s' has color map and not supported", name );
 	}
 
 	if ( ( targa_header.pixel_size != 32 && targa_header.pixel_size != 24 ) && targa_header.image_type != 3 )
 	{
 		ri.FS_FreeFile( buffer );
-		Sys::Drop( "LoadTGA: Only 32 or 24 bit images supported (no colormaps) (%s)", name );
+		Sys::Drop( "TGA image '%s' has unsupported pixel size (%d). "
+			 "Only 32 or 24 bit images supported (except gray ones)", name, targa_header.pixel_size );
 	}
 
 	columns = targa_header.width;
@@ -108,7 +111,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 	if ( !columns || !rows || numPixels > 0x7FFFFFFF || numPixels / columns / 4 != rows )
 	{
 		ri.FS_FreeFile( buffer );
-		Sys::Drop( "LoadTGA: %s has an invalid image size", name );
+		Sys::Drop( "TGA image '%s' has an invalid image size", name );
 	}
 
 	targa_rgba = (byte*) ri.Z_Malloc( numPixels );
@@ -167,7 +170,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 					default:
 						ri.Free( targa_rgba );
 						ri.FS_FreeFile( buffer );
-						Sys::Drop( "LoadTGA: illegal pixel_size '%d' in file '%s'", targa_header.pixel_size, name );
+						Sys::Drop( "TGA image '%s' has illegal pixel_size (%d)", name, targa_header.pixel_size );
 				}
 			}
 		}
@@ -213,7 +216,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 						default:
 							ri.Free( targa_rgba );
 							ri.FS_FreeFile( buffer );
-							Sys::Drop( "LoadTGA: illegal pixel_size '%d' in file '%s'", targa_header.pixel_size, name );
+							Sys::Drop( "TGA image '%s' has illegal pixel_size (%d)", name, targa_header.pixel_size );
 					}
 
 					for ( j = 0; j < packetSize; j++ )
@@ -273,7 +276,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 							default:
 								ri.Free( targa_rgba );
 								ri.FS_FreeFile( buffer );
-								Sys::Drop( "LoadTGA: illegal pixel_size '%d' in file '%s'", targa_header.pixel_size, name );
+								Sys::Drop( "TGA image '%s' has illegal pixel_size (%d)", name, targa_header.pixel_size );
 						}
 
 						column++;

--- a/src/engine/renderer/tr_image_webp.cpp
+++ b/src/engine/renderer/tr_image_webp.cpp
@@ -29,7 +29,7 @@ bool LoadInMemoryWEBP( const char *path, const uint8_t* webpData, size_t webpSiz
 	// Validate data and query image size.
 	if ( !WebPGetInfo( webpData, webpSize, width, height ) )
 	{
-		Log::Warn( "WebP image '%s' is not in WebP format", path );
+		Log::Warn( "WebP image '%s' has an invalid format", path );
 		return false;
 	}
 

--- a/src/engine/renderer/tr_image_webp.cpp
+++ b/src/engine/renderer/tr_image_webp.cpp
@@ -19,9 +19,35 @@ along with Daemon source code; if not, write to the Free Software
 Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
-// tr_image.c
+
 #include "tr_local.h"
 #include <webp/decode.h>
+
+namespace {
+bool LoadInMemoryWEBP( const char *path, const uint8_t* webpData, size_t webpSize, byte **pic, int *width,
+	int *height ) {
+	// Validate data and query image size.
+	if ( !WebPGetInfo( webpData, webpSize, width, height ) )
+	{
+		Log::Warn( "WebP image '%s' is not in WebP format", path );
+		return false;
+	}
+
+	const size_t stride{ *width * sizeof( u8vec4_t ) };
+	const size_t size{ *height * stride };
+	auto *out = (byte*)ri.Z_Malloc( size );
+
+	// Decode into RGBA.
+	if ( !WebPDecodeRGBAInto( webpData, webpSize, out, size, stride ) )
+	{
+		Log::Warn( "WebP image '%s' has bad header or data", path );
+		return false;
+	}
+
+	*pic = out;
+	return true;
+}
+}
 
 /*
 =========================================================
@@ -30,42 +56,18 @@ LoadWEBP
 
 =========================================================
 */
-
-void LoadWEBP( const char *filename, unsigned char **pic, int *width, int *height,
-	       int*, int*, int*, byte )
+void LoadWEBP( const char *path, byte **pic, int *width, int *height, int *, int *, int *, byte )
 {
-	byte *out;
-	int  len;
-	int  stride;
-	int  size;
-	void* filebuf;
-
-	/* read compressed data */
-	len = ri.FS_ReadFile( filename, &filebuf );
-
-	if ( !filebuf || len < 0 )
-	{
+	*pic = nullptr;
+	
+	void *webpData{ nullptr };
+	const size_t webpSize = ri.FS_ReadFile( path, &webpData );
+	if (!webpData) {
 		return;
 	}
-
-	/* validate data and query image size */
-	if ( !WebPGetInfo( static_cast<const uint8_t*>(filebuf), len, width, height ) )
-	{
-		ri.FS_FreeFile( filebuf );
-		return;
+	if ( !LoadInMemoryWEBP( path, static_cast<const uint8_t*>(webpData), webpSize, pic, width, height ) ) {
+		ri.Free( *pic );
+		*pic = nullptr; // This signals failure.
 	}
-
-	stride = *width * sizeof( u8vec4_t );
-	size = *height * stride;
-
-	out = (byte*) ri.Z_Malloc( size );
-
-	if ( !WebPDecodeRGBAInto( static_cast<const uint8_t*>(filebuf), len, out, size, stride ) )
-	{
-		ri.Free( out );
-		return;
-	}
-
-	ri.FS_FreeFile( filebuf );
-	*pic = out;
+	ri.FS_FreeFile( webpData );
 }


### PR DESCRIPTION
* Handle case for non-array cubemap textures.
* Fix out of buffer read for KTX numberOfMipmapLevels.
* Better checks for KTX structure errors.
* Cleanup WebP image reader.
* Common image readers log format like `<image type> image '<image path>' <log message>`.

Fixes https://github.com/DaemonEngine/Daemon/issues/244
@illwieckz could you please check the patch?