### PR TITLE
common: make demo.timedemo cvar temporary

### DIFF
--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -62,7 +62,7 @@ cvar_t *com_dropsim; // 0.0 to 1.0, simulated packet drops
 Cvar::Cvar<bool> cvar_demo_timedemo(
     "demo.timedemo",
     "Whether to show timing statistics at the end of a demo",
-    Cvar::CHEAT,
+    Cvar::CHEAT | Cvar::TEMPORARY,
     false
 );
 cvar_t *com_sv_running;


### PR DESCRIPTION
That cvar has very specific usage and we may want to prevent it to be stored. People making use of it know what they do, and they're usually scripting it already.

Also timedemo being enabled has side effects when not playing demo (like defeating the fps cap), though, the cvar being cheat prevents this to happen in regular games.

This kind of cvar being stored can bite in the back at some unexpected moment.