### PR TITLE
Don't fail on non-GLX backends

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -748,7 +748,11 @@ static rserr_t GLimp_SetMode( int mode, bool fullscreen, bool noborder )
 
 	glewResult = glewInit();
 
+#ifdef GLEW_ERROR_NO_GLX_DISPLAY
+	if ( glewResult != GLEW_OK && glewResult != GLEW_ERROR_NO_GLX_DISPLAY )
+#else
 	if ( glewResult != GLEW_OK )
+#endif
 	{
 		// glewInit failed, something is seriously wrong
 		Sys::Error( "GLW_StartOpenGL() - could not load OpenGL subsystem: %s", glewGetErrorString( glewResult ) );


### PR DESCRIPTION
Not having a GLX context is not a bug: wayland uses EGL for example.
This is inspired by:
https://github.com/endless-sky/endless-sky/pull/5230/commits/5f5fb100422685f2eed443bb5bf7f5dbadef2aa9

This may help in https://github.com/DaemonEngine/Daemon/issues/474.

With this commit, the game will start on wayland, see https://github.com/DaemonEngine/Daemon/issues/482.