### PR TITLE
sys/sdl_glimp: rewrite the workaround for Nvidia GT218 on 340 driver, fix #368

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1138,7 +1138,6 @@ static void GLimp_InitExtensions()
 		glConfig2.drawBuffersAvailable = true;
 	}
 
-	glConfig2.getProgramBinaryAvailable = false;
 	{
 		int formats = 0;
 


### PR DESCRIPTION
This may also match Quadro cards and not apply the workaround to all Nvidia products.