### PR TITLE
restore mover content flag like ioq3/tremulous, avoid collision with nobuild content flag

### DIFF
--- a/src/engine/qcommon/SurfaceFlags.h
+++ b/src/engine/qcommon/SurfaceFlags.h
@@ -57,7 +57,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // undefined                        BIT( 11 ) // 0x800
 // undefined                        BIT( 12 ) // 0x1000     // Unvanquished stores CONTENTS_NOALIENBUILD there
 // undefined                        BIT( 13 ) // 0x2000     // Unvanquished stores CONTENTS_NOHUMANBUILD there
-#define CONTENTS_MOVER              BIT( 14 ) // 0x4000     // Unvanquished stores CONTENTS_NOBUILD there
+#define CONTENTS_MOVER              BIT( 14 ) // 0x4000     // Wolf:ET stores CONTENTS_MOVER there; Unvanquished stores CONTENTS_NOBUILD there
 #define CONTENTS_AREAPORTAL         BIT( 15 ) // 0x8000
 #define CONTENTS_PLAYERCLIP         BIT( 16 ) // 0x10000
 #define CONTENTS_MONSTERCLIP        BIT( 17 ) // 0x20000
@@ -66,7 +66,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONTENTS_CLUSTERPORTAL      BIT( 20 ) // 0x100000
 #define CONTENTS_DONOTENTER         BIT( 21 ) // 0x200000
 #define CONTENTS_DONOTENTER_LARGE   BIT( 22 ) // 0x400000
-// undefined                        BIT( 23 ) // 0x800000
+// undefined                        BIT( 23 ) // 0x800000   // Q3 stores CONTENTS_MOVER there
 #define CONTENTS_ORIGIN             BIT( 24 ) // 0x1000000  // removed from entity before BSP computation
 #define CONTENTS_BODY               BIT( 25 ) // 0x2000000  // not used by brushes (must not), used by game entities
 #define CONTENTS_CORPSE             BIT( 26 ) // 0x4000000
@@ -74,7 +74,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONTENTS_STRUCTURAL         BIT( 28 ) // 0x10000000 // solid brushes from BSP
 #define CONTENTS_TRANSLUCENT        BIT( 29 ) // 0x20000000 // contained surfaces will not be consumed
 #define CONTENTS_TRIGGER            BIT( 30 ) // 0x40000000
-#define CONTENTS_NODROP             BIT( 31 ) // 0x80000000 // delete bodies or items whean dropped, used on things like lava or pit of death to prevent unnecessary polygon pileups
+#define CONTENTS_NODROP             BIT( 31 ) // 0x80000000 // delete bodies or items when dropped, used on things like lava or pit of death to prevent unnecessary polygon pileups
 
 // content flags
 #define SURF_NODAMAGE               BIT( 0 )  // 0x1        // falling on this surface does not give damage
@@ -111,6 +111,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define SURF_LANDMINE               BIT( 31 ) // 0x80000000 // Wolf:ET, landmines can be placed on this surface
 
 // Note about other idTech 3 based games:
-// Jedi Knights games (see OpenJK) also define a third bitfield for flags with MATERIAL prefix to tell surface is water, snow, sand, glass, sort grasss, long grass, etc.
+// Jedi Knights games (see OpenJK) also define a third bitfield for flags with MATERIAL prefix to tell surface is water, snow, sand, glass, short grasss, long grass, etc.
 // Jedi Knights games also redefine a lot of CONTENTS flags (introducing things like CONTENTS_LADDER) and SURF FLAGS (moving SURF_SKY to BIT(13) for example)
 // Smokin'Guns uses a special .tex sidecar files to tweak surfaces flags

--- a/src/engine/qcommon/SurfaceFlags.h
+++ b/src/engine/qcommon/SurfaceFlags.h
@@ -57,7 +57,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // undefined                        BIT( 11 ) // 0x800
 // undefined                        BIT( 12 ) // 0x1000     // Unvanquished stores CONTENTS_NOALIENBUILD there
 // undefined                        BIT( 13 ) // 0x2000     // Unvanquished stores CONTENTS_NOHUMANBUILD there
-#define CONTENTS_MOVER              BIT( 14 ) // 0x4000     // Wolf:ET stores CONTENTS_MOVER there; Unvanquished stores CONTENTS_NOBUILD there
+// undefined                        BIT( 14 ) // 0x4000     // Unvanquished stores CONTENTS_NOBUILD there; RTCW and Wolf:ET store CONTENTS_MOVER there
 #define CONTENTS_AREAPORTAL         BIT( 15 ) // 0x8000
 #define CONTENTS_PLAYERCLIP         BIT( 16 ) // 0x10000
 #define CONTENTS_MONSTERCLIP        BIT( 17 ) // 0x20000
@@ -66,7 +66,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONTENTS_CLUSTERPORTAL      BIT( 20 ) // 0x100000
 #define CONTENTS_DONOTENTER         BIT( 21 ) // 0x200000
 #define CONTENTS_DONOTENTER_LARGE   BIT( 22 ) // 0x400000
-// undefined                        BIT( 23 ) // 0x800000   // Q3 stores CONTENTS_MOVER there
+#define CONTENTS_MOVER              BIT( 23 ) // 0x800000   // Q3 and Tremulous store CONTENTS_MOVER there
 #define CONTENTS_ORIGIN             BIT( 24 ) // 0x1000000  // removed from entity before BSP computation
 #define CONTENTS_BODY               BIT( 25 ) // 0x2000000  // not used by brushes (must not), used by game entities
 #define CONTENTS_CORPSE             BIT( 26 ) // 0x4000000


### PR DESCRIPTION
Restore `mover` content flag to the value used in Tremulous, was probably mistakenly set to Wolf:ET one when merging Wolf:ET code.

This flag seems to be set by the engine to be used by the game, there is no mention of it either in map compiler source code, neither in the `custinfoparms.txt` the map compiler reads, so the `.bsp` file is not expected to carry it.

As long as you recompile the game code with this revision of the engine, there is no regression. Even movers in Wolf:ET maps would work as expected if Wolf:ET code was built and run with this engine.

Restoring this flag to the Quake3/Tremulous value is required to avoid collision with the `nobuild` content flag that is (currently) using the same value. The `nobuild` content flag is set by the map compiler (defined in [`custinfoparms.txt`](https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/blob/master/scripts/custinfoparms.txt)) and written in stone at map compilation, carried by the `.bsp` file. Keeping compatibility with legacy maps without source or without requiring to recompile the `.map` or use `esquirel` to rewrite the flags in the `.bsp` requires to keep the `nobuild` value as it was set in Tremulous back in the day.

Not restoring this flag means:

- the game code mistakenly considers every `nobuild` brush is a `mover`;
- the spectator can fly through `nobuild` brushes like if it was a mover, even if clipping is set for this brush (including `playerclip`);
- we cannot provide a `common/outside` brush to mappers to both clip player, let weapons projectile pass, and forbid building, requiring mappers to do two brushes instead of one anytime they want to delimit the playable, or relying on undocumented behaviors by attempting to merge into one brush the `surfaceparm` or `contentparm` values from the various surfaces of the brush;
- we cannot implement a renderer feature using grid lighting on movers to adjust the lighting while they move (relatively to the ambient lighting of the actual place) instead of light mapping to prevent train or doors to move with their hardcoded shadow from the static place they were compiled, shadow that is wrong as soon as the mover starts to move, otherwise some `nobuild` surfaces neighbouring buildables surfaces (even from the same plane and expected to just be part of the same surface) would be lit like movers but not like the world, with shadow discontinuation and light visually mismatching among triangles of the same surface.

Not restoring this flag for 0.52 means we would have to skip entirely the 0.52 lifecycle and wait for 0.53 release date to start implementing features requiring that fix (easier support for mappers, the mover lightgrid lighting…).

I have tested this patch with maps with movers like spacetracks (trains, doors, elevators), uss tremor (doors, complex lift), etc. without noticing any issue. Anyway getting a regression would be surprised because this is precisely fixing a regression when compared to tremulous. Getting it for RC4 sounds really important to me.

