### PR TITLE
Rewrite SDL warning to fix build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,9 +626,9 @@ if (BUILD_CLIENT OR WIN32)
     if(LINUX)
         find_package(SDL2 QUIET CONFIG)
         if(SDL2_VERSION)
-            if (SDL2_VERSION VERSION_GREATER_EQUAL "2.16"
-                AND SDL2_VERSION VERSION_LESS_EQUAL "2.20")
-                message(WARNING "SDL ${SDL2_VERSION} between version 2.16 and 2.20 is known to be buggy, see https://github.com/DaemonEngine/Daemon/issues/600")
+            if (SDL2_VERSION VERSION_GREATER_EQUAL "2.0.16"
+                AND SDL2_VERSION VERSION_LESS_EQUAL "2.0.20")
+                message(WARNING "SDL ${SDL2_VERSION} between version 2.0.16 and 2.0.20 is known to be buggy, see https://github.com/DaemonEngine/Daemon/issues/600")
             endif()
         else()
             # CMake may be able to find SDL2 without supporting CONFIG

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,6 +623,9 @@ endif()
 
 # SDL, required for all targets on win32 because of iconv and SDL_SetHint(SDL_TIMER_RESOLUTION, 0)
 if (BUILD_CLIENT OR WIN32)
+    find_package(SDL2 REQUIRED)
+    # Non-Linux systems use pre-compiled SDL we provide,
+    # so no one of them is using unapproved version.
     if(LINUX)
         find_package(SDL2 QUIET CONFIG)
         if(SDL2_VERSION)
@@ -633,13 +636,8 @@ if (BUILD_CLIENT OR WIN32)
         else()
             # CMake may be able to find SDL2 without supporting CONFIG
             # If sdl2-config.cmake or SDL2Config.cmake isn't provided.
-            find_package(SDL2 REQUIRED)
             message(STATUS "SDL version is unknown, version can't be checked for known bugs")
         endif()
-    else()
-        # Non-Linux systems use pre-compiled SDL we provide,
-        # so no one is using unapproved version.
-        find_package(SDL2 REQUIRED)
     endif()
 
     include_directories(${SDL2_INCLUDE_DIR})


### PR DESCRIPTION
- fix version, see https://github.com/DaemonEngine/Daemon/issues/600#issuecomment-1107661519
- fix previously merged #621 which was in fact breaking build if `sdl2-config.cmake` was available but the workspace was empty brand new, it looks like `find_package(SDL2 CONFIG)` still requires `find_package(SDL2)`.

- this code may be removed later in favor of #624 but the priority is to make `master` build again.