### PR TITLE
toolchain-pnacl: Use the FindPython2 module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,12 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-cmake_minimum_required (VERSION 2.8.12)
-if (POLICY CMP0017)
-    cmake_policy(SET CMP0017 NEW)
+cmake_minimum_required (VERSION 3.12)
+
+# Choose Python versions by location instead of getting whatever is in PYTHON_EXECUTABLE
+# Can be removed once we require CMake 3.15
+if (POLICY CMP0094)
+    cmake_policy(SET CMP0094 NEW)
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})

--- a/cmake/toolchain-pnacl.cmake
+++ b/cmake/toolchain-pnacl.cmake
@@ -52,13 +52,12 @@ set(CMAKE_C_RESPONSE_FILE_LINK_FLAG "@")
 set(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG "@")
 
 if (NOT CMAKE_HOST_WIN32)
-    set(PythonInterp_FIND_VERSION 2)
-    find_package(PythonInterp 2)
-    if (NOT PYTHONINTERP_FOUND)
-        message(FATAL_ERROR "Please set the PNACLPYTHON environment variable to your Python2 executable")
+    find_package(Python2)
+    if (NOT Python2_Interpreter_FOUND)
+        message(FATAL_ERROR "Please install python2 and/or set the PYTHON_EXECUTABLE CMake variable.")
     endif()
-    set(PNACLPYTHON_PREFIX "env PNACLPYTHON=${PYTHON_EXECUTABLE} ")
-    set(PNACLPYTHON_PREFIX2 env "PNACLPYTHON=${PYTHON_EXECUTABLE} ")
+    set(PNACLPYTHON_PREFIX "env PNACLPYTHON=${Python2_EXECUTABLE} ")
+    set(PNACLPYTHON_PREFIX2 env "PNACLPYTHON=${Python2_EXECUTABLE} ")
 endif()
 
 # These commands can fail on windows if there is a space at the beginning


### PR DESCRIPTION
This makes the toolchain automatically find python2 installation even on
systems with /usr/bin/python that's python3.

The FindPython2 module was intrudoced in CMake 3.12 so Daemon's CMake
requirement is bump to that version. Note that it is an older version
than what's in Debian stable and oldstable's backports.

Fixes #411