### PR TITLE
Gamelogic-configurable netcode for playerState_t

### DIFF
--- a/src/common/IPC/CommonSyscalls.h
+++ b/src/common/IPC/CommonSyscalls.h
@@ -34,6 +34,26 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Primitives.h"
 #include <common/FileSystem.h>
 
+namespace Util {
+    template<> struct SerializeTraits<netField_t> {
+        static void Write(Writer& stream, const netField_t& field)
+        {
+            stream.Write<int>(field.bits);
+            stream.Write<int>(field.offset);
+            stream.Write<std::string>(field.name);
+        }
+        static netField_t Read(Reader& stream)
+        {
+            netField_t field;
+            field.bits = stream.Read<int>();
+            field.offset = stream.Read<int>();
+            field.name = stream.Read<std::string>();
+            field.used = 0;
+            return field;
+        }
+    };
+} // namespace Util
+
 namespace VM {
 
     /*
@@ -145,6 +165,16 @@ namespace VM {
     // CrashDumpMsg
     using CrashDumpMsg = IPC::SyncMessage<
         IPC::Message<IPC::Id<MISC, CRASH_DUMP>, std::vector<uint8_t>>
+    >;
+
+    enum VMMiscMessages {
+        GET_NETCODE_TABLES,
+    };
+
+    // GetNetcodeTablesMsg
+    using GetNetcodeTablesMsg = IPC::SyncMessage <
+        IPC::Message<IPC::Id<MISC, GET_NETCODE_TABLES>>,
+        IPC::Reply<NetcodeTable, int>
     >;
 
     // Command-Related Syscall Definitions

--- a/src/engine/client/cg_api.h
+++ b/src/engine/client/cg_api.h
@@ -28,6 +28,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "engine/renderer/tr_types.h"
 #include "common/KeyIdentification.h"
 #include "common/cm/cm_public.h"
+#ifdef BUILD_CGAME
+// TODO: find a better way that does not depend on a gamelogic file from an engine file
+#include "shared/bg_public.h"
+#endif
 
 #define CGAME_API_VERSION 3
 
@@ -53,7 +57,11 @@ struct snapshot_t
 
 	byte          areamask[ MAX_MAP_AREA_BYTES ]; // portalarea visibility bits
 
+#ifdef BUILD_CGAME
 	playerState_t ps; // complete information about the current player at this time
+#else
+	OpaquePlayerState ps;
+#endif
 
 	// all of the entities that need to be presented at the time of this snapshot
 	std::vector<entityState_t> entities;

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -29,16 +29,20 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace Util {
 	template<> struct SerializeTraits<snapshot_t> {
+#ifdef BUILD_ENGINE
 		static void Write(Writer& stream, const snapshot_t& snap)
 		{
+
 			stream.Write<uint32_t>(snap.snapFlags);
 			stream.Write<uint32_t>(snap.ping);
 			stream.Write<uint32_t>(snap.serverTime);
 			stream.WriteData(&snap.areamask, MAX_MAP_AREA_BYTES);
-			stream.Write<playerState_t>(snap.ps);
+			stream.Write<OpaquePlayerState>(snap.ps);
 			stream.Write<std::vector<entityState_t>>(snap.entities);
 			stream.Write<std::vector<std::string>>(snap.serverCommands);
 		}
+#endif
+#ifdef BUILD_CGAME
 		static snapshot_t Read(Reader& stream)
 		{
 			snapshot_t snap;
@@ -46,11 +50,13 @@ namespace Util {
 			snap.ping = stream.Read<uint32_t>();
 			snap.serverTime = stream.Read<uint32_t>();
 			stream.ReadData(&snap.areamask, MAX_MAP_AREA_BYTES);
-			snap.ps = stream.Read<playerState_t>();
+			auto ops = stream.Read<OpaquePlayerState>();
+			memcpy(&snap.ps, &ops, sizeof(snap.ps));
 			snap.entities = stream.Read<std::vector<entityState_t>>();
 			snap.serverCommands = stream.Read<std::vector<std::string>>();
 			return snap;
 		}
+#endif
 	};
 
 	// For skeletons, only send the bones which are used

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -259,7 +259,7 @@ using GetUserCmdMsg = IPC::SyncMessage<
 >;
 using SetUserCmdValueMsg = IPC::Message<IPC::Id<VM::QVM, CG_SETUSERCMDVALUE>, int, int, float>;
 // TODO what?
-using GetEntityTokenMsg =  IPC::SyncMessage<
+using CgGetEntityTokenMsg =  IPC::SyncMessage<
 	IPC::Message<IPC::Id<VM::QVM, CG_GET_ENTITY_TOKEN>, int>,
 	IPC::Reply<bool, std::string>
 >;

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1167,7 +1167,7 @@ void CGameVM::QVMSyscall(int index, Util::Reader& reader, IPC::Channel& channel)
 			break;
 
 		case CG_GET_ENTITY_TOKEN:
-			IPC::HandleMsg<GetEntityTokenMsg>(channel, std::move(reader), [this] (int len, bool& res, std::string& token) {
+			IPC::HandleMsg<CgGetEntityTokenMsg>(channel, std::move(reader), [this] (int len, bool& res, std::string& token) {
 				std::unique_ptr<char[]> buffer(new char[len]);
 				buffer[0] = '\0';
 				res = re.GetEntityToken(buffer.get(), len);

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1019,6 +1019,10 @@ void CGameVM::CGameStaticInit()
 void CGameVM::CGameInit(int serverMessageNum, int clientNum)
 {
 	this->SendMsg<CGameInitMsg>(serverMessageNum, clientNum, cls.glconfig, cl.gameState);
+	NetcodeTable psTable;
+	size_t psSize;
+	this->SendMsg<VM::GetNetcodeTablesMsg>(psTable, psSize);
+	MSG_InitNetcodeTables(std::move(psTable), psSize);
 }
 
 void CGameVM::CGameShutdown()

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -64,7 +64,7 @@ struct clSnapshot_t
 	byte          areamask[ MAX_MAP_AREA_BYTES ]; // portalarea visibility bits
 
 	int           cmdNum; // the next cmdNum the server is expecting
-	playerState_t ps; // complete information about the current player at this time
+	OpaquePlayerState ps; // complete information about the current player at this time
 
 	int           serverCommandNum; // execute all commands up to this before
 	// making the snapshot current

--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -224,7 +224,7 @@ int MSG_ReadBits( msg_t *msg, int bits )
 	int      value;
 	int      get;
 	bool sgn;
-	int      i, nbits;
+	int      i;
 
 	value = 0;
 
@@ -269,27 +269,15 @@ int MSG_ReadBits( msg_t *msg, int bits )
 	}
 	else
 	{
-		nbits = 0;
-
-		if ( bits & 7 )
+		for ( i = 0; i < ( bits & 7 ); i++ )
 		{
-			nbits = bits & 7;
-
-			for ( i = 0; i < nbits; i++ )
-			{
-				value |= ( Huff_getBit( msg->data, &msg->bit ) << i );
-			}
-
-			bits = bits - nbits;
+			value |= ( Huff_getBit( msg->data, &msg->bit ) << i );
 		}
 
-		if ( bits )
+		for ( ; i < bits; i += 8 )
 		{
-			for ( i = 0; i < bits; i += 8 )
-			{
-				Huff_offsetReceive( msgHuff.decompressor.tree, &get, msg->data, &msg->bit );
-				value |= ( get << ( i + nbits ) );
-			}
+			Huff_offsetReceive( msgHuff.decompressor.tree, &get, msg->data, &msg->bit );
+			value |= get << i;
 		}
 
 		msg->readcount = ( msg->bit >> 3 ) + 1;

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -64,8 +64,6 @@ struct usercmd_t;
 
 struct entityState_t;
 
-struct playerState_t;
-
 void  MSG_WriteBits( msg_t *msg, int value, int bits );
 
 void  MSG_WriteChar( msg_t *sb, int c );
@@ -99,8 +97,9 @@ void  MSG_ReadDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to );
 void  MSG_WriteDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to, bool force );
 void  MSG_ReadDeltaEntity( msg_t *msg, const entityState_t *from, entityState_t *to, int number );
 
-void  MSG_WriteDeltaPlayerstate( msg_t *msg, playerState_t *from, playerState_t *to );
-void  MSG_ReadDeltaPlayerstate( msg_t *msg, playerState_t *from, playerState_t *to );
+void MSG_InitNetcodeTables(NetcodeTable playerStateTable, int playerStateSize);
+void  MSG_WriteDeltaPlayerstate( msg_t *msg, OpaquePlayerState *from, OpaquePlayerState *to );
+void  MSG_ReadDeltaPlayerstate( msg_t *msg, OpaquePlayerState *from, OpaquePlayerState *to );
 
 //============================================================================
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -85,7 +85,7 @@ struct server_t
 	int            gentitySize;
 	int            num_entities; // current number, <= MAX_GENTITIES
 
-	playerState_t  *gameClients;
+	OpaquePlayerState *gameClients;
 	int            gameClientSize; // will be > sizeof(playerState_t) due to game private data
 
 	int            restartTime;
@@ -116,7 +116,7 @@ struct clientSnapshot_t
 {
 	int           areabytes;
 	byte          areabits[ MAX_MAP_AREA_BYTES ]; // portalarea visibility bits
-	playerState_t ps;
+	OpaquePlayerState ps;
 	int           num_entities;
 	int           first_entity; // into the circular sv_packet_entities[]
 	// the entities MUST be in increasing state number
@@ -410,7 +410,7 @@ void SV_SendClientIdle( client_t *client );
 // sv_sgame.c
 //
 sharedEntity_t *SV_GentityNum( int num );
-playerState_t  *SV_GameClientNum( int num );
+OpaquePlayerState *SV_GameClientNum( int num );
 
 svEntity_t     *SV_SvEntityForGentity( sharedEntity_t *gEnt );
 void           SV_InitGameProgs();

--- a/src/engine/server/sg_msgdef.h
+++ b/src/engine/server/sg_msgdef.h
@@ -95,7 +95,7 @@ using GetUsercmdMsg = IPC::SyncMessage<
     IPC::Message<IPC::Id<VM::QVM, G_GET_USERCMD>, int>,
     IPC::Reply<usercmd_t>
 >;
-using GetEntityTokenMsg = IPC::SyncMessage<
+using SgGetEntityTokenMsg = IPC::SyncMessage<
     IPC::Message<IPC::Id<VM::QVM, G_GET_ENTITY_TOKEN>>,
     IPC::Reply<bool, std::string>
 >;

--- a/src/engine/server/sv_ccmds.cpp
+++ b/src/engine/server/sv_ccmds.cpp
@@ -314,7 +314,7 @@ public:
 					connection = "ERROR";
 				}
 			}
-			playerState_t* ps = SV_GameClientNum( i );
+			OpaquePlayerState* ps = SV_GameClientNum( i );
 
 			const char *address = NET_AdrToString( cl.netchan.remoteAddress );
 

--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -500,7 +500,7 @@ static void SVC_Status( const netadr_t& from, const Cmd::Args& args )
 
 		if ( cl->state >= clientState_t::CS_CONNECTED )
 		{
-			playerState_t* ps = SV_GameClientNum( i );
+			OpaquePlayerState* ps = SV_GameClientNum( i );
 			status +=  Str::Format( "%i %i \"%s\"\n", ps->persistant[ PERS_SCORE ], cl->ping, cl->name );
 		}
 	}
@@ -1145,7 +1145,6 @@ void SV_CalcPings()
 	client_t      *cl;
 	int           total, count;
 	int           delta;
-	playerState_t *ps;
 
 	for ( i = 0; i < sv_maxclients->integer; i++ )
 	{
@@ -1199,7 +1198,7 @@ void SV_CalcPings()
 		}
 
 		// let the game module know about the ping
-		ps = SV_GameClientNum( i );
+		OpaquePlayerState* ps = SV_GameClientNum( i );
 		ps->ping = cl->ping;
 	}
 }

--- a/src/engine/server/sv_sgame.cpp
+++ b/src/engine/server/sv_sgame.cpp
@@ -532,7 +532,7 @@ void GameVM::QVMSyscall(int index, Util::Reader& reader, IPC::Channel& channel)
 		break;
 
 	case G_GET_ENTITY_TOKEN:
-		IPC::HandleMsg<GetEntityTokenMsg>(channel, std::move(reader), [this](bool& boolRes, std::string& res) {
+		IPC::HandleMsg<SgGetEntityTokenMsg>(channel, std::move(reader), [this](bool& boolRes, std::string& res) {
 			res = COM_Parse(&sv.entityParsePoint);
 			boolRes = sv.entityParsePoint or res.size() > 0;
 		});

--- a/src/engine/server/sv_snapshot.cpp
+++ b/src/engine/server/sv_snapshot.cpp
@@ -668,7 +668,6 @@ static void SV_BuildClientSnapshot( client_t *client )
 	svEntity_t              *svEnt;
 	sharedEntity_t          *clent;
 	int                     clientNum;
-	playerState_t           *ps;
 
 	// bump the counter used to prevent double adding
 	sv.snapshotCounter++;
@@ -691,8 +690,8 @@ static void SV_BuildClientSnapshot( client_t *client )
 	}
 
 	// grab the current playerState_t
-	ps = SV_GameClientNum( client - svs.clients );
-	frame->ps = *ps;
+	OpaquePlayerState* ps = SV_GameClientNum( client - svs.clients );
+	memcpy(&frame->ps, ps, sizeof(frame->ps));
 
 	// never send client's own entity, because it can
 	// be regenerated from the playerstate

--- a/src/shared/CommonProxies.cpp
+++ b/src/shared/CommonProxies.cpp
@@ -497,8 +497,24 @@ namespace VM {
         Cvar::InitializeProxy();
     }
 
+    static void HandleMiscSyscall(int minor, Util::Reader& reader, IPC::Channel& channel) {
+        switch (minor) {
+            case VM::GET_NETCODE_TABLES:
+                IPC::HandleMsg<GetNetcodeTablesMsg>(VM::rootChannel, std::move(reader), [](NetcodeTable& playerStateTable, int& playerStateSize) {
+                    GetNetcodeTables(playerStateTable, playerStateSize);
+                });
+                break;
+            default:
+                Sys::Drop("Unhandled misc engine->VM syscall %d", minor);
+        }
+    }
+
     void HandleCommonSyscall(int major, int minor, Util::Reader reader, IPC::Channel& channel) {
         switch (major) {
+            case VM::MISC:
+                HandleMiscSyscall(minor, reader, channel);
+                break;
+
             case VM::COMMAND:
                 Cmd::HandleSyscall(minor, reader, channel);
                 break;

--- a/src/shared/VMMain.h
+++ b/src/shared/VMMain.h
@@ -41,6 +41,7 @@ namespace VM {
 	// Functions each specific gamelogic should implement
 	void VMInit();
 	void VMHandleSyscall(uint32_t id, Util::Reader reader);
+	void GetNetcodeTables(NetcodeTable& playerStateTable, int& playerStateSize);
 	extern int VM_API_VERSION;
 
 	// Send a message to the engine

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -99,7 +99,7 @@ bool trap_GetEntityToken( char *buffer, int bufferSize )
 {
 	bool res;
 	std::string token;
-	VM::SendMsg<GetEntityTokenMsg>(bufferSize, res, token);
+	VM::SendMsg<CgGetEntityTokenMsg>(bufferSize, res, token);
 	Q_strncpyz(buffer, token.c_str(), bufferSize);
 	return res;
 }

--- a/src/shared/server/sg_api.cpp
+++ b/src/shared/server/sg_api.cpp
@@ -36,7 +36,7 @@ IPC::SharedMemory shmRegion;
 // Definition of the VM->Engine calls
 
 // The actual shared memory region is handled in this file, and is pretty much invisible to the rest of the code
-void trap_LocateGameData(int numGEntities, int sizeofGEntity_t, playerState_t*, int sizeofGClient)
+void trap_LocateGameData(int numGEntities, int sizeofGEntity_t, int sizeofGClient)
 {
     static bool firstTime = true;
     if (firstTime) {

--- a/src/shared/server/sg_api.cpp
+++ b/src/shared/server/sg_api.cpp
@@ -107,7 +107,7 @@ bool trap_GetEntityToken(char *buffer, int bufferSize)
 {
     std::string text;
     bool res;
-    VM::SendMsg<GetEntityTokenMsg>(res, text);
+    VM::SendMsg<SgGetEntityTokenMsg>(res, text);
     Q_strncpyz(buffer, text.c_str(), bufferSize);
     return res;
 }


### PR DESCRIPTION
A lot of hacks! There are a few fields referenced in the engine code, so I'm keeping those hard-coded in for now. I have only implemented loading the table from sgame so far, not from cgame (though it's matter of trivial copy and paste), so it only works with a local server.

The point is to be able to change the definition of playerState_t without rebuilding the engine.  If we like this, there's another table for entityState_t that it can also be done for.