### PR TITLE
Make GL error check non-fatal in SMP mode

### DIFF
--- a/src/engine/renderer/tr_cmds.cpp
+++ b/src/engine/renderer/tr_cmds.cpp
@@ -813,55 +813,8 @@ void RE_BeginFrame()
 	// check for errors
 	if ( !r_ignoreGLErrors->integer )
 	{
-		int  err;
-		char s[ 128 ];
-
 		R_SyncRenderThread();
-
-		if ( ( err = glGetError() ) != GL_NO_ERROR )
-		{
-			switch ( err )
-			{
-				case GL_INVALID_ENUM:
-					strcpy( s, "GL_INVALID_ENUM" );
-					break;
-
-				case GL_INVALID_VALUE:
-					strcpy( s, "GL_INVALID_VALUE" );
-					break;
-
-				case GL_INVALID_OPERATION:
-					strcpy( s, "GL_INVALID_OPERATION" );
-					break;
-
-				case GL_STACK_OVERFLOW:
-					strcpy( s, "GL_STACK_OVERFLOW" );
-					break;
-
-				case GL_STACK_UNDERFLOW:
-					strcpy( s, "GL_STACK_UNDERFLOW" );
-					break;
-
-				case GL_OUT_OF_MEMORY:
-					strcpy( s, "GL_OUT_OF_MEMORY" );
-					break;
-
-				case GL_TABLE_TOO_LARGE:
-					strcpy( s, "GL_TABLE_TOO_LARGE" );
-					break;
-
-				case GL_INVALID_FRAMEBUFFER_OPERATION:
-					strcpy( s, "GL_INVALID_FRAMEBUFFER_OPERATION" );
-					break;
-
-				default:
-					Com_sprintf( s, sizeof( s ), "0x%X", err );
-					break;
-			}
-
-			//Sys::Error("caught OpenGL error: %s in file %s line %i", s, filename, line);
-			Sys::Error( "RE_BeginFrame() - glGetError() failed (%s)!", s );
-		}
+		GL_CheckErrors_( __FILE__, __LINE__ );
 	}
 
 	// draw buffer stuff

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -367,18 +367,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	/*
 	==================
 	GL_CheckErrors
+
+	Must not be called while the backend rendering thread is running
 	==================
 	*/
 	void GL_CheckErrors_( const char *fileName, int line )
 	{
 		int  err;
 		char s[ 128 ];
-
-		if ( glConfig.smpActive )
-		{
-			// we can't print onto the console while rendering in another thread
-			return;
-		}
 
 		if ( r_ignoreGLErrors->integer )
 		{

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3139,7 +3139,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 
 	void GL_CheckErrors_( const char *filename, int line );
 
-#define         GL_CheckErrors() GL_CheckErrors_(__FILE__, __LINE__)
+#define GL_CheckErrors() do { if (!glConfig.smpActive) GL_CheckErrors_(__FILE__, __LINE__); } while (false)
 
 	void GL_State( uint32_t stateVector );
 	void GL_VertexAttribsState( uint32_t stateBits );


### PR DESCRIPTION
Also remove duplicated code for printing names of GL errors.