### PR TITLE
tr_shade: workaround to not crash on liquidMap when liquidMapping is disabled

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2711,7 +2711,19 @@ void Tess_StageIteratorGeneric()
 
 			case stageType_t::ST_LIQUIDMAP:
 				{
-					Render_liquid( stage );
+					if ( r_liquidMapping->integer )
+					{
+						Render_liquid( stage );
+					}
+					else
+					{
+						/* FIXME: workaround to display something and not crash
+						when liquidMapping is enabled, until we fix liquidMap. */
+						pStage->type = stageType_t::ST_DIFFUSEMAP;
+						pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] = tr.whiteImage;
+						Render_lightMapping( stage );
+					}
+
 					break;
 				}
 


### PR DESCRIPTION
liquidMapping is not functional and not used yet, but we need to not
crash when loading liquidMap test assets while liquidMapping is disabled.

When liquidMapping is disabled this patch just display the liquidMap as
a diffuseMap with a white opaque texture and the liquidMap as normalMap.

No playable map uses liquidMap yet and liquidMap syntax is likely to be
entirely redone in the future so I see no need to implement more complex
workaround (like adding translucency).