### PR TITLE
cg_api: make possible for game to know if an extension-independent image path exists

### DIFF
--- a/src/common/IPC/CommonSyscalls.h
+++ b/src/common/IPC/CommonSyscalls.h
@@ -97,6 +97,8 @@ namespace VM {
         QVM_COMMON_FS_FIND_PAK,
         QVM_COMMON_FS_LOAD_PAK,
         QVM_COMMON_FS_LOAD_MAP_METADATA,
+
+        QVM_COMMON_IMAGE_EXISTS,
     };
 
     using ErrorMsg = IPC::SyncMessage<
@@ -148,6 +150,11 @@ namespace VM {
     >;
     using FSLoadMapMetadataMsg = IPC::SyncMessage<
         IPC::Message<IPC::Id<VM::QVM_COMMON, QVM_COMMON_FS_LOAD_MAP_METADATA>>
+    >;
+
+    using ImageExists = IPC::SyncMessage<
+        IPC::Message<IPC::Id<VM::QVM_COMMON, QVM_COMMON_IMAGE_EXISTS>, std::string>,
+        IPC::Reply<bool>
     >;
 
     // Misc Syscall Definitions

--- a/src/engine/client/cg_api.h
+++ b/src/engine/client/cg_api.h
@@ -130,6 +130,7 @@ int             trap_Argc();
 void            trap_Argv( int n, char *buffer, int bufferLength );
 void            trap_EscapedArgs( char *buffer, int bufferLength );
 void            trap_LiteralArgs( char *buffer, int bufferLength );
+bool            trap_ImageExists( const char *filename );
 int             trap_FS_FOpenFile( const char *qpath, fileHandle_t *f, fsMode_t mode );
 int             trap_FS_Read( void *buffer, int len, fileHandle_t f );
 int             trap_FS_Write( const void *buffer, int len, fileHandle_t f );

--- a/src/engine/framework/CommonVMServices.cpp
+++ b/src/engine/framework/CommonVMServices.cpp
@@ -42,6 +42,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma clang diagnostic ignored "-Wunused-lambda-capture"
 #endif
 
+// From engine/renderer/tr_local.h
+int R_FindImageLoader( const char *baseName );
+
 namespace VM {
 
     // Misc Related
@@ -342,6 +345,12 @@ namespace VM {
             case QVM_COMMON_FS_LOAD_MAP_METADATA:
                 IPC::HandleMsg<FSLoadMapMetadataMsg>(channel, std::move(reader), [this] {
                     FS_LoadAllMapMetadata();
+                });
+                break;
+
+            case QVM_COMMON_IMAGE_EXISTS:
+                IPC::HandleMsg<ImageExists>(channel, std::move(reader), [this](const std::string& filename, bool& test) {
+                    test = R_FindImageLoader( filename.c_str() ) >= 0;
                 });
                 break;
 

--- a/src/shared/CommonProxies.cpp
+++ b/src/shared/CommonProxies.cpp
@@ -629,3 +629,10 @@ void trap_FS_LoadAllMapMetadata()
 {
 	VM::SendMsg<VM::FSLoadMapMetadataMsg>();
 }
+
+bool trap_ImageExists( const char *filename )
+{
+	bool test;
+	VM::SendMsg<VM::ImageExists>( filename, test );
+	return test;
+}


### PR DESCRIPTION
I wanted to know if it's possible for the game to query the engine to know if an extension-independent image path exists, it looks like this code make it possible. It would also be possible to do the same for sounds if we have a need.

What this make possible is for example to check if Unvanquished's `meta/<name>/<mapname>` levelshot exists, but if it does not exist, try to load Quake3-like `levelshot/<name>` instead.