### PR TITLE
renderer/tr_mesh: silent “R_AddMDVSurfaces: no such frame -2147483648” debug log spam on md3 models used in particles

### DIFF
--- a/src/engine/renderer/tr_mesh.cpp
+++ b/src/engine/renderer/tr_mesh.cpp
@@ -269,6 +269,20 @@ void R_AddMDVSurfaces( trRefEntity_t *ent )
 		ent->e.frame %= tr.currentModel->mdv[ 0 ]->numFrames;
 		ent->e.oldframe %= tr.currentModel->mdv[ 0 ]->numFrames;
 	}
+	else if ( ent->e.frame == -2147483648 )
+	{
+		/* HACK: It looks like the previous test is always
+		false with md3 models, e.frame is equal to -2147483648
+		with md3 models used in particles and equal to 0 with
+		others.
+		Setting them to zero when previous test is wrong and
+		this is the well-known boggy use case will silent the
+		later “R_AddMDVSurfaces: no such frame” debug log spam.
+		Other situation will still triggers the debug log.
+		Note that this is probably hiding a bug somewhere else. */
+		ent->e.frame = 0;
+		ent->e.oldframe = 0;
+	}
 
 	// compute LOD
 	if ( ent->e.renderfx & RF_FORCENOLOD )


### PR DESCRIPTION
I was really annoyed by such log spam, and I don't want to use `logs.suppression.enabled` for this (I would like to keep logs unsuppressed for other uses):

[![md3 particle weird log spam](https://dl.illwieckz.net/b/daemon/bugs/md3-particle-weird-log-spam/unvanquished_2020-09-05_185012_001.png)](https://dl.illwieckz.net/b/daemon/bugs/md3-particle-weird-log-spam/unvanquished_2020-09-05_185012_001.png)

While adding some more logging, I noticed that with our md3 models, the `ent->e.frame` thing is either `0` (typically a third person weapon md3 model), either `-2147483648` (it only and always with md3 models used in particles, like weapon  shell or gibs). So, I decided to silent that use case and to keep the debug log for some unknown other situation that may happen.

This is a **HACK**, maybe it is hiding another bug somewhere else. I don't know, but I'm really fed up by this.

Note: we don't have animated md3 models in Unvanquished anymore so I was not able to look at how they behave.

If you know how to fix this issue at its root cause, please do it! At least, now you have an entry point to start investigations…