### PR TITLE
renderer/tr_image: prevents copying when looping cubemap formats

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2075,7 +2075,7 @@ image_t *R_FindCubeImage( const char *imageName, imageParams_t &imageParams )
 		pic[ i ] = nullptr;
 	}
 
-	for ( const multifileCubeMapFormat_t format : multifileCubeMapFormats )
+	for ( const multifileCubeMapFormat_t &format : multifileCubeMapFormats )
 	{
 		int greatestEdge = 0;
 		face_t faces[6];


### PR DESCRIPTION
clang 12 was complaining:

```c
Daemon/src/engine/renderer/tr_image.cpp:2078:39: warning: loop variable 'format' creates a copy from type 'const multifileCubeMapFormat_t' [-Wrange-loop-construct]
        for ( const multifileCubeMapFormat_t format : multifileCubeMapFormats )
                                             ^
Daemon/src/engine/renderer/tr_image.cpp:2078:8: note: use reference type 'const multifileCubeMapFormat_t &' to prevent copying
        for ( const multifileCubeMapFormat_t format : multifileCubeMapFormats )
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                             &
```

I'm not sure this is the way to do it, I'm surprised to not have to modify other lines of code to silent the warning.