### PR TITLE
Stifle warning spam (with self-built OpenAL)

### DIFF
--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -348,7 +348,7 @@ build_openal() {
 	linux*)
 		download "openal-soft-${OPENAL_VERSION}.tar.bz2" "https://openal-soft.org/openal-releases/openal-soft-${OPENAL_VERSION}.tar.bz2" openal
 		cd "openal-soft-${OPENAL_VERSION}"
-		cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DALSOFT_EXAMPLES=OFF -DLIBTYPE=STATIC .
+		cmake -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DALSOFT_EXAMPLES=OFF -DLIBTYPE=STATIC -DCMAKE_BUILD_TYPE=Release .
 		make
 		make install
 		;;


### PR DESCRIPTION
Fixes #445.

Regardless of the build type, you can enable spam by setting `ALSOFT_LOGLEVEL=2` in the environment, or disable it by `ALSOFT_LOGLEVEL=1`.