### PR TITLE
Don't delete master servers with DNS failure

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -250,6 +250,7 @@ struct serverStatic_t
 	int           nextSnapshotEntities; // next snapshotEntities to use
 	std::unique_ptr<entityState_t[]> snapshotEntities; // [numSnapshotEntities]
 	int           nextHeartbeatTime;
+	int nextMasterResolutionTime;
 	receipt_t     infoReceipts[ MAX_INFO_RECEIPTS ];
 
 	int       sampleTimes[ SERVER_PERFORMANCECOUNTER_SAMPLES ];


### PR DESCRIPTION
Instead, establish a 1-minute time limit between attempts to do DNS
lookups of master servers. This also prevents a possible DoS issue in
that it might be possible to force DNS lookups at an unlimited rate by
sending info packets to the server.