### PR TITLE
Remove DEPS_DIR from Mac rpath

### DIFF
--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -335,7 +335,7 @@ endif()
 if (APPLE)
     add_definitions(-DMACOS_X)
     set_linker_flag("-Wl,-no_pie")
-    set(CMAKE_INSTALL_RPATH "@executable_path/;${DEPS_DIR};${DEPS_DIR}/lib")
+    set(CMAKE_INSTALL_RPATH "@executable_path")
     set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 endif()
 


### PR DESCRIPTION
It is redundant since we have the executable's directory in the rpath
also, and we copy the dependencies to this directory in the build.

Fixes #387.