### PR TITLE
renderer: enable GL clear by default

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1177,7 +1177,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_logFile = ri.Cvar_Get( "r_logFile", "0", CVAR_CHEAT );
 		r_debugSurface = ri.Cvar_Get( "r_debugSurface", "0", CVAR_CHEAT );
 		r_nobind = ri.Cvar_Get( "r_nobind", "0", CVAR_CHEAT );
-		r_clear = ri.Cvar_Get( "r_clear", "1", CVAR_CHEAT );
+		r_clear = ri.Cvar_Get( "r_clear", "1", 0 );
 		r_offsetFactor = ri.Cvar_Get( "r_offsetFactor", "-1", CVAR_CHEAT );
 		r_offsetUnits = ri.Cvar_Get( "r_offsetUnits", "-2", CVAR_CHEAT );
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1177,7 +1177,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_logFile = ri.Cvar_Get( "r_logFile", "0", CVAR_CHEAT );
 		r_debugSurface = ri.Cvar_Get( "r_debugSurface", "0", CVAR_CHEAT );
 		r_nobind = ri.Cvar_Get( "r_nobind", "0", CVAR_CHEAT );
-		r_clear = ri.Cvar_Get( "r_clear", "0", CVAR_CHEAT );
+		r_clear = ri.Cvar_Get( "r_clear", "1", CVAR_CHEAT );
 		r_offsetFactor = ri.Cvar_Get( "r_offsetFactor", "-1", CVAR_CHEAT );
 		r_offsetUnits = ri.Cvar_Get( "r_offsetUnits", "-2", CVAR_CHEAT );
 


### PR DESCRIPTION
GL Clear is expected to paint the screen with an arbitrary color before painting anything else, and that action is not expected to slow down things as far as I know. This is used make sure the non-drawn area are filled with something and prevent garbage do be displayed instead.

Enabling GL Clear by default has two benefits:

- prevent legacy maps with small void surfaces to be rendered without glitching. Arachnid2 is one of them. Given the large amount of Tremulous map existing out there and people want to port them, clearing is the best we can do to support those legacy maps with glitchy part without modification. Also, because it is a `cheat` cvar, if it's disabled by default players are not able to hide the void when playing on regular games. Fun stuff is that people playing to Tremulous since more than a decade have reported issues on Unvanquished… that turned to be Arachnid2 void that was there since 2006, but such people only noticed it on Dæmon engine engine.
- make possible for `lowest` preset to use `fastsky` feature, which just skips rendering the sky, relying on the clear function instead (so clear must be enabled), I noticed very noticeable performance gain by doing this on low hardware (skybox rendering is known to be a bit costly in our engine). So, `r_clear 1` + `r_fastsky 1` gives a performance boost, while I never seen `r_clear 0` giving a performance boost, even on very very very old hardware. If `r_clear` is not enabled by default, toggling `r_fastsky` in presets would be unpredictable.

The drawback of enabling GL Clear is that it makes less obvious for the mapper he forgot to paint a wall, because the glitches makes obvious there is some void there. But instead of relying on glitches to debug maps, maybe we would want to use an explicit GL clear color (like red) when loading maps with `devmap`.

For now, we may still enable GL Clear by default.