### PR TITLE
tr_image: add debug log for undocumented formats and add more code names when listing images

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -329,6 +329,30 @@ void R_ImageList_f()
 				imageDataSize *= 4 / 4;
 				break;
 
+			case GL_COMPRESSED_RED_RGTC1:
+				Com_sprintf( buffer, sizeof( buffer ),  "RGTC1r   " );
+				out += buffer;
+				// TODO: find imageDataSize
+				break;
+
+			case GL_COMPRESSED_SIGNED_RED_RGTC1:
+				Com_sprintf( buffer, sizeof( buffer ),  "RGTC1Sr  " );
+				out += buffer;
+				// TODO: find imageDataSize
+				break;
+
+			case GL_COMPRESSED_RG_RGTC2:
+				Com_sprintf( buffer, sizeof( buffer ),  "RGTC2rg  " );
+				out += buffer;
+				// TODO: find imageDataSize
+				break;
+
+			case GL_COMPRESSED_SIGNED_RG_RGTC2:
+				Com_sprintf( buffer, sizeof( buffer ),  "RGTC2Srg " );
+				out += buffer;
+				// TODO: find imageDataSize
+				break;
+
 			case GL_DEPTH_COMPONENT16:
 				Com_sprintf( buffer, sizeof( buffer ),  "D16      " );
 				out += buffer;

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -300,9 +300,9 @@ void R_ImageList_f()
 				break;
 
 			case GL_COMPRESSED_RGBA:
-				Com_sprintf( buffer, sizeof( buffer ),  "      " );
+				Com_sprintf( buffer, sizeof( buffer ),  "RGBAC " );
 				out += buffer;
-				imageDataSize *= 4; // FIXME
+				// TODO: find imageDataSize
 				break;
 
 			case GL_COMPRESSED_RGB_S3TC_DXT1_EXT:

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -199,7 +199,8 @@ void R_ImageList_f()
 				break;
 
 			default:
-				Com_sprintf( buffer, sizeof( buffer ),  "???? " );
+				Log::Debug( "Undocumented image type %i for image %s", image->type, image->name );
+				Com_sprintf( buffer, sizeof( buffer ),  "%5i    ", image->type );
 				out += buffer;
 				imageDataSize = image->uploadWidth * image->uploadHeight;
 				break;
@@ -347,7 +348,8 @@ void R_ImageList_f()
 				break;
 
 			default:
-				Com_sprintf( buffer, sizeof( buffer ),  "????     " );
+				Log::Debug( "Undocumented image format %i for image %s", image->internalFormat, image->name );
+				Com_sprintf( buffer, sizeof( buffer ),  "%5i    ", image->internalFormat );
 				out += buffer;
 				imageDataSize *= 4;
 				break;
@@ -381,6 +383,7 @@ void R_ImageList_f()
 				break;
 
 			default:
+				Log::Debug( "Undocumented wrapType.s %i for image %s", Util::ordinal(image->wrapType.s), image->name );
 				Com_sprintf( buffer, sizeof( buffer ),  "s.%4i  ", Util::ordinal(image->wrapType.s) );
 				out += buffer;
 				break;
@@ -414,6 +417,7 @@ void R_ImageList_f()
 				break;
 
 			default:
+				Log::Debug( "Undocumented wrapType.t %i for image %s", Util::ordinal(image->wrapType.t), image->name );
 				Com_sprintf( buffer, sizeof( buffer ),  "t.%4i  ", Util::ordinal(image->wrapType.t));
 				out += buffer;
 				break;


### PR DESCRIPTION
Some improvements to help debugging:

- add debug log for unknown formats when listing images,
- add some code names for RGTC variant when listing images,
- add code name for compressed RGB when listing images.

Note that I made up myself the code names.

This is the way I did them:

- since `a` in `DXT1a` is for `alpha` channel, I made `RGTC1r` and `RGTC2rg` with `r` and `g` for `red` and `green`,
- since `F` in `RG32F` is for `float` type, I made `RGTC1Sr` and `RGTC2Srg` with `S` for `signed`,
- since `C` in `RGTC` if for `compression`, I made `RGBAC` with `C` for `compressed`.

I made this to investigate #375 and #376.

Before this PR:

```
 209:  128  128  yes   2D   ????     s.rept  t.rept   textures/shared_pk02_src/floor01_n
```

With debug logs added:

```
Debug: Undocumented image format 36285 for image textures/shared_pk02_src/floor01_n
 209:  128  128  yes   2D   36285    s.rept  t.rept   textures/shared_pk02_src/floor01_n
```

With new format code names:

```
 209:  128  128  yes   2D   RGTC2rg  s.rept  t.rept   textures/shared_pk02_src/floor01_n
```

Note that I don't know at all what `imageDataSize` is for, also, it looks like the game did not required it to be set for every formats.
So, I just copy-pasted the `DXT5` value, given `RGTC` looks to be a variant of `DXT5`. I flagged every of those lines so we know how to return at this code later. @gimhael, do you know something about it?

I'm in favor of merging this even if those values are not known to be good, because anyway before those commits those values were not set so the chance they were wrong was the same, and anyway those values seem to not be changed from the default one. This is probably not that hurting and it's flagged correctly as `FIXME`. On the other side, the addition of those debug logs and new code names are needed to make easier to debug the game (for example, #375).