### PR TITLE
Fix DLL unloading on MacOS

### DIFF
--- a/src/common/IPC/Primitives.cpp
+++ b/src/common/IPC/Primitives.cpp
@@ -321,7 +321,7 @@ static void FreeHandles(const NaClHandle* h)
 }
 #endif
 
-#ifndef __native_client__
+#ifdef BUILD_ENGINE
 thread_local
 #endif
 static std::unique_ptr<char[]> recvBuffer;


### PR DESCRIPTION
On MacOS, dlclose has no effect if the shared library contains a
thread_local variable. Get rid of an instance of thread_local
in gamelogic DLLs to fix this. It is important for gamelogic
DLLs to be unloaded and reloaded so that memory is freed and
variables reinitialized.
