### PR TITLE
Fix fullscreen toggling bug (#365)

### DIFF
--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -81,7 +81,7 @@ namespace Cvar {
                 modified = true;
             } else {
                 if (Q_stricmp(var.string, cvar.value.c_str())) {
-                    Log::Notice("The change will take effect after restart.");
+                    Log::Notice("The change to %s will take effect after restart.", var.name);
                     if (var.latchedString) Z_Free(var.latchedString);
                     var.latchedString = CopyString(cvar.value.c_str());
                     modified = true;
@@ -283,7 +283,7 @@ namespace Cvar {
                         OnValueChangedResult undo = cvar->proxy->OnValueChanged(cvar->value);
                         ASSERT(undo.success);
                         if (setLatchedValuesCalled) {
-                            Log::Notice("The change will take effect after restart.");
+                            Log::Notice("The change to %s will take effect after restart.", cvarName);
                         }
                         cvar->latchedValue = value;
                         return;

--- a/src/engine/null/null_renderer.cpp
+++ b/src/engine/null/null_renderer.cpp
@@ -194,7 +194,6 @@ bool RE_BeginRegistration( glconfig_t *config, glconfig2_t *glconfig2 )
 	Com_Memset( config, 0, sizeof( glconfig_t ) );
 	config->vidWidth = 640;
 	config->vidHeight = 480;
-	config->windowAspect = 1.0f;
 	Com_Memset( glconfig2, 0, sizeof( glconfig2_t ) );
 
 	return true;

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -190,7 +190,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_customwidth;
 	cvar_t      *r_customheight;
-	cvar_t      *r_customaspect;
 
 	cvar_t      *r_debugSurface;
 	cvar_t      *r_simpleMipMaps;
@@ -469,7 +468,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	};
 	static const int s_numVidModes = ARRAY_LEN( r_vidModes );
 
-	bool R_GetModeInfo( int *width, int *height, float *windowAspect, int mode )
+	bool R_GetModeInfo( int *width, int *height, int mode )
 	{
 		const vidmode_t *vm;
 
@@ -486,13 +485,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 		if( mode == -2)
 		{
 			// Must set width and height to display size before calling this function!
-			*windowAspect = ( float ) *width / *height;
 		}
 		else if ( mode == -1 )
 		{
 			*width = r_customwidth->integer;
 			*height = r_customheight->integer;
-			*windowAspect = r_customaspect->value;
 		}
 		else
 		{
@@ -500,7 +497,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 			*width = vm->width;
 			*height = vm->height;
-			*windowAspect = ( float ) vm->width / ( vm->height * vm->pixelAspect );
 		}
 
 		return true;
@@ -1068,7 +1064,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_fullscreen = ri.Cvar_Get( "r_fullscreen", "1", CVAR_ARCHIVE );
 		r_customwidth = ri.Cvar_Get( "r_customwidth", "1600", CVAR_LATCH | CVAR_ARCHIVE );
 		r_customheight = ri.Cvar_Get( "r_customheight", "1024", CVAR_LATCH | CVAR_ARCHIVE );
-		r_customaspect = ri.Cvar_Get( "r_customaspect", "1", CVAR_LATCH );
 		r_simpleMipMaps = ri.Cvar_Get( "r_simpleMipMaps", "0", CVAR_LATCH );
 		r_subdivisions = ri.Cvar_Get( "r_subdivisions", "4", CVAR_LATCH );
 		r_dynamicLightCastShadows = ri.Cvar_Get( "r_dynamicLightCastShadows", "1", 0 );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3177,7 +3177,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 
 	bool   R_Init();
 
-	bool   R_GetModeInfo( int *width, int *height, float *windowAspect, int mode );
+	bool   R_GetModeInfo( int *width, int *height, int mode );
 
 	void       R_ImageList_f();
 	void       R_SkinList_f();

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -357,9 +357,6 @@ struct glconfig_t
 
 	int   displayFrequency;
 
-	// synonymous with "does rendering consume the entire screen?", therefore
-	// a Win32 ICD that used CDS will have this set to TRUE
-	bool8_t isFullscreen;
 	bool8_t smpActive; // dual processor
 };
 

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -351,9 +351,6 @@ struct glconfig_t
 	float                maxAnisotropy; //----(SA)  added
 
 	int      vidWidth, vidHeight;
-	// aspect is the screen's physical width / height, which may be different
-	// than scrWidth / scrHeight if the pixels are non-square
-	float windowAspect;
 
 	int   displayFrequency;
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -593,7 +593,6 @@ static rserr_t GLimp_SetMode( int mode, bool fullscreen, bool noborder )
 		if ( fullscreen )
 		{
 			flags |= SDL_WINDOW_FULLSCREEN;
-			glConfig.isFullscreen = true;
 		}
 		else
 		{
@@ -601,8 +600,6 @@ static rserr_t GLimp_SetMode( int mode, bool fullscreen, bool noborder )
 			{
 				flags |= SDL_WINDOW_BORDERLESS;
 			}
-
-			glConfig.isFullscreen = false;
 		}
 
 		colorBits = r_colorbits->integer;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -553,10 +553,8 @@ static rserr_t GLimp_SetMode( int mode, bool fullscreen, bool noborder )
 			glConfig.vidHeight = 480;
 			logger.Notice("Cannot determine display resolution, assuming 640x480" );
 		}
-
-		glConfig.windowAspect = ( float ) glConfig.vidWidth / ( float ) glConfig.vidHeight;
 	}
-	else if ( !R_GetModeInfo( &glConfig.vidWidth, &glConfig.vidHeight, &glConfig.windowAspect, mode ) )
+	else if ( !R_GetModeInfo( &glConfig.vidWidth, &glConfig.vidHeight, mode ) )
 	{
 		logger.Notice(" invalid mode" );
 		return rserr_t::RSERR_INVALID_MODE;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "sdl_icon.h"
 #include "SDL_syswm.h"
 #include "framework/CommandSystem.h"
+#include "framework/CvarSystem.h"
 
 static Log::Logger logger("glconfig", "", Log::Level::NOTICE);
 
@@ -561,8 +562,13 @@ static rserr_t GLimp_SetMode( int mode, bool fullscreen, bool noborder )
 	}
 
 	logger.Notice(" %d %d", glConfig.vidWidth, glConfig.vidHeight );
+	// HACK: We want to set the current value, not the latched value
+	Cvar::ClearFlags("r_customwidth", CVAR_LATCH);
+	Cvar::ClearFlags("r_customheight", CVAR_LATCH);
 	Cvar_Set( "r_customwidth", va("%d", glConfig.vidWidth ) );
 	Cvar_Set( "r_customheight", va("%d", glConfig.vidHeight ) );
+	Cvar::AddFlags("r_customwidth", CVAR_LATCH);
+	Cvar::AddFlags("r_customheight", CVAR_LATCH);
 
 	sscanf( ( const char * ) glewGetString( GLEW_VERSION ), "%d.%d.%d",
 		&GLEWmajor, &GLEWminor, &GLEWmicro );

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -592,12 +592,10 @@ static rserr_t GLimp_SetMode( int mode, bool fullscreen, bool noborder )
 		{
 			flags |= SDL_WINDOW_FULLSCREEN;
 		}
-		else
+
+		if ( noborder )
 		{
-			if ( noborder )
-			{
-				flags |= SDL_WINDOW_BORDERLESS;
-			}
+			flags |= SDL_WINDOW_BORDERLESS;
 		}
 
 		colorBits = r_colorbits->integer;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1179,7 +1179,7 @@ bool GLimp_Init()
 	glConfig.driverType = glDriverType_t::GLDRV_ICD;
 
 	r_sdlDriver = ri.Cvar_Get( "r_sdlDriver", "", CVAR_ROM );
-	r_allowResize = ri.Cvar_Get( "r_allowResize", "0", 0 );
+	r_allowResize = ri.Cvar_Get( "r_allowResize", "0", CVAR_LATCH );
 	r_centerWindow = ri.Cvar_Get( "r_centerWindow", "0", 0 );
 	r_displayIndex = ri.Cvar_Get( "r_displayIndex", "0", 0 );
 	ri.Cvar_Get( "r_availableModes", "", CVAR_ROM );
@@ -1390,6 +1390,8 @@ void GLimp_HandleCvars()
 
 		r_noBorder->modified = false;
 	}
+
+	// TODO: Update r_allowResize using SDL_SetWindowResizable when we have SDL 2.0.5
 }
 
 void GLimp_LogComment( const char *comment )

--- a/src/engine/sys/sdl_input.cpp
+++ b/src/engine/sys/sdl_input.cpp
@@ -611,7 +611,10 @@ static void IN_ShutdownJoystick()
 		stick = nullptr;
 	}
 
-	SDL_QuitSubSystem( SDL_INIT_JOYSTICK );
+	if ( SDL_WasInit( SDL_INIT_JOYSTICK ) )
+	{
+		SDL_QuitSubSystem( SDL_INIT_JOYSTICK );
+	}
 }
 
 static void QueueKeyEvent(Keyboard::Key key, bool down)

--- a/src/engine/sys/sdl_input.cpp
+++ b/src/engine/sys/sdl_input.cpp
@@ -1136,6 +1136,10 @@ static void IN_ProcessEvents( bool dropInput )
 				switch( e.window.event )
 				{
 					case SDL_WINDOWEVENT_RESIZED:
+						extern cvar_t* r_allowResize;
+						// Toggling r_fullscreen does not work well when r_allowResize is enabled -
+						// it generates spurious resize events.
+						if ( r_allowResize->integer )
 						{
 							char width[32], height[32];
 							Com_sprintf( width, sizeof( width ), "%d", e.window.data1 );


### PR DESCRIPTION
This makes it possible to toggle r_fullscreen more than once without getting stuck.

Still want to look at a couple other things:

- Delete the code that makes (undesirable) changes to window cvars in response to SDL window resize events
- I noticed that toggling r_noBorder repeatedly causes a growing black space in the window.