### PR TITLE
Do not use lightTile code when tiled renderer is disabled, fix rendering on Radeon R300 with tiny ALU, fix #344

### DIFF
--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -424,20 +424,26 @@ void R_InitFBOs()
 	R_AttachFBOTexturePackedDepthStencil( tr.currentDepthImage->texnum );
 	R_CheckFBO( tr.mainFBO[1] );
 
-	tr.depthtile1FBO = R_CreateFBO( "_depthtile1", tr.depthtile1RenderImage->width, tr.depthtile1RenderImage->height );
-	R_BindFBO( tr.depthtile1FBO );
-	R_AttachFBOTexture2D( GL_TEXTURE_2D, tr.depthtile1RenderImage->texnum, 0 );
-	R_CheckFBO( tr.depthtile1FBO );
+	if ( r_dynamicLight->integer == 2 )
+	{
+		/* It's only required to create frame buffers only used by the
+		tiled dynamic lighting renderer when this feature is enabled. */
 
-	tr.depthtile2FBO = R_CreateFBO( "_depthtile2", tr.depthtile2RenderImage->width, tr.depthtile2RenderImage->height );
-	R_BindFBO( tr.depthtile2FBO );
-	R_AttachFBOTexture2D( GL_TEXTURE_2D, tr.depthtile2RenderImage->texnum, 0 );
-	R_CheckFBO( tr.depthtile2FBO );
+		tr.depthtile1FBO = R_CreateFBO( "_depthtile1", tr.depthtile1RenderImage->width, tr.depthtile1RenderImage->height );
+		R_BindFBO( tr.depthtile1FBO );
+		R_AttachFBOTexture2D( GL_TEXTURE_2D, tr.depthtile1RenderImage->texnum, 0 );
+		R_CheckFBO( tr.depthtile1FBO );
 
-	tr.lighttileFBO = R_CreateFBO( "_lighttile", tr.lighttileRenderImage->width, tr.lighttileRenderImage->height );
-	R_BindFBO( tr.lighttileFBO );
-	R_AttachFBOTexture3D( tr.lighttileRenderImage->texnum, 0, 0 );
-	R_CheckFBO( tr.lighttileFBO );
+		tr.depthtile2FBO = R_CreateFBO( "_depthtile2", tr.depthtile2RenderImage->width, tr.depthtile2RenderImage->height );
+		R_BindFBO( tr.depthtile2FBO );
+		R_AttachFBOTexture2D( GL_TEXTURE_2D, tr.depthtile2RenderImage->texnum, 0 );
+		R_CheckFBO( tr.depthtile2FBO );
+
+		tr.lighttileFBO = R_CreateFBO( "_lighttile", tr.lighttileRenderImage->width, tr.lighttileRenderImage->height );
+		R_BindFBO( tr.lighttileFBO );
+		R_AttachFBOTexture3D( tr.lighttileRenderImage->texnum, 0, 0 );
+		R_CheckFBO( tr.lighttileFBO );
+	}
 
 	if ( r_shadows->integer >= Util::ordinal(shadowingMode_t::SHADOWING_ESM16) && glConfig2.textureFloatAvailable )
 	{

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -342,7 +342,19 @@ void Tess_DrawArrays( GLenum elementType )
 		return;
 	}
 
-	// move tess data through the GPU, finally
+	/* Move tess data through the GPU, finally.
+
+	Radeon R300 small ALU is known to fail on this glDrawArrays call:
+
+	> r300 FP: Compiler Error:
+	> ../src/gallium/drivers/r300/compiler/r300_fragprog_emit.c::emit_alu(): Too many ALU instructions
+	> Using a dummy shader instead.
+	> r300 FP: Compiler Error:
+	> build_loop_info: Cannot find condition for if
+	> Using a dummy shader instead.
+
+	See https://github.com/DaemonEngine/Daemon/issues/344 */
+
 	glDrawArrays( elementType, 0, tess.numVertexes );
 
 	backEnd.pc.c_drawElements++;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -59,6 +59,12 @@ static void GLSL_InitGPUShadersOrError()
 		// directional sun lighting ( Doom3 style )
 		gl_shaderManager.load( gl_forwardLightingShader_directionalSun );
 	}
+	else if ( r_dynamicLight->integer == 2 )
+	{
+		gl_shaderManager.load( gl_depthtile1Shader );
+		gl_shaderManager.load( gl_depthtile2Shader );
+		gl_shaderManager.load( gl_lighttileShader );
+	}
 
 #if !defined( GLSL_COMPILE_STARTUP_ONLY )
 
@@ -140,10 +146,6 @@ static void GLSL_InitGPUShadersOrError()
 	{
 		Log::Warn("SSAO not used because GL_ARB_texture_gather is not available.");
 	}
-
-	gl_shaderManager.load( gl_depthtile1Shader );
-	gl_shaderManager.load( gl_depthtile2Shader );
-	gl_shaderManager.load( gl_lighttileShader );
 
 	if ( r_FXAA->integer != 0 )
 	{

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -949,6 +949,17 @@ static void R_InitTileVBO()
 	int       x, y, w, h;
 	vboData_t data;
 
+	if ( r_dynamicLight->integer != 2 ) {
+		/* This computation is part of the tiled dynamic lighting renderer,
+		it's better to not run it and save CPU cycles when such effects
+		are disabled.
+
+		There is no need to create vertex buffers that are only used by the
+		tiled dynamic lighting renderer when this feature is disabled. */
+
+		return;
+	}
+
 	R_SyncRenderThread();
 
 	w = tr.depthtile2RenderImage->width;


### PR DESCRIPTION
Do not call `RB_RenderPostDepth` when the tiled renderer is disabled. It looks like this function added in 0bb3550ce16ab7b165a88ebb365edf6b2837d1f5 is only used when the tiled renderer is enabled.

The light tile code is known to be too large for the tiny ALU of the Radeon R300 GPU. See #344.

With this simple modification, the R300s GPU like the X300, X550HM and X1050 become able to run the game.

Also rename `RB_RenderPostDepth` to `RB_RenderPostDepthLightTile` to make this characteristic more obvious when reading the code.

Also disable more light tile code when the tiled renderer is disabled, for better performance in that case.

With that PR merged, we know no one OpenGL 2.1+ hardware that is not able to render Unvanquished.

I would be happy to get a comment by @gimhael since I touched his code. Anyway that looks safe because I tested this code both when the tiled renderer was enabled and disabled without noticing any issue. Maybe some people has some idea for better implementation…?

To properly render the game on those GPUs, merging #377 is also required (bug fix) since those cards are also affected by #375, hence #376.

Here are some screenshots taken with a Radeon X1050 on Ubuntu 20.04, Linux 5.4.0 and Mesa 20.0.8.

As seen on a typical desktop (performance is greatly affected by a VNC server):

[![r300 small alu](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/20201005-045740-000.unvanquished-r300-small-alu.png)](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/20201005-045740-000.unvanquished-r300-small-alu.png)

The common Plat23 scene:

[![r300 small alu](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_065952_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_065952_000.jpg)

Some other scenes, we can see that like other OpenGL 2.1 cards, performance are heavily affected by models, especially alien ones. See https://github.com/Unvanquished/Unvanquished/issues/1207 about that.

[![r300 small alu](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_070000_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_070000_000.jpg)

[![r300 small alu](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_070006_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_070006_000.jpg)

[![r300 small alu](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_071154_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_071154_000.jpg)

[![r300 small alu](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_081200_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_081200_000.jpg)

[![r300 small alu](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_072501_000.png)](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_072501_000.png)

[![r300 small alu](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_072615_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_072615_000.jpg)

[![r300 small alu](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_072619_000.jpg)](https://dl.illwieckz.net/b/daemon/bugs/r300-small-alu/unvanquished_2020-10-05_072619_000.jpg)
