### PR TITLE
PakPath::ReadFile - don't rely on FileExists

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1338,15 +1338,11 @@ const std::vector<LoadedPakInfo>& GetLoadedPaks()
 
 #ifdef BUILD_VM
 std::string ReadFile(Str::StringRef path, std::error_code& err) {
-	if (!PakPath::FileExists(path)) {
-		SetErrorCodeFilesystem(err, filesystem_error::no_such_file, path);
-		return "";
-	}
 	int length, h;
 	const int mode = 0; // fsMode_t::FS_READ
 	VM::SendMsg<VM::FSFOpenFileMsg>(path, true, mode, length, h);
 	if (!h) {
-		SetErrorCodeFilesystem(err, filesystem_error::io_error, path);
+		SetErrorCodeFilesystem(err, filesystem_error::no_such_file, path);
 		return "";
 	}
 	std::string content;

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -331,6 +331,7 @@ namespace PakPath {
 	void CopyFile(Str::StringRef path, const File& dest, std::error_code& err = throws());
 
 	// Check if a file exists
+	// BEWARE: this doesn't work inside a VM if a pak was loaded after the VM starts!
 	bool FileExists(Str::StringRef path);
 
 	// Get the pak a file is in, or null if the file does not exist


### PR DESCRIPTION
My recent filesystem changes on the Unvanquished - in particular, using PakPath::ReadFile more - triggered this bug where ReadFile doesn't work on paks loaded after the first frame.