### PR TITLE
Fast engine shutdown

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -2297,6 +2297,8 @@ void Initialize(Str::StringRef homePath, Str::StringRef libPath, const std::vect
 
 void FlushAll()
 {
+	// Works (in the engine) as both FS::File and the older files.cpp (FS_FOpenFileWrite etc.)
+	// are ultimately based on FILE*
 	fflush(nullptr);
 }
 

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -65,8 +65,7 @@ const std::error_category& filesystem_category();
 // Track ownership of old-style file handles
 enum class Owner
 {
-	UNKNOWN,
-	ENGINE, // TODO: use
+	ENGINE,
 	CGAME,
 	SGAME,
 };

--- a/src/common/System.h
+++ b/src/common/System.h
@@ -188,6 +188,8 @@ void GenRandomBytes(void* dest, size_t size);
 
 bool IsDebuggerAttached();
 
+bool PedanticShutdown();
+
 } // namespace Sys
 
 #endif // COMMON_SYSTEM_H_

--- a/src/engine/client/ClientApplication.cpp
+++ b/src/engine/client/ClientApplication.cpp
@@ -101,10 +101,13 @@ class ClientApplication : public Application {
             #endif
 
             TRY_SHUTDOWN(CL_Shutdown());
-            TRY_SHUTDOWN(
-                SV_Shutdown(error ? Str::Format("Server fatal crashed: %s", message).c_str() : message.c_str())
-            );
-            TRY_SHUTDOWN(NET_Shutdown());
+            std::string serverMessage = error ? "Server fatal error: " + message : std::string(message);
+            if (Sys::PedanticShutdown()) {
+                TRY_SHUTDOWN(SV_Shutdown(message.c_str()));
+                TRY_SHUTDOWN(NET_Shutdown());
+            } else {
+                TRY_SHUTDOWN(SV_QuickShutdown(message.c_str()));
+            }
 
             #if defined(_WIN32) || defined(BUILD_GRAPHICAL_CLIENT)
                 // Always run SDL_Quit, because it restores system resolution and gamma.

--- a/src/engine/client/ClientApplication.cpp
+++ b/src/engine/client/ClientApplication.cpp
@@ -104,7 +104,7 @@ class ClientApplication : public Application {
             TRY_SHUTDOWN(
                 SV_Shutdown(error ? Str::Format("Server fatal crashed: %s", message).c_str() : message.c_str())
             );
-            TRY_SHUTDOWN(Com_Shutdown());
+            TRY_SHUTDOWN(NET_Shutdown());
 
             #if defined(_WIN32) || defined(BUILD_GRAPHICAL_CLIENT)
                 // Always run SDL_Quit, because it restores system resolution and gamma.

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2949,6 +2949,7 @@ void CL_Init()
 ===============
 CL_Shutdown
 
+Called only when Daemon is exiting
 ===============
 */
 void CL_Shutdown()

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2970,6 +2970,17 @@ void CL_Shutdown()
 
 	recursive = true;
 
+	// quick version
+	if ( !Sys::PedanticShutdown() )
+	{
+		CL_ShutdownCGame();
+		CL_SendDisconnect();
+		CL_StopRecord();
+		StopVideo();
+		// TODO: call DL_StopDownload when deleting the temp file is implemented
+		return;
+	}
+
 	CL_Disconnect( true );
 
 	CL_ShutdownCGame();

--- a/src/engine/framework/LogSystem.cpp
+++ b/src/engine/framework/LogSystem.cpp
@@ -160,4 +160,12 @@ namespace Log {
             Sys::Error("Could not open log file %s: %s", logFileName.Get(), err.what());
         }
     }
+
+    void FlushLogFile() {
+        std::error_code err;
+        logfile.logFile.Flush(err);
+        if (err) {
+            Log::Warn("Error flushing log file");
+        }
+    }
 }

--- a/src/engine/framework/LogSystem.h
+++ b/src/engine/framework/LogSystem.h
@@ -50,6 +50,8 @@ namespace Log {
     // Open the log file and start writing to it
     void OpenLogFile();
 
+    void FlushLogFile();
+
     class Target {
         public:
             Target();

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -301,6 +301,11 @@ static void Shutdown(bool error, Str::StringRef message)
 
 void Quit(Str::StringRef message)
 {
+	if (message.empty()) {
+		Log::Notice("Quitting");
+	} else {
+		Log::Notice("Quitting: %s", message);
+	}
 	Shutdown(false, message);
 
 	OSExit(0);

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -283,12 +283,12 @@ static void Shutdown(bool error, Str::StringRef message)
 	// Stop accepting commands from other instances
 	CloseSingletonSocket();
 
-    Application::Shutdown(error, message);
+	Application::Shutdown(error, message);
 
-	if ( !error)
-	{
+	if (PedanticShutdown()) {
 		Cvar::Shutdown();
 	}
+
 	// Always run CON_Shutdown, because it restores the terminal to a usable state.
 	CON_Shutdown();
 

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -275,7 +275,7 @@ static void CloseSingletonSocket()
 }
 
 // Common code for fatal and non-fatal exit
-// TODO: Handle shutdown requests coming from multiple threads
+// TODO: Handle shutdown requests coming from multiple threads (could happen from the *nix signal thread)
 static void Shutdown(bool error, Str::StringRef message)
 {
 	FS::FlushAll();

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -286,6 +286,9 @@ static void Shutdown(bool error, Str::StringRef message)
 	Application::Shutdown(error, message);
 
 	if (PedanticShutdown()) {
+		// could be interesting to see if there are some we forgot to close
+		FS_CloseAllForOwner(FS::Owner::ENGINE);
+
 		Cvar::Shutdown();
 	}
 

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -276,9 +276,10 @@ static void CloseSingletonSocket()
 
 // Common code for fatal and non-fatal exit
 // TODO: Handle shutdown requests coming from multiple threads
-// TODO: Dump log files & other stuff
 static void Shutdown(bool error, Str::StringRef message)
 {
+	FS::FlushAll();
+
 	// Stop accepting commands from other instances
 	CloseSingletonSocket();
 
@@ -290,6 +291,9 @@ static void Shutdown(bool error, Str::StringRef message)
 	}
 	// Always run CON_Shutdown, because it restores the terminal to a usable state.
 	CON_Shutdown();
+
+	// Flush the logs one last time. Logs are turned off when OSExit is called.
+	Log::FlushLogFile();
 }
 
 void Quit(Str::StringRef message)

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -1082,14 +1082,3 @@ void Com_Frame()
 
 	com_frameNumber++;
 }
-
-/*
-=================
-Com_Shutdown
-=================
-*/
-void Com_Shutdown()
-{
-	NET_Shutdown();
-	FS::FlushAll();
-}

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -251,7 +251,6 @@ void FS_CloseAllForOwner(FS::Owner owner)
 	for (int f = 1; f < MAX_FILE_HANDLES; f++) {
 		if (handleTable[f].owner == owner && handleTable[f].isOpen) {
 			FS_FCloseFile(f);
-			++numClosed;
 		}
 	}
 	fsLogs.Verbose("Closed %d outstanding handles for owner %d", numClosed, Util::ordinal(owner));

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -70,7 +70,7 @@ static fileHandle_t FS_AllocHandle()
 	// Don't use handle 0 because it is used to indicate failures
 	for (int i = 1; i < MAX_FILE_HANDLES; i++) {
 		if (!handleTable[i].isOpen) {
-			handleTable[i].owner = FS::Owner::UNKNOWN;
+			handleTable[i].owner = FS::Owner::ENGINE;
 			return i;
 		}
 	}
@@ -229,10 +229,12 @@ int FS_Game_FOpenFileByMode(const char* path, fileHandle_t* handle, fsMode_t mod
 	}
 }
 
+// Set a VM as the owner
 void FS_SetOwner(fileHandle_t f, FS::Owner owner)
 {
 	FS_CheckHandle(f, false);
-	ASSERT_EQ(handleTable[f].owner, FS::Owner::UNKNOWN);
+	ASSERT_EQ(handleTable[f].owner, FS::Owner::ENGINE);
+	ASSERT_NQ(owner, FS::Owner::ENGINE);
 	handleTable[f].owner = owner;
 }
 

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -708,6 +708,7 @@ void CL_ShutdownAll();
 //
 void     SV_Init();
 void     SV_Shutdown( const char *finalmsg );
+void     SV_QuickShutdown( const char *finalmsg );
 void     SV_Frame( int msec );
 void     SV_PacketEvent( const netadr_t& from, msg_t *msg );
 int      SV_FrameMsec();

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -644,7 +644,6 @@ void   Hunk_FreeTempMemory( void *buf );
 // commandLine should not include the executable name (argv[0])
 void   Com_Init();
 void   Com_Frame();
-void   Com_Shutdown();
 
 /*
 ==============================================================

--- a/src/engine/server/ServerApplication.cpp
+++ b/src/engine/server/ServerApplication.cpp
@@ -70,7 +70,7 @@ class ServerApplication : public Application {
             TRY_SHUTDOWN(
                 SV_Shutdown(error ? Str::Format("Server fatal crashed: %s", message).c_str() : message.c_str())
             );
-            TRY_SHUTDOWN(Com_Shutdown());
+            TRY_SHUTDOWN(NET_Shutdown());
         }
 };
 

--- a/src/engine/server/ServerApplication.cpp
+++ b/src/engine/server/ServerApplication.cpp
@@ -67,10 +67,13 @@ class ServerApplication : public Application {
         }
 
         void Shutdown(bool error, Str::StringRef message) override {
-            TRY_SHUTDOWN(
-                SV_Shutdown(error ? Str::Format("Server fatal crashed: %s", message).c_str() : message.c_str())
-            );
-            TRY_SHUTDOWN(NET_Shutdown());
+            std::string serverMessage = error ? "Server fatal error: " + message : std::string(message);
+            if (Sys::PedanticShutdown()) {
+                TRY_SHUTDOWN(SV_Shutdown(message.c_str()));
+                TRY_SHUTDOWN(NET_Shutdown());
+            } else {
+                TRY_SHUTDOWN(SV_QuickShutdown(message.c_str()));
+            }
         }
 };
 

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -725,8 +725,7 @@ void SV_QuickShutdown( const char *finalmsg )
 ================
 SV_Shutdown
 
-Called when each game quits,
-before Sys_Quit or Sys_Error
+Called to shut down the sgame VM, or to clean up after the VM shut down on its own
 ================
 */
 void SV_Shutdown( const char *finalmsg )

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -701,6 +701,26 @@ void SV_FinalCommand( char *cmd, bool disconnect )
 	}
 }
 
+// Used instead of SV_Shutdown when Daemon is exiting
+void SV_QuickShutdown( const char *finalmsg )
+{
+	if ( !com_sv_running || !com_sv_running->integer )
+	{
+		return;
+	}
+
+	PrintBanner( "Server Shutdown" )
+
+	if ( svs.clients )
+	{
+		SV_FinalCommand( va( "print %s", Cmd_QuoteString( finalmsg ) ), true );
+	}
+
+	SV_ShutdownGameProgs();
+
+	// TODO: call SV_MasterShutdown but make it not block on DNS resolution
+}
+
 /*
 ================
 SV_Shutdown
@@ -716,18 +736,12 @@ void SV_Shutdown( const char *finalmsg )
 		return;
 	}
 
-	PrintBanner( "Server Shutdown" )
+	SV_QuickShutdown( finalmsg );
 
 	NET_LeaveMulticast6();
 
-	if ( svs.clients )
-	{
-		SV_FinalCommand( va( "print %s", Cmd_QuoteString( finalmsg ) ), true );
-	}
-
 	SV_RemoveOperatorCommands();
 	SV_MasterShutdown();
-	SV_ShutdownGameProgs();
 
 	// free current level
 	SV_ClearServer();

--- a/src/shared/VMMain.cpp
+++ b/src/shared/VMMain.cpp
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
 	// The socket handle is sent as the first argument
 	if (argc != 2) {
 		fprintf(stderr, "This program is not meant to be invoked directly, it must be invoked by the engine's VM loader.\n");
-		Sys::OSExit(1);
+		exit(1);
 	}
 	char* end;
 #ifdef _WIN32
@@ -132,7 +132,7 @@ int main(int argc, char** argv)
 #endif
 	if (argv[1] == end || *end != '\0') {
 		fprintf(stderr, "Parameter is not a valid handle number\n");
-		Sys::OSExit(1);
+		exit(1);
 	}
 
 	// Set up crash handling for this process. This will allow crashes to be


### PR DESCRIPTION
Shut down the engine quickly instead of doing nonsense like reloading the filesystem before exit. If you want to do all that stuff for debugging purposes (e.g. to detect memory leaks) you can use the `common.pedanticShutdown` cvar.

Things I identified as important shutdown tasks which shouldn't be skipped:
- Flush files
- Terminate gamelogic VMs
- Send "dead heartbeat" to master server (not done because it might block on DNS)
- Restore terminal state
- Close the single-instance lock file
- SDL_Quit to clean up full screen stuff
- For clients, send disconnection packet to the server
- Delete temp files from downloads (not implemented)
- Remove temp files from FS_WRITE_VIA_TEMPORARY
- Finish demo recording
- Finish video recording

Also do proper shutdown when clicking X on the Windows curses window.