### PR TITLE
disable geoip by default, remove it as release build requirement, fix #492

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if(NOT DAEMON_EXTERNAL_APP)
         option(USE_CURSES "Enable fancy colors in terminal's output" ON)
     endif()
     cmake_dependent_option(USE_SMP "Compile with support for running the renderer in a separate thread" 1 BUILD_CLIENT 0)
-    cmake_dependent_option(USE_GEOIP "Allows server to show from which coutry a player logs from" 1 "BUILD_SERVER OR BUILD_CLIENT OR BUILD_TTY_CLIENT" 0)
+    option(USE_GEOIP "Allows server to show from which coutry a player logs from" OFF)
     option(USE_BREAKPAD "Generate Daemon crash dumps (which require Breakpad tools to read)" OFF)
 endif()
 


### PR DESCRIPTION
Disable geoip by default, remove it as release build requirement, fix #492

After this commit support for GeoIP will not be built by default, meaning libgeoip will not be a requirement for release builds anymore.

Since libgeoip will not be a release build requirement, we would be able to remove libgeoip from prebuilt dependencies.

The geoip code is still there and people can still build their own server with geoip support enabled, but that's up to them to decide if it's good or not and it's up to them to deal with the questions regarding to the geoip database.