### PR TITLE
Close file handles of dead VMs

### DIFF
--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -50,6 +50,15 @@ const char PAK_DIR_EXT[] = ".dpkdir/";
 // File offset type. Using 64bit to allow large files.
 using offset_t = int64_t;
 
+// Track ownership of old-style file handles
+enum class Owner
+{
+	UNKNOWN,
+	ENGINE, // TODO: use
+	CGAME,
+	SGAME,
+};
+
 // Special value to indicate the function should throw a system_error instead
 // of returning an error code. This avoids the need to have 2 overloads for each
 // function.

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1003,7 +1003,7 @@ CGameVM::CGameVM(): VM::VMBase("cgame", Cvar::CHEAT), services(nullptr), cmdBuff
 
 void CGameVM::Start()
 {
-	services = std::unique_ptr<VM::CommonVMServices>(new VM::CommonVMServices(*this, "CGame", Cmd::CGAME_VM));
+	services = std::unique_ptr<VM::CommonVMServices>(new VM::CommonVMServices(*this, "CGame", FS::Owner::CGAME, Cmd::CGAME_VM));
 	uint32_t version = this->Create();
 	if ( version != CGAME_API_VERSION ) {
 		Sys::Drop( "CGame ABI mismatch, expected %d, got %d", CGAME_API_VERSION, version );

--- a/src/engine/framework/CommonVMServices.cpp
+++ b/src/engine/framework/CommonVMServices.cpp
@@ -259,6 +259,7 @@ namespace VM {
 
             case QVM_COMMON_FS_READ:
                 IPC::HandleMsg<FSReadMsg>(channel, std::move(reader), [this](int handle, int len, std::string& res, int& ret) {
+                    FS_CheckOwnership(handle, fileOwnership);
                     std::unique_ptr<char[]> buffer(new char[len]);
                     buffer[0] = '\0';
                     ret = FS_Read(buffer.get(), len, handle);
@@ -268,23 +269,27 @@ namespace VM {
 
             case QVM_COMMON_FS_WRITE:
                 IPC::HandleMsg<FSWriteMsg>(channel, std::move(reader), [this](int handle, const std::string& text, int& res) {
+                    FS_CheckOwnership(handle, fileOwnership);
                     res = FS_Write(text.c_str(), text.size(), handle);
                 });
                 break;
 
             case QVM_COMMON_FS_SEEK:
                 IPC::HandleMsg<VM::FSSeekMsg>(channel, std::move(reader), [this] (int f, long offset, int origin, int& res) {
+                    FS_CheckOwnership(f, fileOwnership);
                     res = FS_Seek(f, offset, Util::enum_cast<fsOrigin_t>(origin));
                 });
                 break;
 
             case QVM_COMMON_FS_TELL:
                 IPC::HandleMsg<VM::FSTellMsg>(channel, std::move(reader), [this] (fileHandle_t f, int& res) {
+                    FS_CheckOwnership(f, fileOwnership);
                     res = FS_FTell(f);
                 });
                 break;
 			case QVM_COMMON_FS_FILELENGTH:
 				IPC::HandleMsg<VM::FSFileLengthMsg>(channel, std::move(reader), [this] (fileHandle_t f, int& res) {
+					FS_CheckOwnership(f, fileOwnership);
 					res = FS_filelength(f);
 				});
 				break;
@@ -296,6 +301,7 @@ namespace VM {
 
             case QVM_COMMON_FS_FCLOSE_FILE:
                 IPC::HandleMsg<FSFCloseFileMsg>(channel, std::move(reader), [this](int handle) {
+                    FS_CheckOwnership(handle, fileOwnership);
                     FS_FCloseFile(handle);
                 });
                 break;

--- a/src/engine/framework/CommonVMServices.h
+++ b/src/engine/framework/CommonVMServices.h
@@ -40,13 +40,14 @@ namespace VM {
 
     class CommonVMServices {
         public:
-            CommonVMServices(VMBase& vm, Str::StringRef vmName, int commandFlag);
+            CommonVMServices(VMBase& vm, Str::StringRef vmName, FS::Owner fileOwnership, int commandFlag);
             ~CommonVMServices();
 
             void Syscall(int major, int minor, Util::Reader reader, IPC::Channel& channel);
 
         private:
             std::string vmName;
+            FS::Owner fileOwnership;
             VMBase& vm;
 
             VMBase& GetVM();

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -27,6 +27,8 @@ along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 #include "qcommon.h"
 #include "common/Defs.h"
 
+extern Log::Logger fsLogs;
+
 // There must be some limit for the APIs in this file since they use 'int' for lengths which can be overflowed by large files.
 constexpr FS::offset_t MAX_FILE_LENGTH = 1000 * 1000 * 1000;
 
@@ -41,6 +43,7 @@ struct handleData_t {
 	bool isOpen;
 	bool isPakFile;
 	Util::optional<std::string> renameTo;
+	FS::Owner owner;
 
 	// Normal file info
 	bool forceFlush;
@@ -66,8 +69,10 @@ static fileHandle_t FS_AllocHandle()
 {
 	// Don't use handle 0 because it is used to indicate failures
 	for (int i = 1; i < MAX_FILE_HANDLES; i++) {
-		if (!handleTable[i].isOpen)
+		if (!handleTable[i].isOpen) {
+			handleTable[i].owner = FS::Owner::UNKNOWN;
 			return i;
+		}
 	}
 	Sys::Drop("FS_AllocHandle: none free");
 }
@@ -222,6 +227,25 @@ int FS_Game_FOpenFileByMode(const char* path, fileHandle_t* handle, fsMode_t mod
 	default:
 		Sys::Drop("FS_Game_FOpenFileByMode: bad mode %s", Util::enum_str(mode));
 	}
+}
+
+void FS_SetOwner(fileHandle_t f, FS::Owner owner)
+{
+	FS_CheckHandle(f, false);
+	ASSERT_EQ(handleTable[f].owner, FS::Owner::UNKNOWN);
+	handleTable[f].owner = owner;
+}
+
+void FS_CloseAllForOwner(FS::Owner owner)
+{
+	int numClosed = 0;
+	for (int f = 1; f < MAX_FILE_HANDLES; f++) {
+		if (handleTable[f].owner == owner && handleTable[f].isOpen) {
+			FS_FCloseFile(f);
+			++numClosed;
+		}
+	}
+	fsLogs.Verbose("Closed %d outstanding handles for owner %d", numClosed, Util::ordinal(owner));
 }
 
 int FS_FCloseFile(fileHandle_t handle)

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -236,6 +236,15 @@ void FS_SetOwner(fileHandle_t f, FS::Owner owner)
 	handleTable[f].owner = owner;
 }
 
+void FS_CheckOwnership(fileHandle_t f, FS::Owner owner)
+{
+	if (f == 0)
+		return;
+	FS_CheckHandle(f, false);
+	if (handleTable[f].owner != owner)
+		Sys::Drop("VM %d tried to access file handle it doesn't own", Util::ordinal(owner));
+}
+
 void FS_CloseAllForOwner(FS::Owner owner)
 {
 	int numClosed = 0;

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -382,6 +382,7 @@ int          FS_FOpenFileRead( const char *qpath, fileHandle_t *file );
 
 namespace FS { enum class Owner; }
 void FS_SetOwner( fileHandle_t f, FS::Owner owner );
+void FS_CheckOwnership( fileHandle_t f, FS::Owner owner );
 void FS_CloseAllForOwner( FS::Owner owner );
 
 /*

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -380,6 +380,10 @@ fileHandle_t FS_SV_FOpenFileWrite( const char *filename );
 void         FS_SV_Rename( const char *from, const char *to );
 int          FS_FOpenFileRead( const char *qpath, fileHandle_t *file );
 
+namespace FS { enum class Owner; }
+void FS_SetOwner( fileHandle_t f, FS::Owner owner );
+void FS_CloseAllForOwner( FS::Owner owner );
+
 /*
 if uniqueFILE is true, then a new FILE will be fopened even if the file
 is found in an already open pak file.  If uniqueFILE is false, you must call

--- a/src/engine/server/sv_sgame.cpp
+++ b/src/engine/server/sv_sgame.cpp
@@ -340,7 +340,7 @@ GameVM::GameVM(): VM::VMBase("sgame", Cvar::NONE), services(nullptr) {
 
 void GameVM::Start()
 {
-	services = std::unique_ptr<VM::CommonVMServices>(new VM::CommonVMServices(*this, "SGame", Cmd::SGAME_VM));
+	services = std::unique_ptr<VM::CommonVMServices>(new VM::CommonVMServices(*this, "SGame", FS::Owner::SGAME, Cmd::SGAME_VM));
 
 	uint32_t version = this->Create();
 	if ( version != GAME_API_VERSION ) {


### PR DESCRIPTION
In my tests the cgame and sgame usually had 1 open file each.