### PR TITLE
Also load gl_forwardLightingShader_projXYZ when dynamic shadows are enabled to prevent a crash

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -50,14 +50,28 @@ static void GLSL_InitGPUShadersOrError()
 	// standard light mapping
 	gl_shaderManager.load( gl_lightMappingShader );
 
+	/* Deprecated forward renderer uses r_dynamicLight -1
+
+	Dynamic shadowing code also needs this shader.
+	This code is not well known, so there may be a bug,
+	but commit a09f03bc8e775d83ac5e057593eff4e88cdea7eb mentions this:
+
+	> Use conventional shadow mapping code for inverse lights.
+	> This re-enables shadows for players in the tiled renderer.
+	> -- @gimhael
+
+	See also https://github.com/DaemonEngine/Daemon/pull/606#pullrequestreview-912402293 */
+	if ( r_dynamicLight->integer < 0 || ( r_shadows->integer >= Util::ordinal(shadowingMode_t::SHADOWING_ESM16) ) )
+	{
+		// projective lighting ( Doom3 style )
+		gl_shaderManager.load( gl_forwardLightingShader_projXYZ );
+	}
+
 	// Deprecated forward renderer uses r_dynamicLight -1
 	if ( r_dynamicLight->integer < 0 )
 	{
 		// omni-directional specular bump mapping ( Doom3 style )
 		gl_shaderManager.load( gl_forwardLightingShader_omniXYZ );
-
-		// projective lighting ( Doom3 style )
-		gl_shaderManager.load( gl_forwardLightingShader_projXYZ );
 
 		// directional sun lighting ( Doom3 style )
 		gl_shaderManager.load( gl_forwardLightingShader_directionalSun );


### PR DESCRIPTION
tr_shade: also load gl_forwardLightingShader_projXYZ when dynamic shadows are enabled to prevent a crash

Dynamic shadows are believed to be part of the old forward renderer,
and they are known to be very buggy.

Anyway commit message of a09f03bc8e775d83ac5e057593eff4e88cdea7eb
seems to imply they may be usable with tiled renderer as well:

> Use conventional shadow mapping code for inverse lights.
> This re-enables shadows for players in the tiled renderer.

After this commit no dynamic shadow is rendered but at least there
is no crash when setting to cg_shadows a value greater than 1 to
enable dynamic shadowing.

Note: for some reasons while the cvar is named r_shadows on renderer code,
the cvar is named cg_shadows in game console, probably because of some
quake3 legacy.