### PR TITLE
[client,common,qcommon] Mark allocators with allocator / malloc like

### DIFF
--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -57,6 +57,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // other pointer
 #define MALLOC_LIKE __attribute__((__malloc__))
 
+// Marks this function as memory allocator
+#define ALLOCATOR
+
 // Align the address of a variable to a certain value
 #define ALIGNED(a, x) x __attribute__((__aligned__(a)))
 
@@ -149,7 +152,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PRINTF_LIKE(n)
 #define VPRINTF_LIKE(n)
 #define PRINTF_TRANSLATE_ARG(a)
-#define MALLOC_LIKE __declspec(restrict)
+#if _MSC_VER >= 1900 && !defined( _CORECRT_BUILD )
+#define ALLOCATOR __declspec(allocator)
+#else
+#define ALLOCATOR
+#endif
+#define MALLOC_LIKE ALLOCATOR __declspec(restrict)
 #define ALIGNED(a,x) __declspec(align(a)) x
 #define DLLEXPORT __declspec(dllexport)
 #define DLLIMPORT __declspec(dllimport)
@@ -170,6 +178,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define VPRINTF_LIKE(n)
 #define PRINTF_TRANSLATE_ARG(a)
 #define MALLOC_LIKE
+#define ALLOCATOR
 #define ALIGNED(a,x) x
 #define DLLEXPORT
 #define DLLIMPORT

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2694,7 +2694,7 @@ void CL_StartHunkUsers()
 CL_RefMalloc
 ============
 */
-void           *CL_RefMalloc( int size )
+MALLOC_LIKE void           *CL_RefMalloc( int size )
 {
 	return Z_TagMalloc( size, memtag_t::TAG_RENDERER );
 }

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -211,7 +211,7 @@ Com_Allocate_Aligned
 Aligned Memory Allocations for Posix and Win32
 =================
 */
-void *Com_Allocate_Aligned( size_t alignment, size_t size )
+MALLOC_LIKE void *Com_Allocate_Aligned( size_t alignment, size_t size )
 {
 #ifdef _WIN32
 	return _aligned_malloc( size, alignment );

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -224,7 +224,7 @@ using clipHandle_t = int;
 #define Com_Allocate malloc
 #define Com_Dealloc  free
 
-void *Com_Allocate_Aligned( size_t alignment, size_t size );
+MALLOC_LIKE void *Com_Allocate_Aligned( size_t alignment, size_t size );
 void  Com_Free_Aligned( void *ptr );
 
 	/*

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -611,20 +611,20 @@ temp file loading
 */
 
 // Use malloc instead of the zone allocator
-static inline void* Z_TagMalloc(size_t size, memtag_t tag)
+static inline MALLOC_LIKE void* Z_TagMalloc(size_t size, memtag_t tag)
 {
   Q_UNUSED(tag);
   return calloc(size, 1);
 }
-static inline void* Z_Malloc(size_t size)
+static inline MALLOC_LIKE void* Z_Malloc(size_t size)
 {
   return calloc(size, 1);
 }
-static inline void* S_Malloc(size_t size)
+static inline MALLOC_LIKE void* S_Malloc(size_t size)
 {
   return malloc(size);
 }
-static inline char* CopyString(const char* str)
+static inline ALLOCATOR char* CopyString(const char* str)
 {
   return strdup(str);
 }


### PR DESCRIPTION
Allows compiler to infer pointer usage and optimize better.