### PR TITLE
Do not scale down lightmaps, fix #347

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -498,7 +498,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 				for (int i = 0; i < numLightmaps; i++) {
 					Log::Debug("...loading external lightmap '%s/%s'", mapName, lightmapFiles[i]);
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NORMALMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP);
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NOPICMIP | IF_NORMALMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP);
 					Com_AddToGrowList(&tr.deluxemaps, image);
 				}
 			}
@@ -521,10 +521,10 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 				Log::Debug("...loading external lightmap '%s/%s'", mapName, lightmapFiles[i]);
 
 				if (!tr.worldDeluxeMapping || i % 2 == 0) {
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_LIGHTMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NOPICMIP | IF_LIGHTMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
 					Com_AddToGrowList(&tr.lightmaps, image);
 				} else {
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NORMALMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NOPICMIP | IF_NORMALMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
 					Com_AddToGrowList(&tr.deluxemaps, image);
 				}
 			}
@@ -607,7 +607,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 		tr.fatLightmap = R_CreateImage( va( "_fatlightmap%d", 0 ), (const byte **)&fatbuffer,
 						tr.fatLightmapSize, tr.fatLightmapSize, 1,
-						IF_LIGHTMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
+						IF_NOPICMIP | IF_LIGHTMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
 		Com_AddToGrowList( &tr.lightmaps, tr.fatLightmap );
 
 		ri.Hunk_FreeTempMemory( fatbuffer );

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -2776,6 +2776,7 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			}
 			else if ( !Q_stricmp( token, "lightmap" ) )
 			{
+				imageBits |= IF_NOPICMIP;
 				stage->tcGen_Lightmap = true;
 				stage->tcGen_Environment = false;
 			}


### PR DESCRIPTION
Hardware that hangs with full size texture and full size lightmap does not hang with `1:4` texture and full size lightmap. While downscaling textures may give a 10% performance boost on low end old hardware, not downscaling lightmaps does not have any performance impact on the same hardware.

The fact lightmaps are downscaled looks like a bug: some lightmap format uses `IF_NOPICMIP` some does not. The code already assumes some lightmap have to not be downscaled.

So, this patch prevents all lightmaps to be downscaled, there is no alternative.

It seems there is no usage on earth to downscale the lightmap, and engine has still an option to use lightgrid to not read the lightmap (but GLSL code seems to be more complex for lightgrid, hence it is likely to produce larger shaders and run slower on very low end hardware when all features are disabled: there is a very short lightmap path for such scenario).