### PR TITLE
[windows] Include OS / DPI Aware manifests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -684,6 +684,17 @@ function(AddApplication)
     set_property(TARGET ${A_Target} APPEND PROPERTY COMPILE_DEFINITIONS ${A_Definitions})
     set_target_properties(${A_Target} PROPERTIES OUTPUT_NAME "${A_ExecutableName}" PREFIX "" FOLDER "engine")
 
+    # Append Windows specific manifests.
+    if (WIN32)
+        set(WINDOWS_MANIFESTS_DIR ${ENGINE_DIR}/sys/manifests)
+        target_sources(${A_Target} PRIVATE
+            # App is DPI aware, so Windows doesn't try to scale UI.
+            ${WINDOWS_MANIFESTS_DIR}/dpi-aware.manifest
+            # App supports Windows Vista+, no quirks required.
+            ${WINDOWS_MANIFESTS_DIR}/supported-os.manifest
+        )
+    endif()
+
     message(STATUS ${A_Target})
     ADD_PRECOMPILED_HEADER(${A_Target})
 endfunction()

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -550,15 +550,6 @@ static void Init(int argc, char** argv)
 #ifdef _WIN32
 	// Don't let SDL set the timer resolution. We do that manually in Sys::Sleep.
 	SDL_SetHint(SDL_HINT_TIMER_RESOLUTION, "0");
-
-	// Mark the process as DPI-aware on Vista and above, ignore any errors
-	std::string errorString;
-	Sys::DynamicLib user32 = Sys::DynamicLib::Open("user32.dll", errorString);
-	if (user32) {
-		auto pSetProcessDPIAware = user32.LoadSym<BOOL WINAPI()>("SetProcessDPIAware", errorString);
-		if (pSetProcessDPIAware)
-			pSetProcessDPIAware();
-	}
 #else
 	// Translate non-fatal signals to a quit command
 	Sys::StartSignalThread();

--- a/src/engine/sys/manifests/dpi-aware.manifest
+++ b/src/engine/sys/manifests/dpi-aware.manifest
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Specifies whether the current process is dots per inch (dpi) aware (old).
+           See https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests#dpiaware -->
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+      <!-- Specifies whether the current process is dots per inch (dpi) aware (new).
+           See https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests#dpiawareness -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2, PerMonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/src/engine/sys/manifests/supported-os.manifest
+++ b/src/engine/sys/manifests/supported-os.manifest
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- See https://docs.microsoft.com/en-us/windows/win32/sbscs/application-manifests#supportedos -->
+      <!-- Application supports Windows Vista and Windows Server 2008
+           functionality. -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+      <!-- Application supports Windows 7 and Windows Server 2008 R2
+           functionality. -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Application supports Windows 8 and Windows Server 2012
+           functionality. -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Application supports Windows 8.1 and Windows Server 2012 R2
+           functionality. -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Application supports Windows Windows 10, Windows Server 2016 and
+           Windows Server 2019 functionality. -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
Include manifests for:
* OS support info to signal Windows our app supports it as is without quirks.
* DPI aware v.2 (with v.1 fallback) scaling to disallow Windows to scale our window.