### PR TITLE
Reuse window when attempting to create a context, fix #349

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -699,12 +699,16 @@ static rserr_t GLimp_SetMode( int mode, bool fullscreen, bool noborder )
 			{
 				SDL_GL_SetAttribute( SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG );
 			}
-			window = SDL_CreateWindow( CLIENT_WINDOW_TITLE, x, y, glConfig.vidWidth, glConfig.vidHeight, flags );
 
 			if ( !window )
 			{
-				logger.Warn("SDL_CreateWindow failed: %s\n", SDL_GetError() );
-				continue;
+				window = SDL_CreateWindow( CLIENT_WINDOW_TITLE, x, y, glConfig.vidWidth, glConfig.vidHeight, flags );
+
+				if ( !window )
+				{
+					logger.Warn("SDL_CreateWindow failed: %s\n", SDL_GetError() );
+					continue;
+				}
 			}
 
 			SDL_SetWindowIcon( window, icon );


### PR DESCRIPTION
For each format attempt, the renderer creates a window and try to create a context using this window.
But anytime a context cannot be created, the next one is tried without destroying the previous window first, or reusing it.

This is an attempt to fix #349.