### PR TITLE
Fill window with dark grey at creation time, fix #373

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -722,6 +722,11 @@ static rserr_t GLimp_SetMode( int mode, bool fullscreen, bool noborder )
 			}
 			SDL_GL_SetSwapInterval( r_swapInterval->integer );
 
+			// Fill window with a dark grey (#141414) background.
+			glClearColor( 0.08f, 0.08f, 0.08f, 1.0f );
+			glClear( GL_COLOR_BUFFER_BIT );
+			GLimp_EndFrame();
+
 			glConfig.colorBits = testColorBits;
 			glConfig.depthBits = depthBits;
 			glConfig.stencilBits = stencilBits;


### PR DESCRIPTION
Attempt to fill window with black at creation time, to prevent this (and fix #373):

[![empty window](https://dl.illwieckz.net/b/daemon/bugs/empty-window/20200723-231745-000.unvanquished-empty-window.png)](https://dl.illwieckz.net/b/daemon/bugs/empty-window/20200723-231745-000.unvanquished-empty-window.png)

It works but I know nothing about OpenGL and SDL, so maybe I'm introducing a time bomb…

@gimhael or @Kangz, is it OK to do that?