### PR TITLE
Cleanup GPU detection code, fix #352

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -726,9 +726,6 @@ std::string     GLShaderManager::BuildGPUShaderText( Str::StringRef mainShaderNa
 
 	AddDefine( env, "r_tileStep", glState.tileStep[ 0 ], glState.tileStep[ 1 ] );
 
-	if ( glConfig.driverType == glDriverType_t::GLDRV_MESA )
-		AddDefine( env, "GLDRV_MESA", 1 );
-
 	switch (glConfig.hardwareType)
 	{
 		case glHardwareType_t::GLHW_ATI:

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -731,9 +731,6 @@ std::string     GLShaderManager::BuildGPUShaderText( Str::StringRef mainShaderNa
 		case glHardwareType_t::GLHW_ATI:
 		AddDefine(env, "GLHW_ATI", 1);
 		break;
-	case glHardwareType_t::GLHW_ATI_DX10:
-		AddDefine(env, "GLHW_ATI_DX10", 1);
-		break;
 	default:
 		break;
 	}

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -726,15 +726,6 @@ std::string     GLShaderManager::BuildGPUShaderText( Str::StringRef mainShaderNa
 
 	AddDefine( env, "r_tileStep", glState.tileStep[ 0 ], glState.tileStep[ 1 ] );
 
-	switch (glConfig.hardwareType)
-	{
-		case glHardwareType_t::GLHW_ATI:
-		AddDefine(env, "GLHW_ATI", 1);
-		break;
-	default:
-		break;
-	}
-
 	// We added a lot of stuff but if we do something bad
 	// in the GLSL shaders then we want the proper line
 	// so we have to reset the line counting.

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -511,7 +511,7 @@ static std::string GenEngineConstants() {
 				AddDefine( str, "VSM_CLAMP", 1 );
 		}
 
-		if ( ( glConfig.hardwareType == glHardwareType_t::GLHW_NV_DX10 || glConfig.hardwareType == glHardwareType_t::GLHW_ATI_DX10 ) && r_shadows->integer == Util::ordinal(shadowingMode_t::SHADOWING_VSM32) )
+		if ( ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 ) && r_shadows->integer == Util::ordinal(shadowingMode_t::SHADOWING_VSM32) )
 			AddConst( str, "VSM_EPSILON", 0.000001f );
 		else
 			AddConst( str, "VSM_EPSILON", 0.0001f );

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -734,9 +734,6 @@ std::string     GLShaderManager::BuildGPUShaderText( Str::StringRef mainShaderNa
 	case glHardwareType_t::GLHW_ATI_DX10:
 		AddDefine(env, "GLHW_ATI_DX10", 1);
 		break;
-	case glHardwareType_t::GLHW_NV_DX10:
-		AddDefine(env, "GLHW_NV_DX10", 1);
-		break;
 	default:
 		break;
 	}

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -507,14 +507,20 @@ static std::string GenEngineConstants() {
 		{
 			AddDefine( str, "VSM", 1 );
 
-			if ( glConfig.hardwareType == glHardwareType_t::GLHW_ATI )
+			if ( glConfig.hardwareType == glHardwareType_t::GLHW_R300 )
+			{
 				AddDefine( str, "VSM_CLAMP", 1 );
+			}
 		}
 
 		if ( ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 ) && r_shadows->integer == Util::ordinal(shadowingMode_t::SHADOWING_VSM32) )
+		{
 			AddConst( str, "VSM_EPSILON", 0.000001f );
-		else
+		}
+		else // also required by GLHW_R300 which is not GLDRV_OPENGL3 anyway
+		{
 			AddConst( str, "VSM_EPSILON", 0.0001f );
+		}
 
 		if ( r_lightBleedReduction->value )
 			AddConst( str, "r_LightBleedReduction", r_lightBleedReduction->value );

--- a/src/engine/renderer/glsl_source/depthToColor_fp.glsl
+++ b/src/engine/renderer/glsl_source/depthToColor_fp.glsl
@@ -33,7 +33,7 @@ void	main()
 	// compute depth instead of world vertex position in a [0..1] range
 	float depth = gl_FragCoord.z;
 
-//#if 0 //defined(GLHW_ATI_DX10) || defined(GLHW_NV_DX10)
+//#if 0 //defined(GLHW_ATI_DX10)
 //	outputColor = vec4(0.0, 0.0, 0.0, depth);
 //#else
 	// 32 bit precision

--- a/src/engine/renderer/glsl_source/depthToColor_fp.glsl
+++ b/src/engine/renderer/glsl_source/depthToColor_fp.glsl
@@ -33,7 +33,7 @@ void	main()
 	// compute depth instead of world vertex position in a [0..1] range
 	float depth = gl_FragCoord.z;
 
-//#if 0 //defined(GLHW_ATI_DX10)
+//#if 0
 //	outputColor = vec4(0.0, 0.0, 0.0, depth);
 //#else
 	// 32 bit precision

--- a/src/engine/renderer/glsl_source/volumetricFog_fp.glsl
+++ b/src/engine/renderer/glsl_source/volumetricFog_fp.glsl
@@ -58,7 +58,7 @@ void	main()
 
 	float depthSolid = texture2D(u_DepthMap, st).r;
 
-//#if 0 //defined(GLHW_ATI_DX10)
+//#if 0
 //
 //	float depthBack = texture2D(u_DepthMapBack, st).a;
 //	float depthFront = texture2D(u_DepthMapFront, st).a;

--- a/src/engine/renderer/glsl_source/volumetricFog_fp.glsl
+++ b/src/engine/renderer/glsl_source/volumetricFog_fp.glsl
@@ -58,7 +58,7 @@ void	main()
 
 	float depthSolid = texture2D(u_DepthMap, st).r;
 
-//#if 0 //defined(GLHW_ATI_DX10) || defined(GLHW_NV_DX10)
+//#if 0 //defined(GLHW_ATI_DX10)
 //
 //	float depthBack = texture2D(u_DepthMapBack, st).a;
 //	float depthFront = texture2D(u_DepthMapFront, st).a;

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -2972,8 +2972,6 @@ void RB_RenderBloom()
 	GL_LoadProjectionMatrix( ortho );
 	GL_LoadModelViewMatrix( matrixIdentity );
 
-	// FIXME
-	//if(glConfig.hardwareType != GLHW_ATI)
 	{
 		GL_State( GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -2973,7 +2973,7 @@ void RB_RenderBloom()
 	GL_LoadModelViewMatrix( matrixIdentity );
 
 	// FIXME
-	//if(glConfig.hardwareType != GLHW_ATI && glConfig.hardwareType != GLHW_ATI_DX10)
+	//if(glConfig.hardwareType != GLHW_ATI)
 	{
 		GL_State( GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -987,9 +987,9 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			}
 		}
 
-		if ( glConfig.hardwareType == glHardwareType_t::GLHW_ATI )
+		if ( glConfig.hardwareType == glHardwareType_t::GLHW_R300 )
 		{
-			Log::Debug("HACK: ATI approximations" );
+			Log::Debug("HACK: ATI R300 approximations" );
 		}
 
 		if ( glConfig.textureCompression != textureCompression_t::TC_NONE )

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -997,11 +997,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			Log::Debug("Using S3TC (DXTC) texture compression" );
 		}
 
-		if ( glConfig.hardwareType == glHardwareType_t::GLHW_ATI_DX10 )
-		{
-			Log::Debug("Using ATI DirectX 10 hardware features" );
-		}
-
 		if ( glConfig2.vboVertexSkinningAvailable )
 		{
 			Log::Notice("Using GPU vertex skinning with max %i bones in a single pass", glConfig2.maxVertexSkinningBones );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1002,11 +1002,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			Log::Debug("Using ATI DirectX 10 hardware features" );
 		}
 
-		if ( glConfig.hardwareType == glHardwareType_t::GLHW_NV_DX10 )
-		{
-			Log::Debug("Using NVIDIA DirectX 10 hardware features" );
-		}
-
 		if ( glConfig2.vboVertexSkinningAvailable )
 		{
 			Log::Notice("Using GPU vertex skinning with max %i bones in a single pass", glConfig2.maxVertexSkinningBones );

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -323,7 +323,6 @@ enum class glHardwareType_t
 // XreaL BEGIN
   GLHW_ATI, // where you don't have proper GLSL support
   GLHW_ATI_DX10, // ATI Radeon HD series DX10 hardware
-  GLHW_NV_DX10 // Geforce 8/9 class DX10 hardware
 // XreaL END
 };
 

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -321,7 +321,7 @@ enum class glHardwareType_t
   GLHW_GENERIC, // where everthing works the way it should
 
 // XreaL BEGIN
-  GLHW_ATI, // where you don't have proper GLSL support
+  GLHW_R300, // pre-GL3 ATI hack
 // XreaL END
 };
 

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -311,7 +311,6 @@ enum class glDriverType_t
 
 // XreaL BEGIN
   GLDRV_OPENGL3, // new driver system
-  GLDRV_MESA, // crap
 // XreaL END
 };
 

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -322,7 +322,6 @@ enum class glHardwareType_t
 
 // XreaL BEGIN
   GLHW_ATI, // where you don't have proper GLSL support
-  GLHW_ATI_DX10, // ATI Radeon HD series DX10 hardware
 // XreaL END
 };
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1294,15 +1294,6 @@ success:
 		Q_strncpyz( glConfig.extensions_string, ( char * ) glGetString( GL_EXTENSIONS ), sizeof( glConfig.extensions_string ) );
 	}
 
-	if ( Q_stristr( glConfig.renderer_string, "mesa" ) ||
-	     Q_stristr( glConfig.renderer_string, "gallium" ) ||
-	     Q_stristr( glConfig.vendor_string, "nouveau" ) ||
-	     Q_stristr( glConfig.vendor_string, "mesa" ) )
-	{
-		// suckage
-		glConfig.driverType = glDriverType_t::GLDRV_MESA;
-	}
-
 	if ( Q_stristr( glConfig.vendor_string, "nvidia" ) ||
 	     Q_stristr( glConfig.vendor_string, "nouveau" ) )
 	{
@@ -1346,10 +1337,6 @@ success:
 		else if ( !Q_stricmp( forceGL->string, "opengl3" ))
 		{
 			driverType = glDriverType_t::GLDRV_OPENGL3;
-		}
-		else if ( !Q_stricmp( forceGL->string, "mesa" ))
-		{
-			driverType = glDriverType_t::GLDRV_MESA;
 		}
 
 		forceGL = ri.Cvar_Get( "r_glForceHardware", "", CVAR_LATCH );

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1205,7 +1205,7 @@ static void reportDriverType( bool force )
 static void reportHardwareType( bool force )
 {
 	static const char *const hardware[] = {
-		"generic", "ATI Radeon", "AMD Radeon DX10-class", "nVidia DX10-class"
+		"generic", "ATI Radeon", "AMD Radeon DX10-class"
 	};
 	if (glConfig.hardwareType > glHardwareType_t::GLHW_UNKNOWN && (unsigned) glConfig.hardwareType < ARRAY_LEN( hardware ) )
 	{
@@ -1294,15 +1294,6 @@ success:
 		Q_strncpyz( glConfig.extensions_string, ( char * ) glGetString( GL_EXTENSIONS ), sizeof( glConfig.extensions_string ) );
 	}
 
-	if ( Q_stristr( glConfig.vendor_string, "nvidia" ) ||
-	     Q_stristr( glConfig.vendor_string, "nouveau" ) )
-	{
-		if ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 )
-		{
-			glConfig.hardwareType = glHardwareType_t::GLHW_NV_DX10;
-		}
-	}
-
 	if ( Q_stristr( glConfig.renderer_string, "amd " ) ||
 	     Q_stristr( glConfig.renderer_string, "ati " ) )
 	{
@@ -1353,10 +1344,6 @@ success:
 		          !Q_stricmp( forceGL->string, "radeonhd" ))
 		{
 			hardwareType = glHardwareType_t::GLHW_ATI_DX10;
-		}
-		else if ( !Q_stricmp( forceGL->string, "nvdx10" ))
-		{
-			hardwareType = glHardwareType_t::GLHW_NV_DX10;
 		}
 
 		if ( driverType != glDriverType_t::GLDRV_UNKNOWN )

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1205,7 +1205,7 @@ static void reportDriverType( bool force )
 static void reportHardwareType( bool force )
 {
 	static const char *const hardware[] = {
-		"generic", "ATI Radeon"
+		"generic", "ATI R300"
 	};
 	if (glConfig.hardwareType > glHardwareType_t::GLHW_UNKNOWN && (unsigned) glConfig.hardwareType < ARRAY_LEN( hardware ) )
 	{
@@ -1299,7 +1299,7 @@ success:
 	{
 		if ( glConfig.driverType != glDriverType_t::GLDRV_OPENGL3 )
 		{
-			glConfig.hardwareType = glHardwareType_t::GLHW_ATI;
+			glConfig.hardwareType = glHardwareType_t::GLHW_R300;
 		}
 	}
 
@@ -1332,9 +1332,9 @@ success:
 		{
 			hardwareType = glHardwareType_t::GLHW_GENERIC;
 		}
-		else if ( !Q_stricmp( forceGL->string, "ati" ))
+		else if ( !Q_stricmp( forceGL->string, "r300" ))
 		{
-			hardwareType = glHardwareType_t::GLHW_ATI;
+			hardwareType = glHardwareType_t::GLHW_R300;
 		}
 
 		if ( driverType != glDriverType_t::GLDRV_UNKNOWN )

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1303,73 +1303,26 @@ success:
 		glConfig.driverType = glDriverType_t::GLDRV_MESA;
 	}
 
-	if ( Q_stristr( glConfig.renderer_string, "geforce" ) )
+	if ( Q_stristr( glConfig.vendor_string, "nvidia" ) ||
+	     Q_stristr( glConfig.vendor_string, "nouveau" ) )
 	{
-		if ( Q_stristr( glConfig.renderer_string, "8400" ) ||
-		     Q_stristr( glConfig.renderer_string, "8500" ) ||
-		     Q_stristr( glConfig.renderer_string, "8600" ) ||
-		     Q_stristr( glConfig.renderer_string, "8800" ) ||
-		     Q_stristr( glConfig.renderer_string, "9500" ) ||
-		     Q_stristr( glConfig.renderer_string, "9600" ) ||
-		     Q_stristr( glConfig.renderer_string, "9800" ) ||
-		     Q_stristr( glConfig.renderer_string, "gts 240" ) ||
-		     Q_stristr( glConfig.renderer_string, "gts 250" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 260" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 275" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 280" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 285" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 295" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 320" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 330" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 340" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 415" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 420" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 425" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 430" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 435" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 440" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 520" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 525" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 540" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 550" ) ||
-		     Q_stristr( glConfig.renderer_string, "gt 555" ) ||
-		     Q_stristr( glConfig.renderer_string, "gts 450" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 460" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 470" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 480" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 485" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 560" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 570" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 580" ) ||
-		     Q_stristr( glConfig.renderer_string, "gtx 590" ) )
+		if ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 )
 		{
 			glConfig.hardwareType = glHardwareType_t::GLHW_NV_DX10;
 		}
 	}
-	else if ( Q_stristr( glConfig.renderer_string, "quadro fx" ) )
+
+	if ( Q_stristr( glConfig.renderer_string, "amd " ) ||
+	     Q_stristr( glConfig.renderer_string, "ati " ) )
 	{
-		if ( Q_stristr( glConfig.renderer_string, "3600" ) )
+		if ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 )
 		{
-			glConfig.hardwareType = glHardwareType_t::GLHW_NV_DX10;
+			glConfig.hardwareType = glHardwareType_t::GLHW_ATI_DX10;
 		}
-	}
-	else if ( Q_stristr( glConfig.renderer_string, "gallium" ) &&
-	          Q_stristr( glConfig.renderer_string, " amd " ) )
-	{
-		// anything prior to R600 is listed as ATI.
-		glConfig.hardwareType = glHardwareType_t::GLHW_ATI_DX10;
-	}
-	else if ( Q_stristr( glConfig.renderer_string, "rv770" ) ||
-	          Q_stristr( glConfig.renderer_string, "eah4850" ) ||
-	          Q_stristr( glConfig.renderer_string, "eah4870" ) ||
-	          // previous three are too specific?
-	          Q_stristr( glConfig.renderer_string, "radeon hd" ) )
-	{
-		glConfig.hardwareType = glHardwareType_t::GLHW_ATI_DX10;
-	}
-	else if ( Q_stristr( glConfig.renderer_string, "radeon" ) )
-	{
-		glConfig.hardwareType = glHardwareType_t::GLHW_ATI;
+		else
+		{
+			glConfig.hardwareType = glHardwareType_t::GLHW_ATI;
+		}
 	}
 
 	reportDriverType( false );

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1205,7 +1205,7 @@ static void reportDriverType( bool force )
 static void reportHardwareType( bool force )
 {
 	static const char *const hardware[] = {
-		"generic", "ATI Radeon", "AMD Radeon DX10-class"
+		"generic", "ATI Radeon"
 	};
 	if (glConfig.hardwareType > glHardwareType_t::GLHW_UNKNOWN && (unsigned) glConfig.hardwareType < ARRAY_LEN( hardware ) )
 	{
@@ -1297,11 +1297,7 @@ success:
 	if ( Q_stristr( glConfig.renderer_string, "amd " ) ||
 	     Q_stristr( glConfig.renderer_string, "ati " ) )
 	{
-		if ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 )
-		{
-			glConfig.hardwareType = glHardwareType_t::GLHW_ATI_DX10;
-		}
-		else
+		if ( glConfig.driverType != glDriverType_t::GLDRV_OPENGL3 )
 		{
 			glConfig.hardwareType = glHardwareType_t::GLHW_ATI;
 		}
@@ -1339,11 +1335,6 @@ success:
 		else if ( !Q_stricmp( forceGL->string, "ati" ))
 		{
 			hardwareType = glHardwareType_t::GLHW_ATI;
-		}
-		else if ( !Q_stricmp( forceGL->string, "atidx10" ) ||
-		          !Q_stricmp( forceGL->string, "radeonhd" ))
-		{
-			hardwareType = glHardwareType_t::GLHW_ATI_DX10;
 		}
 
 		if ( driverType != glDriverType_t::GLDRV_UNKNOWN )


### PR DESCRIPTION
See #352, the code was reading GL version to select GL 2 or GL 3 features, but was looking hardcoded string (related to 10 years old hardware and software) to activate some optimizations for pre GL3 hardware.

The code already reads GL version and we can assume an hardware having a driver supporting GL3 is a GL3 hardware.

On a side note, we currently know only one GL 2.1 configuration that works with Unvanquished: the GMA X3100 / GM964 (Core 2 Duo L7500) on Linux. This GPU driver does not support GL 2.1 on Windows, other tested GL 2.1 hardware are either getting serious issues (see #344) or just lacks required extension (see #348). Even the GMA X3100 on Linux is not able to perform 30fps with 800x600 resolution and 1:4 texture size. Then, we can assume everything is GL3 instead of the contrary, and we may still implement specific code path for select obsolete configuration instead of the contrary.