### PR TITLE
Namespace aware autocompletion. Resolves DaemonEngine/Daemon#449

### DIFF
--- a/src/engine/framework/ConsoleField.cpp
+++ b/src/engine/framework/ConsoleField.cpp
@@ -129,9 +129,57 @@ namespace Console {
         //Print the matches if it is ambiguous
         if (candidates.size() >= 2) {
             Log::CommandInteractionMessage(Str::Format("^3-> ^*%s", Str::UTF32To8(GetText())));
-            for (const auto& candidate : candidates) {
+            
+            auto showCandidate = [&]( Cmd::CompletionItem candidate ) {
                 std::string filler(maxCandidateLength - candidate.first.length(), ' ');
                 Log::CommandInteractionMessage(Str::Format("   %s%s %s", candidate.first, filler, candidate.second));
+            };
+            
+            // we only group candidates by namespace for commands, not for arguments
+            if( argNum > 1 ) {
+                // print everything
+                for (const auto& candidate : candidates) {
+                    showCandidate( candidate );
+                }
+            }
+            else {
+                using CompletionIterator = Cmd::CompletionResult::iterator; 
+                
+                // for every candidate (`it`)
+                // we look for the last candidate that shares at least a namespace not included in the prefix (`jt`)
+                // we can do this easily since the candidates are sorted
+                for( CompletionIterator it = candidates.begin(); it != candidates.end(); ++it ) {
+                    // looking for `jt`: the last candidate that shares with `it` a namespace not included in the prefix
+                    CompletionIterator jt;
+                    int nsLen = 0; // the namespace shared by `it` and `jt` is `nsLen` characters
+                    
+                    for( jt = it+1; jt != candidates.end(); ++jt ) {
+                        int commonPrefixLen = Str::LongestPrefixSize( it->first, jt->first );
+                        int commonNSLen = it->first.rfind( '.', commonPrefixLen );
+                        
+                        // let's stop looking at the first candidate that doesn't share a namespace with `it`
+                        if( commonNSLen == commonPrefixLen || commonNSLen < prefixSize ) {
+                            break;
+                        }
+                        
+                        nsLen = commonNSLen;
+                    }
+                    
+                    // `jt` is the first candidate after `it` which doesn't share a namespace with it, take the previous one
+                    -- jt;
+                    
+                    // if `it` doesn't share a namespace with any other candidate, print it entirely
+                    if( it == jt ) {
+                        showCandidate( *it );
+                    }
+                    // else show the namespace and the amount of items inside of it
+                    // then skip all the elements inside such namespace
+                    else {
+                        std::string ns( it->first, 0, nsLen );
+                        Log::CommandInteractionMessage(Str::Format("   %s.{x%i}", ns, jt-it+1));
+                        it = jt;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Some example of how autocompletion behaves with this patch (`↹` is shown where I pressed tab):


```
]se↹
-> /se
   server.{x4}
   set                      sets the value of a cvar
   seta                     sets the value of a cvar and marks the cvar as archived
   sets                     sets the value of a cvar
   setu                     sets the value of a cvar
]ser↹
-> /server.
   server.challenge.{x3}
   server.private           cvar - "3" - server private - Controls how much the server advertises: 0 - Advertise everything, 1 - Don't advertise but reply to status queries, 2 - Don't reply to status queries but accept connections, 3 - Only accept LAN connections.
]server.c↹
-> /server.challenge.
   server.challenge.count   cvar - "1024" - uint - Maximum number of active challenges kept in memory - between 1 and 115292150460684697
   server.challenge.length  cvar - "8" - uint - Length in bytes of the challenge data (The hexadecimal representation will be twice as long) - between 1 and 9223372036854775807
   server.challenge.timeout cvar - "5" - int - Timeout (in seconds) of a challenge - between 1 and 2147483647
```

```
]a↹
-> /a
   alias     creates or view an alias
   arg_all   ""
   arg_count "0"
]/set a.a 1
]a↹
-> /a
   a.a       "1"
   alias     creates or view an alias
   arg_all   ""
   arg_count "0"
]/set a.b 1
]a↹
-> /a
   a.{x2}
   alias     creates or view an alias
   arg_all   ""
   arg_count "0"
]a.↹
-> /a.
   a.a "1"
   a.b "1"
```

```
]log↹
-> /logs.
   logs.logFile.{x4}
   logs.logLevel.{x8}
   logs.suppression.{x4}
```

```
]/set b.b.b.b.0
]/set b.b.b.b.1
]b.↹
-> /b.b.b.b.
   b.b.b.b.0 ""
   b.b.b.b.1 ""
```