### PR TITLE
renderer: tiled renderer is r_dynamicLight > 0, see be7229a

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -688,7 +688,7 @@ static void Render_generic( int stage )
 		GL_BindToTMU( 1, tr.currentDepthImage );
 	}
 
-	if ( r_dynamicLight->integer == 2 )
+	if ( r_dynamicLight->integer > 0 )
 	{
 		GL_BindToTMU( 8, tr.lighttileRenderImage );
 	}
@@ -907,7 +907,7 @@ static void Render_lightMapping( int stage )
 	}
 
 	// bind u_LightTiles
-	if ( r_dynamicLight->integer == 2 )
+	if ( r_dynamicLight->integer > 0 )
 	{
 		GL_BindToTMU( BIND_LIGHTTILES, tr.lighttileRenderImage );
 	}


### PR DESCRIPTION
The forwared renderer is deprecated and now uses -1 value.
The tiled renderer is meant to use 1 value one day, but both 1 and 2
can be usable for tiled renderer in 0.52.0, in order to keep
compatibility with 0.51.0 config files when testing releases candidates.

Those test rewrite were missing in be7229a.

See https://github.com/DaemonEngine/Daemon/issues/386#issuecomment-823196130

The issue was spotted thanks to https://github.com/DaemonEngine/Daemon/issues/386#issuecomment-823196130

I don't expect this to fix #386 if people experiencing problems with Nvidia used `r_dynamicLight` `2`.