### PR TITLE
binds: allow to set modcase commands without / like everywhere else, vstr users can use vstr

### DIFF
--- a/src/engine/client/key_binding.cpp
+++ b/src/engine/client/key_binding.cpp
@@ -815,11 +815,11 @@ public:
 		{
 			if ( *v == '/' || *v == '\\' )
 			{
-				Cmd::BufferCommandTextAfter(va("%s\n", v + 1), true);
+				Cmd::BufferCommandTextAfter(v + 1, true);
 			}
 			else
 			{
-				Cmd::BufferCommandTextAfter(va("vstr %s\n", v), true);
+				Cmd::BufferCommandTextAfter(v, true);
 			}
 		}
 	}


### PR DESCRIPTION
Binds: allow to set modcase commands without / like everywhere else, vstr users can use `vstr`,
also make the code simpler, nowhere else the code requires ending `\n`.

Rogue commit stolen from dead #330.