### PR TITLE
filesystem: enable 1 symlink depth for future res-tremulous community dpk

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -124,7 +124,7 @@ namespace FS {
 
 #ifdef BUILD_ENGINE
 static Cvar::Cvar<bool> fs_legacypaks("fs_legacypaks", "also load pk3s, ignoring version", Cvar::NONE, false);
-static Cvar::Cvar<int> fs_maxSymlinkDepth("fs_maxSymlinkDepth", "max depth of symlinks in zip paks (0 means disabled)", Cvar::NONE, 0);
+static Cvar::Cvar<int> fs_maxSymlinkDepth("fs_maxSymlinkDepth", "max depth of symlinks in zip paks (0 means disabled)", Cvar::NONE, 1);
 
 bool UseLegacyPaks()
 {


### PR DESCRIPTION
While the “symlink in dpk file system” feature was at first implemented to load Xonotic assets to use them as test bed for renderer features like relief mapping, I now believe we have one very good usage for this: third-party compatibility packages, like the [`res-tremulous`](https://github.com/InterstellarOasis/res-tremulous_src.dpkdir) one.

When I first distributed `res-tremulous` to be used by legacy maps being ported from Tremulous, I did a huge deduplication, this plus ad-hoc compression, reduced the `res-tremulous` package to only `13M`.

One thing is that the zip format stores each file independently, so we can't rely on the archive compression to deduplicate files.

Along that manual deduplication I did, I provided a [compatibility `.shader` file](https://github.com/InterstellarOasis/res-tremulous_src.dpkdir/blob/74045dd080a82f3b412b68d83cff71020587b299/scripts/tremulous_compat.shader) that provided alternate path for the deduplicated images.

One thing is that compatibility `.shader` file works perfectly when third-party legacy maps make use of those deduplicated path, but not when third party legacy `.shader` files rely on those path.

For example, let's look at this material:

```
textures/tremor/ship_tex
{
	qer_editorimage textures/niveus/ship_tex
	diffuseMap textures/niveus/ship_tex
}
```

If a map makes use of the `textures/niveus/ship_tex` path, the game will load the `textures/niveus/ship_tex.crn` image directly.

If a map makes use of `textures/tremor/ship_tex` path, the game will load the `textures/tremor/ship_tex` material which will then load the `textures/niveus/ship_tex.crn` image.

But if a map makes use of a `textures/castle/ship_tex` path and provide this custom material:

```
textures/castle/ship_tex
{
	qer_editorimage textures/tremor/ship_tex
	diffuseMap textures/tremor/ship_tex
}
```

The material parser (engine's `tr_shader.cpp`) will fail to load the image.

Those use cases are not very common, bug definitely exist.

At the time, I was alone porting maps so I used a `sed` file to do substitutions when porting maps. But as we seen with the Italian community that recently joined, they started to port maps on their own initiative and that's very good! But I noticed some of those maps display missing textures. I cannot expect any random people to apply the `sed` substitution file I use. So, I think that to make easier for people to port maps while keeping the `res-tremulous` dpk file very lightweight for fast in-game download, we could enable the symlink feature. One depth is enough, I'll take care of `res-tremulous` symlinks to not have more than one depth.

Symlinks would still be strongly discouraged for brand new content a mapper can fix anyway. Things like the `res-tremulous` package are a bit different because they have to provide 15 years of backward compatibility and we can't rewrite the past.