### PR TITLE
Azure Pipelines continuous build for Mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ cache: ccache
 addons:
   apt:
     update: true
-  homebrew:
-    packages:
-    - ninja
-    - ccache
 
 matrix:
   include:
@@ -19,11 +15,6 @@ matrix:
     - name: "Linux build using clang"
       os: linux
       compiler: clang
-  allow_failures:
-    - name: "osx build"
-      os: osx
-      compiler: clang
-    # osx links gcc to clang; so skip
 
 install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
@@ -35,20 +26,11 @@ install:
         libfreetype6-dev libglew-dev libopenal-dev
         liblua5.2-dev ninja-build;
     fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      brew update;
-      touch BrewFile;
-      echo 'brew "ccache"' >> BrewFile;
-      echo 'brew "ninja"' >> BrewFile;
-      brew bundle;
-    fi
   - |
     # workarounds to make ccache work
     if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "clang++" ]; then
       sudo ln -s $(which ccache) /usr/lib/ccache/clang
       sudo ln -s $(which ccache) /usr/lib/ccache/clang++
-    elif [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      export PATH="/usr/local/opt/ccache/libexec:$PATH"
     fi
 
 before_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -433,6 +433,10 @@ if (NACL)
 else()
     add_library(srclibs-nacl-native EXCLUDE_FROM_ALL ${NACLLIST_NATIVE})
     set_target_properties(srclibs-nacl-native PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
+    if (APPLE)
+        # Do not error for OSAtomic* deprecation notices
+        target_compile_options(srclibs-nacl-native PRIVATE "-Wno-error=deprecated-declarations")
+    endif()
     set(LIBS_BASE ${LIBS_BASE} srclibs-nacl-native)
 endif()
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,10 @@
+pool:
+  vmImage: 'macOS-10.15'
+
+steps:
+- script: |
+    set -e
+    git submodule update --init --recursive
+    cmake -DUSE_PRECOMPILED_HEADER=0 -DUSE_WERROR=1 -DBE_VERBOSE=1 -DCMAKE_BUILD_TYPE=Debug -DUSE_DEBUG_OPTIMIZE=0 -H. -Bbuild
+    cmake --build build -- -j`sysctl -n hw.logicalcpu`
+  displayName: 'Build'

--- a/src/common/Serialize.h
+++ b/src/common/Serialize.h
@@ -376,7 +376,7 @@ namespace Util {
 		static void Write(Writer& stream, const std::map<T, U>& value)
 		{
 			stream.WriteSize(value.size());
-			for (const std::pair<T, U>& x: value)
+			for (const std::pair<const T, U>& x: value)
 				stream.Write<std::pair<T, U>>(x);
 		}
 		static std::map<T, U> Read(Reader& stream)
@@ -393,7 +393,7 @@ namespace Util {
 		static void Write(Writer& stream, const std::unordered_map<T, U>& value)
 		{
 			stream.WriteSize(value.size());
-			for (const std::pair<T, U>& x: value)
+			for (const std::pair<const T, U>& x: value)
 				stream.Write<std::pair<T, U>>(x);
 		}
 		static std::unordered_map<T, U> Read(Reader& stream)

--- a/src/engine/client/cl_console.cpp
+++ b/src/engine/client/cl_console.cpp
@@ -436,11 +436,11 @@ void Con_Linefeed()
 	//fall down to input line if scroll lock is configured to do so
 	if(scrollLockMode <= 0)
 	{
-		consoleState.scrollLineIndex = consoleState.lines.size()-1;
+		consoleState.scrollLineIndex = static_cast<int>(consoleState.lines.size()) - 1;
 	}
 
 	//dont scroll a line down on a scrollock configured to do so
-	if ( consoleState.scrollLineIndex >= consoleState.lines.size() - 1 && scrollLockMode < 3 )
+	if ( consoleState.scrollLineIndex >= static_cast<int>(consoleState.lines.size()) - 1 && scrollLockMode < 3 )
 	{
 		consoleState.scrollLineIndex++;
 	}
@@ -524,7 +524,7 @@ bool CL_InternalConsolePrint( const char *text )
 			}
 
 			// word wrap
-			if ( consoleState.lines.back().size() + wordLen >= consoleState.textWidthInChars )
+			if ( consoleState.lines.back().size() + wordLen >= size_t(consoleState.textWidthInChars) )
 			{
 				Con_Linefeed();
 			}
@@ -543,7 +543,7 @@ bool CL_InternalConsolePrint( const char *text )
 					--wordLen;
 				}
 
-				if ( consoleState.lines.back().size() >= consoleState.textWidthInChars )
+				if ( consoleState.lines.back().size() >= size_t(consoleState.textWidthInChars) )
 				{
 					Con_Linefeed();
 				}
@@ -872,7 +872,7 @@ void Con_DrawConsoleContent()
 	for ( ; row >= 0 && lineDrawPosition > textDistanceToTop; lineDrawPosition -= charHeight, row-- )
 	{
 		if ( row == consoleState.lastReadLineIndex - 1
-			&& consoleState.lastReadLineIndex != consoleState.lines.size() - 1 )
+			&& consoleState.lastReadLineIndex != static_cast<int>(consoleState.lines.size()) - 1 )
 		{
 			Con_DrawScrollbackMarkerline( lineDrawPosition );
 		}
@@ -1237,7 +1237,7 @@ void Con_PageDown()
 void Con_ScrollUp( int lines )
 {
 	//do not scroll if there isn't enough to scroll
-	if(consoleState.lines.size() < consoleState.visibleAmountOfLines)
+	if (consoleState.lines.size() < size_t(consoleState.visibleAmountOfLines))
 		return;
 
 	consoleState.scrollLineIndex -= lines;
@@ -1252,7 +1252,7 @@ void Con_ScrollDown( int lines )
 {
 	consoleState.scrollLineIndex += lines;
 
-	if ( consoleState.scrollLineIndex >= consoleState.lines.size() )
+	if ( consoleState.scrollLineIndex >= static_cast<int>(consoleState.lines.size()) )
 	{
 		consoleState.scrollLineIndex = consoleState.lines.size() - 1;
 	}

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -393,7 +393,7 @@ static void HandlePacketEvent(const Sys::PacketEvent& event)
 	// the event buffers are only large enough to hold the
 	// exact payload, but channel messages need to be large
 	// enough to hold fragment reassembly
-	if ( event.data.size() > buf.maxsize )
+	if ( event.data.size() > static_cast<size_t>(buf.maxsize) )
 	{
 		Log::Notice( "Com_EventLoop: oversize packet\n" );
 		return;

--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -1246,7 +1246,7 @@ player_state_t communication
 */
 
 static bool IsValid(const NetcodeTable& table, int size) {
-	if (size % PLAYERSTATE_FIELD_SIZE != 0 || size < offsetof(OpaquePlayerState, END) || size > MAX_PLAYERSTATE_SIZE)
+	if (size % PLAYERSTATE_FIELD_SIZE != 0 || size < int(offsetof(OpaquePlayerState, END)) || size > MAX_PLAYERSTATE_SIZE)
 		return false;
 	for (const netField_t& f : table) {
 		if (f.offset < 0 || f.offset % PLAYERSTATE_FIELD_SIZE != 0)
@@ -1417,7 +1417,7 @@ void MSG_WriteDeltaPlayerstate( msg_t *msg, OpaquePlayerState *from, OpaquePlaye
 
 	MSG_WriteByte( msg, lc );  // # of changes
 
-	for ( size_t i = 0; i < lc; i++ )
+	for ( int i = 0; i < lc; i++ )
 	{
 		netField_t* field = &playerStateFields[i];
 		fromF = ( int * )( ( byte * ) from + field->offset );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -238,7 +238,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		int                 coords[ 4 ];
 	};
 
-	enum frustumBits_t
+	enum frustumBits_t : int
 	{
 	  FRUSTUM_LEFT,
 	  FRUSTUM_RIGHT,


### PR DESCRIPTION
Completely removes the Travis Mac build which stopped working, and adds an Azure Pipelines-based one. Plus some warning fixes so it will run with -Werror.

Unlike Travis, this service lets you download the binaries it builds, so it is also possible to use it for releasing. This what I used to build the Mac version of the updater.

We might consider moving the Linux build to this also (it supports all 3 of our OSes), since it seems to have much shorter queueing times than Travis now.

Ping me if you want to be invited to the "UnvanquishedDevelopment" organization on the Azure Pipelines site.