### PR TITLE
tr_shader: workaround relief not applied on alpha mask by disabling relief, ref #334

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4843,6 +4843,16 @@ static void CollapseStages()
 		stage->enableSpecularMapping = r_specularMapping->integer && stage->hasMaterialMap && !stage->isMaterialPhysical;
 		stage->enableGlowMapping = r_glowMapping->integer && stage->hasGlowMap;
 
+		// FIXME: Workaround for textures having both an alpha mask (like gratings) with an height map,
+		// The engine does not displace the depth test map yet so we disable relief mapping to prevent garbage
+		// to appears between the displaced diffuse map and the non-displaced alpha mask.
+		// See https://github.com/DaemonEngine/Daemon/issues/334
+		if ( stage->enableReliefMapping && stage->stateBits & ~GLS_DEPTHMASK_TRUE )
+		{
+			Log::Debug( "Workaround: disabling relief mapping for stage %d in shader '%s' because of alpha mask", s, shader.name );
+			stage->enableReliefMapping = false;
+		}
+
 		// Finally disable useless heightMapInNormalMap if both normal and relief mapping are disabled.
 		// see https://github.com/DaemonEngine/Daemon/issues/376
 		stage->isHeightMapInNormalMap = stage->isHeightMapInNormalMap && ( stage->enableNormalMapping || stage->enableReliefMapping );


### PR DESCRIPTION
To not delay 0.52 more, I propose to just disable relief mapping on grids for now, see #334.