### PR TITLE
cl_main: rename demo file

### DIFF
--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -392,11 +392,11 @@ std::string GenerateDemoName()
         map_name.erase(0, last_slash + 1);
 
     return Str::Format(
-        "%s-%s_%04i-%02i-%02i_%02i%02i%02i",
-        NET_AdrToString(clc.serverAddress),
-        map_name,
+        "%04i-%02i-%02i_%02i%02i%02i_%s_%s",
         1900 + time.tm_year, time.tm_mon + 1, time.tm_mday,
-        time.tm_hour, time.tm_min, time.tm_sec
+        time.tm_hour, time.tm_min, time.tm_sec,
+        NET_AdrToString(clc.serverAddress),
+        map_name
     );
 }
 


### PR DESCRIPTION
Name demo file as date_time_host_map
instead of host_map_date_time.

This make it easy to sort by date in file browser.
Also, better use _ as field separator in all cases.