### PR TITLE
playerstate: introduce weaponCharge, fix #336

### DIFF
--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -706,6 +706,7 @@ void MSG_WriteDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to )
 	     from->upmove == to->upmove &&
 	     !memcmp( from->buttons, to->buttons, sizeof( from->buttons ) ) &&
 	     from->weapon == to->weapon &&
+	     from->weaponCharge == to->weaponCharge &&
 	     from->flags == to->flags && from->doubleTap == to->doubleTap)
 	{
 		// NERVE - SMF
@@ -725,6 +726,7 @@ void MSG_WriteDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to )
 		MSG_WriteDelta( msg, from->buttons[i], to->buttons[i], 8 );
 	}
 	MSG_WriteDelta( msg, from->weapon, to->weapon, 8 );
+	MSG_WriteDelta( msg, from->weaponCharge, to->weaponCharge, 16 );
 	MSG_WriteDelta( msg, from->flags, to->flags, 8 );
 	MSG_WriteDelta( msg, Util::ordinal(from->doubleTap), Util::ordinal(to->doubleTap), 3 );
 }
@@ -766,6 +768,7 @@ void MSG_ReadDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to )
 			to->buttons[i] = MSG_ReadDelta( msg, from->buttons[i], 8 );
 		}
 		to->weapon = MSG_ReadDelta( msg, from->weapon, 8 );
+		to->weaponCharge = MSG_ReadDelta( msg, from->weaponCharge, 16 );
 		to->flags = MSG_ReadDelta( msg, from->flags, 8 );
 		to->doubleTap = Util::enum_cast<dtType_t>(MSG_ReadDelta(msg, Util::ordinal(from->doubleTap), 3) & 0x7);
 	}
@@ -779,6 +782,7 @@ void MSG_ReadDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to )
 		to->upmove = from->upmove;
 		usercmdCopyButtons( to->buttons, from->buttons );
 		to->weapon = from->weapon;
+		to->weaponCharge = from->weaponCharge;
 		to->flags = from->flags;
 		to->doubleTap = from->doubleTap;
 	}
@@ -860,6 +864,7 @@ static netField_t entityStateFields[] =
 	{ NETF( eventParms[ 2 ] ),   8              , 0 },
 	{ NETF( eventParms[ 3 ] ),   8              , 0 },
 	{ NETF( weapon ),            8              , 0 },
+	{ NETF( weaponCharge ),      16             , 0 },
 	{ NETF( legsAnim ),          ANIM_BITS      , 0 },
 	{ NETF( torsoAnim ),         ANIM_BITS      , 0 },
 	{ NETF( generic1 ),          10             , 0 },
@@ -1339,6 +1344,8 @@ static netField_t playerStateFields[] =
 	{ PSF( clientNum ),            8              , 0 }
 	,
 	{ PSF( weapon ),               7              , 0 }
+	,
+	{ PSF( weaponCharge ),         16             , 0 }
 	,
 	{ PSF( weaponstate ),          4              , 0 }
 	,

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -1844,8 +1844,8 @@ using GameStateCSs = std::array<std::string, MAX_CONFIGSTRINGS>;
 #define USERCMD_BUTTONS     16 // bits allocated for buttons (multiple of 8)
 
 #define BUTTON_ATTACK       0
-#define BUTTON_TALK         1  // disables actions
-#define BUTTON_USE_HOLDABLE 2
+#define BUTTON_ATTACK2      1
+#define BUTTON_ATTACK3      2
 #define BUTTON_GESTURE      3
 #define BUTTON_WALKING      4  // walking can't just be inferred from MOVE_RUN
                                // because a key pressed late in the frame will
@@ -1854,9 +1854,9 @@ using GameStateCSs = std::array<std::string, MAX_CONFIGSTRINGS>;
                                // and won't generate footsteps
 #define BUTTON_SPRINT       5
 #define BUTTON_ACTIVATE     6
-#define BUTTON_ANY          7  // if any key is pressed
-#define BUTTON_ATTACK2      8
-//                          9
+//                          7
+#define BUTTON_ANY          8  // if any key is pressed
+#define BUTTON_TALK         9  // disables actions
 //                          10
 //                          11
 //                          12

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -1798,6 +1798,7 @@ using GameStateCSs = std::array<std::string, MAX_CONFIGSTRINGS>;
 		// weapon info
 		int weapon; // copied to entityState_t->weapon
 		int weaponstate;
+		int weaponCharge;
 
 		vec3_t viewangles; // for fixed views
 		int    viewheight;
@@ -1889,6 +1890,7 @@ using GameStateCSs = std::array<std::string, MAX_CONFIGSTRINGS>;
 		dtType_t    doubleTap; // Arnout: only 3 bits used
 
 		byte        weapon;
+		int         weaponCharge;
 		byte        flags;
 
 		byte        buttons[ USERCMD_BUTTONS / 8 ];
@@ -2053,6 +2055,7 @@ using GameStateCSs = std::array<std::string, MAX_CONFIGSTRINGS>;
 
 		// for players
 		int weapon; // determines weapon and flash model, etc
+		int weaponCharge; // for charging mechanism
 		int legsAnim; // mask off ANIM_TOGGLEBIT
 		int torsoAnim; // mask off ANIM_TOGGLEBIT
 


### PR DESCRIPTION
playerstate: introduce weaponCharge, fix #336

Required by https://github.com/Unvanquished/Unvanquished/pull/1188

Unfortunately includes https://github.com/DaemonEngine/Daemon/pull/330 because of the Unvanquished PR including commits also requiring it (it's hard to split the commits on the other side).
