### PR TITLE
deprecate forward renderer, requires r_dynamicLight to be -1

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -546,7 +546,7 @@ static std::string GenEngineConstants() {
 			AddDefine( str, "r_ShowParallelShadowSplits", 1 );
 	}
 
-	if ( r_dynamicLight->integer )
+	if ( r_dynamicLight->integer != 0 )
 	{
 		AddDefine( str, "r_dynamicLight", r_dynamicLight->integer );
 	}

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -2771,7 +2771,7 @@ void RB_RenderPostDepthLightTile()
 
 	GLimp_LogComment( "--- RB_RenderPostDepthLightTile ---\n" );
 
-	if ( r_dynamicLight->integer != 2 )
+	if ( r_dynamicLight->integer < 1 )
 	{
 		/* Do not run lightTile code when the tiled renderer is not used.
 

--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -424,7 +424,7 @@ void R_InitFBOs()
 	R_AttachFBOTexturePackedDepthStencil( tr.currentDepthImage->texnum );
 	R_CheckFBO( tr.mainFBO[1] );
 
-	if ( r_dynamicLight->integer == 2 )
+	if ( r_dynamicLight->integer > 0 )
 	{
 		/* It's only required to create frame buffers only used by the
 		tiled dynamic lighting renderer when this feature is enabled. */

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1151,6 +1151,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_noLightVisCull = ri.Cvar_Get( "r_noLightVisCull", "0", CVAR_CHEAT );
 		r_noInteractionSort = ri.Cvar_Get( "r_noInteractionSort", "0", CVAR_CHEAT );
 		r_dynamicLight = ri.Cvar_Get( "r_dynamicLight", "2", CVAR_LATCH | CVAR_ARCHIVE );
+
 		r_staticLight = ri.Cvar_Get( "r_staticLight", "2", CVAR_ARCHIVE );
 		r_drawworld = ri.Cvar_Get( "r_drawworld", "1", CVAR_CHEAT );
 		r_portalOnly = ri.Cvar_Get( "r_portalOnly", "0", CVAR_CHEAT );

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -2363,14 +2363,16 @@ void R_AddLightInteractions()
 				continue;
 			}
 		} else if ( light->l.inverseShadows ) {
-			if( !r_dynamicLight->integer ) {
+			if( r_dynamicLight->integer == 0 ) {
 				light->cull = CULL_OUT;
 				continue;
 			}
 		} else {
-			if ( r_dynamicLight->integer != 1 )
+			// Deprecated forward renderer uses r_dynamicLight -1
+			if ( r_dynamicLight->integer > -1 )
 			{
-				if( r_dynamicLight->integer == 2 ) {
+				if( r_dynamicLight->integer > 0 )
+				{
 					tr.refdef.numShaderLights++;
 					tr.pc.c_dlights++;
 				}
@@ -2561,7 +2563,8 @@ void R_AddLightBoundsToVisBounds()
 		}
 		else
 		{
-			if ( r_dynamicLight->integer != 1 )
+			// Deprecated forward renderer uses r_dynamicLight -1
+			if ( r_dynamicLight->integer > -1 )
 			{
 				continue;
 			}

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -48,7 +48,8 @@ static void GLSL_InitGPUShadersOrError()
 	// standard light mapping
 	gl_shaderManager.load( gl_lightMappingShader );
 
-	if ( r_dynamicLight->integer == 1 )
+	// Deprecated forward renderer uses r_dynamicLight -1
+	if ( r_dynamicLight->integer < 0 )
 	{
 		// omni-directional specular bump mapping ( Doom3 style )
 		gl_shaderManager.load( gl_forwardLightingShader_omniXYZ );
@@ -59,7 +60,7 @@ static void GLSL_InitGPUShadersOrError()
 		// directional sun lighting ( Doom3 style )
 		gl_shaderManager.load( gl_forwardLightingShader_directionalSun );
 	}
-	else if ( r_dynamicLight->integer == 2 )
+	else if ( r_dynamicLight->integer > 0 )
 	{
 		gl_shaderManager.load( gl_depthtile1Shader );
 		gl_shaderManager.load( gl_depthtile2Shader );

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -949,7 +949,7 @@ static void R_InitTileVBO()
 	int       x, y, w, h;
 	vboData_t data;
 
-	if ( r_dynamicLight->integer != 2 ) {
+	if ( r_dynamicLight->integer < 1 ) {
 		/* This computation is part of the tiled dynamic lighting renderer,
 		it's better to not run it and save CPU cycles when such effects
 		are disabled.


### PR DESCRIPTION
With this, positive value for `r_dynamicLight ` would enable the tiled renderer, which is the only verified one for dynamic lights.

- This ensure people already having this value set to 1 will get the best we have on 0.52.0 release,
- This ensure people setting this value to 1 will not get what they don't expect.

In the future, we may do “if value equals to 2 then set 1”, but for the moment we can live with any positive value to enable the tiled renderer (and it allows 0.51 and 0.52 cohabitation).

At some point in the future we would want to nuke the forward renderer. In fact it already started to rot: the dynamic lighting seems to be broken. I'm a bit concerned about such huge code deletion since some features are not yet ported (things like real time shadows which is really buggy anyway, and sun lighting, I don't know how to test but I would like to be used).