### PR TITLE
Map paks must be named map-<mapname>

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -2775,20 +2775,6 @@ const std::vector<PakInfo>& GetAvailablePaks()
 	return availablePaks;
 }
 
-
-std::vector<PakInfo> GetAvailableMapPaks()
-{
-	std::vector<PakInfo> infos;
-	for ( const auto& pak : FS::GetAvailablePaks() )
-	{
-		if (UseLegacyPaks() || Str::IsPrefix("map-", pak.name))
-		{
-			infos.push_back(pak);
-		}
-	}
-	return infos;
-}
-
 std::set<std::string> GetAvailableMaps()
 {
 	std::set<std::string> maps;

--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -2791,19 +2791,13 @@ std::set<std::string> GetAvailableMaps()
 	#ifndef BUILD_VM
 		RefreshPaks();
 	#endif
-	std::error_code ignore;
-	for ( const auto& pak : GetAvailableMapPaks() )
-	{
-		FS::PakPath::LoadPakPrefix(pak, "maps", ignore);
-	}
 
-	static const std::string map_suffix = ".bsp";
-
-	for ( const auto& file : FS::PakPath::ListFiles("maps", ignore) )
+	for (const auto& pak : FS::GetAvailablePaks())
 	{
-		if ( Str::IsSuffix(map_suffix, file) )
+		const std::string prefix = "map-";
+		if (Str::IsPrefix(prefix, pak.name) && pak.name.size() > prefix.size())
 		{
-			maps.insert( file.substr(0, file.size() - map_suffix.size()) );
+			maps.insert(pak.name.substr(prefix.size()));
 		}
 	}
 

--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1142,7 +1142,7 @@ static void ParseDeleted(const PakInfo& parent, Str::StringRef deletedData)
 
 // Parse the dependencies file of a package
 // Each line of the dependencies file is a name followed by an optional version
-static void ParseDeps(const PakInfo& parent, Str::StringRef depsData, std::error_code& err)
+static void ParseDeps(const PakInfo& parent, Str::StringRef depsData, Str::StringRef prefix, std::error_code& err)
 {
 	auto lineStart = depsData.begin();
 	int line = 0;
@@ -1176,7 +1176,7 @@ static void ParseDeps(const PakInfo& parent, Str::StringRef depsData, std::error
 				SetErrorCodeFilesystem(err, filesystem_error::missing_dependency);
 				return;
 			}
-			LoadPak(*pak, err);
+			LoadPakPrefix(*pak, prefix, err);
 			if (err)
 				return;
 			lineStart = lineEnd == depsData.end() ? lineEnd : lineEnd + 1;
@@ -1200,7 +1200,7 @@ static void ParseDeps(const PakInfo& parent, Str::StringRef depsData, std::error
 				SetErrorCodeFilesystem(err, filesystem_error::missing_dependency);
 				return;
 			}
-			LoadPak(*pak, err);
+			LoadPakPrefix(*pak, prefix, err);
 			if (err)
 				return;
 			lineStart = lineEnd == depsData.end() ? lineEnd : lineEnd + 1;
@@ -1444,7 +1444,7 @@ static void InternalLoadPak(const PakInfo& pak, Util::optional<uint32_t> expecte
 			} else {
 				ASSERT_UNREACHABLE();
 			}
-			ParseDeps(pak, depsData, err);
+			ParseDeps(pak, depsData, pathPrefix, err);
 		}
 	}
 }

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -310,7 +310,7 @@ namespace PakPath {
 	void LoadPak(const PakInfo& pak, std::error_code& err = throws());
 
 	// Load a subset of a pak, only loading subpaths starting with the given prefix
-	// Includes dependency paks
+	// Does not load dependencies.
 	void LoadPakPrefix(const PakInfo& pak, Str::StringRef pathPrefix, std::error_code& err = throws());
 
 	// Load a pak into the namespace and verify its checksum but *don't* load its dependencies

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -537,7 +537,7 @@ std::string MakePakName(Str::StringRef name, Str::StringRef version, Util::optio
 const std::vector<PakInfo>& GetAvailablePaks();
 
 // Get the list of available map names
-std::set<std::string> GetAvailableMaps();
+std::set<std::string> GetAvailableMaps(bool allowLegacyPaks);
 
 // Get the home path
 const std::string& GetHomePath();

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -310,6 +310,7 @@ namespace PakPath {
 	void LoadPak(const PakInfo& pak, std::error_code& err = throws());
 
 	// Load a subset of a pak, only loading subpaths starting with the given prefix
+	// Includes dependency paks
 	void LoadPakPrefix(const PakInfo& pak, Str::StringRef pathPrefix, std::error_code& err = throws());
 
 	// Load a pak into the namespace and verify its checksum but *don't* load its dependencies

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -536,9 +536,6 @@ std::string MakePakName(Str::StringRef name, Str::StringRef version, Util::optio
 // Get the list of available paks
 const std::vector<PakInfo>& GetAvailablePaks();
 
-// Get the list of available paks that contain maps
-std::vector<PakInfo> GetAvailableMapPaks();
-
 // Get the list of available map names
 std::set<std::string> GetAvailableMaps();
 

--- a/src/common/IPC/CommonSyscalls.h
+++ b/src/common/IPC/CommonSyscalls.h
@@ -291,7 +291,7 @@ namespace VM {
         IPC::Reply<Util::optional<uint64_t>>
     >;
     using FSPakPathLoadPakMsg = IPC::SyncMessage<
-        IPC::Message<IPC::Id<FILESYSTEM, FS_PAKPATH_LOADPAK>, uint32_t, Util::optional<uint32_t>, std::string>
+        IPC::Message<IPC::Id<FILESYSTEM, FS_PAKPATH_LOADPAK>, uint32_t, Util::optional<uint32_t>, std::string, bool>
     >;
 
 }

--- a/src/common/IPC/CommonSyscalls.h
+++ b/src/common/IPC/CommonSyscalls.h
@@ -96,7 +96,6 @@ namespace VM {
         QVM_COMMON_FS_GET_FILE_LIST_RECURSIVE,
         QVM_COMMON_FS_FIND_PAK,
         QVM_COMMON_FS_LOAD_PAK,
-        QVM_COMMON_FS_LOAD_MAP_METADATA,
     };
 
     using ErrorMsg = IPC::SyncMessage<
@@ -148,9 +147,6 @@ namespace VM {
     using FSLoadPakMsg = IPC::SyncMessage<
         IPC::Message<IPC::Id<VM::QVM_COMMON, QVM_COMMON_FS_LOAD_PAK>, std::string, std::string>,
         IPC::Reply<bool>
-    >;
-    using FSLoadMapMetadataMsg = IPC::SyncMessage<
-        IPC::Message<IPC::Id<VM::QVM_COMMON, QVM_COMMON_FS_LOAD_MAP_METADATA>>
     >;
 
     // Misc Syscall Definitions

--- a/src/engine/client/cg_api.h
+++ b/src/engine/client/cg_api.h
@@ -138,7 +138,6 @@ void            trap_FS_FCloseFile( fileHandle_t f );
 int             trap_FS_GetFileList( const char *path, const char *extension, char *listbuf, int bufsize );
 int             trap_FS_GetFileListRecursive( const char *path, const char *extension, char *listbuf, int bufsize );
 bool        trap_FS_LoadPak( const char *pak, const char *prefix );
-void            trap_FS_LoadAllMapMetadata();
 void            trap_SendConsoleCommand( const char *text );
 void            trap_AddCommand( const char *cmdName );
 void            trap_RemoveCommand( const char *cmdName );

--- a/src/engine/framework/CommonVMServices.cpp
+++ b/src/engine/framework/CommonVMServices.cpp
@@ -352,12 +352,6 @@ namespace VM {
                 });
                 break;
 
-            case QVM_COMMON_FS_LOAD_MAP_METADATA:
-                IPC::HandleMsg<FSLoadMapMetadataMsg>(channel, std::move(reader), [this] {
-                    FS_LoadAllMapMetadata();
-                });
-                break;
-
             default:
                 Sys::Drop("Bad log syscall number '%d' for VM '%s'", minor, vmName.c_str());
         }

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -676,28 +676,6 @@ void FS_LoadBasePak()
 	Sys::Error("Could not load default base pak '%s'", DEFAULT_BASE_PAK);
 }
 
-void FS_LoadAllMapMetadata()
-{
-	const std::string pak_map_prefix("map-");
-
-	for (const auto& pak: FS::GetAvailableMapPaks()) {
-		try {
-			// If pak name is long enough to have “map-” prefix,
-			// and pak name without ”map-” prefix is not empty string.
-			if (pak.name.length() > pak_map_prefix.length())
-			{
-				// If pak name starts with “map-” prefix
-				if (Str::IsPrefix(pak_map_prefix, pak.name))
-				{
-					// FIXME: This looks to be game-specific,
-					// not all games use “meta/” mechanism.
-					FS::PakPath::LoadPakPrefix(pak, va("meta/%s/", pak.name.substr(pak_map_prefix.length()).c_str()));
-				}
-			}
-		} catch (std::system_error&) {} // ignore and move on
-	}
-}
-
 bool FS_LoadServerPaks(const char* paks, bool isDemo)
 {
 	Cmd::Args args(paks);

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -454,7 +454,6 @@ const char* FS_LoadedPaks();
 
 bool     FS_LoadPak( const char *name );
 void     FS_LoadBasePak();
-void     FS_LoadAllMapMetadata();
 bool     FS_LoadServerPaks( const char* paks, bool isDemo );
 
 // shutdown and restart the filesystem so changes to fs_gamedir can take effect

--- a/src/engine/server/sv_ccmds.cpp
+++ b/src/engine/server/sv_ccmds.cpp
@@ -61,6 +61,7 @@ class MapCmd: public Cmd::StaticCmd {
             std::string pakName;
 
             //Make sure the map exists to avoid typos that would kill the game
+            // The map searching algorithms here should be in sync with GetAvailableMaps()
             if (FS::FindPak("map-" + mapName) != nullptr) {
                 pakName = "map-" + mapName;
             } else if (FS::UseLegacyPaks()) {
@@ -94,7 +95,7 @@ class MapCmd: public Cmd::StaticCmd {
         Cmd::CompletionResult Complete(int argNum, const Cmd::Args& args, Str::StringRef prefix) const override {
             if (argNum == 1) {
                 Cmd::CompletionResult out;
-                for (auto& map: FS::GetAvailableMaps()) {
+                for (auto& map: FS::GetAvailableMaps(true)) {
                     if (Str::IsPrefix(prefix, map))
                         out.push_back({map, ""});
                 }
@@ -399,7 +400,7 @@ public:
 
 	void Run(const Cmd::Args&) const override
 	{
-		auto maps = FS::GetAvailableMaps();
+		auto maps = FS::GetAvailableMaps(true);
 
 		Print("Listing %d maps:", maps.size());
 

--- a/src/engine/server/sv_ccmds.cpp
+++ b/src/engine/server/sv_ccmds.cpp
@@ -100,6 +100,7 @@ class MapCmd: public Cmd::StaticCmd {
                 }
                 return out;
             } else if (argNum > 1) {
+                // FIXME: a layout could also be in a pak?
                 return FS::HomePath::CompleteFilename(prefix, "game/layouts/" + args.Argv(1), ".dat", false, true);
             }
 

--- a/src/shared/CommonProxies.cpp
+++ b/src/shared/CommonProxies.cpp
@@ -622,8 +622,3 @@ bool trap_FS_LoadPak( const char *pak, const char* prefix )
 	VM::SendMsg<VM::FSLoadPakMsg>(pak, prefix, res);
 	return res;
 }
-
-void trap_FS_LoadAllMapMetadata()
-{
-	VM::SendMsg<VM::FSLoadMapMetadataMsg>();
-}


### PR DESCRIPTION
Implement the restriction that a map named $NAME must be in a pak named map-$NAME. Fixes #557.

This allows us to avoid a big filesystem hit of loading all map paks upon loading a map or listing maps.

Companion: https://github.com/Unvanquished/Unvanquished/pull/1782
