### PR TITLE
avoid some useless texture OpenGL bind for unused feature

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -93,11 +93,8 @@ static void GLSL_InitGPUShadersOrError()
 	// global fog post process effect
 	gl_shaderManager.load( gl_fogGlobalShader );
 
-	if ( r_heatHaze->integer != 0 )
-	{
-		// heatHaze post process effect
-		gl_shaderManager.load( gl_heatHazeShader );
-	}
+	// heatHaze post process effect
+	gl_shaderManager.load( gl_heatHazeShader );
 
 	// NOTE: screen shader seems to be only used by bloom post process effect.
 	if ( r_bloom->integer != 0 )
@@ -2013,6 +2010,11 @@ static void Render_heatHaze( int stage )
 	shaderStage_t *pStage = tess.surfaceStages[ stage ];
 
 	GLimp_LogComment( "--- Render_heatHaze ---\n" );
+
+	if ( r_heatHaze->integer == 0 )
+	{
+		return;
+	}
 
 	// remove alpha test
 	stateBits = pStage->stateBits;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -691,7 +691,10 @@ static void Render_generic( int stage )
 		GL_BindToTMU( 1, tr.currentDepthImage );
 	}
 
-	GL_BindToTMU( 8, tr.lighttileRenderImage );
+	if ( r_dynamicLight->integer == 2 )
+	{
+		GL_BindToTMU( 8, tr.lighttileRenderImage );
+	}
 
 	gl_genericShader->SetRequiredVertexPointers();
 
@@ -907,7 +910,10 @@ static void Render_lightMapping( int stage )
 	}
 
 	// bind u_LightTiles
-	GL_BindToTMU( BIND_LIGHTTILES, tr.lighttileRenderImage );
+	if ( r_dynamicLight->integer == 2 )
+	{
+		GL_BindToTMU( BIND_LIGHTTILES, tr.lighttileRenderImage );
+	}
 
 	// u_DeformGen
 	gl_lightMappingShader->SetUniform_Time( backEnd.refdef.floatTime - backEnd.currentEntity->e.shaderTime );
@@ -959,7 +965,10 @@ static void Render_lightMapping( int stage )
 	}
 
 	// bind u_NormalMap
-	GL_BindToTMU( BIND_NORMALMAP, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
+	if ( !!r_normalMapping->integer || pStage->isHeightMapInNormalMap )
+	{
+		GL_BindToTMU( BIND_NORMALMAP, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
+	}
 
 	// bind u_NormalScale
 	if ( pStage->enableNormalMapping )
@@ -971,7 +980,10 @@ static void Render_lightMapping( int stage )
 	}
 
 	// bind u_MaterialMap
-	GL_BindToTMU( BIND_MATERIALMAP, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
+	if ( !!r_specularMapping->integer || pStage->enablePhysicalMapping )
+	{
+		GL_BindToTMU( BIND_MATERIALMAP, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
+	}
 
 	if ( pStage->enableSpecularMapping )
 	{
@@ -1093,7 +1105,10 @@ static void Render_lightMapping( int stage )
 	GL_BindToTMU( BIND_DELUXEMAP, deluxemap );
 
 	// bind u_GlowMap
-	GL_BindToTMU( BIND_GLOWMAP, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
+	if ( !!r_glowMapping->integer )
+	{
+		GL_BindToTMU( BIND_GLOWMAP, pStage->bundle[ TB_GLOWMAP ].image[ 0 ] );
+	}
 
 	gl_lightMappingShader->SetRequiredVertexPointers();
 


### PR DESCRIPTION
Some really minor change.

1. avoid some useless texture OpenGL bind for unused feature (note: I left intact the forward renderer and other less tested code),
2. a tiny rewriting to move a test outside of a function to inside the function to be consistent with the way other function do.