### PR TITLE
Avoid undefined behaviour when area is set to -1

### DIFF
--- a/src/engine/renderer/tr_world.cpp
+++ b/src/engine/renderer/tr_world.cpp
@@ -830,6 +830,12 @@ static void R_MarkLeaves()
 			}
 		}
 
+		// check if outside map
+		if (leaf->area == -1) {
+			// can't be visible
+			continue;
+		}
+
 		// check for door connection
 		if ( ( tr.refdef.areamask[ leaf->area >> 3 ] & ( 1 << ( leaf->area & 7 ) ) ) )
 		{


### PR DESCRIPTION
This value, according to src/engine/renderer/tr_bsp.cpp, means that the "location is in the void". So it seems appropriate not to try to render it.