### PR TITLE
some revamp on IQM and MD5 model code

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1123,7 +1123,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_vboTriangles = ri.Cvar_Get( "r_vboTriangles", "1", CVAR_CHEAT );
 		r_vboShadows = ri.Cvar_Get( "r_vboShadows", "1", CVAR_CHEAT );
 		r_vboLighting = ri.Cvar_Get( "r_vboLighting", "1", CVAR_CHEAT );
-		r_vboModels = ri.Cvar_Get( "r_vboModels", "1", 0 );
+		r_vboModels = ri.Cvar_Get( "r_vboModels", "1", CVAR_LATCH );
 		r_vboVertexSkinning = ri.Cvar_Get( "r_vboVertexSkinning", "1",  CVAR_LATCH );
 		r_vboDeformVertexes = ri.Cvar_Get( "r_vboDeformVertexes", "1",  CVAR_LATCH );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2208,6 +2208,9 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		int8_t   parentIndex; // parent index (-1 if root)
 		vec3_t   origin;
 		quat_t   rotation;
+
+		// Precompute transform like IQM.
+		transform_t joint;
 	};
 
 	struct md5Model_t

--- a/src/engine/renderer/tr_model_iqm.cpp
+++ b/src/engine/renderer/tr_model_iqm.cpp
@@ -786,7 +786,7 @@ bool R_LoadIQModel( model_t *mod, void *buffer, int filesize,
 		} else {
 			weightbuf = nullptr;
 		}
-
+		
 		qtangentbuf = (i16vec4_t *)ri.Hunk_AllocateTempMemory( sizeof( i16vec4_t ) * IQModel->num_vertexes );
 
 		for(int i = 0; i < IQModel->num_vertexes; i++ ) {
@@ -825,6 +825,16 @@ bool R_LoadIQModel( model_t *mod, void *buffer, int filesize,
 	} else {
 		vbo = nullptr;
 		ibo = nullptr;
+
+		if( IQModel->blendWeights ) {
+			for( int i = 0; i < IQModel->num_vertexes; i++ ) {
+				if( IQModel->blendWeights[ 4 * i + 0 ] == 0 &&
+				    IQModel->blendWeights[ 4 * i + 1 ] == 0 &&
+				    IQModel->blendWeights[ 4 * i + 2 ] == 0 &&
+				    IQModel->blendWeights[ 4 * i + 3 ] == 0 )
+					IQModel->blendWeights[ 4 * i + 0 ] = 255;
+			}
+		}
 	}
 
 	// register shaders

--- a/src/engine/renderer/tr_model_md5.cpp
+++ b/src/engine/renderer/tr_model_md5.cpp
@@ -193,6 +193,10 @@ bool R_LoadMD5( model_t *mod, void *buffer, const char *modName )
 		VectorCopy( boneOrigin, bone->origin );
 		QuatCopy( boneQuat, bone->rotation );
 
+		// Precompute transform like IQM.
+		TransInitRotationQuat( bone->rotation, &bone->joint );
+		TransAddTranslation( bone->origin, &bone->joint );
+
 		// skip )
 		token = COM_ParseExt2( &buf_p, false );
 

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1265,8 +1265,7 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 	{
 		for ( ; bone < lastBone; bone++ )
 		{
-			TransInit( bone );
-			TransAddScale( entityScale, bone );
+			TransInitScale( entityScale, bone );
 			TransInsScale( modelScale, bone );
 		}
 	}
@@ -1635,8 +1634,7 @@ static void Tess_SurfaceVBOMD5Mesh( srfVBOMD5Mesh_t *srf )
 	{
 		for ( ; bone < lastBone; bone++ )
 		{
-			TransInit( bone );
-			TransAddScale( entityScale, bone );
+			TransInitScale( entityScale, bone );
 			TransInsScale( modelScale, bone );
 		}
 	}

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1607,9 +1607,7 @@ static void Tess_SurfaceVBOMD5Mesh( srfVBOMD5Mesh_t *srf )
 			refBone_t *entityBone = &backEnd.currentEntity->e.skeleton.bones[ *boneRemapInverse ];
 			md5Bone_t *modelBone = &model->bones[ *boneRemapInverse ];
 
-			TransInitRotationQuat( modelBone->rotation, bone );
-			TransAddTranslation( modelBone->origin, bone );
-			TransInverse( bone, bone );
+			TransInverse( &modelBone->joint, bone );
 			TransCombine( bone, &entityBone->t, bone );
 			TransAddScale( entityScale, bone );
 			TransInsScale( modelScale, bone );

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1342,14 +1342,6 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 			{
 				vec3_t position, tmp;
 
-				if( modelBlendWeight[ 0 ] == 0 &&
-					modelBlendWeight[ 1 ] == 0 &&
-					modelBlendWeight[ 2 ] == 0 &&
-					modelBlendWeight[ 3 ] == 0 )
-				{
-					modelBlendWeight[ 0 ] = 255;
-				}
-
 				VectorClear( position );
 
 				byte *lastBlendIndex = modelBlendIndex + 4;
@@ -1384,14 +1376,6 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 				modelTexcoord += 2 )
 			{
 				vec3_t position, tangent, binormal, normal, tmp;
-
-				if( modelBlendWeight[ 0 ] == 0 &&
-					modelBlendWeight[ 1 ] == 0 &&
-					modelBlendWeight[ 2 ] == 0 &&
-					modelBlendWeight[ 3 ] == 0 )
-				{
-					modelBlendWeight[ 0 ] = 255;
-				}
 
 				VectorClear( position );
 				VectorClear( normal );

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1586,6 +1586,14 @@ static void Tess_SurfaceVBOMD5Mesh( srfVBOMD5Mesh_t *srf )
 	R_BindVBO( srf->vbo );
 	R_BindIBO( srf->ibo );
 
+	// Tess_SurfaceMD5 has this, is it useful?
+	tess.attribsSet |= ATTR_POSITION | ATTR_TEXCOORD;
+
+	if ( !tess.skipTangentSpaces )
+	{
+		tess.attribsSet |= ATTR_QTANGENT;
+	}
+
 	tess.numIndexes = srf->numIndexes;
 	tess.numVertexes = srf->numVerts;
 	tess.numBones = srf->numBoneRemap;
@@ -1596,7 +1604,6 @@ static void Tess_SurfaceVBOMD5Mesh( srfVBOMD5Mesh_t *srf )
 	transform_t *bone = tess.bones;
 	transform_t *lastBone = bone + tess.numBones;
 
-	// Convert bones back to matrices.
 	if ( backEnd.currentEntity->e.skeleton.type == refSkeletonType_t::SK_ABSOLUTE )
 	{
 		int *boneRemapInverse = srf->boneRemapInverse;
@@ -1610,6 +1617,17 @@ static void Tess_SurfaceVBOMD5Mesh( srfVBOMD5Mesh_t *srf )
 			TransInverse( &modelBone->joint, bone );
 			TransCombine( bone, &entityBone->t, bone );
 			TransAddScale( entityScale, bone );
+			TransInsScale( modelScale, bone );
+		}
+	}
+	else if ( tess.skipTangentSpaces )
+	{
+		md5Bone_t *modelBone = model->bones;
+
+		for ( ; bone < lastBone; bone++,
+			modelBone++ )
+		{
+			TransCopy( &modelBone->joint, bone );
 			TransInsScale( modelScale, bone );
 		}
 	}

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1082,9 +1082,7 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 		for ( ; bone < lastBone; bone++,
 			modelBone++, entityBone++ )
 		{
-			TransInitRotationQuat( modelBone->rotation, bone );
-			TransAddTranslation( modelBone->origin, bone );
-			TransInverse( bone, bone );
+			TransInverse( &modelBone->joint, bone );
 			TransCombine( bone, &entityBone->t, bone );
 			TransAddScale( entityScale, bone );
 			TransInsScale( modelScale, bone );
@@ -1097,8 +1095,7 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 		for ( ; bone < lastBone; bone++,
 			modelBone++ )
 		{
-			TransInitRotationQuat( modelBone->rotation, bone );
-			TransAddTranslation( modelBone->origin, bone );
+			TransCopy( &modelBone->joint, bone );
 			TransInsScale( modelScale, bone );
 		}
 	}

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1358,6 +1358,11 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 				for ( ; modelBlendIndex < lastBlendIndex; modelBlendIndex++,
 					modelBlendWeight++ )
 				{
+					if ( *modelBlendWeight == 0 )
+					{
+						continue;
+					}
+
 					float weight = *modelBlendWeight * weightFactor;
 
 					TransformPoint( &bones[ *modelBlendIndex ], modelPosition, tmp );
@@ -1399,6 +1404,11 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 				for ( ; modelBlendIndex < lastBlendIndex; modelBlendIndex++,
 					modelBlendWeight++ )
 				{
+					if ( *modelBlendWeight == 0 )
+					{
+						continue;
+					}
+
 					float weight = *modelBlendWeight * weightFactor;
 
 					TransformPoint( &bones[ *modelBlendIndex ], modelPosition, tmp );


### PR DESCRIPTION
I was looking to see if there was a way to reduce engine side the impact of some model slowing down a lot the game on some older hardware (see https://github.com/Unvanquished/Unvanquished/issues/1207) so I incrementally did minor changes over minor changes to make it easier to read, understandable and refactorisable and in the end that was what I got.

Now I know why the performance drops so much, and any improvement to this code can't do magic. Anyway, this code now looks better and may even save some cycles (or rely less on compiler optimization). Also, two loops were rewritten at once in a way the code only iterate once for both.

I reported such changes to the MD5 model code and then it gave me some example to clean-up the IQM code a bit more in return.

There is two changes I have committed separately (see commits about `memcpy` and `memcmp`), that's two alternative implementation for a given code, those two commits are there for a question: is there something to gain from them? The idea why I thought about those alternate implementation is that we may assume `memcmp` and `memcpy` may have specific optimized code from standard library. I would like to know if it is better or not, so I can squash them or drop them.

Also, I made `r_vboModels` cvar a latched one, because it is required to restart the engine to see a change.

Basically, people can set `r_vboModels` to `0` to reproduce https://github.com/Unvanquished/Unvanquished/issues/1207 on any hardware.

The issue is that some Unvanquished models have too much bones for the hardware so some fast OpenGL feature cannot be used, despite the feature is supported.