### PR TITLE
FileSystem: do not look for DEPS file in pk3dir

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1166,7 +1166,7 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 		if (err)
 			return;
 		for (auto it = dirRange.begin(); it != dirRange.end();) {
-			if (*it == PAK_DEPS_FILE)
+			if (!isLegacy && (*it == PAK_DEPS_FILE))
 				hasDeps = true;
 			else if (!Str::IsSuffix("/", *it) && Str::IsPrefix(pathPrefix, *it)) {
 				fileMap.emplace(*it, std::pair<uint32_t, offset_t>(loadedPaks.size() - 1, 0));


### PR DESCRIPTION
FileSystem: do not look for DEPS file in pk3dir.

The code already ignores DEPS file in pk3 archives.

I found this by attempting to implement a way for partial dpk and dpkdir to set a list of deleted files to not load from deps.