### PR TITLE
renderer/glimp: new GL detection and selection code

### DIFF
--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2662,7 +2662,7 @@ void CL_StartHunkUsers()
 	if ( !cls.rendererStarted )
 	{
 		CL_ShutdownRef();
-		Sys::Error( "Couldn't load a renderer" );
+		Sys::Error( "Couldn't load a renderer." );
 	}
 
 	if ( !Audio::Init() ) {
@@ -3023,7 +3023,9 @@ void CL_Shutdown()
 
 	recursive = false;
 
-	memset( &cls, 0, sizeof( cls ) );
+	// do not leak.
+	cls.~clientStatic_t();
+	new(&cls) clientStatic_t{};
 
 	Log::Debug( "-----------------------" );
 

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -592,6 +592,37 @@ static void Init(int argc, char** argv)
 
 	// Enable S3TC on Mesa even if libtxc-dxtn is not available
 	setenv("force_s3tc_enable", "true", true);
+
+	/* Enable 2.1 GL on Intel GMA Gen 3 on Linux Mesa driver.
+
+	The Mesa i915 driver for GMA Gen 3 disabled GL 2.1 on such
+	hardware to force Google Chrome to use its CPU fallback
+	that was faster but we don't implement such fallback.
+	See https://gitlab.freedesktop.org/mesa/mesa/-/commit/a1891da7c865c80d95c450abfc0d2bc49db5f678
+
+	Only Mesa i915 on Linux supports GL 2.1 for GMA Gen 3,
+	so there is no similar tweak being required for Windows
+	and macOS.
+
+	Mesa i915 and macOS also supports GL 2.1 on GMA Gen 4
+	while windows drivers don't but those tweaks are not
+	required as the related features are enabled by default.
+
+	First Intel hardware range expected to have drivers
+	supporting GL 2.1 on Windows is GMA Gen 5.
+
+	Enabling those options would at least make the engine
+	properly report missing extension instead of missing
+	GL version, for example the Intel GMA 3100 G33 (Gen 3)
+	will report missing GL_ARB_half_float_vertex extension
+	instead of missing OpenGL 2.1 version.
+
+	The GMA 3150 is known to have wider OpenGL support than
+	GMA 3100, for example it has OpenGL version similar to
+	GMA 4 on Windows while being a GMA 3 so the list of
+	available GL extensions may be larger. */
+	setenv("fragment_shader", "true", true);
+	setenv("stub_occlusion_query", "true", true);
 #endif
 
 	// Initialize the console

--- a/src/engine/renderer/tr_cmds.cpp
+++ b/src/engine/renderer/tr_cmds.cpp
@@ -773,21 +773,12 @@ void RE_BeginFrame()
 	// do overdraw measurement
 	if ( r_measureOverdraw->integer )
 	{
-		if ( glConfig.stencilBits < 4 )
-		{
-			Log::Warn("not enough stencil bits to measure overdraw: %d", glConfig.stencilBits );
-			ri.Cvar_Set( "r_measureOverdraw", "0" );
-		}
-		else
-		{
-			R_SyncRenderThread();
-			glEnable( GL_STENCIL_TEST );
-			glStencilMask( ~0U );
-			GL_ClearStencil( 0U );
-			glStencilFunc( GL_ALWAYS, 0U, ~0U );
-			glStencilOp( GL_KEEP, GL_INCR, GL_INCR );
-		}
-
+		R_SyncRenderThread();
+		glEnable( GL_STENCIL_TEST );
+		glStencilMask( ~0U );
+		GL_ClearStencil( 0U );
+		glStencilFunc( GL_ALWAYS, 0U, ~0U );
+		glStencilOp( GL_KEEP, GL_INCR, GL_INCR );
 		r_measureOverdraw->modified = false;
 	}
 	else

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2811,6 +2811,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_glDebugProfile;
 	extern cvar_t *r_glDebugMode;
 	extern cvar_t *r_glAllowSoftware;
+	extern cvar_t *r_glExtendedValidation;
 
 	extern cvar_t *r_ignore; // used for debugging anything
 	extern cvar_t *r_verbose; // used for verbose debug spew
@@ -2820,7 +2821,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	extern cvar_t *r_znear; // near Z clip plane
 	extern cvar_t *r_zfar;
 
-	extern cvar_t *r_stencilbits; // number of desired stencil bits
 	extern cvar_t *r_depthbits; // number of desired depth bits
 	extern cvar_t *r_colorbits; // number of desired color bits, only relevant for fullscreen
 	extern cvar_t *r_alphabits; // number of desired depth bits

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -37,6 +37,7 @@ Maryland 20850 USA.
 #define __TR_PUBLIC_H
 
 #include "tr_types.h"
+#include <string>
 
 #define REF_API_VERSION 10
 
@@ -44,7 +45,21 @@ struct glconfig2_t
 {
 	bool textureCompressionRGTCAvailable;
 
+	int glHighestMajor;
+	int glHighestMinor;
+
+	int glRequestedMajor;
+	int glRequestedMinor;
+
+	int glMajor;
+	int glMinor;
+
 	bool glCoreProfile;
+	bool glForwardCompatibleContext;
+
+	std::string glExtensionsString;
+	std::string glEnabledExtensionsString;
+	std::string glMissingExtensionsString;
 
 	int      maxCubeMapTextureSize;
 

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -335,12 +335,22 @@ struct glconfig_t
 	char                 renderer_string[ MAX_STRING_CHARS ];
 	char                 vendor_string[ MAX_STRING_CHARS ];
 	char                 version_string[ MAX_STRING_CHARS ];
-	char                 extensions_string[ MAX_STRING_CHARS * 4 ]; // TTimo - bumping, some cards have a big extension string
+
+	// TODO(0.53): Delete, moved to glconfig2_t.
+	char extensions_string[ MAX_STRING_CHARS * 4 ]; // TTimo - bumping, some cards have a big extension string
 
 	int                  maxTextureSize; // queried from GL
-	int                  unused;
 
-	int                  colorBits, depthBits, stencilBits;
+	// TODO(0.53): Delete, unused.
+	int unused;
+
+	int colorBits;
+
+	// TODO(0.53): Delete, unused.
+	int stencilBits;
+
+	// TODO(0.53): Delete, unused.
+	int depthBits;
 
 	glDriverType_t       driverType;
 	glHardwareType_t     hardwareType;


### PR DESCRIPTION
_Update:_ 2022-02-16

~~This PR is low priority (existing code works).~~ This fix many bugs, this is now highly wanted.

The effort was initially motivated by #477 to provide a new GL selection code that first detects the higher GL version supported before trying any custom configuration, and if no custom configuration (or it fails), loads the higher GL version possible. This way `/gfxinfo` displays the higher GL supported by the card (Nvidia proprietary driver rewrites the GL and GLSL version strings with currently requested GL version).

With default configuration, the code only tries OpenGL 3.2 core and 2.1 compatibility for success (and all versions below on error to provide user a meaningful error message). By setting `r_glExtendedValidation` to `1`, an user can also detect (at the cost of a slower startup) the best OpenGL profile his hardware and software support, by iterating all known OpenGL versions, which may produce more useful logs on demand.

Subsequent `vid_restart` calls are also now faster, by skipping validation test that was already done before. There are also more reuse of window and context when possible.

Some bugs were also fixed in the meantime, like fullscreen not being flagged as borderless while borderless option is enabled, meaning switching from fullscreen to windowed would provide user a bordered window instead of a borderless window.

Most error messages are now more meaningful.

Diving in the code and rewriting it also uncovered some unused variables that were not detected as unused because of the code convolution. Unless I did a mistake, the value of `r_ext_multisample` and `r_alphabits` appears to be unused. The first one may explain why I haven't seen multisampling working in years… And also some bugs were caught and fixed, including crashes. In the end, this PR is more about making the code more robust and to fix bugs than to improve logging, logging is just made better in the process (and is easier to make it better).

An extra commit enables extra compatibility in Intel drivers for some Intel cards on Linux (at this point, it helps to have better meaningful error messages).

About logging, It looks like there is no way to know the available GL profiles and versions without testing all of them. Even  [`glxinfo`](https://cgit.freedesktop.org/mesa/demos/tree/src/xdemos/glinfo_common.h#n87) does it. This is because you need to set the version to create a context, and you need the context to be created to query the version… Hence the need for looping every GL version and profile to know what's the best supported ones. 🤦‍♀️

---

## sdl_glimp,tr_init: rewrite the original GL selection code, improve gfxinfo

This commit squashes multiple commits by illwieckz and slipher.

# Squashed commits by illwieckz

## sdl_glimp: rewrite the original GL selection code

- Detect best configuration possible.
- Try custom configuration if exists.
- If no custom configuration or if it fails,
  load the recommended configuration if
  possible (OpenGL 3.2 core) or the best
  one available.
- Reuse window and context when possible.
- Display meaningful popup telling user
  OpenGL version is too low or required
  extensions are missing when that happens.
- Rely on more return codes for GLimp_SetMode().
- Test for negative SDL_Init return value,
  not just -1.

## sdl_glimp,tr_init: do not test all OpenGL versions unless r_glExtendedValidation is set

When r_glExtendedValidation is enabled, the engine
tests if OpenGL versions higher than 3.2 core
are supported for logging and diagnostic purpose,
but still requestes 3.2 core anyway. Some drivers
may provide more than 3.2 when requesting 3.2, this
is not our fault.

## sdl_glimp,tr_init: rewrite logging, improve gfxinfo

- Move GL query for logging purpose from tr_init to sdl_glimp.
- Do not split MODE log message.
- Unify some log.
- Add more debug log when building GL extension list.
- Also increase the extensions_string length to not
  truncate the string, 4096 is not enough, there can
  be more than 6000 characters on an OpenGL 4.6 driver.
- Also log missing extensions to make gfxinfo more useful.
- Rewrite gfxinfo in more useful way.
- List enabled and missing GL extensions.

## sdl_glimp: silence the GL error when querying if context
is core on non-core implementation

- Silence the error that may happen when querying if the
  OpenGL context uses core profile when core profile is not
  supported by the OpenGL implementation to begin with.

For example this may happen on implementations not supporting
higher than OpenGL 2.1, while forcing OpenGL 2.1 on
implementations supporting higher versions including
core profiles may not raise an error.

## sdl_glimp: make GLimp_StartDriverAndSetMode only return true on RSERR_OK

- Only return true on OK, don't return true on unknown errors.

## sdl_glimp: catch errors from GLimp_DetectAvailableModes to prevent further segfault

It may be possible to create a valid context that is unusable.

For example the 3840×2160 resolution is too large for the
Radeon 9700 and the Mesa r300 driver may print this error
when the requested resolution is higher than what is supported
by hardware:

> r300: Implementation error: Render targets are too big in r300_set_framebuffer_state, refusing to bind framebuffer state!

It will unfortunately return a valid but unusable context that will
make the engine segfault when calling GL_SetDefaultState().

## sdl_glimp: flag fullscreen window as borderless when borderless is enabled

Flag fullscreen window as borderless when borderless is enabled
otherwise the window will be bordered when leaving fullscreen
while the borderless option would be enabled.

## sdl_glimp,tr_init: remove unused depthBits

## sdl_glimp: remove SDL_INIT_NOPARACHUTE

In GLimp_StartDriverAndSetMod() the SDL_INIT_NOPARACHUTE flag was
removed from SDL_Init( SDL_INIT_VIDEO ) as this flag is now
ignored, see https://wiki.libsdl.org/SDL_Init

# Squashed commits by slipher

## Better type safety in GL detection code

## Simplify GL_ValidateBestContext duplicate loop

## GLimp_SetMode - simplify error handling

## Rework GL initialization

Have GLimp_ValidateBestContext() validate both the highest-numbered
available context (if r_glExtendedValidation is enabled), and the
highest context that we actually want to use (at most 3.2). This means
most of the code in GLimp_ApplyPreferredOptions can be removed because
it was duplicating the knowledge about version preferences and the code
for instantiating them in GLimp_ValidateBestContext.

## Also cut down on other code duplication.

## Remove dead cvar r_stencilBits

## Fix glConfig.colorBits logging

- show actual not requested
- don't log it twice at notice level

---

## system: enable GL 2.1 on Intel Gen 3 hardware, <3 papap

This may not be enough to make the game run on such
hardware anyway.

The Mesa i915 driver for GMA Gen 3 disabled GL 2.1 on such
hardware to force Google Chrome to use its CPU fallback
that was faster but we don't implement such fallback.
See https://gitlab.freedesktop.org/mesa/mesa/-/commit/a1891da7c865c80d95c450abfc0d2bc49db5f678

Only Mesa i915 on Linux supports GL 2.1 for GMA Gen 3,
so there is no similar tweak being required for Windows
and macOS.

Enabling those options would at least make the engine
properly report missing extension instead of missing
GL version, for example the Intel GMA 3100 G33 (Gen 3)
will report missing GL_ARB_half_float_vertex extension
instead of missing OpenGL 2.1 version.

The GMA 3150 is known to have wider OpenGL support than
GMA 3100, for example it has OpenGL version similar to
GMA 4 on Windows while being a GMA 3 so the list of
available GL extensions may be larger.

Thanks papap and its LanPower association for the kind
report and availability for testing.
http://asso.lanpower.free.fr
