### PR TITLE
disable useless heightMapInNormalMap if both normal and relief mapping are disabled, also fix #376

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4819,6 +4819,10 @@ static void CollapseStages()
 		stage->enableSpecularMapping = r_specularMapping->integer && stage->hasMaterialMap && !stage->isMaterialPhysical;
 		stage->enableGlowMapping = r_glowMapping->integer && stage->hasGlowMap;
 
+		// Finally disable useless heightMapInNormalMap if both normal and relief mapping are disabled.
+		// see https://github.com/DaemonEngine/Daemon/issues/376
+		stage->isHeightMapInNormalMap = stage->isHeightMapInNormalMap && ( stage->enableNormalMapping || stage->enableReliefMapping );
+
 		// Bind fallback textures if required.
 		if ( !stage->enableNormalMapping && !( stage->enableReliefMapping && stage->isHeightMapInNormalMap) )
 		{


### PR DESCRIPTION
Disable useless heightMapInNormalMap if both normal and relief mapping are disabled, fix #376.

Before:

[![wrong normal format detection disables shader](https://dl.illwieckz.net/b/daemon/bugs/wrong-normal-format-detection-disables-shader/unvanquished_2020-09-29_010422_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/wrong-normal-format-detection-disables-shader/unvanquished_2020-09-29_010422_000.jpg)

After:

[![wrong normal format detection disables shader](https://dl.illwieckz.net/b/daemon/bugs/wrong-normal-format-detection-disables-shader/unvanquished_2020-09-30_234455_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/wrong-normal-format-detection-disables-shader/unvanquished_2020-09-30_234455_000.jpg)

This bug is known to affect Nvidia Curie (Geforce 6000/7000 series) with driver Nvidia 304.

Root cause of #376 is fixed in #385. This commit is hardening the fix anyway.