### PR TITLE
gitignore: ignore removed libs/recastnavigation/ submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ build
 *.so
 *.a
 
+#ignore removed submodules
+libs/recastnavigation/
+
 #ignore editor temporary files
 .*.swp
 .#*


### PR DESCRIPTION
When bisecting, it may be pulled again then left over.