### PR TITLE
[renderer] Static array bounds checking for frustum calculators

### DIFF
--- a/src/engine/renderer/tr_light.cpp
+++ b/src/engine/renderer/tr_light.cpp
@@ -406,19 +406,18 @@ void R_SetupLightLocalBounds( trRefLight_t *light )
 			{
 				int    j;
 				vec3_t farCorners[ 4 ];
-				const vec4_t *frustum = (const vec4_t *)light->localFrustum;
 
 				ClearBounds( light->localBounds[ 0 ], light->localBounds[ 1 ] );
 
 				// transform frustum from world space to local space
-				R_CalcFrustumFarCorners( frustum, farCorners );
+				R_CalcFrustumFarCorners( light->localFrustum, farCorners );
 
 				if ( !VectorCompare( light->l.projStart, vec3_origin ) )
 				{
 					vec3_t nearCorners[ 4 ];
 
 					// calculate the vertices defining the top area
-					R_CalcFrustumNearCorners( frustum, nearCorners );
+					R_CalcFrustumNearCorners( light->localFrustum, nearCorners );
 
 					for ( j = 0; j < 4; j++ )
 					{
@@ -429,6 +428,7 @@ void R_SetupLightLocalBounds( trRefLight_t *light )
 				else
 				{
 					vec3_t top;
+					const vec4_t* frustum = (const vec4_t*)light->localFrustum;
 
 					PlanesGetIntersectionPoint( frustum[ FRUSTUM_LEFT ], frustum[ FRUSTUM_RIGHT ], frustum[ FRUSTUM_TOP ], top );
 					AddPointToBounds( top, light->localBounds[ 0 ], light->localBounds[ 1 ] );
@@ -495,16 +495,15 @@ void R_TessLight( const trRefLight_t *light, const Color::Color& color, bool use
 			{
 				vec3_t farCorners[ 4 ];
 				vec4_t quadVerts[ 4 ];
-				const vec4_t *frustum = light->localFrustum;
 
-				R_CalcFrustumFarCorners( frustum, farCorners );
+				R_CalcFrustumFarCorners( light->localFrustum, farCorners );
 
 				if ( !VectorCompare( light->l.projStart, vec3_origin ) )
 				{
 					vec3_t nearCorners[ 4 ];
 
 					// calculate the vertices defining the top area
-					R_CalcFrustumNearCorners( frustum, nearCorners );
+					R_CalcFrustumNearCorners( light->localFrustum, nearCorners );
 
 					// draw outer surfaces
 					for ( j = 0; j < 4; j++ )
@@ -533,6 +532,7 @@ void R_TessLight( const trRefLight_t *light, const Color::Color& color, bool use
 				else
 				{
 					vec3_t top;
+					const vec4_t* frustum = light->localFrustum;
 
 					// no light_start, just use the top vertex (doesn't need to be mirrored)
 					PlanesGetIntersectionPoint( frustum[ FRUSTUM_LEFT ], frustum[ FRUSTUM_RIGHT ], frustum[ FRUSTUM_TOP ], top );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3070,8 +3070,20 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	void           R_RotateLightForViewParms( const trRefLight_t *ent, const viewParms_t *viewParms, orientationr_t *orien );
 
 	void           R_SetupFrustum2( frustum_t frustum, const matrix_t modelViewProjectionMatrix );
-	void           R_CalcFrustumNearCorners(const vec4_t frustum[Util::ordinal(frustumBits_t::FRUSTUM_PLANES)], vec3_t corners[ 4 ] );
-	void           R_CalcFrustumFarCorners( const vec4_t frustum[Util::ordinal(frustumBits_t::FRUSTUM_PLANES)], vec3_t corners[ 4 ] );
+	template<size_t frustumSize>
+	inline
+	typename std::enable_if<(frustumSize >= frustumBits_t::FRUSTUM_NEAR + 1)>::type
+	R_CalcFrustumNearCorners( const vec4_t(&frustum)[frustumSize], vec3_t (&corners)[ 4 ] ) {
+		extern void R_CalcFrustumNearCornersUnsafe( const vec4_t frustum[frustumBits_t::FRUSTUM_NEAR + 1], vec3_t (&corners)[ 4 ] );
+		R_CalcFrustumNearCornersUnsafe( frustum, corners );
+	}
+	template<size_t frustumSize>
+	inline
+	typename std::enable_if<(frustumSize >= frustumBits_t::FRUSTUM_FAR + 1)>::type
+	R_CalcFrustumFarCorners( const vec4_t(&frustum)[frustumSize], vec3_t (&corners)[ 4 ] ) {
+		extern void R_CalcFrustumFarCornersUnsafe( const vec4_t frustum[frustumBits_t::FRUSTUM_FAR + 1], vec3_t (&corners)[ 4 ] );
+		R_CalcFrustumFarCornersUnsafe( frustum, corners );
+	}
 
 	/* Tangent/normal vector calculation functions */
 	void R_CalcFaceNormal( vec3_t normal, const vec3_t v0,

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1086,7 +1086,7 @@ void R_SetupFrustum2( frustum_t frustum, const matrix_t mvp )
 
 // *INDENT-ON*
 
-void R_CalcFrustumNearCorners( const vec4_t frustum[ FRUSTUM_PLANES ], vec3_t corners[ 4 ] )
+void R_CalcFrustumNearCornersUnsafe( const vec4_t frustum[ FRUSTUM_NEAR + 1 ], vec3_t (&corners)[ 4 ] )
 {
 	PlanesGetIntersectionPoint( frustum[ FRUSTUM_LEFT ], frustum[ FRUSTUM_TOP ], frustum[ FRUSTUM_NEAR ], corners[ 0 ] );
 	PlanesGetIntersectionPoint( frustum[ FRUSTUM_RIGHT ], frustum[ FRUSTUM_TOP ], frustum[ FRUSTUM_NEAR ], corners[ 1 ] );
@@ -1094,7 +1094,7 @@ void R_CalcFrustumNearCorners( const vec4_t frustum[ FRUSTUM_PLANES ], vec3_t co
 	PlanesGetIntersectionPoint( frustum[ FRUSTUM_LEFT ], frustum[ FRUSTUM_BOTTOM ], frustum[ FRUSTUM_NEAR ], corners[ 3 ] );
 }
 
-void R_CalcFrustumFarCorners( const vec4_t frustum[ FRUSTUM_PLANES ], vec3_t corners[ 4 ] )
+void R_CalcFrustumFarCornersUnsafe( const vec4_t frustum[ FRUSTUM_FAR + 1 ], vec3_t (&corners)[ 4 ] )
 {
 	PlanesGetIntersectionPoint( frustum[ FRUSTUM_LEFT ], frustum[ FRUSTUM_TOP ], frustum[ FRUSTUM_FAR ], corners[ 0 ] );
 	PlanesGetIntersectionPoint( frustum[ FRUSTUM_RIGHT ], frustum[ FRUSTUM_TOP ], frustum[ FRUSTUM_FAR ], corners[ 1 ] );


### PR DESCRIPTION
In C++ array passed to function as pointer, so no bound checks
performed. For example:

int a[3] = {1, 2, 3};

void accept(int v[4]) {
   v[3] = 1;
}

accept(a);   // Compiles ok, UB in runtime.

To statically check bounds array should be passed as reference:

int a[3] = {1, 2, 3};

void accept(int (&v)[4]) {
   v[3] = 1;
}

accept(a);   // Doesn't compile.

This sample still has problems, as arrays of greater than reference
array length can't be passed in:

int a[5] = {1, 2, 3, 4, 5};

void accept(int (&v)[4]) {
   v[3] = 1;
}

accept(a);   // Doesn't compile, semantically valid.

To allow passing of arrays with length >= acceptable one and do
compile time bounds checks SFINAE can be used:

int three[]{1, 2, 3};
int four[]{1, 2, 3, 4};
int five[]{1, 2, 3, 4, 5};

template<size_t length>
std::enable_if_t<(length >= 4)> accept(int (&v)[length]) {
   v[3] = 1;
}

accept(three);   // Doesn't compile
accept(four);     // Ok
accept(five);      // Ok

Apply ^ in this commit to check frustum / corners array bounds
in compile time.