### PR TITLE
audio: do not abort on missing or busy sound device

### DIFF
--- a/src/engine/audio/Audio.cpp
+++ b/src/engine/audio/Audio.cpp
@@ -33,6 +33,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AudioData.h"
 
 namespace Audio {
+    /* When adding an entry point to the audio subsystem,
+    make sure the non-null implementation returns early
+    when audio subsystem is not initialized.
+    See https://github.com/DaemonEngine/Daemon/pull/524 */
 
     Log::Logger audioLogs("audio");
 
@@ -229,15 +233,27 @@ namespace Audio {
     }
 
     void BeginRegistration() {
+        if (not initialized) {
+            return;
+        }
+
         BeginSampleRegistration();
     }
 
     sfxHandle_t RegisterSFX(Str::StringRef filename) {
+        if (not initialized) {
+            return 0;
+        }
+
         // TODO: what should we do if we aren't initialized?
         return RegisterSample(filename)->GetHandle();
     }
 
     void EndRegistration() {
+        if (not initialized) {
+            return;
+        }
+
         EndSampleRegistration();
     }
 
@@ -340,6 +356,10 @@ namespace Audio {
     }
 
     void StopAllSounds() {
+        if (not initialized) {
+            return;
+        }
+
         StopMusic();
         StopSounds();
     }
@@ -409,6 +429,10 @@ namespace Audio {
     }
 
     void SetReverb(int slotNum, std::string name, float ratio) {
+        if (not initialized) {
+            return;
+        }
+
         if (slotNum < 0 or slotNum >= N_REVERB_SLOTS or std::isnan(ratio)) {
             return;
         }

--- a/src/engine/audio/Sound.cpp
+++ b/src/engine/audio/Sound.cpp
@@ -31,6 +31,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AudioPrivate.h"
 
 namespace Audio {
+    /* When adding an entry point to the audio subsystem,
+    make sure the non-null implementation returns early
+    when audio subsystem is not initialized.
+    See https://github.com/DaemonEngine/Daemon/pull/524 */
 
     //TODO lazily check for the values
     static Cvar::Range<Cvar::Cvar<float>> effectsVolume("audio.volume.effects", "the volume of the effects", Cvar::NONE, 0.8f, 0.0f, 1.0f);
@@ -77,6 +81,10 @@ namespace Audio {
     }
 
     void UpdateSounds() {
+        if (not initialized) {
+            return;
+        }
+
         for (int i = 0; i < nSources; i++) {
             if (sources[i].active) {
                 auto sound = sources[i].usingSound;
@@ -99,6 +107,10 @@ namespace Audio {
     }
 
     void StopSounds() {
+        if (not initialized) {
+            return;
+        }
+
         for (int i = 0; i < nSources; i++) {
             if (sources[i].active) {
                 sources[i].usingSound->Stop();
@@ -107,6 +119,10 @@ namespace Audio {
     }
 
     void AddSound(std::shared_ptr<Emitter> emitter, std::shared_ptr<Sound> sound, int priority) {
+        if (not initialized) {
+            return;
+        }
+
         sourceRecord_t* source = GetSource(priority);
 
         if (source) {

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -1516,14 +1516,14 @@ void CL_Snd_Restart_f()
 		// In the main menu case the cgame is not restarted... but is there anything preventing
 		// the main menu from also using sound handles?
 		if (!Audio::Init()) {
-			Sys::Error("Couldn't initialize the audio subsystem.");
+			Log::Warn("Couldn't initialize the audio subsystem.");
 		}
 		//TODO S_BeginRegistration()
 	}
 	else
 	{
 		if (!Audio::Init()) {
-			Sys::Error("Couldn't initialize the audio subsystem.");
+			Log::Warn("Couldn't initialize the audio subsystem.");
 		}
 		CL_Vid_Restart_f();
 	}
@@ -2670,7 +2670,7 @@ void CL_StartHunkUsers()
 	}
 
 	if ( !Audio::Init() ) {
-		Sys::Error("Couldn't initialize the audio subsystem.");
+		Log::Warn("Couldn't initialize the audio subsystem.");
 	}
 
 	if ( !cls.soundRegistered )

--- a/src/engine/null/NullAudio.cpp
+++ b/src/engine/null/NullAudio.cpp
@@ -31,6 +31,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "common/Common.h"
 
 namespace Audio {
+    /* When adding an entry point to the audio subsystem,
+    make sure the non-null implementation returns early
+    when audio subsystem is not initialized.
+    See https://github.com/DaemonEngine/Daemon/pull/524 */
 
     bool Init() {
         return true;


### PR DESCRIPTION
Do not abort on missing or busy sound device.

fix https://github.com/Unvanquished/Unvanquished/issues/1031

There was already a lot of

```c++
        if (not initialized) {
            return;
        }
```

I added a bunch of others, and turned the `Sys:Error` calls into `Log::Warn` ones.