### PR TITLE
Only center the mouse if we get a mouse event with relative motion

### DIFF
--- a/src/engine/sys/sdl_input.cpp
+++ b/src/engine/sys/sdl_input.cpp
@@ -1083,7 +1083,7 @@ static void IN_ProcessEvents( bool dropInput )
 					{
 						Com_QueueEvent( Util::make_unique<Sys::MouseEvent>(e.motion.xrel, e.motion.yrel) );
 #if defined( __linux__ ) || defined( __BSD__ )
-						if ( !in_nograb->integer )
+						if ( !in_nograb->integer && ( e.motion.xrel || e.motion.yrel ) )
 						{
 							// work around X window managers and edge-based workspace flipping
 							// - without this, we get LeaveNotify, no mouse button events, EnterNotify;


### PR DESCRIPTION
For more information, see the discussion in https://github.com/libsdl-org/SDL/issues/5569

Fixes https://github.com/DaemonEngine/Daemon/issues/600