### PR TITLE
 sv_main: do not reresolve failed master server and send heartbeat before next map load, fix #534

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -347,6 +347,7 @@ void       SV_RemoveOperatorCommands();
 
 void       SV_NET_Config();
 
+void       SV_ResetMasterServersFailureStates();
 void       SV_MasterHeartbeat( const char *hbname );
 void       SV_MasterShutdown();
 

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -431,6 +431,8 @@ void SV_SpawnServer(std::string pakname, std::string mapname)
 	PrintBanner( "Server Initialization" )
 	Log::Notice( "Map: %s", mapname );
 
+	SV_ResetMasterServersFailureStates();
+
 	// if not running a dedicated server CL_MapLoading will connect the client to the server
 	// also print some status stuff
 	CL_MapLoading();


### PR DESCRIPTION
sv_main: reresolve failed master server on every map load but do not send heartbeat until the next map load, fix #534