### PR TITLE
Use the right .cfg files for each application

### DIFF
--- a/src/engine/client/ClientApplication.cpp
+++ b/src/engine/client/ClientApplication.cpp
@@ -63,7 +63,9 @@ class ClientApplication : public Application {
 	        Cmd::BufferCommandText("preset default.cfg");
 	        if (!resetConfig) {
                 Cmd::BufferCommandText("exec -f " CONFIG_NAME);
-                Cmd::BufferCommandText("exec -f " KEYBINDINGS_NAME);
+                if (traits.isClient) {
+                    Cmd::BufferCommandText("exec -f " KEYBINDINGS_NAME);
+                }
                 Cmd::BufferCommandText("exec -f " AUTOEXEC_NAME);
 	        }
         }

--- a/src/engine/null/NullApplication.cpp
+++ b/src/engine/null/NullApplication.cpp
@@ -36,6 +36,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "framework/CommandSystem.h"
 #include "qcommon/qcommon.h"
 
+void FS_CloseAllForOwner(FS::Owner) {}
+
 namespace Application {
 
 class NullApplication : public Application {

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -716,12 +716,14 @@ void Com_WriteConfiguration()
 		return;
 	}
 
+#if defined(BUILD_GRAPHICAL_CLIENT) || defined(BUILD_TTY_CLIENT)
 	if ( cvar_modifiedFlags & CVAR_ARCHIVE_BITS )
 	{
 		cvar_modifiedFlags &= ~CVAR_ARCHIVE_BITS;
 
 		Com_WriteConfigToFile( CONFIG_NAME, Cvar_WriteVariables );
 	}
+#endif
 
 #ifdef BUILD_GRAPHICAL_CLIENT
 	if ( bindingsModified )


### PR DESCRIPTION
Fixes #555. (The config can be reset if you run `daemonded` because it writes autogen.cfg but does not read it.)