### PR TITLE
Avoid some crashes in cubemap code (reflection mapping).

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3948,7 +3948,8 @@ static void RB_RenderDebugUtils()
 		GL_PopMatrix();
 	}
 
-	if ( r_showCubeProbes->integer )
+	// GLSL shader isn't built when reflection mapping is disabled.
+	if ( r_showCubeProbes->integer && gl_reflectionShader != nullptr )
 	{
 		cubemapProbe_t *cubeProbe;
 		int            j;

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3987,6 +3987,13 @@ static void RB_RenderDebugUtils()
 		{
 			cubeProbe = ( cubemapProbe_t * ) Com_GrowListElement( &tr.cubeProbes, j );
 
+			/* Do not crash when cubemaps are being generated,
+			it's also possible to set a default texture instead. */
+			if ( cubeProbe->cubemap == nullptr )
+			{
+				continue;
+			}
+
 			// bind u_ColorMap
 			GL_BindToTMU( 0, cubeProbe->cubemap );
 


### PR DESCRIPTION
Reflection mapping isn't working yet, but those two patches avoid two crashes related to reflection mapping code.