### PR TITLE
tr_sky: clear color buffer when fastsky is enabled, do not clear screen by default

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -33,6 +33,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 backEndData_t  *backEndData[ SMP_FRAMES ];
 backEndState_t backEnd;
 
+static Cvar::Cvar<bool> r_clear( "r_clear", "Clear screen before painting over it on every frame", Cvar::NONE, false );
+
 void GL_Bind( image_t *image )
 {
 	int texnum;
@@ -5623,7 +5625,7 @@ const RenderCommand *ClearBufferCommand::ExecuteSelf( ) const
 	GL_State( GLS_DEFAULT );
 
 	// Clear relevant buffers, r_fastsky always require clearing.
-	if ( r_clear->integer || r_fastsky->integer ) {
+	if ( r_clear.Get() || r_fastsky->integer ) {
 		clearBits |= GL_COLOR_BUFFER_BIT;
 	}
 

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -5622,8 +5622,8 @@ const RenderCommand *ClearBufferCommand::ExecuteSelf( ) const
 	// ensures that depth writes are enabled for the depth clear
 	GL_State( GLS_DEFAULT );
 
-	// clear relevant buffers
-	if ( r_clear->integer ) {
+	// Clear relevant buffers, r_fastsky always require clearing.
+	if ( r_clear->integer || r_fastsky->integer ) {
 		clearBits |= GL_COLOR_BUFFER_BIT;
 	}
 

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -34,6 +34,7 @@ backEndData_t  *backEndData[ SMP_FRAMES ];
 backEndState_t backEnd;
 
 static Cvar::Cvar<bool> r_clear( "r_clear", "Clear screen before painting over it on every frame", Cvar::NONE, false );
+Cvar::Cvar<bool> r_fastsky( "r_fastsky", "Clear sky instead of drawing it", Cvar::NONE, false );
 
 void GL_Bind( image_t *image )
 {
@@ -5625,7 +5626,7 @@ const RenderCommand *ClearBufferCommand::ExecuteSelf( ) const
 	GL_State( GLS_DEFAULT );
 
 	// Clear relevant buffers, r_fastsky always require clearing.
-	if ( r_clear.Get() || r_fastsky->integer ) {
+	if ( r_clear.Get() || r_fastsky.Get() ) {
 		clearBits |= GL_COLOR_BUFFER_BIT;
 	}
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -138,7 +138,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_ignoreMaterialMaxDimension;
 	cvar_t      *r_replaceMaterialMinDimensionIfPresentWithMaxDimension;
 	cvar_t      *r_finish;
-	cvar_t      *r_clear;
 	cvar_t      *r_textureMode;
 	cvar_t      *r_offsetFactor;
 	cvar_t      *r_offsetUnits;
@@ -1183,7 +1182,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_logFile = Cvar_Get( "r_logFile", "0", CVAR_CHEAT );
 		r_debugSurface = Cvar_Get( "r_debugSurface", "0", CVAR_CHEAT );
 		r_nobind = Cvar_Get( "r_nobind", "0", CVAR_CHEAT );
-		r_clear = Cvar_Get( "r_clear", "1", 0 );
 		r_offsetFactor = Cvar_Get( "r_offsetFactor", "-1", CVAR_CHEAT );
 		r_offsetUnits = Cvar_Get( "r_offsetUnits", "-2", CVAR_CHEAT );
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -53,8 +53,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_measureOverdraw;
 
-	cvar_t      *r_fastsky;
-
 	cvar_t      *r_lodBias;
 	cvar_t      *r_lodScale;
 
@@ -1117,7 +1115,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_znear = Cvar_Get( "r_znear", "3", CVAR_CHEAT );
 		r_zfar = Cvar_Get( "r_zfar", "0", CVAR_CHEAT );
 		r_checkGLErrors = Cvar_Get( "r_checkGLErrors", "-1", 0 );
-		r_fastsky = Cvar_Get( "r_fastsky", "0", CVAR_ARCHIVE );
 		r_finish = Cvar_Get( "r_finish", "0", CVAR_CHEAT );
 		r_textureMode = Cvar_Get( "r_textureMode", "GL_LINEAR_MIPMAP_LINEAR", CVAR_ARCHIVE );
 		r_gamma = Cvar_Get( "r_gamma", "1.0", CVAR_ARCHIVE );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2864,7 +2864,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_ambientScale;
 	extern cvar_t *r_lightScale;
 
-	extern cvar_t *r_fastsky; // controls whether sky should be cleared or drawn
+	extern Cvar::Cvar<bool> r_fastsky; // Controls whether sky should be cleared or drawn.
 	extern Cvar::Range<Cvar::Cvar<int>> r_dynamicLightRenderer;
 	extern Cvar::Cvar<bool> r_dynamicLight;
 	extern Cvar::Cvar<bool> r_staticLight;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2932,8 +2932,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 
 	extern cvar_t *r_logFile; // number of frames to emit GL logs
 
-	extern cvar_t *r_clear; // force screen clear every frame
-
 	extern Cvar::Range<Cvar::Cvar<int>> r_shadows;
 	extern cvar_t *r_softShadows;
 	extern cvar_t *r_softShadowsPP;

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -49,7 +49,7 @@ void Tess_StageIteratorSky()
 
 	tr.drawingSky = false;
 
-	if ( r_fastsky->integer )
+	if ( r_fastsky.Get() )
 	{
 		return;
 	}


### PR DESCRIPTION
Clear color buffer but nothing else, even if `r_clear` is disabled, there can be issues when enabling complete clearing by default
with Nvidia proprietary drivers. So clearing the color buffer there prevents void effect in skipped sky without needing to enable `r_clear`.

Anyway, we may want to do it (and even force a color) on purpose, this would mean clearing is the explicit way to draw the fast sky.

This makes possible to workaround #472 by keeping `r_clear` disabled while clearing the color buffer when `r_fastsky` is enabled but not clearing other buffers (because disabled `r_clear`).

This **DOES NOT** fix #472. We still have to figure out why we get what looks like precision loss on Nvidia proprietary driver.
