### PR TITLE
renderer: print shader and macro names at glsl build time

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1015,6 +1015,10 @@ void GLShaderManager::CompileGPUShaders( GLShader *shader, shaderProgram_t *prog
 		}
 	}
 
+	Log::Debug( "building %s shader permutation with macro: %s",
+		shader->GetMainShaderName(),
+		compileMacros.empty() ? "none" : compileMacros );
+
 	// add them
 	std::string vertexShaderTextWithMacros = macrosString + shader->_vertexShaderText;
 	std::string fragmentShaderTextWithMacros = macrosString + shader->_fragmentShaderText;


### PR DESCRIPTION
Print shader name and macro at build time, may help to trouble shoot various things.

That debug code prints something like that in console:

```
Debug: building shadowFill shader permutation with macro: none
Debug: building shadowFill shader permutation with macro: USE_VERTEX_SKINNING
Debug: building shadowFill shader permutation with macro: USE_VERTEX_ANIMATION
Debug: building shadowFill shader permutation with macro: LIGHT_DIRECTIONAL
Debug: building shadowFill shader permutation with macro: USE_VERTEX_SKINNING LIGHT_DIRECTIONAL
Debug: building shadowFill shader permutation with macro: USE_VERTEX_ANIMATION LIGHT_DIRECTIONAL
```