### PR TITLE
Add syscalls for reading only one of homepath/pakpath

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1338,13 +1338,15 @@ const std::vector<LoadedPakInfo>& GetLoadedPaks()
 
 #ifdef BUILD_VM
 std::string ReadFile(Str::StringRef path, std::error_code& err) {
+	// The VM has a list of all the pak files, so this may save a round trip
+	// if the file doesn't exist, as well as allowing a more specific error.
+	// It may be wrong if more paks are loaded after initialization though?
 	if (!PakPath::FileExists(path)) {
 		SetErrorCodeFilesystem(err, filesystem_error::no_such_file, path);
 		return "";
 	}
 	int length, h;
-	const int mode = 0; // fsMode_t::FS_READ
-	VM::SendMsg<VM::FSFOpenFileMsg>(path, true, mode, length, h);
+	VM::SendMsg<VM::FSOpenPakFileReadMsg>(path, length, h);
 	if (!h) {
 		SetErrorCodeFilesystem(err, filesystem_error::io_error, path);
 		return "";

--- a/src/common/IPC/CommonSyscalls.h
+++ b/src/common/IPC/CommonSyscalls.h
@@ -85,6 +85,7 @@ namespace VM {
         QVM_COMMON_SEND_CONSOLE_COMMAND,
 
         QVM_COMMON_FS_FOPEN_FILE,
+        QVM_COMMON_FS_OPEN_PAK_FILE_READ,
         QVM_COMMON_FS_READ,
         QVM_COMMON_FS_WRITE,
         QVM_COMMON_FS_SEEK,
@@ -105,6 +106,10 @@ namespace VM {
 
     using FSFOpenFileMsg = IPC::SyncMessage<
         IPC::Message<IPC::Id<VM::QVM_COMMON, QVM_COMMON_FS_FOPEN_FILE>, std::string, bool, int>,
+        IPC::Reply<int, int>
+    >;
+    using FSOpenPakFileReadMsg = IPC::SyncMessage<
+        IPC::Message<IPC::Id<VM::QVM_COMMON, QVM_COMMON_FS_OPEN_PAK_FILE_READ>, std::string>,
         IPC::Reply<int, int>
     >;
     using FSReadMsg = IPC::SyncMessage<

--- a/src/common/IPC/CommonSyscalls.h
+++ b/src/common/IPC/CommonSyscalls.h
@@ -90,7 +90,6 @@ namespace VM {
         QVM_COMMON_FS_SEEK,
         QVM_COMMON_FS_TELL,
         QVM_COMMON_FS_FILELENGTH,
-        QVM_COMMON_FS_RENAME,
         QVM_COMMON_FS_FCLOSE_FILE,
         QVM_COMMON_FS_GET_FILE_LIST,
         QVM_COMMON_FS_GET_FILE_LIST_RECURSIVE,
@@ -128,7 +127,6 @@ namespace VM {
 		IPC::Message<IPC::Id<VM::QVM_COMMON, QVM_COMMON_FS_FILELENGTH>, fileHandle_t>,
 		IPC::Reply<int>
 	>;
-    using FSRenameMsg = IPC::Message<IPC::Id<VM::QVM_COMMON, QVM_COMMON_FS_RENAME>, std::string, std::string>;
     using FSFCloseFileMsg = IPC::Message<IPC::Id<VM::QVM_COMMON, QVM_COMMON_FS_FCLOSE_FILE>, int>;
     using FSGetFileListMsg = IPC::SyncMessage<
         IPC::Message<IPC::Id<VM::QVM_COMMON, QVM_COMMON_FS_GET_FILE_LIST>, std::string, std::string, int>,

--- a/src/engine/framework/CommonVMServices.cpp
+++ b/src/engine/framework/CommonVMServices.cpp
@@ -293,11 +293,6 @@ namespace VM {
 					res = FS_filelength(f);
 				});
 				break;
-            case QVM_COMMON_FS_RENAME:
-                IPC::HandleMsg<FSRenameMsg>(channel, std::move(reader), [this](const std::string& from, const std::string& to) {
-                    FS_Rename(from.c_str(), to.c_str());
-                });
-                break;
 
             case QVM_COMMON_FS_FCLOSE_FILE:
                 IPC::HandleMsg<FSFCloseFileMsg>(channel, std::move(reader), [this](int handle) {

--- a/src/engine/framework/CommonVMServices.cpp
+++ b/src/engine/framework/CommonVMServices.cpp
@@ -257,6 +257,19 @@ namespace VM {
                 });
                 break;
 
+            case QVM_COMMON_FS_OPEN_PAK_FILE_READ:
+                IPC::HandleMsg<FSOpenPakFileReadMsg>(channel, std::move(reader), [this](const std::string& filename, int& length, int& handle) {
+                    if (!FS::PakPath::FileExists(filename)) {
+                        handle = 0;
+                        length = -1;
+                        return;
+                    }
+                    length = FS_FOpenFileRead(filename.c_str(), &handle);
+                    if (handle > 0)
+                        FS_SetOwner(handle, fileOwnership);
+                });
+                break;
+
             case QVM_COMMON_FS_READ:
                 IPC::HandleMsg<FSReadMsg>(channel, std::move(reader), [this](int handle, int len, std::string& res, int& ret) {
                     FS_CheckOwnership(handle, fileOwnership);

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -223,10 +223,8 @@ int FS_Game_FOpenFileByMode(const char* path, fileHandle_t* handle, fsMode_t mod
 		*handle = FS_FOpenFileAppend(FS::Path::Build("game", path).c_str());
 		handleTable[*handle].forceFlush = mode == fsMode_t::FS_APPEND_SYNC;
 		return *handle == 0 ? -1 : 0;
-
-	default:
-		Sys::Drop("FS_Game_FOpenFileByMode: bad mode %s", Util::enum_str(mode));
 	}
+	Sys::Drop("FS_Game_FOpenFileByMode: bad mode %s", Util::enum_str(mode));
 }
 
 void FS_SetOwner(fileHandle_t f, FS::Owner owner)

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -202,25 +202,25 @@ static int FS_SV_FOpenFileRead(const char* path, fileHandle_t* handle)
 	return length;
 }
 
+// Opens a file in <homepath>/game/
 int FS_Game_FOpenFileByMode(const char* path, fileHandle_t* handle, fsMode_t mode)
 {
+	std::string path2 = FS::Path::Build("game", path);
 	switch (mode) {
 	case fsMode_t::FS_READ:
-		if (FS::PakPath::FileExists(path))
-			return FS_FOpenFileRead(path, handle);
-		else {
-			int size = FS_SV_FOpenFileRead(FS::Path::Build("game", path).c_str(), handle);
-			return (!handle || *handle) ? size : -1;
-		}
+	{
+		int size = FS_SV_FOpenFileRead(path2.c_str(), handle);
+		return (!handle || *handle) ? size : -1;
+	}
 
 	case fsMode_t::FS_WRITE:
 	case fsMode_t::FS_WRITE_VIA_TEMPORARY:
-		*handle = FS_FOpenFileWrite_internal(FS::Path::Build("game", path).c_str(), mode == fsMode_t::FS_WRITE_VIA_TEMPORARY);
+		*handle = FS_FOpenFileWrite_internal(path2.c_str(), mode == fsMode_t::FS_WRITE_VIA_TEMPORARY);
 		return *handle == 0 ? -1 : 0;
 
 	case fsMode_t::FS_APPEND:
 	case fsMode_t::FS_APPEND_SYNC:
-		*handle = FS_FOpenFileAppend(FS::Path::Build("game", path).c_str());
+		*handle = FS_FOpenFileAppend(path2.c_str());
 		handleTable[*handle].forceFlush = mode == fsMode_t::FS_APPEND_SYNC;
 		return *handle == 0 ? -1 : 0;
 	}

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -430,18 +430,13 @@ int FS_Delete(const char* path)
 	return 0;
 }
 
-void FS_Rename(const char* from, const char* to)
+void FS_SV_Rename(const char* from, const char* to)
 {
 	try {
 		FS::HomePath::MoveFile(to, from);
 	} catch (std::system_error& err) {
 		Log::Notice("Failed to move '%s' to '%s': %s\n", from, to, err.what());
 	}
-}
-
-void FS_SV_Rename(const char* from, const char* to)
-{
-	FS_Rename(from, to);
 }
 
 void FS_WriteFile(const char* path, const void* buffer, int size)

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -1379,8 +1379,6 @@ void         ByteToDir( int b, vec3_t dir );
 	  FS_WRITE,
 	  FS_APPEND,
 	  FS_APPEND_SYNC,
-	  FS_READ_DIRECT,
-	  FS_UPDATE,
 	  FS_WRITE_VIA_TEMPORARY,
 	};
 

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -462,8 +462,6 @@ bool     FS_LoadServerPaks( const char* paks, bool isDemo );
 void FS_DeletePaksWithBadChecksum();
 bool FS_ComparePaks(char* neededpaks, int len);
 
-void       FS_Rename( const char *from, const char *to );
-
 /*
 ==============================================================
 

--- a/src/shared/CommonProxies.cpp
+++ b/src/shared/CommonProxies.cpp
@@ -589,11 +589,6 @@ int trap_FS_FileLength( fileHandle_t f )
 	return ret;
 }
 
-void trap_FS_Rename(const char *from, const char *to)
-{
-	VM::SendMsg<VM::FSRenameMsg>(from, to);
-}
-
 void trap_FS_FCloseFile(fileHandle_t f)
 {
 	VM::SendMsg<VM::FSFCloseFileMsg>(f);

--- a/src/shared/CommonProxies.cpp
+++ b/src/shared/CommonProxies.cpp
@@ -530,6 +530,7 @@ void trap_SendConsoleCommand(const char *text)
 	VM::SendMsg<VM::SendConsoleCommandMsg>(text);
 }
 
+// Open a file in <homepath>/game/
 int trap_FS_FOpenFile(const char *qpath, fileHandle_t *f, fsMode_t mode)
 {
 	int length, handle;
@@ -542,12 +543,8 @@ int trap_FS_FOpenFile(const char *qpath, fileHandle_t *f, fsMode_t mode)
 // Open for reading
 int trap_FS_OpenPakFile(Str::StringRef path, fileHandle_t &f)
 {
-	if (!FS::PakPath::FileExists(path)) {
-		f = 0;
-		return -1;
-	}
 	int length;
-	VM::SendMsg<VM::FSFOpenFileMsg>(path, true, Util::ordinal(fsMode_t::FS_READ), length, f);
+	VM::SendMsg<VM::FSOpenPakFileReadMsg>(path, length, f);
 	return length;
 }
 


### PR DESCRIPTION
Used to make it possible to have files which can be in either of homepath or pakpath, but with homepath taking predence.