### PR TITLE
introduce r_imageMaxDimension (from #394)

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -92,6 +92,8 @@ set(RENDERERLIST
     ${ENGINE_DIR}/renderer/tr_fbo.cpp
     ${ENGINE_DIR}/renderer/tr_flares.cpp
     ${ENGINE_DIR}/renderer/tr_font.cpp
+    ${ENGINE_DIR}/renderer/InternalImage.cpp
+    ${ENGINE_DIR}/renderer/InternalImage.h
     ${ENGINE_DIR}/renderer/tr_image.cpp
     ${ENGINE_DIR}/renderer/tr_image.h
     ${ENGINE_DIR}/renderer/tr_image_crn.cpp

--- a/src/engine/renderer/InternalImage.cpp
+++ b/src/engine/renderer/InternalImage.cpp
@@ -1,0 +1,181 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2013-2016 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Daemon developers nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// InternalImage.cpp
+#include "tr_local.h"
+
+// Comments may include short quotes from other authors.
+
+/*
+===============
+R_GetImageCustomScalingStep
+
+Returns amount of downscaling step to be done on the given image
+to perform optional picmip or other downscaling operation.
+
+- the r_picMip cvar tells the renderer to downscale textures as many time as this cvar value;
+- the imageMaxDimension material keyword tells the renderer to downscale related textures
+  to that dimension if natively larger than that dimension;
+- the r_imageMaxDimension cvar tells the renderer to downscale all textures to that dimension
+  if natively larger than that dimension;
+- the r_ignoreMaterialMaxDimension cvar tells the renderer to ignore the imageMaxDimension material
+  keyword, r_imageMaxDimension still applies;
+- the imageMinDimension material keyword tells the renderer to not downscale related textures
+  below that dimension, has priority over r_picMip and r_imageMaxDimension;
+- the r_ignoreMaterialMinDemension cvar tells the renderer to ignore the imageMinDimension material
+  keyword;
+- the r_replaceMaterialMinDimensionIfPresentWithMaxDimension cvar tells the renderer to use the
+  maximum texture size for textures having a material keyword setting a minimum dimension;
+
+Examples of scenarii:
+
+- r_picMip set 3 with some materials having imageMinDimension set to 128:
+  attempt to reduce three times the images, but for materials having that keyword,
+  stop before the image dimension would be smaller than 128;
+- r_imageMaxDimension set to 64 with some materials having imageMinDimension set to 128:
+  reduce images having dimension greater than 64 to fit 64 dimension, but for materials
+  having that keyword, reduce image to fit 128 dimension;
+- r_imageMaxDimension set to 64 with some materials having imageMaxDimension set to 32:
+  reduce images having dimension greater than 64 to fit 64 dimension, but for materials
+  having that keyword, reduce image to fit 32 dimension;
+- r_imageMaxDimension set to 64 and r_replaceMaterialMinDimensionIfPresentWithMaxDimension
+  enabled: reduce images having dimension greater than 64 to fit 64 dimension, but for
+  materials having that keyword, keep the native dimension, or the one set by material
+  imageMaxDimension keyword;
+
+Examples of use cases:
+
+- Movie producer wanting to record a movie from a demo using the highest image definition
+  possible even if the game developper configured them to be downscaled for performance
+  purpose:
+    set r_ignoreMaterialMaxDimension on
+- Low budget player wanting to reduce all textures to low definition but keep configured
+  minimum definition on the textures the game developer configured to not be reduced to a
+  given size to keep the game playable:
+    set r_imageMaxDimension 64
+- Very low budget player wanting to reduce all textures to low definition in all case,
+  taking risk stuff may not look as the game developers expect anyway:
+    set r_imageMaxDimension 64
+    set r_ignoreMaterialMinDimension on
+- Competitive player wanting to reduce all textures to one flat color but keep configured
+  minimum definition on the textures the game developer configured to not be reduced to a
+  given size to keep the game playable:
+    set r_imageMaxDimension 1
+- Competitive player wanting to reduce all textures to one flat color but keep high definition
+  on the textures the game developer configured to not be reduced to keep the game playable:
+    ser r_imageMaxDimension 1
+    set r_replaceMaterialMinDimensionIfPresentWithMaxDimension on
+ 
+===============
+*/
+int R_GetImageCustomScalingStep( const image_t *image, const imageParams_t &imageParams )
+{
+	if ( image->bits & IF_NOPICMIP )
+	{
+		return 0;
+	}
+
+	int materialMinDimension = r_ignoreMaterialMinDimension->integer ? 0 : imageParams.minDimension;
+	int materialMaxDimension = r_ignoreMaterialMaxDimension->integer ? 0 : imageParams.maxDimension;
+
+	int minDimension;
+
+	if ( materialMinDimension <= 0 )
+	{
+		minDimension = 1;
+	}
+	else if ( r_replaceMaterialMinDimensionIfPresentWithMaxDimension->integer )
+	{
+		minDimension = materialMaxDimension > 0 ? materialMaxDimension : std::numeric_limits<int>::max();
+	}
+	else
+	{
+		minDimension = materialMinDimension;
+	}
+
+	int maxDimension = materialMaxDimension > 0 ? materialMaxDimension : std::numeric_limits<int>::max();
+
+	if ( r_imageMaxDimension->integer > 0 )
+	{
+		maxDimension = std::min( maxDimension, r_imageMaxDimension->integer );
+	}
+
+	// Consider the larger edge as the "image dimension"
+	int scaledDimension = std::max( image->width, image->height );
+	int scalingStep = 0;
+
+	// 1st priority: scaledDimension >= minDimension
+	// 2nd priority: scaledDimension <= maxDimension
+	// 3rd priority: scalingStep >= r_picMip->integer
+	// 4th priority: scalingStep as low as possible
+	while ( scaledDimension > maxDimension || scalingStep < r_picMip->integer )
+	{
+		scaledDimension >>= 1;
+
+		if ( scaledDimension < minDimension )
+		{
+			break;
+		}
+
+		++scalingStep;
+	}
+
+	return scalingStep;
+}
+
+void R_DownscaleImageDimensions( int scalingStep, int *scaledWidth, int *scaledHeight, const byte ***dataArray, int numLayers, int *numMips )
+{
+	scalingStep = std::min(scalingStep, *numMips - 1);
+
+	if ( scalingStep > 0 )
+	{
+		*scaledWidth >>= scalingStep;
+		*scaledHeight >>= scalingStep;
+
+		if( *dataArray && *numMips > scalingStep ) {
+			*dataArray += numLayers * scalingStep;
+			*numMips -= scalingStep;
+		}
+	}
+
+	// Clamp to minimum size.
+	if ( *scaledWidth < 1 )
+	{
+		*scaledWidth = 1;
+	}
+
+	if ( *scaledHeight < 1 )
+	{
+		*scaledHeight = 1;
+	}
+}

--- a/src/engine/renderer/InternalImage.h
+++ b/src/engine/renderer/InternalImage.h
@@ -1,0 +1,43 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2013-2016 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Daemon developers nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// InternalImage.h
+
+#ifndef INTERNAL_IMAGE_H
+#define INTERNAL_IMAGE_H
+#include "tr_local.h"
+
+int R_GetImageCustomScalingStep( const image_t *image, const imageParams_t &imageParams );
+void R_DownscaleImageDimensions( int scalingStep, int *scaledWidth, int *scaledHeight, const byte ***dataArray, int numLayers, int *numMips );
+
+#endif // INTERNAL_IMAGE_H

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -6695,7 +6695,9 @@ void R_BuildCubeMaps()
 		cubeProbe->cubemap->filterType = filterType_t::FT_LINEAR;
 		cubeProbe->cubemap->wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
 
-		R_UploadImage( ( const byte ** ) tr.cubeTemp, 6, 1, cubeProbe->cubemap );
+		imageParams_t imageParams = {};
+
+		R_UploadImage( ( const byte ** ) tr.cubeTemp, 6, 1, cubeProbe->cubemap, imageParams );
 	}
 
 	Log::Notice("\n");

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -485,7 +485,12 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 				width = height = 0;
 				LoadRGBEToBytes( va( "%s/%s", mapName, lightmapFiles[ i ] ), &ldrImage, &width, &height );
 
-				auto image = R_CreateImage( va( "%s/%s", mapName, lightmapFiles[ i ] ), (const byte **)&ldrImage, width, height, 1, IF_NOPICMIP | IF_LIGHTMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
+				imageParams_t imageParams = {};
+				imageParams.bits = IF_NOPICMIP | IF_LIGHTMAP;
+				imageParams.filterType = filterType_t::FT_DEFAULT;
+				imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+				auto image = R_CreateImage( va( "%s/%s", mapName, lightmapFiles[ i ] ), (const byte **)&ldrImage, width, height, 1, imageParams );
 
 				Com_AddToGrowList( &tr.lightmaps, image );
 
@@ -504,7 +509,13 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 				for (int i = 0; i < numLightmaps; i++) {
 					Log::Debug("...loading external lightmap '%s/%s'", mapName, lightmapFiles[i]);
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NOPICMIP | IF_NORMALMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP);
+
+					imageParams_t imageParams = {};
+					imageParams.bits = IF_NOPICMIP | IF_NORMALMAP;
+					imageParams.filterType = filterType_t::FT_DEFAULT;
+					imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), imageParams);
 					Com_AddToGrowList(&tr.deluxemaps, image);
 				}
 			}
@@ -527,10 +538,20 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 				Log::Debug("...loading external lightmap '%s/%s'", mapName, lightmapFiles[i]);
 
 				if (!tr.worldDeluxeMapping || i % 2 == 0) {
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NOPICMIP | IF_LIGHTMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
+					imageParams_t imageParams = {};
+					imageParams.bits = IF_NOPICMIP | IF_LIGHTMAP;
+					imageParams.filterType = filterType_t::FT_LINEAR;
+					imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), imageParams);
 					Com_AddToGrowList(&tr.lightmaps, image);
 				} else {
-					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), IF_NOPICMIP | IF_NORMALMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
+					imageParams_t imageParams = {};
+					imageParams.bits = IF_NOPICMIP | IF_NORMALMAP;
+					imageParams.filterType = filterType_t::FT_LINEAR;
+					imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), imageParams);
 					Com_AddToGrowList(&tr.deluxemaps, image);
 				}
 			}
@@ -611,9 +632,12 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 			}
 		}
 
-		tr.fatLightmap = R_CreateImage( va( "_fatlightmap%d", 0 ), (const byte **)&fatbuffer,
-						tr.fatLightmapSize, tr.fatLightmapSize, 1,
-						IF_NOPICMIP | IF_LIGHTMAP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_CLAMP );
+		imageParams_t imageParams = {};
+		imageParams.bits = IF_NOPICMIP | IF_LIGHTMAP;
+		imageParams.filterType = filterType_t::FT_DEFAULT;
+		imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+		tr.fatLightmap = R_CreateImage( va( "_fatlightmap%d", 0 ), (const byte **)&fatbuffer, tr.fatLightmapSize, tr.fatLightmapSize, 1, imageParams );
 		Com_AddToGrowList( &tr.lightmaps, tr.fatLightmap );
 
 		ri.Hunk_FreeTempMemory( fatbuffer );
@@ -3970,14 +3994,13 @@ void R_LoadLightGrid( lump_t *l )
 		w->lightGridData1 = gridPoint1;
 		w->lightGridData2 = gridPoint2;
 
-		tr.lightGrid1Image = R_Create3DImage("<lightGrid1>", (const byte *)w->lightGridData1,
-						     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-						     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
-						     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
-		tr.lightGrid2Image = R_Create3DImage("<lightGrid2>", (const byte *)w->lightGridData2,
-						     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-						     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
-						     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
+		imageParams_t imageParams = {};
+		imageParams.bits = IF_NOPICMIP | IF_NOLIGHTSCALE;
+		imageParams.filterType = filterType_t::FT_DEFAULT;
+		imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+		tr.lightGrid1Image = R_Create3DImage("<lightGrid1>", (const byte *)w->lightGridData1, w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ], w->lightGridBounds[ 2 ], imageParams );
+		tr.lightGrid2Image = R_Create3DImage("<lightGrid2>", (const byte *)w->lightGridData2, w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ], w->lightGridBounds[ 2 ], imageParams );
 
 		return;
 	}
@@ -4099,14 +4122,13 @@ void R_LoadLightGrid( lump_t *l )
 		}
 	}
 
-	tr.lightGrid1Image = R_Create3DImage("<lightGrid1>", (const byte *)w->lightGridData1,
-					     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-					     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
-					     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
-	tr.lightGrid2Image = R_Create3DImage("<lightGrid2>", (const byte *)w->lightGridData2,
-					     w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ],
-					     w->lightGridBounds[ 2 ], IF_NOPICMIP | IF_NOLIGHTSCALE,
-					     filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP | IF_NOLIGHTSCALE;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+	tr.lightGrid1Image = R_Create3DImage("<lightGrid1>", (const byte *)w->lightGridData1, w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ], w->lightGridBounds[ 2 ], imageParams );
+	tr.lightGrid2Image = R_Create3DImage("<lightGrid2>", (const byte *)w->lightGridData2, w->lightGridBounds[ 0 ], w->lightGridBounds[ 1 ], w->lightGridBounds[ 2 ], imageParams );
 
 	Log::Debug("%i light grid points created", w->numLightGridPoints );
 }

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -808,8 +808,7 @@ level 1 has only numLayers/2 layers. There are still numLayers pointers in
 the dataArray for every mip level, the unneeded elements at the end aren't used.
 ===============
 */
-void R_UploadImage( const byte **dataArray, int numLayers, int numMips,
-		    image_t *image )
+void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t *image )
 {
 	const byte *data;
 	byte       *scaledBuffer = nullptr;
@@ -1434,8 +1433,7 @@ static void R_ExportTexture( image_t *image )
 R_CreateImage
 ================
 */
-image_t        *R_CreateImage( const char *name, const byte **pic, int width, int height,
-			       int numMips, int bits, filterType_t filterType, wrapType_t wrapType )
+image_t *R_CreateImage( const char *name, const byte **pic, int width, int height, int numMips, const imageParams_t &imageParams )
 {
 	image_t *image;
 
@@ -1451,9 +1449,9 @@ image_t        *R_CreateImage( const char *name, const byte **pic, int width, in
 	image->width = width;
 	image->height = height;
 
-	image->bits = bits;
-	image->filterType = filterType;
-	image->wrapType = wrapType;
+	image->bits = imageParams.bits;
+	image->filterType = imageParams.filterType;
+	image->wrapType = imageParams.wrapType;
 
 	R_UploadImage( pic, 1, numMips, image );
 
@@ -1513,9 +1511,7 @@ image_t *R_CreateGlyph( const char *name, const byte *pic, int width, int height
 R_CreateCubeImage
 ================
 */
-image_t        *R_CreateCubeImage( const char *name,
-                                   const byte *pic[ 6 ],
-                                   int width, int height, int bits, filterType_t filterType, wrapType_t wrapType )
+image_t *R_CreateCubeImage( const char *name, const byte *pic[ 6 ], int width, int height, const imageParams_t &imageParams )
 {
 	image_t *image;
 
@@ -1525,15 +1521,15 @@ image_t        *R_CreateCubeImage( const char *name,
 	{
 		return nullptr;
 	}
-
+	
 	image->type = GL_TEXTURE_CUBE_MAP;
 
 	image->width = width;
 	image->height = height;
 
-	image->bits = bits;
-	image->filterType = filterType;
-	image->wrapType = wrapType;
+	image->bits = imageParams.bits;
+	image->filterType = imageParams.filterType;
+	image->wrapType = imageParams.wrapType;
 
 	R_UploadImage( pic, 6, 1, image );
 
@@ -1549,11 +1545,7 @@ image_t        *R_CreateCubeImage( const char *name,
 R_Create3DImage
 ================
 */
-image_t        *R_Create3DImage( const char *name,
-				 const byte *pic,
-				 int width, int height, int depth,
-				 int bits, filterType_t filterType,
-				 wrapType_t wrapType )
+image_t *R_Create3DImage( const char *name, const byte *pic, int width, int height, int depth, const imageParams_t &imageParams )
 {
 	image_t *image;
 	const byte **pics;
@@ -1580,9 +1572,9 @@ image_t        *R_Create3DImage( const char *name,
 		pics = nullptr;
 	}
 
-	image->bits = bits;
-	image->filterType = filterType;
-	image->wrapType = wrapType;
+	image->bits = imageParams.bits;
+	image->filterType = imageParams.filterType;
+	image->wrapType = imageParams.wrapType;
 
 	R_UploadImage( pics, depth, 1, image );
 
@@ -1775,7 +1767,7 @@ Finds or loads the given image.
 Returns nullptr if it fails, not a default image.
 ==============
 */
-image_t        *R_FindImageFile( const char *imageName, int bits, filterType_t filterType, wrapType_t wrapType )
+image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 {
 	image_t       *image = nullptr;
 	int           width = 0, height = 0, numLayers = 0, numMips = 0;
@@ -1801,14 +1793,14 @@ image_t        *R_FindImageFile( const char *imageName, int bits, filterType_t f
 			// the white image can be used with any set of parms, but other mismatches are errors
 			if ( Q_stricmp( buffer, "_white" ) )
 			{
-				diff = bits ^ image->bits;
+				diff = imageParams.bits ^ image->bits;
 
 				if ( diff & IF_NOPICMIP )
 				{
 					Log::Warn("reused image '%s' with mixed allowPicmip parm for shader", imageName );
 				}
 
-				if ( image->wrapType != wrapType )
+				if ( image->wrapType != imageParams.wrapType )
 				{
 					Log::Warn("reused image '%s' with mixed glWrapType parm for shader", imageName);
 				}
@@ -1821,7 +1813,7 @@ image_t        *R_FindImageFile( const char *imageName, int bits, filterType_t f
 	// load the pic from disk
 	pic[ 0 ] = nullptr;
 	buffer_p = &buffer[ 0 ];
-	R_LoadImage( &buffer_p, pic, &width, &height, &numLayers, &numMips, &bits );
+	R_LoadImage( &buffer_p, pic, &width, &height, &numLayers, &numMips, &imageParams.bits );
 
 	if ( (mallocPtr = pic[ 0 ]) == nullptr || numLayers > 0 )
 	{
@@ -1832,14 +1824,12 @@ image_t        *R_FindImageFile( const char *imageName, int bits, filterType_t f
 		return nullptr;
 	}
 
-	if ( bits & IF_LIGHTMAP )
+	if ( imageParams.bits & IF_LIGHTMAP )
 	{
-		R_ProcessLightmap( pic[ 0 ], 4, width, height, bits, pic[ 0 ] );
+		R_ProcessLightmap( pic[ 0 ], 4, width, height, imageParams.bits, pic[ 0 ] );
 	}
 
-	image = R_CreateImage( ( char * ) buffer, (const byte **)pic,
-			       width, height, numMips, bits,
-			       filterType, wrapType );
+	image = R_CreateImage( ( char * ) buffer, (const byte **)pic, width, height, numMips, imageParams );
 
 	ri.Free( mallocPtr );
 	return image;
@@ -2057,7 +2047,7 @@ struct face_t
 	int height;
 };
 
-image_t *R_FindCubeImage( const char *imageName, int bits, filterType_t filterType, wrapType_t wrapType )
+image_t *R_FindCubeImage( const char *imageName, imageParams_t &imageParams )
 {
 	int i, j;
 	image_t *image = nullptr;
@@ -2093,10 +2083,10 @@ image_t *R_FindCubeImage( const char *imageName, int bits, filterType_t filterTy
 		if( R_FindImageLoader( cubeMapName.c_str() ) >= 0 )
 		{
 			Log::Debug( "found %s cube map '%s'", loader.ext, cubeMapBaseName );
-			loader.ImageLoader( cubeMapName.c_str(), pic, &width, &height, &numLayers, &numMips, &bits, 0 );
+			loader.ImageLoader( cubeMapName.c_str(), pic, &width, &height, &numLayers, &numMips, &imageParams.bits, 0 );
 
 			if( numLayers == 6 && pic[0] ) {
-				image = R_CreateCubeImage( ( char * ) buffer, ( const byte ** ) pic, width, height, bits, filterType, wrapType );
+				image = R_CreateCubeImage( ( char * ) buffer, ( const byte ** ) pic, width, height, imageParams );
 				R_FreeCubePics( pic, 1 );
 				return image;
 			}
@@ -2122,7 +2112,7 @@ image_t *R_FindCubeImage( const char *imageName, int bits, filterType_t filterTy
 			Log::Debug( "looking for %s cube map face '%s'", format.name, filename );
 
 			filename_p = &filename[ 0 ];
-			R_LoadImage( &filename_p, &pic[ i ], &width, &height, &numLayers, &numMips, &bits );
+			R_LoadImage( &filename_p, &pic[ i ], &width, &height, &numLayers, &numMips, &imageParams.bits );
 
 			if ( pic[ i ] == nullptr )
 			{
@@ -2133,7 +2123,7 @@ image_t *R_FindCubeImage( const char *imageName, int bits, filterType_t filterTy
 				break;
 			}
 
-			if ( IsImageCompressed( bits ) )
+			if ( IsImageCompressed( imageParams.bits ) )
 			{
 				Log::Warn("cube map face '%s' has DXTn compression, cube map unusable", filename );
 				break;
@@ -2206,7 +2196,7 @@ image_t *R_FindCubeImage( const char *imageName, int bits, filterType_t filterTy
 			}
 
 			Log::Debug( "found %s multifile cube map '%s'", format.name, imageName );
-			image = R_CreateCubeImage( ( char * ) buffer, ( const byte ** ) pic, greatestEdge, greatestEdge, bits, filterType, wrapType );
+			image = R_CreateCubeImage( ( char * ) buffer, ( const byte ** ) pic, greatestEdge, greatestEdge, imageParams );
 			R_FreeCubePics( pic, i );
 			return image;
 		}
@@ -2313,8 +2303,12 @@ static void R_CreateFogImage()
 	// standard openGL clamping doesn't really do what we want -- it includes
 	// the border color at the edges.  OpenGL 1.2 has clamp-to-edge, which does
 	// what we want.
-	tr.fogImage = R_CreateImage( "_fog", ( const byte ** ) &data,
-				     FOG_S, FOG_T, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.fogImage = R_CreateImage( "_fog", ( const byte ** ) &data, FOG_S, FOG_T, 1, imageParams );
 	ri.Hunk_FreeTempMemory( data );
 
 	borderColor[ 0 ] = 1.0;
@@ -2352,8 +2346,12 @@ static void R_CreateDefaultImage()
 		  data[ x ][ DEFAULT_SIZE - 1 ][ 1 ] = data[ x ][ DEFAULT_SIZE - 1 ][ 2 ] = data[ x ][ DEFAULT_SIZE - 1 ][ 3 ] = 255;
 	}
 
-	tr.defaultImage = R_CreateImage( "_default", ( const byte ** ) &dataPtr,
-					 DEFAULT_SIZE, DEFAULT_SIZE, 1, IF_NOPICMIP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_REPEAT );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_REPEAT;
+
+	tr.defaultImage = R_CreateImage( "_default", ( const byte ** ) &dataPtr, DEFAULT_SIZE, DEFAULT_SIZE, 1, imageParams );
 }
 
 static void R_CreateRandomNormalsImage()
@@ -2387,8 +2385,12 @@ static void R_CreateRandomNormalsImage()
 		}
 	}
 
-	tr.randomNormalsImage = R_CreateImage( "_randomNormals", ( const byte ** ) &dataPtr,
-					       DEFAULT_SIZE, DEFAULT_SIZE, 1, IF_NOPICMIP, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_REPEAT );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_REPEAT;
+
+	tr.randomNormalsImage = R_CreateImage( "_randomNormals", ( const byte ** ) &dataPtr, DEFAULT_SIZE, DEFAULT_SIZE, 1, imageParams );
 }
 
 static void R_CreateNoFalloffImage()
@@ -2399,8 +2401,12 @@ static void R_CreateNoFalloffImage()
 
 	byte *dataPtr = &data[0][0][0];
 
-	tr.noFalloffImage = R_CreateImage( "_noFalloff", ( const byte ** ) &dataPtr,
-					   8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+	tr.noFalloffImage = R_CreateImage( "_noFalloff", ( const byte ** ) &dataPtr, 8, 8, 1, imageParams );
 }
 
 static const int ATTENUATION_XY_SIZE = 128;
@@ -2438,9 +2444,12 @@ static void R_CreateAttenuationXYImage()
 		}
 	}
 
-	tr.attenuationXYImage =
-	  R_CreateImage( "_attenuationXY", ( const byte ** ) &dataPtr,
-			 ATTENUATION_XY_SIZE, ATTENUATION_XY_SIZE, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP);
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.attenuationXYImage = R_CreateImage( "_attenuationXY", ( const byte ** ) &dataPtr, ATTENUATION_XY_SIZE, ATTENUATION_XY_SIZE, 1, imageParams );
 }
 
 static void R_CreateContrastRenderFBOImage()
@@ -2450,7 +2459,12 @@ static void R_CreateContrastRenderFBOImage()
 	width = glConfig.vidWidth * 0.25f;
 	height = glConfig.vidHeight * 0.25f;
 
-	tr.contrastRenderFBOImage = R_CreateImage( "_contrastRenderFBO", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_DEFAULT;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.contrastRenderFBOImage = R_CreateImage( "_contrastRenderFBO", nullptr, width, height, 1, imageParams );
 }
 
 static void R_CreateBloomRenderFBOImage()
@@ -2463,7 +2477,12 @@ static void R_CreateBloomRenderFBOImage()
 
 	for ( i = 0; i < 2; i++ )
 	{
-		tr.bloomRenderFBOImage[ i ] = R_CreateImage( va( "_bloomRenderFBO%d", i ), nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP );
+		imageParams_t imageParams = {};
+		imageParams.bits = IF_NOPICMIP;
+		imageParams.filterType = filterType_t::FT_DEFAULT;
+		imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+		tr.bloomRenderFBOImage[ i ] = R_CreateImage( va( "_bloomRenderFBO%d", i ), nullptr, width, height, 1, imageParams );
 	}
 }
 
@@ -2474,9 +2493,17 @@ static void R_CreateCurrentRenderImage()
 	width = glConfig.vidWidth;
 	height = glConfig.vidHeight;
 
-	tr.currentRenderImage[0] = R_CreateImage( "_currentRender[0]", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-	tr.currentRenderImage[1] = R_CreateImage( "_currentRender[1]", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-	tr.currentDepthImage = R_CreateImage( "_currentDepth", nullptr, width, height, 1, IF_NOPICMIP | IF_PACKED_DEPTH24_STENCIL8, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_NEAREST;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.currentRenderImage[0] = R_CreateImage( "_currentRender[0]", nullptr, width, height, 1, imageParams );
+	tr.currentRenderImage[1] = R_CreateImage( "_currentRender[1]", nullptr, width, height, 1, imageParams );
+
+	imageParams.bits |= IF_PACKED_DEPTH24_STENCIL8;
+
+	tr.currentDepthImage = R_CreateImage( "_currentDepth", nullptr, width, height, 1, imageParams );
 }
 
 static void R_CreateDepthRenderImage()
@@ -2488,21 +2515,37 @@ static void R_CreateDepthRenderImage()
 
 	w = (width + TILE_SIZE_STEP1 - 1) >> TILE_SHIFT_STEP1;
 	h = (height + TILE_SIZE_STEP1 - 1) >> TILE_SHIFT_STEP1;
-	tr.depthtile1RenderImage = R_CreateImage( "_depthtile1Render", nullptr, w, h, 1, IF_NOPICMIP | IF_RGBA32F, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_ONE_CLAMP );
+
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP | IF_RGBA32F;
+	imageParams.filterType = filterType_t::FT_NEAREST;
+	imageParams.wrapType = wrapTypeEnum_t::WT_ONE_CLAMP;
+
+	tr.depthtile1RenderImage = R_CreateImage( "_depthtile1Render", nullptr, w, h, 1, imageParams );
 
 	w = (width + TILE_SIZE - 1) >> TILE_SHIFT;
 	h = (height + TILE_SIZE - 1) >> TILE_SHIFT;
-	tr.depthtile2RenderImage = R_CreateImage( "_depthtile2Render", nullptr, w, h, 1, IF_NOPICMIP | IF_RGBA32F, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.depthtile2RenderImage = R_CreateImage( "_depthtile2Render", nullptr, w, h, 1, imageParams );
 
 	if ( glConfig2.textureIntegerAvailable ) {
-		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, 4, IF_NOPICMIP | IF_RGBA32UI, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+		imageParams.bits = IF_NOPICMIP | IF_RGBA32UI;
+
+		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, 4, imageParams );
 	} else {
-		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, 4, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+		imageParams.bits = IF_NOPICMIP;
+
+		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, 4, imageParams );
 	}
 
 	if( !glConfig2.uniformBufferObjectAvailable ) {
 		w = 64; h = 3 * MAX_REF_LIGHTS / w;
-		tr.dlightImage = R_CreateImage("_dlightImage", nullptr, w, h, 4, IF_NOPICMIP | IF_RGBA32F, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	
+		imageParams.bits = IF_NOPICMIP | IF_RGBA32F;
+
+		tr.dlightImage = R_CreateImage("_dlightImage", nullptr, w, h, 4, imageParams );
 	}
 }
 
@@ -2513,7 +2556,12 @@ static void R_CreatePortalRenderImage()
 	width = glConfig.vidWidth;
 	height = glConfig.vidHeight;
 
-	tr.portalRenderImage = R_CreateImage( "_portalRender", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_NEAREST;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.portalRenderImage = R_CreateImage( "_portalRender", nullptr, width, height, 1, imageParams );
 }
 
 static void R_CreateDepthToColorFBOImages()
@@ -2523,10 +2571,13 @@ static void R_CreateDepthToColorFBOImages()
 	width = glConfig.vidWidth;
 	height = glConfig.vidHeight;
 
-	{
-		tr.depthToColorBackFacesFBOImage = R_CreateImage( "_depthToColorBackFacesFBORender", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-		tr.depthToColorFrontFacesFBOImage = R_CreateImage( "_depthToColorFrontFacesFBORender", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
-	}
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_NEAREST;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.depthToColorBackFacesFBOImage = R_CreateImage( "_depthToColorBackFacesFBORender", nullptr, width, height, 1, imageParams );
+	tr.depthToColorFrontFacesFBOImage = R_CreateImage( "_depthToColorFrontFacesFBORender", nullptr, width, height, 1, imageParams );
 }
 
 // Tr3B: clean up this mess some day ...
@@ -2537,11 +2588,16 @@ static void R_CreateDownScaleFBOImages()
 	width = glConfig.vidWidth * 0.25f;
 	height = glConfig.vidHeight * 0.25f;
 
-	tr.downScaleFBOImage_quarter = R_CreateImage( "_downScaleFBOImage_quarter", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_NEAREST;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.downScaleFBOImage_quarter = R_CreateImage( "_downScaleFBOImage_quarter", nullptr, width, height, 1, imageParams );
 
 	width = height = 64;
 
-	tr.downScaleFBOImage_64x64 = R_CreateImage( "_downScaleFBOImage_64x64", nullptr, width, height, 1, IF_NOPICMIP, filterType_t::FT_NEAREST, wrapTypeEnum_t::WT_CLAMP );
+	tr.downScaleFBOImage_64x64 = R_CreateImage( "_downScaleFBOImage_64x64", nullptr, width, height, 1, imageParams );
 }
 
 // *INDENT-OFF*
@@ -2598,12 +2654,17 @@ static void R_CreateShadowMapFBOImage()
 		filter = filterType_t::FT_NEAREST;
 	}
 
+	imageParams_t imageParams = {};
+	imageParams.bits = format;
+	imageParams.filterType = filter;
+	imageParams.wrapType = wrapTypeEnum_t::WT_ONE_CLAMP;
+
 	for ( i = 0; i < numShadowMaps; i++ )
 	{
 		width = height = shadowMapResolutions[ i % MAX_SHADOWMAPS ];
 
-		tr.shadowMapFBOImage[ i ] = R_CreateImage( va( "_shadowMapFBO%d", i ), nullptr, width, height, 1, format, filter, wrapTypeEnum_t::WT_ONE_CLAMP );
-		tr.shadowClipMapFBOImage[ i ] = R_CreateImage( va( "_shadowClipMapFBO%d", i ), nullptr, width, height, 1, format, filter, wrapTypeEnum_t::WT_ONE_CLAMP );
+		tr.shadowMapFBOImage[ i ] = R_CreateImage( va( "_shadowMapFBO%d", i ), nullptr, width, height, 1, imageParams );
+		tr.shadowClipMapFBOImage[ i ] = R_CreateImage( va( "_shadowClipMapFBO%d", i ), nullptr, width, height, 1, imageParams );
 	}
 
 	// sun shadow maps
@@ -2611,8 +2672,8 @@ static void R_CreateShadowMapFBOImage()
 	{
 		width = height = sunShadowMapResolutions[ i % MAX_SHADOWMAPS ];
 
-		tr.sunShadowMapFBOImage[ i ] = R_CreateImage( va( "_sunShadowMapFBO%d", i ), nullptr, width, height, 1, format, filter, wrapTypeEnum_t::WT_ONE_CLAMP );
-		tr.sunShadowClipMapFBOImage[ i ] = R_CreateImage( va( "_sunShadowClipMapFBO%d", i ), nullptr, width, height, 1, format, filter, wrapTypeEnum_t::WT_ONE_CLAMP );
+		tr.sunShadowMapFBOImage[ i ] = R_CreateImage( va( "_sunShadowMapFBO%d", i ), nullptr, width, height, 1, imageParams );
+		tr.sunShadowClipMapFBOImage[ i ] = R_CreateImage( va( "_sunShadowClipMapFBO%d", i ), nullptr, width, height, 1, imageParams );
 	}
 }
 
@@ -2671,12 +2732,17 @@ static void R_CreateShadowCubeFBOImage()
 		filter = filterType_t::FT_NEAREST;
 	}
 
+	imageParams_t imageParams = {};
+	imageParams.bits = format;
+	imageParams.filterType = filter;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
 	for ( j = 0; j < 5; j++ )
 	{
 		width = height = shadowMapResolutions[ j ];
 
-		tr.shadowCubeFBOImage[ j ] = R_CreateCubeImage( va( "_shadowCubeFBO%d", j ), nullptr, width, height, format, filter, wrapTypeEnum_t::WT_EDGE_CLAMP );
-		tr.shadowClipCubeFBOImage[ j ] = R_CreateCubeImage( va( "_shadowClipCubeFBO%d", j ), nullptr, width, height, format, filter, wrapTypeEnum_t::WT_EDGE_CLAMP );
+		tr.shadowCubeFBOImage[ j ] = R_CreateCubeImage( va( "_shadowCubeFBO%d", j ), nullptr, width, height, imageParams );
+		tr.shadowClipCubeFBOImage[ j ] = R_CreateCubeImage( va( "_shadowClipCubeFBO%d", j ), nullptr, width, height, imageParams );
 	}
 }
 
@@ -2698,8 +2764,13 @@ static void R_CreateBlackCubeImage()
 		Com_Memset( data[ i ], 0, width * height * 4 );
 	}
 
-	tr.blackCubeImage = R_CreateCubeImage( "_blackCube", ( const byte ** ) data, width, height, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
-	tr.autoCubeImage = R_CreateCubeImage( "_autoCube", ( const byte ** ) data, width, height, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+	tr.blackCubeImage = R_CreateCubeImage( "_blackCube", ( const byte ** ) data, width, height, imageParams );
+	tr.autoCubeImage = R_CreateCubeImage( "_autoCube", ( const byte ** ) data, width, height, imageParams );
 
 	for ( i = 5; i >= 0; i-- )
 	{
@@ -2725,7 +2796,12 @@ static void R_CreateWhiteCubeImage()
 		Com_Memset( data[ i ], 0xFF, width * height * 4 );
 	}
 
-	tr.whiteCubeImage = R_CreateCubeImage( "_whiteCube", ( const byte ** ) data, width, height, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_EDGE_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+	tr.whiteCubeImage = R_CreateCubeImage( "_whiteCube", ( const byte ** ) data, width, height, imageParams );
 
 	for ( i = 5; i >= 0; i-- )
 	{
@@ -2758,13 +2834,12 @@ static void R_CreateColorGradeImage()
 		}
 	}
 
-	tr.colorGradeImage = R_Create3DImage( "_colorGrade", data,
-					      REF_COLORGRADEMAP_SIZE,
-					      REF_COLORGRADEMAP_SIZE,
-					      REF_COLORGRADE_SLOTS * REF_COLORGRADEMAP_SIZE,
-					      IF_NOPICMIP | IF_NOLIGHTSCALE,
-					      filterType_t::FT_LINEAR,
-						  wrapTypeEnum_t::WT_EDGE_CLAMP );
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP | IF_NOLIGHTSCALE;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+	tr.colorGradeImage = R_Create3DImage( "_colorGrade", data, REF_COLORGRADEMAP_SIZE, REF_COLORGRADEMAP_SIZE, REF_COLORGRADE_SLOTS * REF_COLORGRADEMAP_SIZE, imageParams );
 
 	ri.Hunk_FreeTempMemory( data );
 }
@@ -2787,13 +2862,17 @@ void R_CreateBuiltinImages()
 
 	// we use a solid white image instead of disabling texturing
 	Com_Memset( data, 255, sizeof( data ) );
-	tr.whiteImage = R_CreateImage( "_white", ( const byte ** ) &dataPtr,
-				       8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_REPEAT;
+
+	tr.whiteImage = R_CreateImage( "_white", ( const byte ** ) &dataPtr, 8, 8, 1, imageParams );
 
 	// we use a solid black image instead of disabling texturing
 	Com_Memset( data, 0, sizeof( data ) );
-	tr.blackImage = R_CreateImage( "_black", ( const byte ** ) &dataPtr,
-				       8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+	tr.blackImage = R_CreateImage( "_black", ( const byte ** ) &dataPtr, 8, 8, 1, imageParams );
 
 	// red
 	for ( x = DEFAULT_SIZE * DEFAULT_SIZE, out = &data[0][0][0]; x; --x, out += 4 )
@@ -2802,8 +2881,7 @@ void R_CreateBuiltinImages()
 		out[ 0 ] = out[ 3 ] = 255;
 	}
 
-	tr.redImage = R_CreateImage( "_red", ( const byte ** ) &dataPtr,
-				     8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+	tr.redImage = R_CreateImage( "_red", ( const byte ** ) &dataPtr, 8, 8, 1, imageParams );
 
 	// green
 	for ( x = DEFAULT_SIZE * DEFAULT_SIZE, out = &data[0][0][0]; x; --x, out += 4 )
@@ -2812,8 +2890,7 @@ void R_CreateBuiltinImages()
 		out[ 1 ] = out[ 3 ] = 255;
 	}
 
-	tr.greenImage = R_CreateImage( "_green", ( const byte ** ) &dataPtr,
-				       8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+	tr.greenImage = R_CreateImage( "_green", ( const byte ** ) &dataPtr, 8, 8, 1, imageParams );
 
 	// blue
 	for ( x = DEFAULT_SIZE * DEFAULT_SIZE, out = &data[0][0][0]; x; --x, out += 4 )
@@ -2822,8 +2899,7 @@ void R_CreateBuiltinImages()
 		out[ 2 ] = out[ 3 ] = 255;
 	}
 
-	tr.blueImage = R_CreateImage( "_blue", ( const byte ** ) &dataPtr,
-				      8, 8, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+	tr.blueImage = R_CreateImage( "_blue", ( const byte ** ) &dataPtr, 8, 8, 1, imageParams );
 
 	// generate a default normalmap with a fully opaque heightmap (no displacement)
 	for ( x = DEFAULT_SIZE * DEFAULT_SIZE, out = &data[0][0][0]; x; --x, out += 4 )
@@ -2833,8 +2909,9 @@ void R_CreateBuiltinImages()
 		out[ 3 ] = 255;
 	}
 
-	tr.flatImage = R_CreateImage( "_flat", ( const byte ** ) &dataPtr,
-				      8, 8, 1, IF_NOPICMIP | IF_NORMALMAP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_REPEAT );
+	imageParams.bits = IF_NOPICMIP | IF_NORMALMAP;
+
+	tr.flatImage = R_CreateImage( "_flat", ( const byte ** ) &dataPtr, 8, 8, 1, imageParams );
 
 	out = &data[ 0 ][ 0 ][ 0 ];
 
@@ -2857,10 +2934,10 @@ void R_CreateBuiltinImages()
 		}
 	}
 
-	tr.quadraticImage =
-		R_CreateImage( "_quadratic", ( const byte ** ) &dataPtr,
-			       DEFAULT_SIZE, DEFAULT_SIZE, 1, IF_NOPICMIP, filterType_t::FT_LINEAR,
-					   wrapTypeEnum_t::WT_CLAMP );
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	tr.quadraticImage = R_CreateImage( "_quadratic", ( const byte ** ) &dataPtr, DEFAULT_SIZE, DEFAULT_SIZE, 1, imageParams );
 
 	R_CreateRandomNormalsImage();
 	R_CreateFogImage();
@@ -2981,5 +3058,11 @@ qhandle_t RE_GenerateTexture( const byte *pic, int width, int height )
 {
 	const char *name = va( "rocket%d", numTextures++ );
 	R_SyncRenderThread();
-	return RE_RegisterShaderFromImage( name, R_CreateImage( name, &pic, width, height, 1, IF_NOPICMIP, filterType_t::FT_LINEAR, wrapTypeEnum_t::WT_CLAMP ) );
+
+	imageParams_t imageParams = {};
+	imageParams.bits = IF_NOPICMIP;
+	imageParams.filterType = filterType_t::FT_LINEAR;
+	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+	return RE_RegisterShaderFromImage( name, R_CreateImage( name, &pic, width, height, 1, imageParams ) );
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -149,6 +149,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_singleShader;
 	cvar_t      *r_colorMipLevels;
 	cvar_t      *r_picMip;
+	cvar_t      *r_imageMaxDimension;
+	cvar_t      *r_ignoreMaterialMinDimension;
+	cvar_t      *r_ignoreMaterialMaxDimension;
+	cvar_t      *r_replaceMaterialMinDimensionIfPresentWithMaxDimension;
 	cvar_t      *r_finish;
 	cvar_t      *r_clear;
 	cvar_t      *r_swapInterval;
@@ -945,6 +949,10 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		Log::Debug("texturemode: %s", r_textureMode->string );
 		Log::Debug("picmip: %d", r_picMip->integer );
+		Log::Debug("imageMaxDimension: %d", r_imageMaxDimension->integer );
+		Log::Debug("ignoreMaterialMinDimension: %d", r_ignoreMaterialMinDimension->integer );
+		Log::Debug("ignoreMaterialMaxDimension: %d", r_ignoreMaterialMaxDimension->integer );
+		Log::Debug("replaceMaterialMinDimensionIfPresentWithMaxDimension: %d", r_replaceMaterialMinDimensionIfPresentWithMaxDimension->integer );
 
 		if ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 )
 		{
@@ -1046,6 +1054,11 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		r_picMip = ri.Cvar_Get( "r_picMip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		AssertCvarRange( r_picmip, 0, 3, true );
+		r_imageMaxDimension = ri.Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
+		r_ignoreMaterialMinDimension = ri.Cvar_Get( "r_ignoreMaterialMinDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
+		r_ignoreMaterialMaxDimension = ri.Cvar_Get( "r_ignoreMaterialMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
+		r_replaceMaterialMinDimensionIfPresentWithMaxDimension
+			= ri.Cvar_Get( "r_replaceMaterialMinDimensionIfPresentWithMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_colorMipLevels = ri.Cvar_Get( "r_colorMipLevels", "0", CVAR_LATCH );
 		r_colorbits = ri.Cvar_Get( "r_colorbits", "0",  CVAR_LATCH );
 		r_alphabits = ri.Cvar_Get( "r_alphabits", "0",  CVAR_LATCH );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1053,7 +1053,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_arb_gpu_shader5 = ri.Cvar_Get( "r_arb_gpu_shader5", "1", CVAR_CHEAT | CVAR_LATCH );
 
 		r_picMip = ri.Cvar_Get( "r_picMip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
-		AssertCvarRange( r_picmip, 0, 3, true );
 		r_imageMaxDimension = ri.Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_ignoreMaterialMinDimension = ri.Cvar_Get( "r_ignoreMaterialMinDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_ignoreMaterialMaxDimension = ri.Cvar_Get( "r_ignoreMaterialMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -148,7 +148,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_nobind;
 	cvar_t      *r_singleShader;
 	cvar_t      *r_colorMipLevels;
-	cvar_t      *r_picmip;
+	cvar_t      *r_picMip;
 	cvar_t      *r_finish;
 	cvar_t      *r_clear;
 	cvar_t      *r_swapInterval;
@@ -944,7 +944,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		}
 
 		Log::Debug("texturemode: %s", r_textureMode->string );
-		Log::Debug("picmip: %d", r_picmip->integer );
+		Log::Debug("picmip: %d", r_picMip->integer );
 
 		if ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 )
 		{
@@ -1044,7 +1044,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_arb_texture_gather = ri.Cvar_Get( "r_arb_texture_gather", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_arb_gpu_shader5 = ri.Cvar_Get( "r_arb_gpu_shader5", "1", CVAR_CHEAT | CVAR_LATCH );
 
-		r_picmip = ri.Cvar_Get( "r_picmip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
+		r_picMip = ri.Cvar_Get( "r_picMip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		AssertCvarRange( r_picmip, 0, 3, true );
 		r_colorMipLevels = ri.Cvar_Get( "r_colorMipLevels", "0", CVAR_LATCH );
 		r_colorbits = ri.Cvar_Get( "r_colorbits", "0",  CVAR_LATCH );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -586,6 +586,12 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	static inline bool operator ==( const wrapType_t &a, const wrapType_t &b ) { return a.s == b.s && a.t == b.t; }
 	static inline bool operator !=( const wrapType_t &a, const wrapType_t &b ) { return a.s != b.s || a.t != b.t; }
 
+	struct imageParams_t
+	{
+		int bits = 0;
+		filterType_t filterType;
+		wrapType_t wrapType;
+	};
 
 	struct image_t
 	{
@@ -3197,27 +3203,19 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	void    R_ShutdownImages();
 
 	int R_FindImageLoader( const char *baseName );
-	image_t *R_FindImageFile( const char *name, int bits, filterType_t filterType, wrapType_t wrapType );
-	image_t *R_FindCubeImage( const char *name, int bits, filterType_t filterType, wrapType_t wrapType );
+	image_t *R_FindImageFile( const char *name, imageParams_t &imageParams );
+	image_t *R_FindCubeImage( const char *name, imageParams_t &imageParams );
 
-	image_t *R_CreateImage( const char *name, const byte **pic,
-				int width, int height, int bits, int numMips,
-				filterType_t filterType, wrapType_t wrapType );
+	image_t *R_CreateImage( const char *name, const byte **pic, int width, int height, int numMips, const imageParams_t &imageParams );
 
-	image_t *R_CreateCubeImage( const char *name, const byte *pic[ 6 ],
-	                            int width, int height, int bits,
-				    filterType_t filterType, wrapType_t wrapType );
-	image_t        *R_Create3DImage( const char *name,
-					 const byte *pic,
-					 int width, int height, int depth,
-					 int bits, filterType_t filterType,
-					 wrapType_t wrapType );
+	image_t *R_CreateCubeImage( const char *name, const byte *pic[ 6 ], int width, int height, const imageParams_t &imageParams );
+	image_t *R_Create3DImage( const char *name, const byte *pic, int width, int height, int depth, const imageParams_t &imageParams );
 
 	image_t *R_CreateGlyph( const char *name, const byte *pic, int width, int height );
 	qhandle_t RE_GenerateTexture( const byte *pic, int width, int height );
 
 	image_t *R_AllocImage( const char *name, bool linkIntoHashTable );
-	void    R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t *image );
+	void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t *image );
 
 	void    RE_GetTextureSize( int textureID, int *width, int *height );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2876,7 +2876,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_nobind; // turns off binding to appropriate textures
 	extern cvar_t *r_singleShader; // make most world faces use default shader
 	extern cvar_t *r_colorMipLevels; // development aid to see texture mip usage
-	extern cvar_t *r_picmip; // controls picmip values
+	extern cvar_t *r_picMip; // controls picmip values
 	extern cvar_t *r_finish;
 	extern cvar_t *r_drawBuffer;
 	extern cvar_t *r_swapInterval;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -31,7 +31,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "tr_public.h"
 #include "iqm.h"
 
-#define GLEW_NO_GLU
 #include <GL/glew.h>
 
 #define DYN_BUFFER_SIZE ( 4 * 1024 * 1024 )
@@ -240,7 +239,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		int                 coords[ 4 ];
 	};
 
-	enum frustumBits_t : int
+	enum frustumBits_t
 	{
 	  FRUSTUM_LEFT,
 	  FRUSTUM_RIGHT,
@@ -591,6 +590,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		int bits = 0;
 		filterType_t filterType;
 		wrapType_t wrapType;
+		int minDimension = 0;
+		int maxDimension = 0;
 	};
 
 	struct image_t
@@ -1270,6 +1271,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 		float          polygonOffsetValue;
 
 		bool       noPicMip; // for images that must always be full resolution
+		int        imageMinDimension;   // for images that must not be loaded with smaller size
+		int        imageMaxDimension;   // for images that must not be loaded with larger size
 		filterType_t   filterType; // for console fonts, 2D elements, etc.
 		wrapType_t     wrapType;
 
@@ -2883,6 +2886,10 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_singleShader; // make most world faces use default shader
 	extern cvar_t *r_colorMipLevels; // development aid to see texture mip usage
 	extern cvar_t *r_picMip; // controls picmip values
+	extern cvar_t *r_imageMaxDimension;
+	extern cvar_t *r_ignoreMaterialMinDimension;
+	extern cvar_t *r_ignoreMaterialMaxDimension;
+	extern cvar_t *r_replaceMaterialMinDimensionIfPresentWithMaxDimension;
 	extern cvar_t *r_finish;
 	extern cvar_t *r_drawBuffer;
 	extern cvar_t *r_swapInterval;
@@ -3215,7 +3222,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	qhandle_t RE_GenerateTexture( const byte *pic, int width, int height );
 
 	image_t *R_AllocImage( const char *name, bool linkIntoHashTable );
-	void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t *image );
+	void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t *image, const imageParams_t &imageParams );
 
 	void    RE_GetTextureSize( int textureID, int *width, int *height );
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1449,7 +1449,8 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 	}
 
 	imageParams_t imageParams = {};
-	imageParams.bits = 0;
+	imageParams.minDimension = shader.imageMinDimension;
+	imageParams.maxDimension = shader.imageMaxDimension;
 
 	// determine image options
 	if ( stage->overrideNoPicMip || shader.noPicMip || stage->highQuality || stage->forceHighQuality )
@@ -2162,6 +2163,8 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			imageParams.bits = imageBits;
 			imageParams.filterType = filterType;
 			imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+			imageParams.minDimension = shader.imageMinDimension;
+			imageParams.maxDimension = shader.imageMaxDimension;
 
 			stage->bundle[ 0 ].image[ 0 ] = R_FindImageFile( token, imageParams );
 
@@ -2209,6 +2212,8 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 					imageParams.bits = IF_NONE;
 					imageParams.filterType = filterType_t::FT_DEFAULT;
 					imageParams.wrapType = wrapTypeEnum_t::WT_REPEAT;
+					imageParams.minDimension = shader.imageMinDimension;
+					imageParams.maxDimension = shader.imageMaxDimension;
 
 					stage->bundle[ 0 ].image[ num ] = R_FindImageFile( token, imageParams );
 
@@ -2265,6 +2270,8 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			imageParams.bits = imageBits;
 			imageParams.filterType = filterType;
 			imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+			imageParams.minDimension = shader.imageMinDimension;
+			imageParams.maxDimension = shader.imageMaxDimension;
 
 			stage->bundle[ 0 ].image[ 0 ] = R_FindCubeImage( token, imageParams );
 
@@ -3454,6 +3461,8 @@ static void ParseSkyParms( const char **text )
 		imageParams.bits = IF_NONE;
 		imageParams.filterType = filterType_t::FT_DEFAULT;
 		imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+		imageParams.minDimension = shader.imageMinDimension;
+		imageParams.maxDimension = shader.imageMaxDimension;
 
 		shader.sky.outerbox = R_FindCubeImage( prefix, imageParams );
 
@@ -3499,6 +3508,8 @@ static void ParseSkyParms( const char **text )
 		imageParams.bits = IF_NONE;
 		imageParams.filterType = filterType_t::FT_DEFAULT;
 		imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+		imageParams.minDimension = shader.imageMinDimension;
+		imageParams.maxDimension = shader.imageMaxDimension;
 
 		shader.sky.innerbox = R_FindCubeImage( prefix, imageParams );
 
@@ -3959,6 +3970,30 @@ static bool ParseShader( const char *_text )
 		else if ( !Q_stricmp( token, "nopicmip" ) )
 		{
 			shader.noPicMip = true;
+			continue;
+		}
+		// imageMinDimension enforcement
+		else if ( !Q_stricmp( token, "imageMinDimension" ) )
+		{
+			token = COM_ParseExt2( text, false );
+
+			if ( token[ 0 ] )
+			{
+				shader.imageMinDimension = atoi( token );
+			}
+
+			continue;
+		}
+		// imageMaxDimension enforcement
+		else if ( !Q_stricmp( token, "imageMaxDimension" ) )
+		{
+			token = COM_ParseExt2( text, false );
+
+			if ( token[ 0 ] )
+			{
+				shader.imageMaxDimension = atoi( token );
+			}
+
 			continue;
 		}
 		// RF, allow each shader to permit compression if available (removed option)

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1402,8 +1402,6 @@ static bool ParseMap( const char **text, char *buffer, int bufferSize )
 static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleIndex = TB_COLORMAP )
 {
 	char         *token;
-	int          imageBits = 0;
-	filterType_t filterType;
 	const char         *buffer_p = &buffer[ 0 ];
 
 	if ( !buffer || !buffer[ 0 ] )
@@ -1450,10 +1448,13 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 		return true;
 	}
 
+	imageParams_t imageParams = {};
+	imageParams.bits = 0;
+
 	// determine image options
 	if ( stage->overrideNoPicMip || shader.noPicMip || stage->highQuality || stage->forceHighQuality )
 	{
-		imageBits |= IF_NOPICMIP;
+		imageParams.bits |= IF_NOPICMIP;
 	}
 
 	switch ( stage->type )
@@ -1461,7 +1462,7 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 		case stageType_t::ST_NORMALMAP:
 		case stageType_t::ST_HEATHAZEMAP:
 		case stageType_t::ST_LIQUIDMAP:
-			imageBits |= IF_NORMALMAP;
+			imageParams.bits |= IF_NORMALMAP;
 		default:
 			// silence warning for other types, we don't have to take care of them:
 			//    warning: enumeration value ‘ST_GLOWMAP’ not handled in switch [-Wswitch]
@@ -1470,24 +1471,24 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 
 	if ( stage->stateBits & ( GLS_ATEST_BITS ) )
 	{
-		imageBits |= IF_ALPHATEST; // FIXME: this is unused
+		imageParams.bits |= IF_ALPHATEST; // FIXME: this is unused
 	}
 
 	if ( stage->overrideFilterType )
 	{
-		filterType = stage->filterType;
+		imageParams.filterType = stage->filterType;
 	}
 	else
 	{
-		filterType = shader.filterType;
+		imageParams.filterType = shader.filterType;
 	}
 
-	wrapType_t wrapType = stage->overrideWrapType ? stage->wrapType : shader.wrapType;
+	imageParams.wrapType = stage->overrideWrapType ? stage->wrapType : shader.wrapType;
 
 	// try to load the image
 	if ( stage->isCubeMap )
 	{
-		stage->bundle[ bundleIndex ].image[ 0 ] = R_FindCubeImage( buffer, imageBits, filterType, wrapType );
+		stage->bundle[ bundleIndex ].image[ 0 ] = R_FindCubeImage( buffer, imageParams );
 
 		if ( !stage->bundle[ bundleIndex ].image[ 0 ] )
 		{
@@ -1497,7 +1498,7 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 	}
 	else
 	{
-		stage->bundle[ bundleIndex ].image[ 0 ] = R_FindImageFile( buffer, imageBits, filterType, wrapType );
+		stage->bundle[ bundleIndex ].image[ 0 ] = R_FindImageFile( buffer, imageParams );
 
 		if ( !stage->bundle[ bundleIndex ].image[ 0 ] )
 		{
@@ -2157,7 +2158,12 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 				filterType = shader.filterType;
 			}
 
-			stage->bundle[ 0 ].image[ 0 ] = R_FindImageFile( token, imageBits, filterType, wrapTypeEnum_t::WT_CLAMP );
+			imageParams_t imageParams = {};
+			imageParams.bits = imageBits;
+			imageParams.filterType = filterType;
+			imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+			stage->bundle[ 0 ].image[ 0 ] = R_FindImageFile( token, imageParams );
 
 			if ( !stage->bundle[ 0 ].image[ 0 ] )
 			{
@@ -2199,7 +2205,12 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 
 				if ( num < MAX_IMAGE_ANIMATIONS )
 				{
-					stage->bundle[ 0 ].image[ num ] = R_FindImageFile( token, IF_NONE, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_REPEAT );
+					imageParams_t imageParams = {};
+					imageParams.bits = IF_NONE;
+					imageParams.filterType = filterType_t::FT_DEFAULT;
+					imageParams.wrapType = wrapTypeEnum_t::WT_REPEAT;
+
+					stage->bundle[ 0 ].image[ num ] = R_FindImageFile( token, imageParams );
 
 					if ( !stage->bundle[ 0 ].image[ num ] )
 					{
@@ -2250,7 +2261,12 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 				filterType = shader.filterType;
 			}
 
-			stage->bundle[ 0 ].image[ 0 ] = R_FindCubeImage( token, imageBits, filterType, wrapTypeEnum_t::WT_EDGE_CLAMP );
+			imageParams_t imageParams = {};
+			imageParams.bits = imageBits;
+			imageParams.filterType = filterType;
+			imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+			stage->bundle[ 0 ].image[ 0 ] = R_FindCubeImage( token, imageParams );
 
 			if ( !stage->bundle[ 0 ].image[ 0 ] )
 			{
@@ -3434,7 +3450,12 @@ static void ParseSkyParms( const char **text )
 	{
 		Q_strncpyz( prefix, token, sizeof( prefix ) );
 
-		shader.sky.outerbox = R_FindCubeImage( prefix, IF_NONE, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_EDGE_CLAMP );
+		imageParams_t imageParams = {};
+		imageParams.bits = IF_NONE;
+		imageParams.filterType = filterType_t::FT_DEFAULT;
+		imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+		shader.sky.outerbox = R_FindCubeImage( prefix, imageParams );
 
 		if ( !shader.sky.outerbox )
 		{
@@ -3474,7 +3495,12 @@ static void ParseSkyParms( const char **text )
 	{
 		Q_strncpyz( prefix, token, sizeof( prefix ) );
 
-		shader.sky.innerbox = R_FindCubeImage( prefix, IF_NONE, filterType_t::FT_DEFAULT, wrapTypeEnum_t::WT_EDGE_CLAMP );
+		imageParams_t imageParams = {};
+		imageParams.bits = IF_NONE;
+		imageParams.filterType = filterType_t::FT_DEFAULT;
+		imageParams.wrapType = wrapTypeEnum_t::WT_EDGE_CLAMP;
+
+		shader.sky.innerbox = R_FindCubeImage( prefix, imageParams );
 
 		if ( !shader.sky.innerbox )
 		{
@@ -5730,11 +5756,19 @@ shader_t       *R_FindShader( const char *name, shaderType_t type,
 	if( !(bits & RSF_NOMIP) ) {
 		LoadExtraMaps( &stages[ 0 ], fileName );
 
-		image = R_FindImageFile( fileName, bits, filterType_t::FT_DEFAULT,
-					 wrapTypeEnum_t::WT_REPEAT );
+		imageParams_t imageParams = {};
+		imageParams.bits = bits;
+		imageParams.filterType = filterType_t::FT_DEFAULT;
+		imageParams.wrapType = wrapTypeEnum_t::WT_REPEAT;
+
+		image = R_FindImageFile( fileName, imageParams );
 	} else {
-		image = R_FindImageFile( fileName, bits, filterType_t::FT_LINEAR,
-					 wrapTypeEnum_t::WT_CLAMP );
+		imageParams_t imageParams = {};
+		imageParams.bits = bits;
+		imageParams.filterType = filterType_t::FT_LINEAR;
+		imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+		image = R_FindImageFile( fileName, imageParams );
 	}
 
 	if ( !image )


### PR DESCRIPTION
I imported `imageMinDimension`/`imageMaxDimension`, `r_imageMinDimension`/`r_imageMaxDimension` from #394.

What's interesting for the release is `r_imageMaxDimension` (engine cvar) and `imageMinDimension` (material keyword).