### PR TITLE
filesystem: only load paks with map name when testing if map name has valid map pak

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -2768,21 +2768,45 @@ const std::vector<PakInfo>& GetAvailablePaks()
 	return availablePaks;
 }
 
-
-std::vector<PakInfo> GetAvailableMapPaks()
+// mapName is optional and set to "" by default (list paks for all map names)
+std::vector<PakInfo> GetAvailableMapPaks( std::string mapName )
 {
 	std::vector<PakInfo> infos;
 	for ( const auto& pak : FS::GetAvailablePaks() )
 	{
-		if (UseLegacyPaks() || Str::IsPrefix("map-", pak.name))
+		// Legacy pak has empty version string
+		if ( pak.version.empty() )
 		{
-			infos.push_back(pak);
+			if ( UseLegacyPaks() )
+			{
+				infos.push_back(pak);
+			}
+		}
+		else
+		{
+			std::string mapPrefix = "map-";
+			if ( mapName.empty() )
+			{
+				if ( Str::IsPrefix( mapPrefix, pak.name ) )
+				{
+					infos.push_back(pak);
+				}
+			}
+			else
+			{
+				std::string mapBasename = mapPrefix + mapName;
+				if ( mapBasename == pak.name )
+				{
+					infos.push_back(pak);
+				}
+			}
 		}
 	}
 	return infos;
 }
 
-std::set<std::string> GetAvailableMaps()
+// mapName is optional and set to "" by default (list all map names)
+std::set<std::string> GetAvailableMaps( std::string mapName )
 {
 	std::set<std::string> maps;
 
@@ -2790,7 +2814,7 @@ std::set<std::string> GetAvailableMaps()
 		RefreshPaks();
 	#endif
 	std::error_code ignore;
-	for ( const auto& pak : GetAvailableMapPaks() )
+	for ( const auto& pak : GetAvailableMapPaks( mapName ) )
 	{
 		FS::PakPath::LoadPakPrefix(pak, "maps", ignore);
 	}

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -267,7 +267,7 @@ struct PakInfo {
 	// Base name of the pak, may include directories
 	std::string name;
 
-	// Version of the pak
+	// Version of the pak, empty if legacy pak
 	std::string version;
 
 	// CRC32 checksum of the pak, if given in the pak filename. Note that it
@@ -536,10 +536,12 @@ std::string MakePakName(Str::StringRef name, Str::StringRef version, Util::optio
 const std::vector<PakInfo>& GetAvailablePaks();
 
 // Get the list of available paks that contain maps
-std::vector<PakInfo> GetAvailableMapPaks();
+// Optional mapName to only list paks for this map name
+std::vector<PakInfo> GetAvailableMapPaks( std::string mapName = "" );
 
 // Get the list of available map names
-std::set<std::string> GetAvailableMaps();
+// Optional mapName to only list paks for this map name
+std::set<std::string> GetAvailableMaps( std::string mapName = "" );
 
 // Get the home path
 const std::string& GetHomePath();

--- a/src/engine/server/sv_ccmds.cpp
+++ b/src/engine/server/sv_ccmds.cpp
@@ -59,7 +59,7 @@ class MapCmd: public Cmd::StaticCmd {
             const std::string& mapName = args.Argv(1);
 
             //Make sure the map exists to avoid typos that would kill the game
-            FS::GetAvailableMaps();
+            FS::GetAvailableMaps(mapName);
             const auto loadedPakInfo = FS::PakPath::LocateFile(Str::Format("maps/%s.bsp", mapName));
             if (!loadedPakInfo) {
                 Print("Can't find map %s", mapName);


### PR DESCRIPTION
Only load paks with map name when testing if map name has valid map pak (has bsp file with same name).

Also, only load legacy paks whatever the name when legacy paks are enabled instead of loading all paks whatever the name when legacy paks are enabled.