### PR TITLE
sdl_windowevent_restored adjustment

### DIFF
--- a/src/engine/sys/sdl_input.cpp
+++ b/src/engine/sys/sdl_input.cpp
@@ -1144,7 +1144,7 @@ static void IN_ProcessEvents( bool dropInput )
 						break;
 
 					case SDL_WINDOWEVENT_MINIMIZED:    Cvar_SetValue( "com_minimized", 1 ); break;
-					case SDL_WINDOWEVENT_RESTORED:
+					case SDL_WINDOWEVENT_RESTORED:     Cvar_SetValue( "com_minimized", 0 ); break;
 					case SDL_WINDOWEVENT_MAXIMIZED:    Cvar_SetValue( "com_minimized", 0 ); break;
 					case SDL_WINDOWEVENT_FOCUS_LOST:   Cvar_SetValue( "com_unfocused", 1 ); break;
 					case SDL_WINDOWEVENT_FOCUS_GAINED: Cvar_SetValue( "com_unfocused", 0 ); break;


### PR DESCRIPTION
According to the docs I could find, restored is the same as unminimised and should be treated as such. Also the missing break; No idea how important that is/ was.

Also I was wondering something more like extending the others as a Just in case, like so: ?
`case SDL_WINDOWEVENT_MAXIMIZED:    Cvar_SetValue( "com_minimized", 0 ); Cvar_SetValue( "com_unfocused", 0 ); break;`