### PR TITLE
Lower maximum FPS to 333 to avoid various issues

### DIFF
--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -912,25 +912,28 @@ void Com_Frame()
 		{
 			if ( com_minimized->integer && maxfpsMinimized.Get() > 0 )
 			{
-				minMsec = 1000 / maxfpsMinimized.Get();
+				minMsec = 1000 / std::min(maxfpsMinimized.Get(), 333);
 			}
 			else if ( com_unfocused->integer && maxfpsUnfocused.Get() > 0 )
 			{
-				minMsec = 1000 / maxfpsUnfocused.Get();
+				minMsec = 1000 / std::min(maxfpsUnfocused.Get(), 333);
 			}
 			else if ( maxfps.Get() > 0 )
 			{
-				minMsec = 1000 / maxfps.Get();
+				minMsec = 1000 / std::min(maxfps.Get(), 333);
 			}
 			else
 			{
-				minMsec = 1;
+				minMsec = 3;
 			}
 		}
 	}
 	else
 	{
-		minMsec = 1; // Bad things happen if this is 0
+		// Bad things happen if this is 0.
+		// At 1 or 2, the game still runs but exhibits various issues
+		// (such as the first-person weapon model flickering).
+		minMsec = 3;
 	}
 
 	Com_EventLoop();


### PR DESCRIPTION
This prevents the first-person weapon model from flickering and also avoids persistent "Connection Interrupted" screens. 333 FPS is still enough to feed almost any monitor out there (excluding the currently elusive 360 Hz and 390 Hz monitors), provided your hardware is fast enough.

Note: I don't have a development setup, so I didn't test this.

This closes https://github.com/Unvanquished/Unvanquished/issues/1734.