### PR TITLE
logs.logLevel -> logs.level in cvar names

### DIFF
--- a/src/common/Log.cpp
+++ b/src/common/Log.cpp
@@ -34,7 +34,7 @@ namespace Log {
 
     Logger::Logger(Str::StringRef name, std::string prefix, Level defaultLevel)
         : filterLevel(new Cvar::Cvar<Log::Level>(
-              "logs.logLevel." + name, "Log::Level - logs from '" + name + "' below the level specified are filtered", 0, defaultLevel)),
+              "logs.level." + name, "Log::Level - logs from '" + name + "' below the level specified are filtered", 0, defaultLevel)),
           prefix(prefix), enableSuppression(true) {
     }
 

--- a/src/common/Log.h
+++ b/src/common/Log.h
@@ -70,7 +70,7 @@ namespace Log {
      *   });
      *
      * In addition the user/developer can control the filtering level with
-     *   /set logs.logLevel.foo.bar {warning, info, verbose, debug}
+     *   /set logs.level.foo.bar {warning, info, verbose, debug}
      *
      * To intentionally print a message repeatedly at high volume without getting it blocked as
      * log spam, do like thus:
@@ -114,7 +114,7 @@ namespace Log {
 
             std::string Prefix(std::string message) const;
 
-            // the cvar logs.logLevel.<name>
+            // the cvar logs.level.<name>
             std::shared_ptr<Cvar::Cvar<Level>> filterLevel;
 
             // a prefix appended to all the messages of this logger


### PR DESCRIPTION
`logs.logLevel` is too long and repetitive :)