### PR TITLE
WIP: resize textures using GL_PROXY mechanism (and other things)

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -92,6 +92,8 @@ set(RENDERERLIST
     ${ENGINE_DIR}/renderer/tr_fbo.cpp
     ${ENGINE_DIR}/renderer/tr_flares.cpp
     ${ENGINE_DIR}/renderer/tr_font.cpp
+    ${ENGINE_DIR}/renderer/InternalImage.cpp
+    ${ENGINE_DIR}/renderer/InternalImage.h
     ${ENGINE_DIR}/renderer/tr_image.cpp
     ${ENGINE_DIR}/renderer/tr_image.h
     ${ENGINE_DIR}/renderer/tr_image_crn.cpp

--- a/src/engine/renderer/InternalImage.cpp
+++ b/src/engine/renderer/InternalImage.cpp
@@ -1,0 +1,129 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2013-2016 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Daemon developers nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// InternalImage.cpp
+#include "tr_local.h"
+
+// Comments may include short quotes from other authors.
+
+int R_GetImageCustomScalingStep( const image_t *image, imageParams_t *imageParams )
+{
+	int scalingStep = 0;
+
+	// Perform optional picmip operation.
+	if ( !( image->bits & IF_NOPICMIP ) )
+	{
+		int imageMinDimension = std::max( -1, r_imageMinDimension->integer );
+		int imageMaxDimension = std::max( 0, r_imageMaxDimension->integer );
+		int shaderMinDimension = 0;
+		int shaderMaxDimension = 0;
+
+		if ( imageParams != nullptr )
+		{
+			shaderMinDimension = std::max( 0, imageParams->minDimension );
+			shaderMaxDimension = std::max( 0, imageParams->maxDimension );
+		}
+
+		// If shader has imageMaxDimension value set, enforce downscaling using this value.
+		if ( shaderMaxDimension != 0 )
+		{
+			// Except if r_imageMaxDimension is set and smaller.
+			if ( imageMaxDimension == 0 || imageMaxDimension >= shaderMaxDimension )
+			{
+				imageMaxDimension = shaderMaxDimension;
+			}
+		}
+
+		// If r_imageMinDimension == -1 and shader has imageMinDimension value set, keep original size.
+		if ( imageMinDimension == -1 && shaderMinDimension != 0 )
+		{
+			imageMaxDimension = 0;
+		}
+
+		if ( imageMaxDimension != 0 )
+		{
+			// If image has imageMinDimension value set and r_imageMinDimension > 0,
+			// use greater value between imageMinDimension and imageMaxDimension.
+			if ( shaderMinDimension > 0 && imageMinDimension > 0 )
+			{
+				imageMaxDimension = std::max( imageMinDimension, imageMaxDimension );
+			}
+
+			// Do not downscale this image below imageMinDimension size.
+			if ( imageMaxDimension < shaderMinDimension )
+			{
+				imageMaxDimension = shaderMinDimension;
+			}
+
+			// Downscale image to imageMaxDimension size.
+			int scaledWidth = image->width;
+			int scaledHeight = image->height;
+
+			while ( imageMaxDimension < scaledWidth || imageMaxDimension < scaledHeight )
+			{
+				scaledWidth >>= 1;
+				scaledHeight >>= 1;
+				scalingStep++;
+			}
+		}
+
+		scalingStep = std::max( scalingStep, std::max( 0, r_picmip->integer ) );
+	}
+
+	return scalingStep;
+}
+
+void R_DownscaleImageDimensions( int scalingStep, int *scaledWidth, int *scaledHeight, const byte ***dataArray, int numLayers, int *numMips )
+{
+	if ( scalingStep > 0 )
+	{
+		*scaledWidth >>= scalingStep;
+		*scaledHeight >>= scalingStep;
+
+		if( *dataArray && *numMips > scalingStep ) {
+			*dataArray += numLayers * scalingStep;
+			*numMips -= scalingStep;
+		}
+	}
+
+	// Clamp to minimum size.
+	if ( *scaledWidth < 1 )
+	{
+		*scaledWidth = 1;
+	}
+
+	if ( *scaledHeight < 1 )
+	{
+		*scaledHeight = 1;
+	}
+}

--- a/src/engine/renderer/InternalImage.cpp
+++ b/src/engine/renderer/InternalImage.cpp
@@ -36,6 +36,731 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Comments may include short quotes from other authors.
 
+/*
+===============
+GetInternalImageSize
+
+Returns internal size in GPU memory in bytes.
+===============
+*/
+int R_GetInternalImageSize( const image_t *image )
+{
+
+	constexpr int s8 = 8;
+	constexpr int s16 = 16;
+	constexpr int i8 = 8;
+	constexpr int i16 = 16;
+	constexpr int i32 = 32;
+	constexpr int ui2= 2;
+	constexpr int ui8 = 8;
+	constexpr int ui10 = 10;
+	constexpr int ui16 = 16;
+	constexpr int ui32 = 32;
+	constexpr int f10 = 10;
+	constexpr int f11 = 11;
+	constexpr int f16 = 16;
+	constexpr int f32 = 32;
+
+	int texelPerBlock = 1;
+	int texelDivisor = 1;
+
+	int texelSize;
+	int imageSize;
+
+	int texelCount = image->uploadWidth * image->uploadHeight;
+
+	switch ( image->internalFormat )
+	{
+		/* Sized formats
+
+		Values described as:
+			red + green + blue + alpha + shared
+		borrowed from:
+			https://www.khronos.org/opengl/wiki/GLAPI/glTexStorage3D */
+
+		case GL_R8:
+			texelSize = 8;
+			break;
+		case GL_R8_SNORM:
+			texelSize = s8;
+			break;
+		case GL_R16:
+			texelSize = 16;
+			break;
+		case GL_R16_SNORM:
+			texelSize = s16;
+			break;
+		case GL_RG8:
+			texelSize = 8 + 8;
+			break;
+		case GL_RG8_SNORM:
+			texelSize = s8 + s8;
+			break;
+		case GL_RG16:
+			texelSize = 16 + 16;
+			break;
+		case GL_RG16_SNORM:
+			texelSize = s16 + s16;
+			break;
+		case GL_R3_G3_B2:
+			texelSize = 3 + 3 + 2;
+			break;
+		case GL_RGB4:
+			texelSize = 4 + 4 + 4;
+			break;
+		case GL_RGB5:
+			texelSize = 5 + 5 + 5;
+			break;
+		case GL_RGB8:
+			texelSize = 8 + 8 + 8;
+			break;
+		case GL_RGB8_SNORM:
+			texelSize = s8 + s8 + s8;
+			break;
+		case GL_RGB10:
+			texelSize = 10 + 10 + 10;
+			break;
+		case GL_RGB12:
+			texelSize = 12 + 12 + 12;
+			break;
+		case GL_RGB16_SNORM:
+			texelSize = 16 + 16 + 16;
+			break;
+		case GL_RGBA2:
+			texelSize = 2 + 2 + 2 + 2;
+			break;
+		case GL_RGBA4:
+			texelSize = 4 + 4 + 4 + 4;
+			break;
+		case GL_RGB5_A1:
+			texelSize = 5 + 5 + 5 + 1;
+			break;
+		case GL_RGBA8:
+			texelSize = 8 + 8 + 8 + 8;
+			break;
+		case GL_RGBA8_SNORM:
+			texelSize = s8 + s8 + s8 + s8;
+			break;
+		case GL_RGB10_A2:
+			texelSize = 10 + 10 + 10 + 2;
+			break;
+		case GL_RGB10_A2UI:
+			texelSize = ui10 + ui10 + ui10 + ui2;
+			break;
+		case GL_RGBA12:
+			texelSize = 12 + 12 + 12 + 12;
+			break;
+		case GL_RGBA16:
+			texelSize = 16 + 16 + 16 + 16;
+			break;
+		case GL_SRGB8:
+			texelSize = 8 + 8 + 8;
+			break;
+		case GL_SRGB8_ALPHA8:
+			texelSize = 8 + 8 + 8 + 8;
+			break;
+		case GL_R16F:
+			texelSize = f16;
+			break;
+		case GL_RG16F:
+			texelSize = f16 + f16;
+			break;
+		case GL_RGB16F:
+			texelSize = f16 + f16 + f16;
+			break;
+		case GL_RGBA16F:
+			texelSize = f16 + f16 + f16 + f16;
+			break;
+		case GL_R32F:
+			texelSize = f32;
+			break;
+		case GL_RG32F:
+			texelSize = f32 + f32;
+			break;
+		case GL_RGB32F:
+			texelSize = f32 + f32 + f32;
+			break;
+		case GL_RGBA32F:
+			texelSize = f32 + f32 + f32 + f32;
+			break;
+		case GL_R11F_G11F_B10F:
+			texelSize = f11 + f11 + f10;
+			break;
+		case GL_RGB9_E5:
+			texelSize = 9 + 9 + 9 + 0 + 5;
+			break;
+		case GL_R8I:
+			texelSize = i8;
+			break;
+		case GL_R8UI:
+			texelSize = ui8;
+			break;
+		case GL_R16I:
+			texelSize = i16;
+			break;
+		case GL_R16UI:
+			texelSize = ui16;
+			break;
+		case GL_R32I:
+			texelSize = i32;
+			break;
+		case GL_R32UI:
+			texelSize = ui32;
+			break;
+		case GL_RG8I:
+			texelSize = i8 + i8;
+			break;
+		case GL_RG8UI:
+			texelSize = ui8 + ui8;
+			break;
+		case GL_RG16I:
+			texelSize = i16 + i16;
+			break;
+		case GL_RG16UI:
+			texelSize = ui16 + ui16;
+			break;
+		case GL_RG32I:
+			texelSize = i32 + i32;
+			break;
+		case GL_RG32UI:
+			texelSize = ui32 + ui32;
+			break;
+		case GL_RGB8I:
+			texelSize = i8 + i8 + i8;
+			break;
+		case GL_RGB8UI:
+			texelSize = ui8 + ui8 + ui8;
+			break;
+		case GL_RGB16I:
+			texelSize = i16 + i16 + i16;
+			break;
+		case GL_RGB16UI:
+			texelSize = ui16 + ui16 + ui16;
+			break;
+		case GL_RGB32I:
+			texelSize = i32 + i32 + i32;
+			break;
+		case GL_RGB32UI:
+			texelSize = ui32 + ui32 + ui32;
+			break;
+		case GL_RGBA8I:
+			texelSize = i8 + i8 + i8 + i8;
+			break;
+		case GL_RGBA8UI:
+			texelSize = ui8 + ui8 + ui8 + ui8;
+			break;
+		case GL_RGBA16I:
+			texelSize = i16 + i16 + i16 + i16;
+			break;
+		case GL_RGBA16UI:
+			texelSize = ui16 + ui16 + ui16 + ui16;
+			break;
+		case GL_RGBA32I:
+			texelSize = i32 + i32 + i32 + i32;
+			break;
+		case GL_RGBA32UI:
+			texelSize = ui32 + ui32 + ui32 + ui32;
+			break;
+
+		/* Sized depth and stencil formats
+
+		Values described as:
+			depth + stencil
+		borrowed from:
+			https://www.khronos.org/opengl/wiki/GLAPI/glTexStorage3D */
+
+		case GL_DEPTH_COMPONENT16:
+			texelSize = 16;
+			break;
+		case GL_DEPTH_COMPONENT24:
+			texelSize = 24;
+			break;
+		case GL_DEPTH_COMPONENT32:
+			texelSize = 32;
+			break;
+		case GL_DEPTH_COMPONENT32F:
+			texelSize = f32;
+			break;
+		case GL_DEPTH24_STENCIL8:
+			texelSize = 24 + 8;
+			break;
+		case GL_DEPTH32F_STENCIL8:
+			texelSize = f32 + 8;
+			break;
+		case GL_STENCIL_INDEX8:
+			texelSize = 0 + 8;
+			break;
+
+		/* ARB texture float formats
+
+		Values described as:
+			red + green + blue + alpha + luminance + intensity
+		borrowed from:
+			https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_texture_float.txt
+
+		Some are already defined without _ARB suffix:
+
+		case GL_RGB16F_ARB:
+			texelSize = f16 + f16 + f16;
+			break;
+		case GL_RGBA16F_ARB:
+			texelSize = f16 + f16 + f16 + f16;
+			break;
+		case GL_RGB32F_ARB:
+			texelSize = f32 + f32 + f32;
+			break;
+		case GL_RGBA32F_ARB:
+			texelSize = f32 + f32 + f32 + f32;
+			break;
+
+		But not the following ones. */
+
+		case GL_ALPHA16F_ARB:
+			texelSize = 0 + 0 + 0 + f16;
+			break;
+		case GL_LUMINANCE16F_ARB:
+			texelSize = 0 + 0 + 0 + 0 + f16;
+			break;
+		case GL_LUMINANCE_ALPHA16F_ARB:
+			texelSize = 0 + 0 + 0 + f16 + f16;
+			break;
+		case GL_INTENSITY16F_ARB:
+			texelSize = 0 + 0 + 0 + 0 + 0 + f16;
+			break;
+		case GL_ALPHA32F_ARB:
+			texelSize = 0 + 0 + 0 + f32;
+			break;
+		case GL_LUMINANCE32F_ARB:
+			texelSize = 0 + 0 + 0 + 0 + f32;
+			break;
+		case GL_LUMINANCE_ALPHA32F_ARB:
+			texelSize = 0 + 0 + 0 + f32 + f32;
+			break;
+		case GL_INTENSITY32F_ARB:
+			texelSize = 0 + 0 + 0 + 0 + 0 + f32;
+			break;
+
+		/* S3TC DXT1 RGB formats
+
+		> A DXT1-compressed image is an RGB image format.
+		> As such, the alpha of any color is assumed to be 1.
+		> Each 4x4 block takes up 64-bits of data, so compared
+		> to a 24-bit RGB format, it provides 6:1 compression.
+
+		> Each 4x4 block stores color data as follows. There
+		> are 2 16-bit color values, color0 followed by color1.
+		> Following this is a 32-bit unsigned integer containing
+		> values that describe how the two colors are combined to
+		> determine the color for a given texel.
+		-- https://www.khronos.org/opengl/wiki/S3_Texture_Compression
+
+		> Most compression formats have a fixed size of blocks. S3TC, BPTC,
+		> and RGTC all use 4x4 texel blocks. The byte sizes can be different
+		> based on different variations of the format. DXT1 in S3TC uses
+		> 8-byte blocks, while DXT3/5 use 16-byte blocks.
+		-- https://www.khronos.org/opengl/wiki/ASTC_Texture_Compression
+
+		So we can either do:
+			24 / 6 
+		or do:
+			( 16 + 16 + 32 ) / ( 4 * 4 )
+		or do:
+			( 8 * 8 ) / ( 4 * 4 )
+		which gives:
+			4
+
+		Also, texels are stored in 4×4 blocks:
+
+		The sRGB variant only uses different values to code colors.
+
+		Both DXT1, DXT3 and DXT5 are little-endian formats. */
+
+		case GL_COMPRESSED_RGB_S3TC_DXT1_EXT:
+			texelPerBlock = 16;
+			texelSize = 4;
+			break;
+		case GL_COMPRESSED_SRGB_S3TC_DXT1_EXT:
+			texelPerBlock = 16;
+			texelSize = 4;
+			break;
+
+		/* S3TC DXT1 RGBA compressed formats
+
+		> The format of the data is identical to the above case,
+		> which is why this is still DXT1 compression.
+		> The interpretation differs slightly.
+		-- https://www.khronos.org/opengl/wiki/S3_Texture_Compression
+
+		The sRGB variant only uses different values to code colors. */
+
+		case GL_COMPRESSED_RGBA_S3TC_DXT1_EXT:
+			texelPerBlock = 16;
+			texelSize = 4;
+			break;
+		case GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT:
+			texelPerBlock = 16;
+			texelSize = 4;
+			break;
+
+		/* S3TC DXT3 compressed formats
+
+		> The DXT3 format is an RGBA format. Each 4x4 block takes up
+		> 128 bits of data. Thus, compared to a 32-bit RGBA texture,
+		> it offers 4:1 compression.
+		> Each block of 128 bits is broken into 2 64-bit chunks.
+		> The second chunk contains the color information, compressed
+		> almost as in the DXT1 case;
+		> The alpha 64-bit chunk is stored as a little-endian 64-bit
+		> unsigned integer.
+		-- https://www.khronos.org/opengl/wiki/S3_Texture_Compression
+
+		So we can either do:
+			32 / 4
+		or do:
+			( 64 + 64 ) / ( 4 * 4 )
+		or do:
+			( 16 * 8 ) / ( 4 * 4 )
+		which gives:
+			8
+
+		The sRGB variant only uses different values to code colors. */
+
+		case GL_COMPRESSED_RGBA_S3TC_DXT3_EXT:
+			texelPerBlock = 16;
+			texelSize = 8;
+			break;
+		case GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT:
+			texelPerBlock = 16;
+			texelSize = 8;
+			break;
+
+		/* S3TC DXT5 compressed formats
+
+		> The DXT5 format is an alternate RGBA format. As in the DXT3 case,
+		> each 4x4 block takes up 128 bits. So it provides the same 4:1
+		> compression as in the DXT3 case.
+		> The alpha data is stored as 2 8-bit alpha values, alpha0 and alpha1,
+		> followed by a 48-bit unsigned integer that describes how to combine
+		> these two reference alpha values to achieve the final alpha value.
+
+		So we can either do:
+			32 / 4
+		or do:
+			( 64 + ( 8 + 8 ) + 48 ) / ( 4 * 4 )
+		or do:
+			( 16 * 8 ) / ( 4 * 4 )
+		which gives:
+			8
+
+		The sRGB variant only uses different values to code colors. */
+
+		case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
+			texelPerBlock = 16;
+			texelSize = 8;
+			break;
+		case GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT:
+			texelPerBlock = 16;
+			texelSize = 8;
+			break;
+
+		/* Red Green compressed formats
+
+		> All of these basically work the same. They use compression identical
+		> to the alpha form of DXT5. So for red only formats, you have 1 64-bit
+		> block of the format used for DXT5's alpha; this represents the red color.
+		> For red/green formats you have 2 64-bit blocks, so that red and green
+		> can vary independently of one another.
+		> The signed formats are almost identical. The two control colors are
+		> simply considered to be two's compliment 8-bit signed integers rather
+		> than unsigned integers, and all arithmetic is signed rather than unsigned.
+		-- https://www.khronos.org/opengl/wiki/Red_Green_Texture_Compression
+
+		So for RED we can do:
+			64 / ( 4 * 4 )
+		which gives:
+			4
+		And for RG we can do:
+			( 64 + 64 ) / ( 4 * 4 )
+		which gives:
+			8
+
+		The signed variants have the same size. */
+
+		case GL_COMPRESSED_RED_RGTC1:
+			texelPerBlock = 16;
+			texelSize = 4;
+			break;
+		case GL_COMPRESSED_SIGNED_RED_RGTC1:
+			texelPerBlock = 16;
+			texelSize = 4;
+			break;
+		case GL_COMPRESSED_RG_RGTC2:
+			texelPerBlock = 16;
+			texelSize = 8;
+			break;
+		case GL_COMPRESSED_SIGNED_RG_RGTC2:
+			texelPerBlock = 16;
+			texelSize = 8;
+			break;
+
+		/* BPTC compression formats
+
+		> Both formats use 4x4 texel blocks, and each block in both compression
+		> format is 128-bits in size. Unlike S3 Texture Compression, the blocks
+		> are taken as byte streams, and thus they are endian-independent. 
+		-- https://www.khronos.org/opengl/wiki/BPTC_Texture_Compression
+
+		So we can do:
+			128 / ( 4 * 4 )
+		which gives:
+			8
+
+		The sRGB variants only use different values to code colors. */
+
+		case GL_COMPRESSED_RGBA_BPTC_UNORM:
+			texelPerBlock = 16;
+			texelSize = 8;
+			break;
+		case GL_COMPRESSED_SRGB_ALPHA_BPTC_UNORM:
+			texelPerBlock = 16;
+			texelSize = 8;
+			break;
+		case GL_COMPRESSED_RGB_BPTC_SIGNED_FLOAT:
+			texelPerBlock = 16;
+			texelSize = 8;
+			break;
+		case GL_COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT:
+			texelPerBlock = 16;
+			texelSize = 8;
+			break;
+
+		/* ASTC compression formats
+
+		With ASTC, bits per texel is a float. To avoid float computation
+		texel size is premultiplied by 100, then once texel size is multiplied
+		with texel count, the result is divised by 100.
+
+		See https://www.khronos.org/opengl/wiki/ASTC_Texture_Compression */
+
+		case GL_COMPRESSED_RGBA_ASTC_4x4_KHR:
+			texelPerBlock = 4 * 4;
+			texelDivisor = 100;
+			texelSize = 800;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_5x4_KHR:
+			texelPerBlock = 5 * 4;
+			texelDivisor = 100;
+			texelSize = 640;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_5x5_KHR:
+			texelPerBlock = 5 * 5;
+			texelDivisor = 100;
+			texelSize = 512;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_6x5_KHR:
+			texelPerBlock = 6 * 5;
+			texelDivisor = 100;
+			texelSize = 427;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_6x6_KHR:
+			texelPerBlock = 6 * 6;
+			texelDivisor = 100;
+			texelSize = 356;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_8x5_KHR:
+			texelPerBlock = 8 * 5;
+			texelDivisor = 100;
+			texelSize = 320;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_8x6_KHR:
+			texelPerBlock = 8 * 6;
+			texelDivisor = 100;
+			texelSize = 267;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_10x5_KHR:
+			texelPerBlock = 10 * 5;
+			texelDivisor = 100;
+			texelSize = 256;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_10x6_KHR:
+			texelPerBlock = 10 * 6;
+			texelDivisor = 100;
+			texelSize = 213;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_8x8_KHR:
+			texelPerBlock = 8 * 8;
+			texelDivisor = 100;
+			texelSize = 200;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_10x8_KHR:
+			texelPerBlock = 10 * 8;
+			texelDivisor = 100;
+			texelSize = 160;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_10x10_KHR:
+			texelPerBlock = 10 * 10;
+			texelDivisor = 100;
+			texelSize = 128;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_12x10_KHR:
+			texelPerBlock = 12 * 10;
+			texelDivisor = 100;
+			texelSize = 107;
+			break;
+
+		case GL_COMPRESSED_RGBA_ASTC_12x12_KHR:
+			texelPerBlock = 12 * 12;
+			texelDivisor = 100;
+			texelSize = 89;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR:
+			texelPerBlock = 4 * 4;
+			texelDivisor = 100;
+			texelSize = 800;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR:
+			texelPerBlock = 5 * 4;
+			texelDivisor = 100;
+			texelSize = 640;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR:
+			texelPerBlock = 5 * 5;
+			texelDivisor = 100;
+			texelSize = 512;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR:
+			texelPerBlock = 6 * 5;
+			texelDivisor = 100;
+			texelSize = 427;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR:
+			texelPerBlock = 6 * 6;
+			texelDivisor = 100;
+			texelSize = 356;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR:
+			texelPerBlock = 8 * 5;
+			texelDivisor = 100;
+			texelSize = 320;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR:
+			texelPerBlock = 8 * 6;
+			texelDivisor = 100;
+			texelSize = 267;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR:
+			texelPerBlock = 10 * 5;
+			texelDivisor = 100;
+			texelSize = 256;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR:
+			texelPerBlock = 10 * 6;
+			texelDivisor = 100;
+			texelSize = 213;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR:
+			texelPerBlock = 8 * 8;
+			texelDivisor = 100;
+			texelSize = 200;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR:
+			texelPerBlock = 10 * 8;
+			texelDivisor = 100;
+			texelSize = 160;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR:
+			texelPerBlock = 10 * 10;
+			texelDivisor = 100;
+			texelSize = 128;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR:
+			texelPerBlock = 12 * 10;
+			texelDivisor = 100;
+			texelSize = 107;
+			break;
+
+		case GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR:
+			texelPerBlock = 12 * 12;
+			texelDivisor = 100;
+			texelSize = 89;
+			break;
+
+		/* Compressed formats
+
+		> Generic formats don't have any particular internal representation.
+		> OpenGL implementations are free to do whatever it wants to the data,
+		> including using a regular uncompressed format if it so desires.
+		> These formats rely on the driver to compress the data for you.
+		> Because of this uncertainty, it is suggested that you avoid these
+		> in favor of compressed formats with a specific compression format.
+		-- https://www.khronos.org/opengl/wiki/Image_Format
+
+		> GL_TEXTURE_COMPRESSED_IMAGE_SIZE
+		> params returns a single integer value, the number of unsigned
+		> bytes of the compressed texture image that would be returned
+		> from glGetCompressedTexImage.
+		-- https://www.khronos.org/opengl/wiki/GLAPI/glGetTexLevelParameter
+
+		The sRGB variants only use different values to code colors. */
+
+		case GL_COMPRESSED_RED:
+		case GL_COMPRESSED_RG:
+		case GL_COMPRESSED_RGB:
+		case GL_COMPRESSED_RGBA:
+		case GL_COMPRESSED_SRGB:
+		case GL_COMPRESSED_SRGB_ALPHA:
+			glGetIntegeri_v( GL_TEXTURE_COMPRESSED_IMAGE_SIZE, image->texnum, &imageSize );
+			return imageSize;
+
+		/* Others
+
+		Assume RGBA8 because 8 bit per channel is pretty common
+		and GL is known to sample RED, RG and RGB to RGBA */
+
+		default:
+			Log::Debug( "Unknown texel size for undocumented internal format %i for image %s", image->internalFormat, image->name );
+			texelSize = 8 + 8 + 8 + 8;
+			break;
+	}
+
+	if ( texelCount < texelPerBlock )
+	{
+		imageSize = texelPerBlock * texelSize / texelDivisor / 8;
+	}
+	else
+	{
+		imageSize = texelCount * texelSize / texelDivisor / 8;
+	}
+
+	// Assume the minimal size for any data is a byte.
+	return 8 > imageSize ? 8 : imageSize;
+}
+
 int R_GetImageCustomScalingStep( const image_t *image, imageParams_t *imageParams )
 {
 	int scalingStep = 0;

--- a/src/engine/renderer/InternalImage.h
+++ b/src/engine/renderer/InternalImage.h
@@ -1,0 +1,43 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2013-2016 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Daemon developers nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// InternalImage.h
+
+#ifndef INTERNAL_IMAGE_H
+#define INTERNAL_IMAGE_H
+#include "tr_local.h"
+
+int R_GetImageCustomScalingStep( const image_t *image, imageParams_t *imageParams );
+void R_DownscaleImageDimensions( int scalingStep, int *scaledWidth, int *scaledHeight, const byte ***dataArray, int numLayers, int *numMips );
+
+#endif // INTERNAL_IMAGE_H

--- a/src/engine/renderer/InternalImage.h
+++ b/src/engine/renderer/InternalImage.h
@@ -38,7 +38,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tr_local.h"
 
 int R_GetInternalImageSize( const image_t *image );
+int R_GetBlockSize( const image_t *image );
+int R_GetMipSize( int imageWidth, int imageHeight, int blockSize );
+int R_GetMipSize( const image_t *image );
 int R_GetImageCustomScalingStep( const image_t *image, imageParams_t *imageParams );
+int R_GetImageHardwareScalingStep( image_t *image, GLenum format );
 void R_DownscaleImageDimensions( int scalingStep, int *scaledWidth, int *scaledHeight, const byte ***dataArray, int numLayers, int *numMips );
 
 #endif // INTERNAL_IMAGE_H

--- a/src/engine/renderer/InternalImage.h
+++ b/src/engine/renderer/InternalImage.h
@@ -37,6 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define INTERNAL_IMAGE_H
 #include "tr_local.h"
 
+int R_GetInternalImageSize( const image_t *image );
 int R_GetImageCustomScalingStep( const image_t *image, imageParams_t *imageParams );
 void R_DownscaleImageDimensions( int scalingStep, int *scaledWidth, int *scaledHeight, const byte ***dataArray, int numLayers, int *numMips );
 

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -485,7 +485,12 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 				width = height = 0;
 				LoadRGBEToBytes( va( "%s/%s", mapName, lightmapFiles[ i ] ), &ldrImage, &width, &height );
 
-				auto image = R_CreateImage( va( "%s/%s", mapName, lightmapFiles[ i ] ), (const byte **)&ldrImage, width, height, 1, IF_NOPICMIP | IF_LIGHTMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
+				imageParams_t imageParams = {};
+				imageParams.bits = IF_NOPICMIP | IF_LIGHTMAP;
+				imageParams.filterType = filterType_t::FT_DEFAULT;
+				imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+				auto image = R_CreateImage( va( "%s/%s", mapName, lightmapFiles[ i ] ), (const byte **)&ldrImage, width, height, 1, &imageParams );
 
 				Com_AddToGrowList( &tr.lightmaps, image );
 
@@ -504,7 +509,13 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 				for (int i = 0; i < numLightmaps; i++) {
 					Log::Debug("...loading external lightmap '%s/%s'", mapName, lightmapFiles[i]);
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NOPICMIP | IF_NORMALMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP);
+
+					imageParams_t imageParams = {};
+					imageParams.bits = IF_NOPICMIP | IF_NORMALMAP;
+					imageParams.filterType = filterType_t::FT_DEFAULT;
+					imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), &imageParams);
 					Com_AddToGrowList(&tr.deluxemaps, image);
 				}
 			}
@@ -527,10 +538,20 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 				Log::Debug("...loading external lightmap '%s/%s'", mapName, lightmapFiles[i]);
 
 				if (!tr.worldDeluxeMapping || i % 2 == 0) {
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NOPICMIP | IF_LIGHTMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
+					imageParams_t imageParams = {};
+					imageParams.bits = IF_NOPICMIP | IF_LIGHTMAP;
+					imageParams.filterType = filterType_t::FT_LINEAR;
+					imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), &imageParams);
 					Com_AddToGrowList(&tr.lightmaps, image);
 				} else {
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NOPICMIP | IF_NORMALMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
+					imageParams_t imageParams = {};
+					imageParams.bits = IF_NOPICMIP | IF_NORMALMAP;
+					imageParams.filterType = filterType_t::FT_LINEAR;
+					imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), &imageParams);
 					Com_AddToGrowList(&tr.deluxemaps, image);
 				}
 			}
@@ -611,9 +632,12 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 			}
 		}
 
-		tr.fatLightmap = R_CreateImage( va( "_fatlightmap%d", 0 ), (const byte **)&fatbuffer,
-						tr.fatLightmapSize, tr.fatLightmapSize, 1,
-						IF_NOPICMIP | IF_LIGHTMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
+		imageParams_t imageParams = {};
+		imageParams.bits = IF_NOPICMIP | IF_LIGHTMAP;
+		imageParams.filterType = filterType_t::FT_DEFAULT;
+		imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+		tr.fatLightmap = R_CreateImage( va( "_fatlightmap%d", 0 ), (const byte **)&fatbuffer, tr.fatLightmapSize, tr.fatLightmapSize, 1, &imageParams );
 		Com_AddToGrowList( &tr.lightmaps, tr.fatLightmap );
 
 		ri.Hunk_FreeTempMemory( fatbuffer );
@@ -3965,14 +3989,13 @@ void R_LoadLightGrid( lump_t *l )
 		w->lightGridData1 = gridPoint1;
 		w->lightGridData2 = gridPoint2;
 
-		tr.lightGrid1Image = R_Create3DImage("<lightGrid1>", (const byte *)w->lightGridData1,
-						     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-						     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
-						     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
-		tr.lightGrid2Image = R_Create3DImage("<lightGrid2>", (const byte *)w->lightGridData2,
-						     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-						     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
-						     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
+		imageParams_t imageParams = {};
+		imageParams.bits = IF_NOPICMIP | IF_NOLIGHTSCALE;
+		imageParams.filterType = filterType_t::FT_DEFAULT;
+		imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+		tr.lightGrid1Image = R_Create3DImage("<lightGrid1>", (const byte *)w->lightGridData1, w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ], w->lightGridBounds[ 2 ], &imageParams );
+		tr.lightGrid2Image = R_Create3DImage("<lightGrid2>", (const byte *)w->lightGridData2, w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ], w->lightGridBounds[ 2 ], &imageParams );
 
 		return;
 	}
@@ -4094,14 +4117,13 @@ void R_LoadLightGrid( lump_t *l )
 		}
 	}
 
-	tr.lightGrid1Image = R_Create3DImage("<lightGrid1>", (const byte *)w->lightGridData1,
-					     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-					     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
-					     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
-	tr.lightGrid2Image = R_Create3DImage("<lightGrid2>", (const byte *)w->lightGridData2,
-					     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-					     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
-					     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP | IF_NOLIGHTSCALE;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+	tr.lightGrid1Image = R_Create3DImage("<lightGrid1>", (const byte *)w->lightGridData1, w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ], w->lightGridBounds[ 2 ], &imageParams );
+	tr.lightGrid2Image = R_Create3DImage("<lightGrid2>", (const byte *)w->lightGridData2, w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ], w->lightGridBounds[ 2 ], &imageParams );
 
 	Log::Debug("%i light grid points created", w->numLightGridPoints );
 }
@@ -6668,7 +6690,7 @@ void R_BuildCubeMaps()
 		cubeProbe->cubemap->filterType = filterType_t::FT_LINEAR;
 		cubeProbe->cubemap->wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
 
-		R_UploadImage( ( const byte ** ) tr.cubeTemp, 6, 1, cubeProbe->cubemap );
+		R_UploadImage( ( const byte ** ) tr.cubeTemp, 6, 1, cubeProbe->cubemap, nullptr );
 	}
 
 	Log::Notice("\n");

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -170,9 +170,8 @@ void R_ImageList_f()
 	for ( i = 0; i < tr.images.currentElements; i++ )
 	{
 		image = (image_t*) Com_GrowListElement( &tr.images, i );
-		char buffer[ MAX_TOKEN_CHARS ];
-		char imageType[ MAX_TOKEN_CHARS ];
 		int sizeFactor = 1;
+		std::string imageType;
 		std::string out;
 
 		if ( filter && !Com_Filter( filter, image->name, true ) )
@@ -183,17 +182,17 @@ void R_ImageList_f()
 		switch ( image->type )
 		{
 			case GL_TEXTURE_2D:
-				Com_sprintf( imageType, sizeof( imageType ),  "2D    " );
+				imageType = "2D    ";
 				break;
 
 			case GL_TEXTURE_CUBE_MAP:
 				sizeFactor = 6;
-				Com_sprintf( imageType, sizeof( imageType ),  "CUBE  " );
+				imageType = "CUBE  ";
 				break;
 
 			default:
 				Log::Debug( "Undocumented image imageType %i for image %s", image->type, image->name );
-				Com_sprintf( imageType, sizeof( imageType ),  "%5i ", image->type );
+				imageType = Str::Format( "%5i ", image->type );
 				break;
 		}
 
@@ -202,7 +201,7 @@ void R_ImageList_f()
 		int texelCount = image->uploadWidth * image->uploadHeight * sizeFactor;
 		int imagePixelSize = imageDataSize * 8 / texelCount;
 
-		Com_sprintf( buffer, sizeof( buffer ), "%4i: %4i %4i %4i   %9i %s  %s ",
+		out += Str::Format( "%4i: %4i %4i %4i   %9i %s  %s ",
 			i,
 			image->uploadWidth,
 			image->uploadHeight,
@@ -211,227 +210,183 @@ void R_ImageList_f()
 			yesno[ image->filterType == filterType_t::FT_DEFAULT ],
 			imageType );
 
-		out += buffer;
-
 		switch ( image->internalFormat )
 		{
 			case GL_RGB8:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGB8     " );
-				out += buffer;
+				out += "RGB8     ";
 				break;
 
 			case GL_RGBA8:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGBA8    " );
-				out += buffer;
+				out += "RGBA8    ";
 				break;
 
 			case GL_RGB16:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGB      " );
-				out += buffer;
+				out += "RGB      ";
 				break;
 
 			case GL_RGB16F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGB16F   " );
-				out += buffer;
+				out += "RGB16F   ";
 				break;
 
 			case GL_RGB32F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGB32F   " );
-				out += buffer;
+				out += "RGB32F   ";
 				break;
 
 			case GL_RGBA16F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGBA16F  " );
-				out += buffer;
+				out += "RGBA16F  ";
 				break;
 
 			case GL_RGBA32F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGBA32F  " );
-				out += buffer;
+				out += "RGBA32F  ";
 				break;
 
 			case GL_ALPHA16F_ARB:
-				Com_sprintf( buffer, sizeof( buffer ),  "A16F     " );
-				out += buffer;
+				out += "A16F     ";
 				break;
 
 			case GL_ALPHA32F_ARB:
-				Com_sprintf( buffer, sizeof( buffer ),  "A32F     " );
-				out += buffer;
+				out += "A32F     ";
 				break;
 
 			case GL_R16F:
-				Com_sprintf( buffer, sizeof( buffer ),  "R16F     " );
-				out += buffer;
+				out += "R16F     ";
 				break;
 
 			case GL_R32F:
-				Com_sprintf( buffer, sizeof( buffer ),  "R32F     " );
-				out += buffer;
+				out += "R32F     ";
 				break;
 
 			case GL_LUMINANCE_ALPHA16F_ARB:
-				Com_sprintf( buffer, sizeof( buffer ),  "LA16F    " );
-				out += buffer;
+				out += "LA16F    ";
 				break;
 
 			case GL_LUMINANCE_ALPHA32F_ARB:
-				Com_sprintf( buffer, sizeof( buffer ),  "LA32F    " );
-				out += buffer;
+				out += "LA32F    ";
 				break;
 
 			case GL_RG16F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RG16F    " );
-				out += buffer;
+				out += "RG16F    ";
 				break;
 
 			case GL_RG32F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RG32F    " );
-				out += buffer;
+				out += "RG32F    ";
 				break;
 
 			case GL_COMPRESSED_RGBA:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGBAC " );
-				out += buffer;
+				out += "RGBAC ";
 				break;
 
 			case GL_COMPRESSED_RGB_S3TC_DXT1_EXT:
-				Com_sprintf( buffer, sizeof( buffer ),  "DXT1     " );
-				out += buffer;
+				out += "DXT1     ";
 				break;
 
 			case GL_COMPRESSED_RGBA_S3TC_DXT1_EXT:
-				Com_sprintf( buffer, sizeof( buffer ),  "DXT1a    " );
-				out += buffer;
+				out += "DXT1a    ";
 				break;
 
 			case GL_COMPRESSED_RGBA_S3TC_DXT3_EXT:
-				Com_sprintf( buffer, sizeof( buffer ),  "DXT3     " );
-				out += buffer;
+				out += "DXT3     ";
 				break;
 
 			case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
-				Com_sprintf( buffer, sizeof( buffer ),  "DXT5     " );
-				out += buffer;
+				out += "DXT5     ";
 				break;
 
 			case GL_COMPRESSED_RED_RGTC1:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGTC1r   " );
-				out += buffer;
+				out += "RGTC1r   ";
 				break;
 
 			case GL_COMPRESSED_SIGNED_RED_RGTC1:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGTC1Sr  " );
-				out += buffer;
+				out += "RGTC1Sr  ";
 				break;
 
 			case GL_COMPRESSED_RG_RGTC2:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGTC2rg  " );
-				out += buffer;
+				out += "RGTC2rg  ";
 				break;
 
 			case GL_COMPRESSED_SIGNED_RG_RGTC2:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGTC2Srg " );
-				out += buffer;
+				out += "RGTC2Srg ";
 				break;
 
 			case GL_DEPTH_COMPONENT16:
-				Com_sprintf( buffer, sizeof( buffer ),  "D16      " );
-				out += buffer;
+				out += "D16      ";
 				break;
 
 			case GL_DEPTH_COMPONENT24:
-				Com_sprintf( buffer, sizeof( buffer ),  "D24      " );
-				out += buffer;
+				out += "D24      ";
 				break;
 
 			case GL_DEPTH_COMPONENT32:
-				Com_sprintf( buffer, sizeof( buffer ),  "D32      " );
-				out += buffer;
+				out += "D32      ";
 				break;
 
 			default:
 				Log::Debug( "Undocumented image format %i for image %s", image->internalFormat, image->name );
-				Com_sprintf( buffer, sizeof( buffer ),  "%5i    ", image->internalFormat );
-				out += buffer;
+				out += Str::Format( "%5i    ", image->internalFormat );
 				break;
 		}
 
 		switch ( image->wrapType.s )
 		{
 			case wrapTypeEnum_t::WT_REPEAT:
-				Com_sprintf( buffer, sizeof( buffer ), "s.rept   " );
-				out += buffer;
+				out += "s.rept   ";
 				break;
 
 			case wrapTypeEnum_t::WT_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ), "s.clmp   " );
-				out += buffer;
+				out += "s.clmp   ";
 				break;
 
 			case wrapTypeEnum_t::WT_EDGE_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ), "s.eclmp  " );
-				out += buffer;
+				out += "s.eclmp  ";
 				break;
 
 			case wrapTypeEnum_t::WT_ZERO_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ), "s.0clmp  " );
-				out += buffer;
+				out += "s.0clmp  ";
 				break;
 
 			case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ), "s.a0clmp " );
-				out += buffer;
+				out += "s.a0clmp ";
 				break;
 
 			case wrapTypeEnum_t::WT_ONE_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ), "t.1clmp  " );
-				out+= buffer;
+				out += "t.1clmp  ";
 				break;
 
 			default:
 				Log::Debug( "Undocumented wrapType.s %i for image %s", Util::ordinal(image->wrapType.s), image->name );
-				Com_sprintf( buffer, sizeof( buffer ), "s.%4i   ", Util::ordinal(image->wrapType.s) );
-				out += buffer;
+				out += Str::Format( "s.%4i   ", Util::ordinal(image->wrapType.s) );
 				break;
 		}
 
 		switch ( image->wrapType.t )
 		{
 			case wrapTypeEnum_t::WT_REPEAT:
-				Com_sprintf( buffer, sizeof( buffer ), "t.rept   " );
-				out += buffer;
+				out += "t.rept   ";
 				break;
 
 			case wrapTypeEnum_t::WT_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ), "t.clmp   " );
-				out += buffer;
+				out += "t.clmp   ";
 				break;
 
 			case wrapTypeEnum_t::WT_EDGE_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ), "t.eclmp  " );
-				out += buffer;
+				out += "t.eclmp  ";
 				break;
 
 			case wrapTypeEnum_t::WT_ZERO_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ), "t.0clmp  " );
-				out += buffer;
+				out += "t.0clmp  ";
 				break;
 
 			case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ), "t.a0clmp " );
-				out += buffer;
+				out += "t.a0clmp ";
 				break;
 
 			case wrapTypeEnum_t::WT_ONE_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ), "t.1clmp  " );
-				out+= buffer;
+				out += "t.1clmp  ";
 				break;
 
 			default:
 				Log::Debug( "Undocumented wrapType.t %i for image %s", Util::ordinal(image->wrapType.t), image->name );
-				Com_sprintf( buffer, sizeof( buffer ), "t.%4i   ", Util::ordinal(image->wrapType.t));
-				out += buffer;
+				out += Str::Format( "t.%4i   ", Util::ordinal(image->wrapType.t) );
 				break;
 		}
 

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1098,7 +1098,7 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 			{
 				case GL_TEXTURE_3D:
 					if( scaledBuffer ) {
-						glTexSubImage3D( GL_TEXTURE_3D, 0, 0, 0, i, scaledWidth, scaledHeight, 1, format, GL_UNSIGNED_BYTE, scaledBuffer );
+						glTexSubImage3D( target, 0, 0, 0, i, scaledWidth, scaledHeight, 1, format, GL_UNSIGNED_BYTE, scaledBuffer );
 					}
 					break;
 

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1015,6 +1015,8 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 		{
 			glTexImage3D( GL_TEXTURE_3D, i, internalFormat, mipWidth, mipHeight, mipLayers, 0, format, GL_UNSIGNED_BYTE, nullptr );
 
+			GL_CheckErrors();
+
 			if( mipWidth  > 1 )
 			{
 				mipWidth  >>= 1;
@@ -1104,16 +1106,22 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 
 				case GL_TEXTURE_CUBE_MAP:
 					glTexImage2D( target + i, 0, internalFormat, scaledWidth, scaledHeight, 0, format, GL_UNSIGNED_BYTE, scaledBuffer );
+
+						GL_CheckErrors();
 					break;
 
 				default:
 					if ( image->bits & IF_PACKED_DEPTH24_STENCIL8 )
 					{
 						glTexImage2D( target, 0, internalFormat, scaledWidth, scaledHeight, 0, format, GL_UNSIGNED_INT_24_8, nullptr );
+
+						GL_CheckErrors();
 					}
 					else
 					{
 						glTexImage2D( target, 0, internalFormat, scaledWidth, scaledHeight, 0, format, GL_UNSIGNED_BYTE, scaledBuffer );
+
+						GL_CheckErrors();
 					}
 					break;
 			}
@@ -1124,6 +1132,8 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 				{
 					glGenerateMipmap( image->type );
 					glTexParameteri( image->type, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );  // default to trilinear
+
+					GL_CheckErrors();
 				}
 			}
 		}
@@ -1174,14 +1184,20 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 				{
 					case GL_TEXTURE_3D:
 						glCompressedTexSubImage3D( GL_TEXTURE_3D, i, 0, 0, j, mipWidth, mipHeight, 1, internalFormat, mipSize, data );
+
+						GL_CheckErrors();
 					break;
 
 					case GL_TEXTURE_CUBE_MAP:
 						glCompressedTexImage2D( target + j, i, internalFormat, mipWidth, mipHeight, 0, mipSize, data );
+
+						GL_CheckErrors();
 						break;
 
 					default:
 						glCompressedTexImage2D( target, i, internalFormat, mipWidth, mipHeight, 0, mipSize, data );
+
+						GL_CheckErrors();
 						break;
 				}
 
@@ -1202,8 +1218,6 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 			}
 		}
 	}
-
-	GL_CheckErrors();
 
 	// set filter type
 	switch ( image->filterType )

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1081,6 +1081,15 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 				}
 			}
 
+			if ( image->width == scaledWidth || image->height == scaledHeight )
+			{
+				Log::Debug( "Uploading image %s with %d×%d original size, layer %d", image->name, image->width, image->height, i );
+			}
+			else
+			{
+				Log::Debug( "Uploading image %s with %d×%d size, downscaled from %d×%d size, layer %d", image->name, scaledWidth, scaledHeight, image->width, image->height, i );
+			}
+
 			image->uploadWidth = scaledWidth;
 			image->uploadHeight = scaledHeight;
 			image->internalFormat = internalFormat;
@@ -1146,6 +1155,19 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 				else
 				{
 					data = nullptr;
+				}
+
+				if ( i != 0 )
+				{
+					Log::Debug( "Uploading compressed image %s with %d×%d size, mip %d, layer %d", image->name, mipWidth, mipHeight, image->width, image->height, i, j );
+				}
+				if ( image->width == mipWidth || image->height == mipHeight )
+				{
+					Log::Debug( "Uploading compressed image %s with %d×%d original size, mip %d, layer %d", image->name, image->width, image->height, i, j );
+				}
+				else
+				{
+					Log::Debug( "Uploading compressed image %s with %d×%d size, downscaled from %d×%d size, mip %d, layer %d", image->name, mipWidth, mipHeight, image->width, image->height, i, j );
 				}
 
 				switch ( image->type )

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -808,8 +808,7 @@ level 1 has only numLayers/2 layers. There are still numLayers pointers in
 the dataArray for every mip level, the unneeded elements at the end aren't used.
 ===============
 */
-void R_UploadImage( const byte **dataArray, int numLayers, int numMips,
-		    image_t *image )
+void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t *image, imageParams_t *imageParams )
 {
 	const byte *data;
 	byte       *scaledBuffer = nullptr;
@@ -1434,8 +1433,7 @@ static void R_ExportTexture( image_t *image )
 R_CreateImage
 ================
 */
-image_t        *R_CreateImage( const char *name, const byte **pic, int width, int height,
-			       int numMips, int bits, filterType_t filterType, wrapType_t wrapType )
+image_t *R_CreateImage( const char *name, const byte **pic, int width, int height, int numMips, imageParams_t* imageParams )
 {
 	image_t *image;
 
@@ -1451,11 +1449,11 @@ image_t        *R_CreateImage( const char *name, const byte **pic, int width, in
 	image->width = width;
 	image->height = height;
 
-	image->bits = bits;
-	image->filterType = filterType;
-	image->wrapType = wrapType;
+	image->bits = imageParams->bits;
+	image->filterType = imageParams->filterType;
+	image->wrapType = imageParams->wrapType;
 
-	R_UploadImage( pic, 1, numMips, image );
+	R_UploadImage( pic, 1, numMips, image, imageParams );
 
 	if( r_exportTextures->integer ) {
 		R_ExportTexture( image );
@@ -1513,9 +1511,7 @@ image_t *R_CreateGlyph( const char *name, const byte *pic, int width, int height
 R_CreateCubeImage
 ================
 */
-image_t        *R_CreateCubeImage( const char *name,
-                                   const byte *pic[ 6 ],
-                                   int width, int height, int bits, filterType_t filterType, wrapType_t wrapType )
+image_t *R_CreateCubeImage( const char *name, const byte *pic[ 6 ], int width, int height, imageParams_t *imageParams )
 {
 	image_t *image;
 
@@ -1525,17 +1521,17 @@ image_t        *R_CreateCubeImage( const char *name,
 	{
 		return nullptr;
 	}
-
+	
 	image->type = GL_TEXTURE_CUBE_MAP;
 
 	image->width = width;
 	image->height = height;
 
-	image->bits = bits;
-	image->filterType = filterType;
-	image->wrapType = wrapType;
+	image->bits = imageParams->bits;
+	image->filterType = imageParams->filterType;
+	image->wrapType = imageParams->wrapType;
 
-	R_UploadImage( pic, 6, 1, image );
+	R_UploadImage( pic, 6, 1, image, imageParams );
 
 	if( r_exportTextures->integer ) {
 		R_ExportTexture( image );
@@ -1549,11 +1545,7 @@ image_t        *R_CreateCubeImage( const char *name,
 R_Create3DImage
 ================
 */
-image_t        *R_Create3DImage( const char *name,
-				 const byte *pic,
-				 int width, int height, int depth,
-				 int bits, filterType_t filterType,
-				 wrapType_t wrapType )
+image_t *R_Create3DImage( const char *name, const byte *pic, int width, int height, int depth, imageParams_t *imageParams )
 {
 	image_t *image;
 	const byte **pics;
@@ -1580,11 +1572,11 @@ image_t        *R_Create3DImage( const char *name,
 		pics = nullptr;
 	}
 
-	image->bits = bits;
-	image->filterType = filterType;
-	image->wrapType = wrapType;
+	image->bits = imageParams->bits;
+	image->filterType = imageParams->filterType;
+	image->wrapType = imageParams->wrapType;
 
-	R_UploadImage( pics, depth, 1, image );
+	R_UploadImage( pics, depth, 1, image, imageParams );
 
 	if( pics ) {
 		ri.Hunk_FreeTempMemory( pics );
@@ -1775,7 +1767,7 @@ Finds or loads the given image.
 Returns nullptr if it fails, not a default image.
 ==============
 */
-image_t        *R_FindImageFile( const char *imageName, int bits, filterType_t filterType, wrapType_t wrapType )
+image_t *R_FindImageFile( const char *imageName, imageParams_t *imageParams )
 {
 	image_t       *image = nullptr;
 	int           width = 0, height = 0, numLayers = 0, numMips = 0;
@@ -1801,14 +1793,14 @@ image_t        *R_FindImageFile( const char *imageName, int bits, filterType_t f
 			// the white image can be used with any set of parms, but other mismatches are errors
 			if ( Q_stricmp( buffer, "_white" ) )
 			{
-				diff = bits ^ image->bits;
+				diff = imageParams->bits ^ image->bits;
 
 				if ( diff & IF_NOPICMIP )
 				{
 					Log::Warn("reused image '%s' with mixed allowPicmip parm for shader", imageName );
 				}
 
-				if ( image->wrapType != wrapType )
+				if ( image->wrapType != imageParams->wrapType )
 				{
 					Log::Warn("reused image '%s' with mixed glWrapType parm for shader", imageName);
 				}
@@ -1821,7 +1813,7 @@ image_t        *R_FindImageFile( const char *imageName, int bits, filterType_t f
 	// load the pic from disk
 	pic[ 0 ] = nullptr;
 	buffer_p = &buffer[ 0 ];
-	R_LoadImage( &buffer_p, pic, &width, &height, &numLayers, &numMips, &bits );
+	R_LoadImage( &buffer_p, pic, &width, &height, &numLayers, &numMips, &imageParams->bits );
 
 	if ( (mallocPtr = pic[ 0 ]) == nullptr || numLayers > 0 )
 	{
@@ -1832,14 +1824,12 @@ image_t        *R_FindImageFile( const char *imageName, int bits, filterType_t f
 		return nullptr;
 	}
 
-	if ( bits & IF_LIGHTMAP )
+	if ( imageParams->bits & IF_LIGHTMAP )
 	{
-		R_ProcessLightmap( pic[ 0 ], 4, width, height, bits, pic[ 0 ] );
+		R_ProcessLightmap( pic[ 0 ], 4, width, height, imageParams->bits, pic[ 0 ] );
 	}
 
-	image = R_CreateImage( ( char * ) buffer, (const byte **)pic,
-			       width, height, numMips, bits,
-			       filterType, wrapType );
+	image = R_CreateImage( ( char * ) buffer, (const byte **)pic, width, height, numMips, imageParams );
 
 	ri.Free( mallocPtr );
 	return image;
@@ -2057,7 +2047,7 @@ struct face_t
 	int height;
 };
 
-image_t *R_FindCubeImage( const char *imageName, int bits, filterType_t filterType, wrapType_t wrapType )
+image_t *R_FindCubeImage( const char *imageName, imageParams_t *imageParams )
 {
 	int i, j;
 	image_t *image = nullptr;
@@ -2093,10 +2083,10 @@ image_t *R_FindCubeImage( const char *imageName, int bits, filterType_t filterTy
 		if( R_FindImageLoader( cubeMapName.c_str() ) >= 0 )
 		{
 			Log::Debug( "found %s cube map '%s'", loader.ext, cubeMapBaseName );
-			loader.ImageLoader( cubeMapName.c_str(), pic, &width, &height, &numLayers, &numMips, &bits, 0 );
+			loader.ImageLoader( cubeMapName.c_str(), pic, &width, &height, &numLayers, &numMips, &imageParams->bits, 0 );
 
 			if( numLayers == 6 && pic[0] ) {
-				image = R_CreateCubeImage( ( char * ) buffer, ( const byte ** ) pic, width, height, bits, filterType, wrapType );
+				image = R_CreateCubeImage( ( char * ) buffer, ( const byte ** ) pic, width, height, imageParams );
 				R_FreeCubePics( pic, 1 );
 				return image;
 			}
@@ -2122,7 +2112,7 @@ image_t *R_FindCubeImage( const char *imageName, int bits, filterType_t filterTy
 			Log::Debug( "looking for %s cube map face '%s'", format.name, filename );
 
 			filename_p = &filename[ 0 ];
-			R_LoadImage( &filename_p, &pic[ i ], &width, &height, &numLayers, &numMips, &bits );
+			R_LoadImage( &filename_p, &pic[ i ], &width, &height, &numLayers, &numMips, &imageParams->bits );
 
 			if ( pic[ i ] == nullptr )
 			{
@@ -2133,7 +2123,7 @@ image_t *R_FindCubeImage( const char *imageName, int bits, filterType_t filterTy
 				break;
 			}
 
-			if ( IsImageCompressed( bits ) )
+			if ( IsImageCompressed( imageParams->bits ) )
 			{
 				Log::Warn("cube map face '%s' has DXTn compression, cube map unusable", filename );
 				break;
@@ -2206,7 +2196,7 @@ image_t *R_FindCubeImage( const char *imageName, int bits, filterType_t filterTy
 			}
 
 			Log::Debug( "found %s multifile cube map '%s'", format.name, imageName );
-			image = R_CreateCubeImage( ( char * ) buffer, ( const byte ** ) pic, greatestEdge, greatestEdge, bits, filterType, wrapType );
+			image = R_CreateCubeImage( ( char * ) buffer, ( const byte ** ) pic, greatestEdge, greatestEdge, imageParams );
 			R_FreeCubePics( pic, i );
 			return image;
 		}
@@ -2313,8 +2303,12 @@ static void R_CreateFogImage()
 	// standard openGL clamping doesn't really do what we want -- it includes
 	// the border color at the edges.  OpenGL 1.2 has clamp-to-edge, which does
 	// what we want.
-	tr.fogImage = R_CreateImage( "_fog", ( const byte ** ) &data,
-				     FOG_S, FOG_T, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.fogImage = R_CreateImage( "_fog", ( const byte ** ) &data, FOG_S, FOG_T, 1, &imageParams );
 	ri.Hunk_FreeTempMemory( data );
 
 	borderColor[ 0 ] = 1.0;
@@ -2352,8 +2346,12 @@ static void R_CreateDefaultImage()
 		  data[ x ][ DEFAULT_SIZE - 1 ][ 1 ] = data[ x ][ DEFAULT_SIZE - 1 ][ 2 ] = data[ x ][ DEFAULT_SIZE - 1 ][ 3 ] = 255;
 	}
 
-	tr.defaultImage = R_CreateImage( "_default", ( const byte ** ) &dataPtr,
-					 DEFAULT_SIZE, DEFAULT_SIZE, 1, IF_NOPICMIP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_REPEAT );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_REPEAT;
+
+	tr.defaultImage = R_CreateImage( "_default", ( const byte ** ) &dataPtr, DEFAULT_SIZE, DEFAULT_SIZE, 1, &imageParams );
 }
 
 static void R_CreateRandomNormalsImage()
@@ -2387,8 +2385,12 @@ static void R_CreateRandomNormalsImage()
 		}
 	}
 
-	tr.randomNormalsImage = R_CreateImage( "_randomNormals", ( const byte ** ) &dataPtr,
-					       DEFAULT_SIZE, DEFAULT_SIZE, 1, IF_NOPICMIP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_REPEAT );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_REPEAT;
+
+	tr.randomNormalsImage = R_CreateImage( "_randomNormals", ( const byte ** ) &dataPtr, DEFAULT_SIZE, DEFAULT_SIZE, 1, &imageParams );
 }
 
 static void R_CreateNoFalloffImage()
@@ -2399,8 +2401,12 @@ static void R_CreateNoFalloffImage()
 
 	byte *dataPtr = &data[0][0][0];
 
-	tr.noFalloffImage = R_CreateImage( "_noFalloff", ( const byte ** ) &dataPtr,
-					   8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+	tr.noFalloffImage = R_CreateImage( "_noFalloff", ( const byte ** ) &dataPtr, 8, 8, 1, &imageParams );
 }
 
 static const int ATTENUATION_XY_SIZE = 128;
@@ -2438,9 +2444,12 @@ static void R_CreateAttenuationXYImage()
 		}
 	}
 
-	tr.attenuationXYImage =
-	  R_CreateImage( "_attenuationXY", ( const byte ** ) &dataPtr,
-			 ATTENUATION_XY_SIZE, ATTENUATION_XY_SIZE, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.attenuationXYImage = R_CreateImage( "_attenuationXY", ( const byte ** ) &dataPtr, ATTENUATION_XY_SIZE, ATTENUATION_XY_SIZE, 1, &imageParams );
 }
 
 static void R_CreateContrastRenderFBOImage()
@@ -2450,7 +2459,12 @@ static void R_CreateContrastRenderFBOImage()
 	width = glConfig.vidWidth * 0.25f;
 	height = glConfig.vidHeight * 0.25f;
 
-	tr.contrastRenderFBOImage = R_CreateImage( "_contrastRenderFBO", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.contrastRenderFBOImage = R_CreateImage( "_contrastRenderFBO", nullptr, width, height, 1, &imageParams );
 }
 
 static void R_CreateBloomRenderFBOImage()
@@ -2463,7 +2477,12 @@ static void R_CreateBloomRenderFBOImage()
 
 	for ( i = 0; i < 2; i++ )
 	{
-		tr.bloomRenderFBOImage[ i ] = R_CreateImage( va( "_bloomRenderFBO%d", i ), nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP );
+		imageParams_t imageParams = {};
+		imageParams.bits = IF_NOPICMIP;
+		imageParams.filterType = filterType_t::FT_DEFAULT;
+		imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+		tr.bloomRenderFBOImage[ i ] = R_CreateImage( va( "_bloomRenderFBO%d", i ), nullptr, width, height, 1, &imageParams );
 	}
 }
 
@@ -2474,9 +2493,17 @@ static void R_CreateCurrentRenderImage()
 	width = glConfig.vidWidth;
 	height = glConfig.vidHeight;
 
-	tr.currentRenderImage[0] = R_CreateImage( "_currentRender[0]", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-	tr.currentRenderImage[1] = R_CreateImage( "_currentRender[1]", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-	tr.currentDepthImage = R_CreateImage( "_currentDepth", nullptr, width, height, 1, IF_NOPICMIP | IF_PACKED_DEPTH24_STENCIL8, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_NEAREST;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.currentRenderImage[0] = R_CreateImage( "_currentRender[0]", nullptr, width, height, 1, &imageParams );
+	tr.currentRenderImage[1] = R_CreateImage( "_currentRender[1]", nullptr, width, height, 1, &imageParams );
+
+	imageParams.bits |= IF_PACKED_DEPTH24_STENCIL8;
+
+	tr.currentDepthImage = R_CreateImage( "_currentDepth", nullptr, width, height, 1, &imageParams );
 }
 
 static void R_CreateDepthRenderImage()
@@ -2488,21 +2515,37 @@ static void R_CreateDepthRenderImage()
 
 	w = (width + TILE_SIZE_STEP1 - 1) >> TILE_SHIFT_STEP1;
 	h = (height + TILE_SIZE_STEP1 - 1) >> TILE_SHIFT_STEP1;
-	tr.depthtile1RenderImage = R_CreateImage( "_depthtile1Render", nullptr, w, h, 1, IF_NOPICMIP | IF_RGBA32F, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_ONE_CLAMP );
+
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP | IF_RGBA32F;
+	imageParams.filterType = filterType_t::FT_NEAREST;
+	imageParams.wrapType = wrapTypeEnum_t::WT_ONE_CLAMP;
+
+	tr.depthtile1RenderImage = R_CreateImage( "_depthtile1Render", nullptr, w, h, 1, &imageParams );
 
 	w = (width + TILE_SIZE - 1) >> TILE_SHIFT;
 	h = (height + TILE_SIZE - 1) >> TILE_SHIFT;
-	tr.depthtile2RenderImage = R_CreateImage( "_depthtile2Render", nullptr, w, h, 1, IF_NOPICMIP | IF_RGBA32F, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.depthtile2RenderImage = R_CreateImage( "_depthtile2Render", nullptr, w, h, 1, &imageParams );
 
 	if ( glConfig2.textureIntegerAvailable ) {
-		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, 4, IF_NOPICMIP | IF_RGBA32UI, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+		imageParams.bits = IF_NOPICMIP | IF_RGBA32UI;
+
+		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, 4, &imageParams );
 	} else {
-		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, 4, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+		imageParams.bits = IF_NOPICMIP;
+
+		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, 4, &imageParams );
 	}
 
 	if( !glConfig2.uniformBufferObjectAvailable ) {
 		w = 64; h = 3 * MAX_REF_LIGHTS / w;
-		tr.dlightImage = R_CreateImage("_dlightImage", nullptr, w, h, 4, IF_NOPICMIP | IF_RGBA32F, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	
+		imageParams.bits = IF_NOPICMIP | IF_RGBA32F;
+
+		tr.dlightImage = R_CreateImage("_dlightImage", nullptr, w, h, 4, &imageParams );
 	}
 }
 
@@ -2513,7 +2556,12 @@ static void R_CreatePortalRenderImage()
 	width = glConfig.vidWidth;
 	height = glConfig.vidHeight;
 
-	tr.portalRenderImage = R_CreateImage( "_portalRender", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_NEAREST;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.portalRenderImage = R_CreateImage( "_portalRender", nullptr, width, height, 1, &imageParams );
 }
 
 static void R_CreateDepthToColorFBOImages()
@@ -2523,10 +2571,13 @@ static void R_CreateDepthToColorFBOImages()
 	width = glConfig.vidWidth;
 	height = glConfig.vidHeight;
 
-	{
-		tr.depthToColorBackFacesFBOImage = R_CreateImage( "_depthToColorBackFacesFBORender", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-		tr.depthToColorFrontFacesFBOImage = R_CreateImage( "_depthToColorFrontFacesFBORender", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-	}
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_NEAREST;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.depthToColorBackFacesFBOImage = R_CreateImage( "_depthToColorBackFacesFBORender", nullptr, width, height, 1, &imageParams );
+	tr.depthToColorFrontFacesFBOImage = R_CreateImage( "_depthToColorFrontFacesFBORender", nullptr, width, height, 1, &imageParams );
 }
 
 // Tr3B: clean up this mess some day ...
@@ -2537,11 +2588,16 @@ static void R_CreateDownScaleFBOImages()
 	width = glConfig.vidWidth * 0.25f;
 	height = glConfig.vidHeight * 0.25f;
 
-	tr.downScaleFBOImage_quarter = R_CreateImage( "_downScaleFBOImage_quarter", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_NEAREST;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.downScaleFBOImage_quarter = R_CreateImage( "_downScaleFBOImage_quarter", nullptr, width, height, 1, &imageParams );
 
 	width = height = 64;
 
-	tr.downScaleFBOImage_64x64 = R_CreateImage( "_downScaleFBOImage_64x64", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	tr.downScaleFBOImage_64x64 = R_CreateImage( "_downScaleFBOImage_64x64", nullptr, width, height, 1, &imageParams );
 }
 
 // *INDENT-OFF*
@@ -2598,12 +2654,17 @@ static void R_CreateShadowMapFBOImage()
 		filter = filterType_t::FT_NEAREST;
 	}
 
+	imageParams_t imageParams = {};
+	imageParams.bits = format;
+	imageParams.filterType = filter;
+	imageParams.wrapType = wrapTypeEnum_t::WT_ONE_CLAMP;
+
 	for ( i = 0; i < numShadowMaps; i++ )
 	{
 		width = height = shadowMapResolutions[ i % MAX_SHADOWMAPS ];
 
-		tr.shadowMapFBOImage[ i ] = R_CreateImage( va( "_shadowMapFBO%d", i ), nullptr, width, height, 1, format, filter, wrapTypeEnum_t::WT_ONE_CLAMP );
-		tr.shadowClipMapFBOImage[ i ] = R_CreateImage( va( "_shadowClipMapFBO%d", i ), nullptr, width, height, 1, format, filter, wrapTypeEnum_t::WT_ONE_CLAMP );
+		tr.shadowMapFBOImage[ i ] = R_CreateImage( va( "_shadowMapFBO%d", i ), nullptr, width, height, 1, &imageParams );
+		tr.shadowClipMapFBOImage[ i ] = R_CreateImage( va( "_shadowClipMapFBO%d", i ), nullptr, width, height, 1, &imageParams );
 	}
 
 	// sun shadow maps
@@ -2611,8 +2672,8 @@ static void R_CreateShadowMapFBOImage()
 	{
 		width = height = sunShadowMapResolutions[ i % MAX_SHADOWMAPS ];
 
-		tr.sunShadowMapFBOImage[ i ] = R_CreateImage( va( "_sunShadowMapFBO%d", i ), nullptr, width, height, 1, format, filter, wrapTypeEnum_t::WT_ONE_CLAMP );
-		tr.sunShadowClipMapFBOImage[ i ] = R_CreateImage( va( "_sunShadowClipMapFBO%d", i ), nullptr, width, height, 1, format, filter, wrapTypeEnum_t::WT_ONE_CLAMP );
+		tr.sunShadowMapFBOImage[ i ] = R_CreateImage( va( "_sunShadowMapFBO%d", i ), nullptr, width, height, 1, &imageParams );
+		tr.sunShadowClipMapFBOImage[ i ] = R_CreateImage( va( "_sunShadowClipMapFBO%d", i ), nullptr, width, height, 1, &imageParams );
 	}
 }
 
@@ -2671,12 +2732,17 @@ static void R_CreateShadowCubeFBOImage()
 		filter = filterType_t::FT_NEAREST;
 	}
 
+	imageParams_t imageParams = {};
+	imageParams.bits = format;
+	imageParams.filterType = filter;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
 	for ( j = 0; j < 5; j++ )
 	{
 		width = height = shadowMapResolutions[ j ];
 
-		tr.shadowCubeFBOImage[ j ] = R_CreateCubeImage( va( "_shadowCubeFBO%d", j ), nullptr, width, height, format, filter, wrapTypeEnum_t::WT_EDGE_CLAMP );
-		tr.shadowClipCubeFBOImage[ j ] = R_CreateCubeImage( va( "_shadowClipCubeFBO%d", j ), nullptr, width, height, format, filter, wrapTypeEnum_t::WT_EDGE_CLAMP );
+		tr.shadowCubeFBOImage[ j ] = R_CreateCubeImage( va( "_shadowCubeFBO%d", j ), nullptr, width, height, &imageParams );
+		tr.shadowClipCubeFBOImage[ j ] = R_CreateCubeImage( va( "_shadowClipCubeFBO%d", j ), nullptr, width, height, &imageParams );
 	}
 }
 
@@ -2698,8 +2764,13 @@ static void R_CreateBlackCubeImage()
 		Com_Memset( data[ i ], 0, width * height * 4 );
 	}
 
-	tr.blackCubeImage = R_CreateCubeImage( "_blackCube", ( const byte ** ) data, width, height, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
-	tr.autoCubeImage = R_CreateCubeImage( "_autoCube", ( const byte ** ) data, width, height, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+	tr.blackCubeImage = R_CreateCubeImage( "_blackCube", ( const byte ** ) data, width, height, &imageParams );
+	tr.autoCubeImage = R_CreateCubeImage( "_autoCube", ( const byte ** ) data, width, height, &imageParams );
 
 	for ( i = 5; i >= 0; i-- )
 	{
@@ -2725,7 +2796,12 @@ static void R_CreateWhiteCubeImage()
 		Com_Memset( data[ i ], 0xFF, width * height * 4 );
 	}
 
-	tr.whiteCubeImage = R_CreateCubeImage( "_whiteCube", ( const byte ** ) data, width, height, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+	tr.whiteCubeImage = R_CreateCubeImage( "_whiteCube", ( const byte ** ) data, width, height, &imageParams );
 
 	for ( i = 5; i >= 0; i-- )
 	{
@@ -2758,13 +2834,12 @@ static void R_CreateColorGradeImage()
 		}
 	}
 
-	tr.colorGradeImage = R_Create3DImage( "_colorGrade", data,
-					      REF_COLORGRADEMAP_SIZE,
-					      REF_COLORGRADEMAP_SIZE,
-					      REF_COLORGRADE_SLOTS * REF_COLORGRADEMAP_SIZE,
-					      IF_NOPICMIP | IF_NOLIGHTSCALE,
-					      filterType_t::FT_LINEAR,
-						  wrapTypeEnum_t::WT_EDGE_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP | IF_NOLIGHTSCALE;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+	tr.colorGradeImage = R_Create3DImage( "_colorGrade", data, REF_COLORGRADEMAP_SIZE, REF_COLORGRADEMAP_SIZE, REF_COLORGRADE_SLOTS * REF_COLORGRADEMAP_SIZE, &imageParams );
 
 	ri.Hunk_FreeTempMemory( data );
 }
@@ -2787,13 +2862,17 @@ void R_CreateBuiltinImages()
 
 	// we use a solid white image instead of disabling texturing
 	Com_Memset( data, 255, sizeof( data ) );
-	tr.whiteImage = R_CreateImage( "_white", ( const byte ** ) &dataPtr,
-				       8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_REPEAT;
+
+	tr.whiteImage = R_CreateImage( "_white", ( const byte ** ) &dataPtr, 8, 8, 1, &imageParams );
 
 	// we use a solid black image instead of disabling texturing
 	Com_Memset( data, 0, sizeof( data ) );
-	tr.blackImage = R_CreateImage( "_black", ( const byte ** ) &dataPtr,
-				       8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+	tr.blackImage = R_CreateImage( "_black", ( const byte ** ) &dataPtr, 8, 8, 1, &imageParams );
 
 	// red
 	for ( x = DEFAULT_SIZE * DEFAULT_SIZE, out = &data[0][0][0]; x; --x, out += 4 )
@@ -2802,8 +2881,7 @@ void R_CreateBuiltinImages()
 		out[ 0 ] = out[ 3 ] = 255;
 	}
 
-	tr.redImage = R_CreateImage( "_red", ( const byte ** ) &dataPtr,
-				     8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+	tr.redImage = R_CreateImage( "_red", ( const byte ** ) &dataPtr, 8, 8, 1, &imageParams );
 
 	// green
 	for ( x = DEFAULT_SIZE * DEFAULT_SIZE, out = &data[0][0][0]; x; --x, out += 4 )
@@ -2812,8 +2890,7 @@ void R_CreateBuiltinImages()
 		out[ 1 ] = out[ 3 ] = 255;
 	}
 
-	tr.greenImage = R_CreateImage( "_green", ( const byte ** ) &dataPtr,
-				       8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+	tr.greenImage = R_CreateImage( "_green", ( const byte ** ) &dataPtr, 8, 8, 1, &imageParams );
 
 	// blue
 	for ( x = DEFAULT_SIZE * DEFAULT_SIZE, out = &data[0][0][0]; x; --x, out += 4 )
@@ -2822,8 +2899,7 @@ void R_CreateBuiltinImages()
 		out[ 2 ] = out[ 3 ] = 255;
 	}
 
-	tr.blueImage = R_CreateImage( "_blue", ( const byte ** ) &dataPtr,
-				      8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+	tr.blueImage = R_CreateImage( "_blue", ( const byte ** ) &dataPtr, 8, 8, 1, &imageParams );
 
 	// generate a default normalmap with a fully opaque heightmap (no displacement)
 	for ( x = DEFAULT_SIZE * DEFAULT_SIZE, out = &data[0][0][0]; x; --x, out += 4 )
@@ -2833,8 +2909,9 @@ void R_CreateBuiltinImages()
 		out[ 3 ] = 255;
 	}
 
-	tr.flatImage = R_CreateImage( "_flat", ( const byte ** ) &dataPtr,
-				      8, 8, 1, IF_NOPICMIP | IF_NORMALMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+	imageParams.bits = IF_NOPICMIP | IF_NORMALMAP;
+
+	tr.flatImage = R_CreateImage( "_flat", ( const byte ** ) &dataPtr, 8, 8, 1, &imageParams );
 
 	out = &data[ 0 ][ 0 ][ 0 ];
 
@@ -2857,10 +2934,10 @@ void R_CreateBuiltinImages()
 		}
 	}
 
-	tr.quadraticImage =
-		R_CreateImage( "_quadratic", ( const byte ** ) &dataPtr,
-			       DEFAULT_SIZE, DEFAULT_SIZE, 1, IF_NOPICMIP, filterType_t::FT_LINEAR,
-					   wrapTypeEnum_t::WT_CLAMP );
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.quadraticImage = R_CreateImage( "_quadratic", ( const byte ** ) &dataPtr, DEFAULT_SIZE, DEFAULT_SIZE, 1, &imageParams );
 
 	R_CreateRandomNormalsImage();
 	R_CreateFogImage();
@@ -2981,5 +3058,11 @@ qhandle_t RE_GenerateTexture( const byte *pic, int width, int height )
 {
 	const char *name = va( "rocket%d", numTextures++ );
 	R_SyncRenderThread();
-	return RE_RegisterShaderFromImage( name, R_CreateImage( name, &pic, width, height, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP ) );
+
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	return RE_RegisterShaderFromImage( name, R_CreateImage( name, &pic, width, height, 1, &imageParams ) );
 }

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -384,6 +384,11 @@ void R_ImageList_f()
 				out += buffer;
 				break;
 
+			case wrapTypeEnum_t::WT_ONE_CLAMP:
+				Com_sprintf( buffer, sizeof( buffer ), "t.1clmp  " );
+				out+= buffer;
+				break;
+
 			default:
 				Log::Debug( "Undocumented wrapType.s %i for image %s", Util::ordinal(image->wrapType.s), image->name );
 				Com_sprintf( buffer, sizeof( buffer ), "s.%4i   ", Util::ordinal(image->wrapType.s) );
@@ -416,6 +421,11 @@ void R_ImageList_f()
 			case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
 				Com_sprintf( buffer, sizeof( buffer ), "t.a0clmp " );
 				out += buffer;
+				break;
+
+			case wrapTypeEnum_t::WT_ONE_CLAMP:
+				Com_sprintf( buffer, sizeof( buffer ), "t.1clmp  " );
+				out+= buffer;
 				break;
 
 			default:

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1013,7 +1013,7 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 
 		for( i = 0; i < numMips; i++ )
 		{
-			glTexImage3D( GL_TEXTURE_3D, i, internalFormat, scaledWidth, scaledHeight, mipLayers, 0, format, GL_UNSIGNED_BYTE, nullptr );
+			glTexImage3D( GL_TEXTURE_3D, i, internalFormat, mipWidth, mipHeight, mipLayers, 0, format, GL_UNSIGNED_BYTE, nullptr );
 
 			if( mipWidth  > 1 )
 			{
@@ -1173,7 +1173,7 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 				switch ( image->type )
 				{
 					case GL_TEXTURE_3D:
-						glCompressedTexSubImage3D( GL_TEXTURE_3D, i, 0, 0, j, scaledWidth, scaledHeight, 1, internalFormat, mipSize, data );
+						glCompressedTexSubImage3D( GL_TEXTURE_3D, i, 0, 0, j, mipWidth, mipHeight, 1, internalFormat, mipSize, data );
 					break;
 
 					case GL_TEXTURE_CUBE_MAP:

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1049,7 +1049,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_arb_gpu_shader5 = ri.Cvar_Get( "r_arb_gpu_shader5", "1", CVAR_CHEAT | CVAR_LATCH );
 
 		r_picmip = ri.Cvar_Get( "r_picmip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
-		AssertCvarRange( r_picmip, 0, 3, true );
 		r_imageMinDimension = ri.Cvar_Get( "r_imageMinDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_imageMaxDimension = ri.Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_colorMipLevels = ri.Cvar_Get( "r_colorMipLevels", "0", CVAR_LATCH );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -149,6 +149,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_singleShader;
 	cvar_t      *r_colorMipLevels;
 	cvar_t      *r_picmip;
+	cvar_t      *r_imageMinDimension;
+	cvar_t      *r_imageMaxDimension;
 	cvar_t      *r_finish;
 	cvar_t      *r_clear;
 	cvar_t      *r_swapInterval;
@@ -945,6 +947,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		Log::Debug("texturemode: %s", r_textureMode->string );
 		Log::Debug("picmip: %d", r_picmip->integer );
+		Log::Debug("imageMinDimension: %d", r_imageMinDimension->integer );
+		Log::Debug("imageMaxDimension: %d", r_imageMaxDimension->integer );
 
 		if ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 )
 		{
@@ -1046,6 +1050,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		r_picmip = ri.Cvar_Get( "r_picmip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		AssertCvarRange( r_picmip, 0, 3, true );
+		r_imageMinDimension = ri.Cvar_Get( "r_imageMinDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
+		r_imageMaxDimension = ri.Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_colorMipLevels = ri.Cvar_Get( "r_colorMipLevels", "0", CVAR_LATCH );
 		r_colorbits = ri.Cvar_Get( "r_colorbits", "0",  CVAR_LATCH );
 		r_alphabits = ri.Cvar_Get( "r_alphabits", "0",  CVAR_LATCH );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1051,6 +1051,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_picmip = ri.Cvar_Get( "r_picmip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_imageMinDimension = ri.Cvar_Get( "r_imageMinDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_imageMaxDimension = ri.Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
+		r_imageMinDimension = ri.Cvar_Get( "r_imageMinDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
+		r_imageMaxDimension = ri.Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_colorMipLevels = ri.Cvar_Get( "r_colorMipLevels", "0", CVAR_LATCH );
 		r_colorbits = ri.Cvar_Get( "r_colorbits", "0",  CVAR_LATCH );
 		r_alphabits = ri.Cvar_Get( "r_alphabits", "0",  CVAR_LATCH );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -589,6 +589,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		int bits = 0;
 		filterType_t filterType;
 		wrapType_t wrapType;
+		int minDimension = 0;
+		int maxDimension = 0;
 	};
 
 	struct image_t
@@ -1268,6 +1270,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		float          polygonOffsetValue;
 
 		bool       noPicMip; // for images that must always be full resolution
+		int        imageMinDimension;   // for images that must not be loaded with smaller size
+		int        imageMaxDimension;   // for images that must not be loaded with larger size
 		filterType_t   filterType; // for console fonts, 2D elements, etc.
 		wrapType_t     wrapType;
 
@@ -2881,6 +2885,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_singleShader; // make most world faces use default shader
 	extern cvar_t *r_colorMipLevels; // development aid to see texture mip usage
 	extern cvar_t *r_picmip; // controls picmip values
+	extern cvar_t *r_imageMinDimension;
+	extern cvar_t *r_imageMaxDimension;
 	extern cvar_t *r_finish;
 	extern cvar_t *r_drawBuffer;
 	extern cvar_t *r_swapInterval;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -584,6 +584,12 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	static inline bool operator ==( const wrapType_t &a, const wrapType_t &b ) { return a.s == b.s && a.t == b.t; }
 	static inline bool operator !=( const wrapType_t &a, const wrapType_t &b ) { return a.s != b.s || a.t != b.t; }
 
+	struct imageParams_t
+	{
+		int bits = 0;
+		filterType_t filterType;
+		wrapType_t wrapType;
+	};
 
 	struct image_t
 	{
@@ -3194,27 +3200,19 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	void    R_ShutdownImages();
 
 	int R_FindImageLoader( const char *baseName );
-	image_t *R_FindImageFile( const char *name, int bits, filterType_t filterType, wrapType_t wrapType );
-	image_t *R_FindCubeImage( const char *name, int bits, filterType_t filterType, wrapType_t wrapType );
+	image_t *R_FindImageFile( const char *name, imageParams_t *imageParams );
+	image_t *R_FindCubeImage( const char *name, imageParams_t *imageParams );
 
-	image_t *R_CreateImage( const char *name, const byte **pic,
-				int width, int height, int bits, int numMips,
-				filterType_t filterType, wrapType_t wrapType );
+	image_t *R_CreateImage( const char *name, const byte **pic, int width, int height, int numMips, imageParams_t *imageParams );
 
-	image_t *R_CreateCubeImage( const char *name, const byte *pic[ 6 ],
-	                            int width, int height, int bits,
-				    filterType_t filterType, wrapType_t wrapType );
-	image_t        *R_Create3DImage( const char *name,
-					 const byte *pic,
-					 int width, int height, int depth,
-					 int bits, filterType_t filterType,
-					 wrapType_t wrapType );
+	image_t *R_CreateCubeImage( const char *name, const byte *pic[ 6 ], int width, int height, imageParams_t *imageParams );
+	image_t *R_Create3DImage( const char *name, const byte *pic, int width, int height, int depth, imageParams_t *imageParams );
 
 	image_t *R_CreateGlyph( const char *name, const byte *pic, int width, int height );
 	qhandle_t RE_GenerateTexture( const byte *pic, int width, int height );
 
 	image_t *R_AllocImage( const char *name, bool linkIntoHashTable );
-	void    R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t *image );
+	void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t *image, imageParams_t *imageParams );
 
 	void    RE_GetTextureSize( int textureID, int *width, int *height );
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1451,6 +1451,8 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 
 	imageParams_t imageParams = {};
 	imageParams.bits = 0;
+	imageParams.minDimension = shader.imageMinDimension;
+	imageParams.maxDimension = shader.imageMaxDimension;
 
 	// determine image options
 	if ( stage->overrideNoPicMip || shader.noPicMip || stage->highQuality || stage->forceHighQuality )
@@ -2163,6 +2165,8 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			imageParams.bits = imageBits;
 			imageParams.filterType = filterType;
 			imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+			imageParams.minDimension = shader.imageMinDimension;
+			imageParams.maxDimension = shader.imageMaxDimension;
 
 			stage->bundle[ 0 ].image[ 0 ] = R_FindImageFile( token, &imageParams );
 
@@ -2210,6 +2214,8 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 					imageParams.bits = IF_NONE;
 					imageParams.filterType = filterType_t::FT_DEFAULT;
 					imageParams.wrapType = wrapTypeEnum_t::WT_REPEAT;
+					imageParams.minDimension = shader.imageMinDimension;
+					imageParams.maxDimension = shader.imageMaxDimension;
 
 					stage->bundle[ 0 ].image[ num ] = R_FindImageFile( token, &imageParams );
 
@@ -2266,6 +2272,8 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			imageParams.bits = imageBits;
 			imageParams.filterType = filterType;
 			imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+			imageParams.minDimension = shader.imageMinDimension;
+			imageParams.maxDimension = shader.imageMaxDimension;
 
 			stage->bundle[ 0 ].image[ 0 ] = R_FindCubeImage( token, &imageParams );
 
@@ -3455,6 +3463,8 @@ static void ParseSkyParms( const char **text )
 		imageParams.bits = IF_NONE;
 		imageParams.filterType = filterType_t::FT_DEFAULT;
 		imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+		imageParams.minDimension = shader.imageMinDimension;
+		imageParams.maxDimension = shader.imageMaxDimension;
 
 		shader.sky.outerbox = R_FindCubeImage( prefix, &imageParams );
 
@@ -3500,6 +3510,8 @@ static void ParseSkyParms( const char **text )
 		imageParams.bits = IF_NONE;
 		imageParams.filterType = filterType_t::FT_DEFAULT;
 		imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+		imageParams.minDimension = shader.imageMinDimension;
+		imageParams.maxDimension = shader.imageMaxDimension;
 
 		shader.sky.innerbox = R_FindCubeImage( prefix, &imageParams );
 
@@ -3960,6 +3972,30 @@ static bool ParseShader( const char *_text )
 		else if ( !Q_stricmp( token, "nopicmip" ) )
 		{
 			shader.noPicMip = true;
+			continue;
+		}
+		// imageMinDimension enforcement
+		else if ( !Q_stricmp( token, "imageMinDimension" ) )
+		{
+			token = COM_ParseExt2( text, false );
+
+			if ( token[ 0 ] )
+			{
+				shader.imageMinDimension = atof( token );
+			}
+
+			continue;
+		}
+		// imageMaxDimension enforcement
+		else if ( !Q_stricmp( token, "imageMaxDimension" ) )
+		{
+			token = COM_ParseExt2( text, false );
+
+			if ( token[ 0 ] )
+			{
+				shader.imageMaxDimension = atof( token );
+			}
+
 			continue;
 		}
 		// RF, allow each shader to permit compression if available (removed option)

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -2127,6 +2127,8 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			else
 			{
 				loadMap = true;
+				imageBits |= IF_LIGHTMAP;
+				imageBits |= IF_NOPICMIP;
 			}
 		}
 		// clampmap <name>
@@ -2828,6 +2830,7 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			}
 			else if ( !Q_stricmp( token, "lightmap" ) )
 			{
+				imageBits |= IF_LIGHTMAP;
 				imageBits |= IF_NOPICMIP;
 				stage->tcGen_Lightmap = true;
 				stage->tcGen_Environment = false;


### PR DESCRIPTION
1. Resize textures using GL_PROXY mechanism
2. Introduce picMin and picMax

The ATI X1950 PRO can display the game with medium preset including full size textures except the skybox that is `1024^6` size:

[![picmax](https://dl.illwieckz.net/b/daemon/features/picmax/unvanquished_2020-10-27_184412_000.jpg)](https://dl.illwieckz.net/b/daemon/features/picmax/unvanquished_2020-10-27_184412_000.jpg)

With `r_picMax` set to `512`, everything looks good:

[![picmax](https://dl.illwieckz.net/b/daemon/features/picmax/unvanquished_2020-10-27_184517_000.jpg)](https://dl.illwieckz.net/b/daemon/features/picmax/unvanquished_2020-10-27_184517_000.jpg)

The `r_picMax` cvar expects the size of an edge, so `r_picMax` 512 will scale down every image larger than a square image of `512×512` size.

Using `r_picMax 512` will scale down textures from `tex-vega` that are `1024×1024` large but will not scale down textures from `tex-pk01` that are `512x512` large. This way a map using both vega and pk01 textures will look highly textured with `512×512` textures everywhere while using `r_picmip 1` would have displayed a mix of nice `512x512` and ugly `256×256` images.

Both `r_picmip` and `r_picMax` can be used at the same time. For example, by using `r_picmip 1` and `r_picMax 512`, once minimap is set as nopicmip (see https://github.com/Unvanquished/Unvanquished/pull/1230 ), the game will scale down all textures but the minimap to keep it clear, unless it is larger than 512, _but minimaps with size up to 512 will not be scaled down_…

I added two shader keywords: `picMin` and `picMax`.

The `picMin` one allows an artist to tell the renderer to never downscale a texture under this size. This is useful for models for example, since seeing details like the eyes and others is better.

The `picMax` allows an artist to tell the renderer to downscale the texture to this size, even if the player is playing full size.

I added another cvar, `r_picMin`, which allows to override the `picMin` value set in shader, and when it is set to `-1`, never downscale images that has `picMin` value (it would be like making them `nopicmip`).