### PR TITLE
cmake: download deps with https

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,7 +375,7 @@ if (DEPS_DIR)
     if (NOT EXISTS ${DEPS_DIR})
         file(MAKE_DIRECTORY ${EXTERNAL_DEPS_DIR})
         get_filename_component(BASENAME ${DEPS_DIR} NAME)
-        set(REMOTE "http://dl.unvanquished.net/deps/${BASENAME}${DEPS_EXT}")
+        set(REMOTE "https://dl.unvanquished.net/deps/${BASENAME}${DEPS_EXT}")
         message(STATUS "Downloading dependencies from '${REMOTE}'")
         file(DOWNLOAD ${REMOTE} ${OBJ_DIR}/${BASENAME}${DEPS_EXT}
             SHOW_PROGRESS


### PR DESCRIPTION
I noticed the deps download is initiated with http then redirected to https, it's better to request https directly.