### PR TITLE
Drop custom Com_Memset, Com_Memcpy, Com_Allocate and Com_Dealloc

### DIFF
--- a/src/common/cm/cm_load.cpp
+++ b/src/common/cm/cm_load.cpp
@@ -114,7 +114,7 @@ void CMod_LoadShaders(const byte *const cmod_base, lump_t *l)
 	cm.shaders = ( dshader_t * ) CM_Alloc( count * sizeof( *cm.shaders ) );
 	cm.numShaders = count;
 
-	Com_Memcpy( cm.shaders, in, count * sizeof( *cm.shaders ) );
+	memcpy( cm.shaders, in, count * sizeof( *cm.shaders ) );
 
 	if ( LittleLong( 1 ) != 1 )
 	{
@@ -651,7 +651,7 @@ static void CMod_CreateBrushSideWindings()
 		brush->edges = ( cbrushedge_t * ) CM_Alloc( edgesAlloc );
 
 		// Copy temporary buffer to permanent buffer
-		Com_Memcpy( brush->edges, tempEdges, edgesAlloc );
+		memcpy( brush->edges, tempEdges, edgesAlloc );
 
 		// Free temporary buffer
 		free( tempEdges );
@@ -675,7 +675,7 @@ void CMod_LoadEntityString(const byte *const cmod_base, lump_t *l)
 
 	cm.entityString = ( char * ) CM_Alloc( l->filelen + 1);
 	cm.numEntityChars = l->filelen;
-	Com_Memcpy( cm.entityString, cmod_base + l->fileofs, l->filelen );
+	memcpy( cm.entityString, cmod_base + l->fileofs, l->filelen );
 	cm.entityString[l->filelen] = '\0';
 
 	p = cm.entityString;
@@ -754,7 +754,7 @@ void CMod_LoadVisibility(const byte *const cmod_base, lump_t *l)
 	cm.visibility = ( byte * ) CM_Alloc( len - VIS_HEADER );
 	cm.numClusters = LittleLong( ( ( int * ) buf ) [ 0 ] );
 	cm.clusterBytes = LittleLong( ( ( int * ) buf ) [ 1 ] );
-	Com_Memcpy( cm.visibility, buf + VIS_HEADER, len - VIS_HEADER );
+	memcpy( cm.visibility, buf + VIS_HEADER, len - VIS_HEADER );
 }
 
 //==================================================================
@@ -974,7 +974,7 @@ CM_ClearMap
 */
 void CM_ClearMap()
 {
-	Com_Memset( &cm, 0, sizeof( cm ) );
+	memset( &cm, 0, sizeof( cm ) );
 	CM_ClearLevelPatches();
 }
 

--- a/src/common/cm/cm_patch.cpp
+++ b/src/common/cm/cm_patch.cpp
@@ -691,7 +691,7 @@ static void CM_SurfaceCollideFromGrid( cGrid_t *grid, cSurfaceCollide_t *sc )
 			}
 
 			facet = &facets[ numFacets ];
-			Com_Memset( facet, 0, sizeof( *facet ) );
+			memset( facet, 0, sizeof( *facet ) );
 
 			if ( gridPlanes[ i ][ j ][ 0 ] == gridPlanes[ i ][ j ][ 1 ] )
 			{
@@ -753,7 +753,7 @@ static void CM_SurfaceCollideFromGrid( cGrid_t *grid, cSurfaceCollide_t *sc )
 				}
 
 				facet = &facets[ numFacets ];
-				Com_Memset( facet, 0, sizeof( *facet ) );
+				memset( facet, 0, sizeof( *facet ) );
 
 				facet->surfacePlane = gridPlanes[ i ][ j ][ 1 ];
 				facet->numBorders = 3;
@@ -788,9 +788,9 @@ static void CM_SurfaceCollideFromGrid( cGrid_t *grid, cSurfaceCollide_t *sc )
 	sc->numPlanes = numPlanes;
 	sc->numFacets = numFacets;
 	sc->facets = ( cFacet_t * ) CM_Alloc( numFacets * sizeof( *sc->facets ) );
-	Com_Memcpy( sc->facets, facets, numFacets * sizeof( *sc->facets ) );
+	memcpy( sc->facets, facets, numFacets * sizeof( *sc->facets ) );
 	sc->planes = ( cPlane_t * ) CM_Alloc( numPlanes * sizeof( *sc->planes ) );
-	Com_Memcpy( sc->planes, planes, numPlanes * sizeof( *sc->planes ) );
+	memcpy( sc->planes, planes, numPlanes * sizeof( *sc->planes ) );
 }
 
 /*

--- a/src/common/cm/cm_trace.cpp
+++ b/src/common/cm/cm_trace.cpp
@@ -1343,7 +1343,7 @@ static void CM_ProximityToBrush( traceWork_t *tw, cbrush_t *brush )
 	traceWork_t  tw2;
 
 	// cheapish purely linear trace to test for intersection
-	Com_Memset( &tw2, 0, sizeof( tw2 ) );
+	memset( &tw2, 0, sizeof( tw2 ) );
 
 	tw2.trace.fraction = 1.0f;
 	tw2.type = traceType_t::TT_CAPSULE;
@@ -1405,7 +1405,7 @@ static void CM_ProximityToSurface( traceWork_t *tw, cSurface_t *surface )
 	traceWork_t tw2;
 
 	// cheapish purely linear trace to test for intersection
-	Com_Memset( &tw2, 0, sizeof( tw2 ) );
+	memset( &tw2, 0, sizeof( tw2 ) );
 
 	tw2.trace.fraction = 1.0f;
 	tw2.type = traceType_t::TT_CAPSULE;
@@ -2075,7 +2075,7 @@ static void CM_Trace( trace_t *results, const vec3_t start, const vec3_t end, co
 	c_traces++; // for statistics, may be zeroed
 
 	// fill in a default trace
-	Com_Memset( &tw, 0, sizeof( tw ) );
+	memset( &tw, 0, sizeof( tw ) );
 	tw.trace.fraction = 1; // assume it goes the entire distance until shown otherwise
 	VectorCopy( origin, tw.modelOrigin );
 	tw.type = type;
@@ -2454,7 +2454,7 @@ void CM_BiSphereTrace( trace_t *results, const vec3_t start, const vec3_t end, f
 	c_traces++; // for statistics, may be zeroed
 
 	// fill in a default trace
-	Com_Memset( &tw, 0, sizeof( tw ) );
+	memset( &tw, 0, sizeof( tw ) );
 	tw.trace.fraction = 1.0f; // assume it goes the entire distance until shown otherwise
 	VectorCopy( vec3_origin, tw.modelOrigin );
 	tw.type = traceType_t::TT_BISPHERE;

--- a/src/common/cm/cm_trisoup.cpp
+++ b/src/common/cm/cm_trisoup.cpp
@@ -210,7 +210,7 @@ static void CM_SurfaceCollideFromTriangleSoup( cTriangleSoup_t *triSoup, cSurfac
 	for ( i = 0; i < triSoup->numTriangles; i++ )
 	{
 		facet = &facets[ numFacets ];
-		Com_Memset( facet, 0, sizeof( *facet ) );
+		memset( facet, 0, sizeof( *facet ) );
 
 		p1 = triSoup->points[ i ][ 0 ];
 		p2 = triSoup->points[ i ][ 1 ];
@@ -267,11 +267,11 @@ static void CM_SurfaceCollideFromTriangleSoup( cTriangleSoup_t *triSoup, cSurfac
 	// copy the results out
 	sc->numPlanes = numPlanes;
 	sc->planes = ( cPlane_t * ) CM_Alloc( numPlanes * sizeof( *sc->planes ) );
-	Com_Memcpy( sc->planes, planes, numPlanes * sizeof( *sc->planes ) );
+	memcpy( sc->planes, planes, numPlanes * sizeof( *sc->planes ) );
 
 	sc->numFacets = numFacets;
 	sc->facets = ( cFacet_t * ) CM_Alloc( numFacets * sizeof( *sc->facets ) );
-	Com_Memcpy( sc->facets, facets, numFacets * sizeof( *sc->facets ) );
+	memcpy( sc->facets, facets, numFacets * sizeof( *sc->facets ) );
 }
 
 /*

--- a/src/engine/client/cl_avi.cpp
+++ b/src/engine/client/cl_avi.cpp
@@ -94,7 +94,7 @@ WRITE_STRING
 static inline void WRITE_STRING( const char *s )
 {
 	size_t len = strlen(s);
-	Com_Memcpy( &buffer[ bufIndex ], s, len );
+	memcpy( &buffer[ bufIndex ], s, len );
 	bufIndex += len;
 }
 
@@ -331,7 +331,7 @@ bool CL_OpenAVIForWriting( const char *fileName )
 		return false;
 	}
 
-	Com_Memset( &afd, 0, sizeof( aviFileData_t ) );
+	memset( &afd, 0, sizeof( aviFileData_t ) );
 
 	// Don't start if a framerate has not been chosen
 	if ( cl_aviFrameRate->integer <= 0 )

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -3445,11 +3445,11 @@ void CL_LocalServers_f()
 	for ( i = 0; i < MAX_OTHER_SERVERS; i++ )
 	{
 		bool b = cls.localServers[ i ].visible;
-		Com_Memset( &cls.localServers[ i ], 0, sizeof( cls.localServers[ i ] ) );
+		memset( &cls.localServers[ i ], 0, sizeof( cls.localServers[ i ] ) );
 		cls.localServers[ i ].visible = b;
 	}
 
-	Com_Memset( &to, 0, sizeof( to ) );
+	memset( &to, 0, sizeof( to ) );
 
 	// The 'xxx' in the message is a challenge that will be echoed back
 	// by the server.  We don't care about that here, but master servers
@@ -3763,7 +3763,7 @@ void CL_Ping_f()
 		server = Cmd_Argv( 2 );
 	}
 
-	Com_Memset( &to, 0, sizeof( netadr_t ) );
+	memset( &to, 0, sizeof( netadr_t ) );
 
 	if ( !NET_StringToAdr( server, &to, family ) )
 	{
@@ -3948,7 +3948,7 @@ void CL_ServerStatus_f()
 
 	if ( !toptr )
 	{
-		Com_Memset( &to, 0, sizeof( netadr_t ) );
+		memset( &to, 0, sizeof( netadr_t ) );
 
 		if ( argc == 2 )
 		{

--- a/src/engine/null/null_renderer.cpp
+++ b/src/engine/null/null_renderer.cpp
@@ -190,10 +190,10 @@ const char *RE_ShaderNameFromHandle( qhandle_t )
 
 bool RE_BeginRegistration( glconfig_t *config, glconfig2_t *glconfig2 )
 {
-	Com_Memset( config, 0, sizeof( glconfig_t ) );
+	memset( config, 0, sizeof( glconfig_t ) );
 	config->vidWidth = 640;
 	config->vidHeight = 480;
-	Com_Memset( glconfig2, 0, sizeof( glconfig2_t ) );
+	memset( glconfig2, 0, sizeof( glconfig2_t ) );
 
 	return true;
 }

--- a/src/engine/qcommon/huffman.cpp
+++ b/src/engine/qcommon/huffman.cpp
@@ -488,7 +488,7 @@ void Huff_Decompress( msg_t *mbuf, int offset )
 		return;
 	}
 
-	Com_Memset( &huff, 0, sizeof( huff_t ) );
+	memset( &huff, 0, sizeof( huff_t ) );
 	// Initialize the tree & list with the NYT node
 	huff.tree = huff.lhead = huff.ltail = huff.loc[ NYT ] = & ( huff.nodeList[ huff.blocNode++ ] );
 	huff.tree->symbol = NYT;
@@ -537,7 +537,7 @@ void Huff_Decompress( msg_t *mbuf, int offset )
 	}
 
 	mbuf->cursize = cch + offset;
-	Com_Memcpy( mbuf->data + offset, seq, cch );
+	memcpy( mbuf->data + offset, seq, cch );
 }
 
 void Huff_Compress( msg_t *mbuf, int offset )
@@ -555,7 +555,7 @@ void Huff_Compress( msg_t *mbuf, int offset )
 		return;
 	}
 
-	Com_Memset( &huff, 0, sizeof( huff_t ) );
+	memset( &huff, 0, sizeof( huff_t ) );
 	// Add the NYT (not yet transmitted) node into the tree/list */
 	huff.tree = huff.lhead = huff.loc[ NYT ] = & ( huff.nodeList[ huff.blocNode++ ] );
 	huff.tree->symbol = NYT;
@@ -579,13 +579,13 @@ void Huff_Compress( msg_t *mbuf, int offset )
 	bloc += 8; // next byte
 
 	mbuf->cursize = ( bloc >> 3 ) + offset;
-	Com_Memcpy( mbuf->data + offset, seq, ( bloc >> 3 ) );
+	memcpy( mbuf->data + offset, seq, ( bloc >> 3 ) );
 }
 
 void Huff_Init( huffman_t *huff )
 {
-	Com_Memset( &huff->compressor, 0, sizeof( huff_t ) );
-	Com_Memset( &huff->decompressor, 0, sizeof( huff_t ) );
+	memset( &huff->compressor, 0, sizeof( huff_t ) );
+	memset( &huff->decompressor, 0, sizeof( huff_t ) );
 
 	// Initialize the tree & list with the NYT node
 	huff->decompressor.tree = huff->decompressor.lhead = huff->decompressor.ltail = huff->decompressor.loc[ NYT ] =

--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -56,7 +56,7 @@ void MSG_Init( msg_t *buf, byte *data, int length )
 		MSG_initHuffman();
 	}
 
-	Com_Memset( buf, 0, sizeof( *buf ) );
+	memset( buf, 0, sizeof( *buf ) );
 	buf->data = data;
 	buf->maxsize = length;
 }
@@ -68,7 +68,7 @@ void MSG_InitOOB( msg_t *buf, byte *data, int length )
 		MSG_initHuffman();
 	}
 
-	Com_Memset( buf, 0, sizeof( *buf ) );
+	memset( buf, 0, sizeof( *buf ) );
 	buf->data = data;
 	buf->maxsize = length;
 	buf->oob = true;
@@ -121,9 +121,9 @@ void MSG_Copy( msg_t *buf, byte *data, int length, msg_t *src )
 		Sys::Drop( "MSG_Copy: can't copy %d into a smaller %d msg_t buffer", src->cursize, length );
 	}
 
-	Com_Memcpy( buf, src, sizeof( msg_t ) );
+	memcpy( buf, src, sizeof( msg_t ) );
 	buf->data = data;
-	Com_Memcpy( buf->data, src->data, src->cursize );
+	memcpy( buf->data, src->data, src->cursize );
 }
 
 /*

--- a/src/engine/qcommon/net_chan.cpp
+++ b/src/engine/qcommon/net_chan.cpp
@@ -98,7 +98,7 @@ called to open a channel to a remote system
 */
 void Netchan_Setup( netsrc_t sock, netchan_t *chan, const netadr_t& adr, int qport )
 {
-	Com_Memset( chan, 0, sizeof( *chan ) );
+	memset( chan, 0, sizeof( *chan ) );
 
 	chan->sock = sock;
 	chan->remoteAddress = adr;
@@ -193,7 +193,7 @@ void Netchan_Transmit( netchan_t *chan, int length, const byte *data )
 	{
 		chan->unsentFragments = true;
 		chan->unsentLength = length;
-		Com_Memcpy( chan->unsentBuffer, data, length );
+		memcpy( chan->unsentBuffer, data, length );
 
 		// only send the first fragment now
 		Netchan_TransmitNextFragment( chan );
@@ -375,7 +375,7 @@ bool Netchan_Process( netchan_t *chan, msg_t *msg )
 			return false;
 		}
 
-		Com_Memcpy( chan->fragmentBuffer + chan->fragmentLength,
+		memcpy( chan->fragmentBuffer + chan->fragmentLength,
 		            msg->data + msg->readcount, fragmentLength );
 
 		chan->fragmentLength += fragmentLength;
@@ -399,7 +399,7 @@ bool Netchan_Process( netchan_t *chan, msg_t *msg )
 		// make sure the sequence number is still there
 		* ( int * ) msg->data = LittleLong( sequence );
 
-		Com_Memcpy( msg->data + 4, chan->fragmentBuffer, chan->fragmentLength );
+		memcpy( msg->data + 4, chan->fragmentBuffer, chan->fragmentLength );
 		msg->cursize = chan->fragmentLength + 4;
 		chan->fragmentLength = 0;
 		msg->readcount = 4; // past the sequence number
@@ -468,9 +468,9 @@ bool        NET_GetLoopPacket( netsrc_t sock, netadr_t *net_from, msg_t *net_mes
 	i = loop->get & ( MAX_LOOPBACK - 1 );
 	loop->get++;
 
-	Com_Memcpy( net_message->data, loop->msgs[ i ].data, loop->msgs[ i ].datalen );
+	memcpy( net_message->data, loop->msgs[ i ].data, loop->msgs[ i ].datalen );
 	net_message->cursize = loop->msgs[ i ].datalen;
-	Com_Memset( net_from, 0, sizeof( *net_from ) );
+	memset( net_from, 0, sizeof( *net_from ) );
 	net_from->type = netadrtype_t::NA_LOOPBACK;
 	return true;
 }
@@ -485,7 +485,7 @@ void NET_SendLoopPacket( netsrc_t sock, int length, const void *data )
 	i = loop->send & ( MAX_LOOPBACK - 1 );
 	loop->send++;
 
-	Com_Memcpy( loop->msgs[ i ].data, data, length );
+	memcpy( loop->msgs[ i ].data, data, length );
 	loop->msgs[ i ].datalen = length;
 }
 
@@ -515,7 +515,7 @@ static void NET_QueuePacket( int length, const void *data, const netadr_t& to,
 
 	newp = (packetQueue_t*) S_Malloc( sizeof( packetQueue_t ) );
 	newp->data = (byte*) S_Malloc( length );
-	Com_Memcpy( newp->data, data, length );
+	memcpy( newp->data, data, length );
 	newp->length = length;
 	newp->to = to;
 	newp->release = Sys_Milliseconds() + ( int )( ( float ) offset / com_timescale->value );
@@ -595,7 +595,7 @@ int NET_StringToAdr( const char *s, netadr_t *a, netadrtype_t family )
 
 	if ( !strcmp( s, "loopback" ) )
 	{
-		Com_Memset( a, 0, sizeof( *a ) );
+		memset( a, 0, sizeof( *a ) );
 		a->type = netadrtype_t::NA_LOOPBACK;
 		// as NA_LOOPBACK doesn't require ports report port was given.
 		return 1;

--- a/src/engine/qcommon/q_math.cpp
+++ b/src/engine/qcommon/q_math.cpp
@@ -3312,7 +3312,7 @@ void TransInit( transform_t *t )
 // copy a transform
 void TransCopy( const transform_t *in, transform_t *out )
 {
-	Com_Memcpy( out, in, sizeof( transform_t ) );
+	memcpy( out, in, sizeof( transform_t ) );
 }
 
 // apply a transform to a point

--- a/src/engine/qcommon/q_shared.cpp
+++ b/src/engine/qcommon/q_shared.cpp
@@ -44,20 +44,16 @@ GROWLISTS
 ============================================================================
 */
 
-// Com_Allocate / free all in one place for debugging
-//extern          "C" void *Com_Allocate(int bytes);
-//extern          "C" void Com_Dealloc(void *ptr);
-
 void Com_InitGrowList( growList_t *list, int maxElements )
 {
 	list->maxElements = maxElements;
 	list->currentElements = 0;
-	list->elements = ( void ** ) Com_Allocate( list->maxElements * sizeof( void * ) );
+	list->elements = ( void ** ) malloc( list->maxElements * sizeof( void * ) );
 }
 
 void Com_DestroyGrowList( growList_t *list )
 {
-	Com_Dealloc( list->elements );
+	free( list->elements );
 	memset( list, 0, sizeof( *list ) );
 }
 
@@ -90,16 +86,16 @@ int Com_AddToGrowList( growList_t *list, void *data )
 
 //  Log::Debug("Resizing growlist to %i maxElements", list->maxElements);
 
-	list->elements = ( void ** ) Com_Allocate( list->maxElements * sizeof( void * ) );
+	list->elements = ( void ** ) malloc( list->maxElements * sizeof( void * ) );
 
 	if ( !list->elements )
 	{
         Sys::Drop( "Growlist alloc failed" );
 	}
 
-	Com_Memcpy( list->elements, old, list->currentElements * sizeof( void * ) );
+	memcpy( list->elements, old, list->currentElements * sizeof( void * ) );
 
-	Com_Dealloc( old );
+	free( old );
 
 	return Com_AddToGrowList( list, data );
 }
@@ -999,7 +995,7 @@ char           *COM_ParseExt2( const char **data_p, bool allowLineBreaks )
 		if ( j == l )
 		{
 			// a valid multi-character punctuation
-			Com_Memcpy( com_token, *punc, l );
+			memcpy( com_token, *punc, l );
 			com_token[ l ] = 0;
 			data += l;
 			*data_p = ( char * ) data;
@@ -1258,7 +1254,7 @@ const char *Com_ClearForeignCharacters( const char *str )
 
 	free( clean );
 	size = strlen( str );
-	clean = (char*)Com_Allocate ( size + 1 ); // guaranteed sufficient
+	clean = (char*)malloc ( size + 1 ); // guaranteed sufficient
 
 	i = -1;
 	j = 0;

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -218,12 +218,6 @@ using clipHandle_t = int;
 	  h_dontcare
 	};
 
-#define Com_Memset   memset
-#define Com_Memcpy   memcpy
-
-#define Com_Allocate malloc
-#define Com_Dealloc  free
-
 MALLOC_LIKE void *Com_Allocate_Aligned( size_t alignment, size_t size );
 void  Com_Free_Aligned( void *ptr );
 

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -740,7 +740,7 @@ static void SetViewportAndScissor()
 	float	mat[16], scale;
 	vec4_t	q, c;
 
-	Com_Memcpy( mat, backEnd.viewParms.projectionMatrix, sizeof(mat) );
+	memcpy( mat, backEnd.viewParms.projectionMatrix, sizeof(mat) );
 	if( backEnd.viewParms.portalLevel > 0 )
 	{
 		VectorCopy(backEnd.viewParms.portalFrustum[FRUSTUM_NEAR].normal, c);
@@ -2247,7 +2247,7 @@ static void RB_RenderInteractionsShadowMapped()
 					else
 					{
 						// set up the transformation matrix
-						Com_Memset( &backEnd.orientation, 0, sizeof( backEnd.orientation ) );
+						memset( &backEnd.orientation, 0, sizeof( backEnd.orientation ) );
 
 						backEnd.orientation.axis[ 0 ][ 0 ] = 1;
 						backEnd.orientation.axis[ 1 ][ 1 ] = 1;
@@ -2426,7 +2426,7 @@ static void RB_RenderInteractionsShadowMapped()
 						else
 						{
 							// set up the transformation matrix
-							Com_Memset( &backEnd.orientation, 0, sizeof( backEnd.orientation ) );
+							memset( &backEnd.orientation, 0, sizeof( backEnd.orientation ) );
 
 							backEnd.orientation.axis[ 0 ][ 0 ] = 1;
 							backEnd.orientation.axis[ 1 ][ 1 ] = 1;

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -346,7 +346,7 @@ void LoadRGBEToFloats( const char *name, float **pic, int *width, int *height )
 		Sys::Drop( "RGBE image '%s' has an invalid image size", name );
 	}
 
-	*pic = (float*) Com_Allocate( w * h * 3 * sizeof( float ) );
+	*pic = (float*) malloc( w * h * 3 * sizeof( float ) );
 	floatbuf = *pic;
 
 	for ( i = 0; i < ( w * h ); i++ )
@@ -417,7 +417,7 @@ static void LoadRGBEToBytes( const char *name, byte **ldrImage, int *width, int 
 		*pixbuf++ = ( byte ) 255;
 	}
 
-	Com_Dealloc( hdrImage );
+	free( hdrImage );
 }
 
 static char **R_LoadExternalLightmaps(
@@ -604,7 +604,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 		fatbuffer = (byte*) ri.Hunk_AllocateTempMemory( sizeof( byte ) * tr.fatLightmapSize * tr.fatLightmapSize * 4 );
 
-		Com_Memset( fatbuffer, 128, tr.fatLightmapSize * tr.fatLightmapSize * 4 );
+		memset( fatbuffer, 128, tr.fatLightmapSize * tr.fatLightmapSize * 4 );
 
 		for ( int i = 0; i < numLightmaps; i++ )
 		{
@@ -693,7 +693,7 @@ static void R_LoadVisibility( lump_t *l )
 
 	len = ( s_worldData.numClusters + 63 ) & ~63;
 	s_worldData.novis = (byte*) ri.Hunk_Alloc( len, ha_pref::h_low );
-	Com_Memset( s_worldData.novis, 0xff, len );
+	memset( s_worldData.novis, 0xff, len );
 
 	len = l->filelen;
 
@@ -718,7 +718,7 @@ static void R_LoadVisibility( lump_t *l )
 		byte *dest;
 
 		dest = (byte*) ri.Hunk_Alloc( len - 8, ha_pref::h_low );
-		Com_Memcpy( dest, buf + 8, len - 8 );
+		memcpy( dest, buf + 8, len - 8 );
 		s_worldData.vis = dest;
 	}
 
@@ -2693,21 +2693,21 @@ void R_MovePatchSurfacesToHunk()
 		//
 		size = sizeof( *grid );
 		hunkgrid = (srfGridMesh_t*) ri.Hunk_Alloc( size, ha_pref::h_low );
-		Com_Memcpy( hunkgrid, grid, size );
+		memcpy( hunkgrid, grid, size );
 
 		hunkgrid->widthLodError = (float*) ri.Hunk_Alloc( grid->width * 4, ha_pref::h_low );
-		Com_Memcpy( hunkgrid->widthLodError, grid->widthLodError, grid->width * 4 );
+		memcpy( hunkgrid->widthLodError, grid->widthLodError, grid->width * 4 );
 
 		hunkgrid->heightLodError = (float*) ri.Hunk_Alloc( grid->height * 4, ha_pref::h_low );
-		Com_Memcpy( hunkgrid->heightLodError, grid->heightLodError, grid->height * 4 );
+		memcpy( hunkgrid->heightLodError, grid->heightLodError, grid->height * 4 );
 
 		hunkgrid->numTriangles = grid->numTriangles;
 		hunkgrid->triangles = (srfTriangle_t*) ri.Hunk_Alloc( grid->numTriangles * sizeof( srfTriangle_t ), ha_pref::h_low );
-		Com_Memcpy( hunkgrid->triangles, grid->triangles, grid->numTriangles * sizeof( srfTriangle_t ) );
+		memcpy( hunkgrid->triangles, grid->triangles, grid->numTriangles * sizeof( srfTriangle_t ) );
 
 		hunkgrid->numVerts = grid->numVerts;
 		hunkgrid->verts = (srfVert_t*) ri.Hunk_Alloc( grid->numVerts * sizeof( srfVert_t ), ha_pref::h_low );
-		Com_Memcpy( hunkgrid->verts, grid->verts, grid->numVerts * sizeof( srfVert_t ) );
+		memcpy( hunkgrid->verts, grid->verts, grid->numVerts * sizeof( srfVert_t ) );
 
 		R_FreeSurfaceGridMesh( grid );
 
@@ -3652,7 +3652,7 @@ static void R_LoadShaders( lump_t *l )
 	s_worldData.shaders = out;
 	s_worldData.numShaders = count;
 
-	Com_Memcpy( out, in, count * sizeof( *out ) );
+	memcpy( out, in, count * sizeof( *out ) );
 
 	for ( i = 0; i < count; i++ )
 	{
@@ -6170,9 +6170,9 @@ unsigned int VertexCoordGenerateHash( const vec3_t xyz )
 
 vertexHash_t **NewVertexHashTable()
 {
-	vertexHash_t **hashTable = (vertexHash_t**) Com_Allocate( HASHTABLE_SIZE * sizeof( vertexHash_t * ) );
+	vertexHash_t **hashTable = (vertexHash_t**) malloc( HASHTABLE_SIZE * sizeof( vertexHash_t * ) );
 
-	Com_Memset( hashTable, 0, HASHTABLE_SIZE * sizeof( vertexHash_t * ) );
+	memset( hashTable, 0, HASHTABLE_SIZE * sizeof( vertexHash_t * ) );
 
 	return hashTable;
 }
@@ -6198,12 +6198,12 @@ void FreeVertexHashTable( vertexHash_t **hashTable )
 			{
 				nextVertexHash = vertexHash->next;
 
-				Com_Dealloc( vertexHash );
+				free( vertexHash );
 			}
 		}
 	}
 
-	Com_Dealloc( hashTable );
+	free( hashTable );
 }
 
 vertexHash_t *FindVertexInHashTable( vertexHash_t **hashTable, const vec3_t xyz, float distance )
@@ -6261,7 +6261,7 @@ vertexHash_t *AddVertexToHashTable( vertexHash_t **hashTable, vec3_t xyz, void *
 		return nullptr;
 	}
 
-	vertexHash = (vertexHash_t*) Com_Allocate( sizeof( vertexHash_t ) );
+	vertexHash = (vertexHash_t*) malloc( sizeof( vertexHash_t ) );
 
 	if ( !vertexHash )
 	{
@@ -6761,7 +6761,7 @@ void RE_LoadWorldMap( const char *name )
 	tr.worldDeluxeMapping = false;
 	tr.worldHDR_RGBE = false;
 
-	Com_Memset( &s_worldData, 0, sizeof( s_worldData ) );
+	memset( &s_worldData, 0, sizeof( s_worldData ) );
 	Q_strncpyz( s_worldData.name, name, sizeof( s_worldData.name ) );
 
 	Q_strncpyz( s_worldData.baseName, COM_SkipPath( s_worldData.name ), sizeof( s_worldData.name ) );

--- a/src/engine/renderer/tr_cmds.cpp
+++ b/src/engine/renderer/tr_cmds.cpp
@@ -35,8 +35,8 @@ void R_PerformanceCounters()
 	if ( !r_speeds->integer )
 	{
 		// clear the counters even if we aren't printing
-		Com_Memset( &tr.pc, 0, sizeof( tr.pc ) );
-		Com_Memset( &backEnd.pc, 0, sizeof( backEnd.pc ) );
+		memset( &tr.pc, 0, sizeof( tr.pc ) );
+		memset( &backEnd.pc, 0, sizeof( backEnd.pc ) );
 		return;
 	}
 
@@ -117,8 +117,8 @@ void R_PerformanceCounters()
 		           tr.pc.c_decalSurfacesCreated );
 	}
 
-	Com_Memset( &tr.pc, 0, sizeof( tr.pc ) );
-	Com_Memset( &backEnd.pc, 0, sizeof( backEnd.pc ) );
+	memset( &tr.pc, 0, sizeof( tr.pc ) );
+	memset( &backEnd.pc, 0, sizeof( backEnd.pc ) );
 }
 
 /*
@@ -537,7 +537,7 @@ void RE_SetClipRegion( const float *region )
 {
 	if ( region == nullptr )
 	{
-		Com_Memset( tr.clipRegion, 0, sizeof( vec4_t ) );
+		memset( tr.clipRegion, 0, sizeof( vec4_t ) );
 	}
 	else
 	{

--- a/src/engine/renderer/tr_curve.cpp
+++ b/src/engine/renderer/tr_curve.cpp
@@ -358,7 +358,7 @@ static void InvertErrorTable( float errorTable[ 2 ][ MAX_GRID_SIZE ], int width,
 	int   i;
 	float copy[ 2 ][ MAX_GRID_SIZE ];
 
-	Com_Memcpy( copy, errorTable, sizeof( copy ) );
+	memcpy( copy, errorTable, sizeof( copy ) );
 
 	for ( i = 0; i < width; i++ )
 	{
@@ -422,36 +422,36 @@ static srfGridMesh_t *R_CreateSurfaceGridMesh( int width, int height,
 
 	if ( r_stitchCurves->integer )
 	{
-		grid = (srfGridMesh_t*)/*ri.Hunk_Alloc */ Com_Allocate( size );
-		Com_Memset( grid, 0, size );
+		grid = (srfGridMesh_t*)/*ri.Hunk_Alloc */ malloc( size );
+		memset( grid, 0, size );
 
-		grid->widthLodError = (float*)/*ri.Hunk_Alloc */ Com_Allocate( width * 4 );
-		Com_Memcpy( grid->widthLodError, errorTable[ 0 ], width * 4 );
+		grid->widthLodError = (float*)/*ri.Hunk_Alloc */ malloc( width * 4 );
+		memcpy( grid->widthLodError, errorTable[ 0 ], width * 4 );
 
-		grid->heightLodError = (float*)/*ri.Hunk_Alloc */ Com_Allocate( height * 4 );
-		Com_Memcpy( grid->heightLodError, errorTable[ 1 ], height * 4 );
+		grid->heightLodError = (float*)/*ri.Hunk_Alloc */ malloc( height * 4 );
+		memcpy( grid->heightLodError, errorTable[ 1 ], height * 4 );
 
 		grid->numTriangles = numTriangles;
-		grid->triangles = (srfTriangle_t*) Com_Allocate( grid->numTriangles * sizeof( srfTriangle_t ) );
-		Com_Memcpy( grid->triangles, triangles, numTriangles * sizeof( srfTriangle_t ) );
+		grid->triangles = (srfTriangle_t*) malloc( grid->numTriangles * sizeof( srfTriangle_t ) );
+		memcpy( grid->triangles, triangles, numTriangles * sizeof( srfTriangle_t ) );
 
 		grid->numVerts = ( width * height );
-		grid->verts = (srfVert_t*) Com_Allocate( grid->numVerts * sizeof( srfVert_t ) );
+		grid->verts = (srfVert_t*) malloc( grid->numVerts * sizeof( srfVert_t ) );
 	}
 	else
 	{
 		grid = (srfGridMesh_t*) ri.Hunk_Alloc( size, ha_pref::h_low );
-		Com_Memset( grid, 0, size );
+		memset( grid, 0, size );
 
 		grid->widthLodError = (float*) ri.Hunk_Alloc( width * 4, ha_pref::h_low );
-		Com_Memcpy( grid->widthLodError, errorTable[ 0 ], width * 4 );
+		memcpy( grid->widthLodError, errorTable[ 0 ], width * 4 );
 
 		grid->heightLodError = (float*) ri.Hunk_Alloc( height * 4, ha_pref::h_low );
-		Com_Memcpy( grid->heightLodError, errorTable[ 1 ], height * 4 );
+		memcpy( grid->heightLodError, errorTable[ 1 ], height * 4 );
 
 		grid->numTriangles = numTriangles;
 		grid->triangles = (srfTriangle_t*) ri.Hunk_Alloc( grid->numTriangles * sizeof( srfTriangle_t ), ha_pref::h_low );
-		Com_Memcpy( grid->triangles, triangles, numTriangles * sizeof( srfTriangle_t ) );
+		memcpy( grid->triangles, triangles, numTriangles * sizeof( srfTriangle_t ) );
 
 		grid->numVerts = ( width * height );
 		grid->verts = (srfVert_t*) ri.Hunk_Alloc( grid->numVerts * sizeof( srfVert_t ), ha_pref::h_low );
@@ -491,11 +491,11 @@ R_FreeSurfaceGridMesh
 */
 void R_FreeSurfaceGridMesh( srfGridMesh_t *grid )
 {
-	Com_Dealloc( grid->widthLodError );
-	Com_Dealloc( grid->heightLodError );
-	Com_Dealloc( grid->triangles );
-	Com_Dealloc( grid->verts );
-	Com_Dealloc( grid );
+	free( grid->widthLodError );
+	free( grid->heightLodError );
+	free( grid->triangles );
+	free( grid->verts );
+	free( grid );
 }
 
 static srfTriangle_t gridtriangles[ SHADER_MAX_TRIANGLES ];

--- a/src/engine/renderer/tr_decals.cpp
+++ b/src/engine/renderer/tr_decals.cpp
@@ -313,7 +313,7 @@ void RE_ProjectDecal( qhandle_t hShader, int numPoints, vec3_t *points, vec4_t p
 
 	/* create a new projector */
 	dp = &tr.refdef.decalProjectors[ r_numDecalProjectors & DECAL_PROJECTOR_MASK ];
-	Com_Memcpy( dp, &temp, sizeof( *dp ) );
+	memcpy( dp, &temp, sizeof( *dp ) );
 
 	/* we have a winner */
 	r_numDecalProjectors++;
@@ -451,7 +451,7 @@ static void ChopWindingBehindPlane( int numInPoints, vec3_t inPoints[ MAX_DECAL_
 	if ( counts[ Util::ordinal(planeSide_t::SIDE_FRONT) ] == 0 )
 	{
 		*numOutPoints = numInPoints;
-		Com_Memcpy( outPoints, inPoints, numInPoints * sizeof( vec3_t ) );
+		memcpy( outPoints, inPoints, numInPoints * sizeof( vec3_t ) );
 		return;
 	}
 
@@ -859,7 +859,7 @@ void R_AddDecalSurface( decal_t *decal )
 	/* set it up */
 	srf->surfaceType = surfaceType_t::SF_DECAL;
 	srf->numVerts = decal->numVerts;
-	Com_Memcpy( srf->verts, decal->verts, srf->numVerts * sizeof( *srf->verts ) );
+	memcpy( srf->verts, decal->verts, srf->numVerts * sizeof( *srf->verts ) );
 
 	/* fade colors */
 	if ( decal->fadeStartTime < tr.refdef.time && decal->fadeStartTime < decal->fadeEndTime )

--- a/src/engine/renderer/tr_flares.cpp
+++ b/src/engine/renderer/tr_flares.cpp
@@ -89,7 +89,7 @@ void R_ClearFlares()
 {
 	int i;
 
-	Com_Memset( r_flareStructs, 0, sizeof( r_flareStructs ) );
+	memset( r_flareStructs, 0, sizeof( r_flareStructs ) );
 	r_activeFlares = nullptr;
 	r_inactiveFlares = nullptr;
 

--- a/src/engine/renderer/tr_font.cpp
+++ b/src/engine/renderer/tr_font.cpp
@@ -146,7 +146,7 @@ FT_Bitmap      *R_RenderGlyph( FT_GlyphSlot glyph, glyphInfo_t *glyphOut )
 		bit2->buffer = (unsigned char*) ri.Z_Malloc( pitch * height );
 		bit2->num_grays = 256;
 
-		Com_Memset( bit2->buffer, 0, size );
+		memset( bit2->buffer, 0, size );
 
 		FT_Outline_Translate( &glyph->outline, -left, -bottom );
 
@@ -176,7 +176,7 @@ static glyphInfo_t *RE_ConstructGlyphInfo( unsigned char *imageOut, int *xOut, i
 	float              scaledWidth, scaledHeight;
 	FT_Bitmap          *bitmap = nullptr;
 
-	Com_Memset( &glyph, 0, sizeof( glyphInfo_t ) );
+	memset( &glyph, 0, sizeof( glyphInfo_t ) );
 
 	// make sure everything is here
 	if ( face != nullptr )
@@ -278,7 +278,7 @@ static glyphInfo_t *RE_ConstructGlyphInfo( unsigned char *imageOut, int *xOut, i
 		{
 			for ( i = 0; i < glyph.height; i++ )
 			{
-				Com_Memcpy( dst, src, glyph.pitch );
+				memcpy( dst, src, glyph.pitch );
 				src += glyph.pitch;
 				dst += FONT_SIZE;
 			}
@@ -470,7 +470,7 @@ void RE_RenderChunk( fontInfo_t *font, const int chunk )
 		return;
 	}
 
-	Com_Memset( out, 0, FONT_SIZE * FONT_SIZE );
+	memset( out, 0, FONT_SIZE * FONT_SIZE );
 
 	// calculate max height
 	maxHeight = 0;
@@ -503,13 +503,13 @@ void RE_RenderChunk( fontInfo_t *font, const int chunk )
 		if ( glyph )
 		{
 			rendered = true;
-			Com_Memcpy( glyphs + i, glyph, sizeof( glyphInfo_t ) );
+			memcpy( glyphs + i, glyph, sizeof( glyphInfo_t ) );
 		}
 
 		if ( xOut == -1 )
 		{
 			RE_StoreImage( font, chunk, page++, lastStart, i, out, yOut + maxHeight + 1 );
-			Com_Memset( out, 0, FONT_SIZE * FONT_SIZE );
+			memset( out, 0, FONT_SIZE * FONT_SIZE );
 			xOut = yOut = 0;
 			rendered = false;
 			lastStart = i;

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -778,7 +778,7 @@ R_ConvertBC5Image(const byte **in, byte **out, int numMips, int numLayers,
 
 			for( k = 0; k < mipSize; k++ ) {
 				// red channel is unchanged
-				Com_Memcpy( to, from, 8 );
+				memcpy( to, from, 8 );
 
 				// green channel is converted to DXT1
 				R_UnpackDXT5A( from + 8, data );
@@ -1065,7 +1065,7 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 				// copy or resample data as appropriate for first MIP level
 				if ( ( scaledWidth == image->width ) && ( scaledHeight == image->height ) )
 				{
-					Com_Memcpy( scaledBuffer, data, scaledWidth * scaledHeight * 4 );
+					memcpy( scaledBuffer, data, scaledWidth * scaledHeight * 4 );
 				}
 				else
 				{
@@ -1366,7 +1366,7 @@ image_t        *R_AllocImage( const char *name, bool linkIntoHashTable )
 	}
 
 	image = (image_t*) ri.Hunk_Alloc( sizeof( image_t ), ha_pref::h_low );
-	Com_Memset( image, 0, sizeof( image_t ) );
+	memset( image, 0, sizeof( image_t ) );
 
 	glGenTextures( 1, &image->texnum );
 
@@ -2307,7 +2307,7 @@ static void R_CreateDefaultImage()
 	byte *dataPtr = &data[0][0][0];
 
 	// the default image will be a box, to allow you to see the mapping coordinates
-	Com_Memset( data, 32, sizeof( data ) );
+	memset( data, 32, sizeof( data ) );
 
 	for ( x = 0; x < DEFAULT_SIZE; x++ )
 	{
@@ -2334,7 +2334,7 @@ static void R_CreateRandomNormalsImage()
 	int  x, y;
 	byte data[ DEFAULT_SIZE ][ DEFAULT_SIZE ][ 4 ];
 	// the default image will be a box, to allow you to see the mapping coordinates
-	Com_Memset(data, 32, sizeof(data));
+	memset(data, 32, sizeof(data));
 
 	byte *ptr = &data[0][0][0];
 	byte *dataPtr = &data[0][0][0];
@@ -2372,7 +2372,7 @@ static void R_CreateNoFalloffImage()
 {
 	byte data[ DEFAULT_SIZE ][ DEFAULT_SIZE ][ 4 ];
 	// we use a solid white image instead of disabling texturing
-	Com_Memset(data, 255, sizeof(data));
+	memset(data, 255, sizeof(data));
 
 	byte *dataPtr = &data[0][0][0];
 
@@ -2720,7 +2720,7 @@ static void R_CreateBlackCubeImage()
 	for ( i = 0; i < 6; i++ )
 	{
 		data[ i ] = (byte*) ri.Hunk_AllocateTempMemory( width * height * 4 );
-		Com_Memset( data[ i ], 0, width * height * 4 );
+		memset( data[ i ], 0, width * height * 4 );
 	}
 
 	imageParams_t imageParams = {};
@@ -2752,7 +2752,7 @@ static void R_CreateWhiteCubeImage()
 	for ( i = 0; i < 6; i++ )
 	{
 		data[ i ] = (byte*) ri.Hunk_AllocateTempMemory( width * height * 4 );
-		Com_Memset( data[ i ], 0xFF, width * height * 4 );
+		memset( data[ i ], 0xFF, width * height * 4 );
 	}
 
 	imageParams_t imageParams = {};
@@ -2820,7 +2820,7 @@ void R_CreateBuiltinImages()
 	R_CreateDefaultImage();
 
 	// we use a solid white image instead of disabling texturing
-	Com_Memset( data, 255, sizeof( data ) );
+	memset( data, 255, sizeof( data ) );
 
 	imageParams_t imageParams = {};
 	imageParams.bits = IF_NOPICMIP;
@@ -2830,7 +2830,7 @@ void R_CreateBuiltinImages()
 	tr.whiteImage = R_CreateImage( "_white", ( const byte ** ) &dataPtr, 8, 8, 1, imageParams );
 
 	// we use a solid black image instead of disabling texturing
-	Com_Memset( data, 0, sizeof( data ) );
+	memset( data, 0, sizeof( data ) );
 	tr.blackImage = R_CreateImage( "_black", ( const byte ** ) &dataPtr, 8, 8, 1, imageParams );
 
 	// red
@@ -2924,7 +2924,7 @@ void R_InitImages()
 {
 	Log::Debug("------- R_InitImages -------" );
 
-	Com_Memset( r_imageHashTable, 0, sizeof( r_imageHashTable ) );
+	memset( r_imageHashTable, 0, sizeof( r_imageHashTable ) );
 	Com_InitGrowList( &tr.images, 4096 );
 	Com_InitGrowList( &tr.lightmaps, 128 );
 	Com_InitGrowList( &tr.deluxemaps, 128 );
@@ -2967,7 +2967,7 @@ void R_ShutdownImages()
 		glDeleteTextures( 1, &image->texnum );
 	}
 
-	Com_Memset( glState.currenttextures, 0, sizeof( glState.currenttextures ) );
+	memset( glState.currenttextures, 0, sizeof( glState.currenttextures ) );
 
 	Com_DestroyGrowList( &tr.images );
 	Com_DestroyGrowList( &tr.lightmaps );

--- a/src/engine/renderer/tr_image_dds.cpp
+++ b/src/engine/renderer/tr_image_dds.cpp
@@ -346,7 +346,7 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 	}
 
 	data[0] = (byte*) ri.Z_Malloc( size );
-	Com_Memcpy( data[0], ddsd + 1, size );
+	memcpy( data[0], ddsd + 1, size );
 
 	if( compressed ) {
 		for( i = 1; i < *numMips; i++ ) {

--- a/src/engine/renderer/tr_image_ktx.cpp
+++ b/src/engine/renderer/tr_image_ktx.cpp
@@ -246,12 +246,12 @@ bool LoadInMemoryKTX( const char *name, void *ktxData, size_t ktxSize,
 	uint32_t imageSize{ GetImageSize( ptr, needReverseBytes ) };
 	ptr += sizeof(uint32_t);
 
-	Com_Memcpy( data[ 0 ], ptr, imageSize );
+	memcpy( data[ 0 ], ptr, imageSize );
 	ptr += imageSize;
 
 	for(uint32_t j{ 1 }; j < hdr->numberOfFaces; j++) {
 		data[ j ] = data[ j - 1 ] + imageSize;
-		Com_Memcpy( data[ j ], ptr, imageSize );
+		memcpy( data[ j ], ptr, imageSize );
 
 		ptr += imageSize;
 	}
@@ -264,7 +264,7 @@ bool LoadInMemoryKTX( const char *name, void *ktxData, size_t ktxSize,
 			const uint32_t idx{ i * hdr->numberOfFaces + j };
 
 			data[ idx ] = data[ idx - 1 ] + imageSize;
-			Com_Memcpy( data[ idx ], ptr, imageSize );
+			memcpy( data[ idx ], ptr, imageSize );
 
 			ptr += imageSize;
 		}
@@ -770,8 +770,8 @@ void LoadKTX( const char *name, byte **pic, int *width, int *height,
 void SaveImageKTX( const char *path, image_t *img )
 {
 	KTX_header_t hdr;
-	Com_Memset( &hdr, 0, sizeof(hdr) );
-	Com_Memcpy( &hdr.identifier, KTX_identifier, sizeof( KTX_identifier ) );
+	memset( &hdr, 0, sizeof(hdr) );
+	memcpy( &hdr.identifier, KTX_identifier, sizeof( KTX_identifier ) );
 	hdr.endianness = KTX_endianness;
 
 	GLenum target;
@@ -861,7 +861,7 @@ void SaveImageKTX( const char *path, image_t *img )
 	
 	byte *data = (byte *)ri.Hunk_AllocateTempMemory( size + sizeof( hdr ) );
 	byte *ptr = data;
-	Com_Memcpy( ptr, &hdr, sizeof( hdr ) );
+	memcpy( ptr, &hdr, sizeof( hdr ) );
 	ptr += sizeof( hdr );
 
 	mipWidth = std::max(hdr.pixelWidth, 1U);

--- a/src/engine/renderer/tr_image_png.cpp
+++ b/src/engine/renderer/tr_image_png.cpp
@@ -40,7 +40,7 @@ PNG LOADING
 static void png_read_data( png_structp png, png_bytep data, png_size_t length )
 {
 	byte *io_ptr = (byte*) png_get_io_ptr( png );
-	Com_Memcpy( data, io_ptr, length );
+	memcpy( data, io_ptr, length );
 	png_init_io( png, ( png_FILE_p )( io_ptr + length ) );
 }
 
@@ -214,7 +214,7 @@ static int png_compressed_size;
 static void png_write_data( png_structp png, png_bytep data, png_size_t length )
 {
 	byte *io_ptr = (byte*) png_get_io_ptr( png );
-	Com_Memcpy( io_ptr, data, length );
+	memcpy( io_ptr, data, length );
 	png_init_io( png, ( png_FILE_p )( io_ptr + length ) );
 	png_compressed_size += length;
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -562,7 +562,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 		// with 18 bytes for the TGA file header
 		buffer = RB_ReadPixels( x, y, width, height, 18 );
-		Com_Memset( buffer, 0, 18 );
+		memset( buffer, 0, 18 );
 
 		buffer[ 2 ] = 2; // uncompressed type
 		buffer[ 12 ] = width & 255;
@@ -1528,7 +1528,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		Log::Debug("GetRefAPI()" );
 
-		Com_Memset( &re, 0, sizeof( re ) );
+		memset( &re, 0, sizeof( re ) );
 
 		if ( apiVersion != REF_API_VERSION )
 		{

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -319,7 +319,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	{
 		link_t *l;
 
-		l = ( link_t * ) Com_Allocate( sizeof( *l ) );
+		l = ( link_t * ) malloc( sizeof( *l ) );
 		InitLink( l, data );
 
 		InsertLink( l, sentinel );
@@ -339,7 +339,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 
 		RemoveLink( top );
 		data = top->data;
-		Com_Dealloc( top );
+		free( top );
 
 		return data;
 	}
@@ -365,7 +365,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	{
 		link_t *l;
 
-		l = ( link_t * ) Com_Allocate( sizeof( *l ) );
+		l = ( link_t * ) malloc( sizeof( *l ) );
 		InitLink( l, data );
 
 		InsertLink( l, sentinel );
@@ -382,7 +382,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 
 		RemoveLink( tail );
 		data = tail->data;
-		Com_Dealloc( tail );
+		free( tail );
 
 		l->numElements--;
 

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -695,7 +695,7 @@ void R_RotateEntityForLight( const trRefEntity_t *ent, const trRefLight_t *light
 
 	if ( ent->e.reType != refEntityType_t::RT_MODEL )
 	{
-		Com_Memset( orientation , 0, sizeof( * orientation ) );
+		memset( orientation , 0, sizeof( * orientation ) );
 
 		orientation ->axis[ 0 ][ 0 ] = 1;
 		orientation ->axis[ 1 ][ 1 ] = 1;
@@ -785,7 +785,7 @@ void R_RotateForViewer()
 {
 	matrix_t transformMatrix;
 
-	Com_Memset( &tr.orientation, 0, sizeof( tr.orientation ) );
+	memset( &tr.orientation, 0, sizeof( tr.orientation ) );
 	tr.orientation.axis[ 0 ][ 0 ] = 1;
 	tr.orientation.axis[ 1 ][ 1 ] = 1;
 	tr.orientation.axis[ 2 ][ 2 ] = 1;
@@ -1217,7 +1217,7 @@ void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane )
 
 	if ( !surfType )
 	{
-		Com_Memset( plane, 0, sizeof( *plane ) );
+		memset( plane, 0, sizeof( *plane ) );
 		plane->normal[ 0 ] = 1;
 		return;
 	}
@@ -1246,7 +1246,7 @@ void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane )
 			return;
 
 		default:
-			Com_Memset( plane, 0, sizeof( *plane ) );
+			memset( plane, 0, sizeof( *plane ) );
 			plane->normal[ 0 ] = 1;
 			return;
 	}

--- a/src/engine/renderer/tr_marks.cpp
+++ b/src/engine/renderer/tr_marks.cpp
@@ -92,7 +92,7 @@ static void R_ChopPolyBehindPlane( int numInPoints, vec3_t inPoints[ MAX_VERTS_O
 	if ( !counts[ 1 ] )
 	{
 		*numOutPoints = numInPoints;
-		Com_Memcpy( outPoints, inPoints, numInPoints * sizeof( vec3_t ) );
+		memcpy( outPoints, inPoints, numInPoints * sizeof( vec3_t ) );
 		return;
 	}
 
@@ -275,7 +275,7 @@ void R_AddMarkFragments( int numClipPoints, vec3_t clipPoints[ 2 ][ MAX_VERTS_ON
 	mf->firstPoint = ( *returnedPoints );
 	mf->numPoints = numClipPoints;
 
-	Com_Memcpy( pointBuffer + ( *returnedPoints ) * 3, clipPoints[ pingPong ], numClipPoints * sizeof( vec3_t ) );
+	memcpy( pointBuffer + ( *returnedPoints ) * 3, clipPoints[ pingPong ], numClipPoints * sizeof( vec3_t ) );
 
 	( *returnedPoints ) += numClipPoints;
 	( *returnedFragments ) ++;

--- a/src/engine/renderer/tr_model_iqm.cpp
+++ b/src/engine/renderer/tr_model_iqm.cpp
@@ -567,7 +567,7 @@ bool R_LoadIQModel( model_t *mod, void *buffer, int filesize,
 	for(unsigned i = 0; i < header->num_joints; i++, joint++ ) {
 		name = ( char* )IQMPtr( header, header->ofs_text + joint->name );
 		len = strlen( name ) + 1;
-		Com_Memcpy( str, name, len );
+		memcpy( str, name, len );
 		str += len;
 	}
 
@@ -595,7 +595,7 @@ bool R_LoadIQModel( model_t *mod, void *buffer, int filesize,
 
 		name = ( char* )IQMPtr( header, header->ofs_text + anim->name );
 		len = strlen( name ) + 1;
-		Com_Memcpy( str, name, len );
+		memcpy( str, name, len );
 		str += len;
 	}
 
@@ -687,7 +687,7 @@ bool R_LoadIQModel( model_t *mod, void *buffer, int filesize,
 		switch( vertexarray->type ) {
 		case IQM_POSITION:
 			ClearBounds( IQModel->bounds[ 0 ], IQModel->bounds[ 1 ] );
-			Com_Memcpy( IQModel->positions,
+			memcpy( IQModel->positions,
 				    IQMPtr( header, vertexarray->offset ),
 				    n * sizeof(float) );
 			for( int j = 0; j < n; j += vertexarray->size ) {
@@ -707,7 +707,7 @@ bool R_LoadIQModel( model_t *mod, void *buffer, int filesize,
 
 			break;
 		case IQM_NORMAL:
-			Com_Memcpy( IQModel->normals,
+			memcpy( IQModel->normals,
 				    IQMPtr( header, vertexarray->offset ),
 				    n * sizeof(float) );
 			break;
@@ -723,7 +723,7 @@ bool R_LoadIQModel( model_t *mod, void *buffer, int filesize,
 			}
 			break;
 		case IQM_BLENDINDEXES:
-			Com_Memcpy( IQModel->blendIndexes,
+			memcpy( IQModel->blendIndexes,
 				    IQMPtr( header, vertexarray->offset ),
 				    n * sizeof(byte) );
 			break;
@@ -737,7 +737,7 @@ bool R_LoadIQModel( model_t *mod, void *buffer, int filesize,
 			}
 			break;
 		case IQM_COLOR:
-			Com_Memcpy( IQModel->colors,
+			memcpy( IQModel->colors,
 				    IQMPtr( header, vertexarray->offset ),
 				    n * sizeof(byte) );
 			break;
@@ -848,7 +848,7 @@ bool R_LoadIQModel( model_t *mod, void *buffer, int filesize,
 			surface->name = str;
 			name = ( char* )IQMPtr( header, header->ofs_text + mesh->name );
 			len = strlen( name ) + 1;
-			Com_Memcpy( str, name, len );
+			memcpy( str, name, len );
 			str += len;
 		} else {
 			surface->name = nullptr;

--- a/src/engine/renderer/tr_model_md5.cpp
+++ b/src/engine/renderer/tr_model_md5.cpp
@@ -578,7 +578,7 @@ bool R_LoadMD5( model_t *mod, void *buffer, const char *modName )
         tri = surf->triangles;
 		for (unsigned j = 0; j < surf->numTriangles; j++, tri++ )
 		{
-			skelTriangle_t *sortTri = (skelTriangle_t*) Com_Allocate( sizeof( *sortTri ) );
+			skelTriangle_t *sortTri = (skelTriangle_t*) malloc( sizeof( *sortTri ) );
 
 			for (unsigned k = 0; k < 3; k++ )
 			{
@@ -596,7 +596,7 @@ bool R_LoadMD5( model_t *mod, void *buffer, const char *modName )
 		while ( numRemaining )
 		{
 			numBoneReferences = 0;
-			Com_Memset( boneReferences, 0, sizeof( boneReferences ) );
+			memset( boneReferences, 0, sizeof( boneReferences ) );
 
 			Com_InitGrowList( &vboTriangles, 1000 );
 
@@ -632,7 +632,7 @@ bool R_LoadMD5( model_t *mod, void *buffer, const char *modName )
 		{
 			skelTriangle_t *sortTri = (skelTriangle_t*) Com_GrowListElement( &sortedTriangles, j );
 
-			Com_Dealloc( sortTri );
+			free( sortTri );
 		}
 
 		Com_DestroyGrowList( &sortedTriangles );

--- a/src/engine/renderer/tr_model_skel.cpp
+++ b/src/engine/renderer/tr_model_skel.cpp
@@ -34,7 +34,7 @@ bool AddTriangleToVBOTriangleList( growList_t *vboTriangles, skelTriangle_t *tri
 	hasWeights = false;
 
 	numNewReferences = 0;
-	Com_Memset( newReferences, -1, sizeof( newReferences ) );
+	memset( newReferences, -1, sizeof( newReferences ) );
 
 	for (unsigned i = 0; i < 3; i++ )
 	{
@@ -138,8 +138,8 @@ void AddSurfaceToVBOSurfacesList( growList_t *vboSurfaces, growList_t *vboTriang
 	indexes = ( glIndex_t * ) ri.Hunk_AllocateTempMemory( indexesNum * sizeof( glIndex_t ) );
 
 	vboSurf->numBoneRemap = 0;
-	Com_Memset( vboSurf->boneRemap, 0, sizeof( vboSurf->boneRemap ) );
-	Com_Memset( vboSurf->boneRemapInverse, 0, sizeof( vboSurf->boneRemapInverse ) );
+	memset( vboSurf->boneRemap, 0, sizeof( vboSurf->boneRemap ) );
+	memset( vboSurf->boneRemapInverse, 0, sizeof( vboSurf->boneRemapInverse ) );
 
 	for ( j = 0; j < MAX_BONES; j++ )
 	{

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -189,7 +189,7 @@ static void R_AddPolysToScene( qhandle_t hShader, int numVerts, const polyVert_t
 		poly->numVerts = numVerts;
 		poly->verts = &backEndData[ tr.smpFrame ]->polyVerts[ r_numPolyVerts ];
 
-		Com_Memcpy( poly->verts, &verts[ numVerts * j ], numVerts * sizeof( *verts ) );
+		memcpy( poly->verts, &verts[ numVerts * j ], numVerts * sizeof( *verts ) );
 
 		// done.
 		r_numPolys++;
@@ -281,7 +281,7 @@ void RE_AddRefEntityToScene( const refEntity_t *ent )
 		Sys::Drop("RE_AddRefEntityToScene: bad reType %s", Util::enum_str(ent->reType));
 	}
 
-	Com_Memcpy( &backEndData[ tr.smpFrame ]->entities[ r_numEntities ].e, ent, sizeof( refEntity_t ) );
+	memcpy( &backEndData[ tr.smpFrame ]->entities[ r_numEntities ].e, ent, sizeof( refEntity_t ) );
 	backEndData[ tr.smpFrame ]->entities[ r_numEntities ].lightingCalculated = false;
 
 	r_numEntities++;
@@ -317,7 +317,7 @@ void RE_AddRefLightToScene( const refLight_t *l )
 	}
 
 	light = &backEndData[ tr.smpFrame ]->lights[ r_numLights++ ];
-	Com_Memcpy( &light->l, l, sizeof( light->l ) );
+	memcpy( &light->l, l, sizeof( light->l ) );
 
 	light->isStatic = false;
 	light->additive = true;
@@ -373,7 +373,7 @@ static void R_AddWorldLightsToScene()
 			continue;
 		}
 
-		Com_Memcpy( &backEndData[ tr.smpFrame ]->lights[ r_numLights ], light, sizeof( trRefLight_t ) );
+		memcpy( &backEndData[ tr.smpFrame ]->lights[ r_numLights ], light, sizeof( trRefLight_t ) );
 		r_numLights++;
 	}
 }
@@ -578,7 +578,7 @@ void RE_RenderScene( const refdef_t *fd )
 	// The refdef takes 0-at-the-top y coordinates, so
 	// convert to GL's 0-at-the-bottom space
 	//
-	Com_Memset( &parms, 0, sizeof( parms ) );
+	memset( &parms, 0, sizeof( parms ) );
 
 	if ( tr.refdef.pixelTarget == nullptr )
 	{

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5074,7 +5074,7 @@ static shader_t *GeneratePermanentShader()
 		{
 			size = newShader->stages[ i ]->bundle[ b ].numTexMods * sizeof( texModInfo_t );
 			newShader->stages[ i ]->bundle[ b ].texMods = (texModInfo_t*) ri.Hunk_Alloc( size, ha_pref::h_low );
-			Com_Memcpy( newShader->stages[ i ]->bundle[ b ].texMods, stages[ i ].bundle[ b ].texMods, size );
+			memcpy( newShader->stages[ i ]->bundle[ b ].texMods, stages[ i ].bundle[ b ].texMods, size );
 		}
 	}
 
@@ -5709,8 +5709,8 @@ shader_t       *R_FindShader( const char *name, shaderType_t type,
 	}
 
 	// clear the global shader
-	Com_Memset( &shader, 0, sizeof( shader ) );
-	Com_Memset( &stages, 0, sizeof( stages ) );
+	memset( &shader, 0, sizeof( shader ) );
+	memset( &stages, 0, sizeof( stages ) );
 	Q_strncpyz( shader.name, strippedName, sizeof( shader.name ) );
 	shader.type = type;
 
@@ -5907,8 +5907,8 @@ qhandle_t RE_RegisterShaderFromImage( const char *name, image_t *image )
 	}
 
 	// clear the global shader
-	Com_Memset( &shader, 0, sizeof( shader ) );
-	Com_Memset( &stages, 0, sizeof( stages ) );
+	memset( &shader, 0, sizeof( shader ) );
+	memset( &stages, 0, sizeof( stages ) );
 	Q_strncpyz( shader.name, name, sizeof( shader.name ) );
 	shader.type = shaderType_t::SHADER_2D;
 	shader.cullType = CT_TWO_SIDED;
@@ -6355,7 +6355,7 @@ static void ScanAndLoadShaderFiles()
 	// free up memory
 	ri.FS_FreeFileList( shaderFiles );
 
-	Com_Memset( shaderTextHashTableSizes, 0, sizeof( shaderTextHashTableSizes ) );
+	memset( shaderTextHashTableSizes, 0, sizeof( shaderTextHashTableSizes ) );
 	size = 0;
 
 	p = s_shaderText;
@@ -6397,7 +6397,7 @@ static void ScanAndLoadShaderFiles()
 		hashMem += shaderTextHashTableSizes[ i ] + 1;
 	}
 
-	Com_Memset( shaderTextHashTableSizes, 0, sizeof( shaderTextHashTableSizes ) );
+	memset( shaderTextHashTableSizes, 0, sizeof( shaderTextHashTableSizes ) );
 
 	p = s_shaderText;
 
@@ -6422,7 +6422,7 @@ static void ScanAndLoadShaderFiles()
 			bool      alreadyCreated;
 
 			// zeroes all shaders, booleans can be assumed as false
-			Com_Memset( &table, 0, sizeof( table ) );
+			memset( &table, 0, sizeof( table ) );
 
 			token = COM_ParseExt2( &p, true );
 
@@ -6510,8 +6510,8 @@ static void CreateInternalShaders()
 	tr.numShaders = 0;
 
 	// init the default shader
-	Com_Memset( &shader, 0, sizeof( shader ) );
-	Com_Memset( &stages, 0, sizeof( stages ) );
+	memset( &shader, 0, sizeof( shader ) );
+	memset( &stages, 0, sizeof( stages ) );
 
 	Q_strncpyz( shader.name, "<default>", sizeof( shader.name ) );
 
@@ -6542,8 +6542,8 @@ R_InitShaders
 */
 void R_InitShaders()
 {
-	Com_Memset( shaderTableHashTable, 0, sizeof( shaderTableHashTable ) );
-	Com_Memset( shaderHashTable, 0, sizeof( shaderHashTable ) );
+	memset( shaderTableHashTable, 0, sizeof( shaderTableHashTable ) );
+	memset( shaderHashTable, 0, sizeof( shaderHashTable ) );
 
 	CreateInternalShaders();
 

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -497,7 +497,7 @@ static void DrawSkyBox()
 	sky_min = 0;
 	sky_max = 1;
 
-	Com_Memset( s_skyTexCoords, 0, sizeof( s_skyTexCoords ) );
+	memset( s_skyTexCoords, 0, sizeof( s_skyTexCoords ) );
 
 	// set up for drawing
 	tess.multiDrawPrimitives = 0;

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1284,7 +1284,7 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 	{
 		if( model->num_joints > 0 )
 		{
-			Com_Memcpy( tess.bones, bones, model->num_joints * sizeof(transform_t) );
+			memcpy( tess.bones, bones, model->num_joints * sizeof(transform_t) );
 			tess.numBones = model->num_joints;
 		}
 		else

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -408,7 +408,7 @@ void SV_ClearServer()
 		}
 	}
 
-	Com_Memset( &sv, 0, sizeof( sv ) );
+	memset( &sv, 0, sizeof( sv ) );
 }
 
 /*

--- a/src/engine/server/sv_snapshot.cpp
+++ b/src/engine/server/sv_snapshot.cpp
@@ -677,7 +677,7 @@ static void SV_BuildClientSnapshot( client_t *client )
 
 	// clear everything in this snapshot
 	entityNumbers.numSnapshotEntities = 0;
-	Com_Memset( frame->areabits, 0, sizeof( frame->areabits ) );
+	memset( frame->areabits, 0, sizeof( frame->areabits ) );
 
 	// show_bug.cgi?id=62
 	frame->num_entities = 0;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -361,8 +361,8 @@ void GLimp_Shutdown()
 
 	SDL_QuitSubSystem( SDL_INIT_VIDEO );
 
-	Com_Memset( &glConfig, 0, sizeof( glConfig ) );
-	Com_Memset( &glState, 0, sizeof( glState ) );
+	memset( &glConfig, 0, sizeof( glConfig ) );
+	memset( &glState, 0, sizeof( glState ) );
 }
 
 static void GLimp_Minimize()
@@ -534,7 +534,7 @@ static rserr_t GLimp_SetMode( int mode, bool fullscreen, bool noborder )
 	}
 	else
 	{
-		Com_Memset( &desktopMode, 0, sizeof( SDL_DisplayMode ) );
+		memset( &desktopMode, 0, sizeof( SDL_DisplayMode ) );
 
 		logger.Notice("Cannot determine display aspect (%s), assuming 1.333", SDL_GetError() );
 	}


### PR DESCRIPTION
They are only silencing compiler warnings about their incorrect usage