### PR TITLE
Nuke GeoIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,6 @@ if(NOT DAEMON_EXTERNAL_APP)
         option(USE_CURSES "Enable fancy colors in terminal's output" ON)
     endif()
     cmake_dependent_option(USE_SMP "Compile with support for running the renderer in a separate thread" 1 BUILD_CLIENT 0)
-    option(USE_GEOIP "Allows server to show from which coutry a player logs from" OFF)
     option(USE_BREAKPAD "Generate Daemon crash dumps (which require Breakpad tools to read)" OFF)
 endif()
 
@@ -589,14 +588,6 @@ if (BUILD_CLIENT OR BUILD_TTY_CLIENT OR BUILD_SERVER)
     add_library(srclibs-findlocale EXCLUDE_FROM_ALL ${FINDLOCALELIST})
     set_target_properties(srclibs-findlocale PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
     set(LIBS_ENGINE ${LIBS_ENGINE} srclibs-findlocale)
-
-    # GeoIP
-    if (USE_GEOIP)
-        find_package(GeoIP REQUIRED)
-        add_definitions(-DHAVE_GEOIP)
-        set(LIBS_ENGINE ${LIBS_ENGINE} ${GeoIP_LIBRARIES})
-        include_directories(${GeoIP_INCLUDE_DIRS})
-    endif()
 
     # Nettle
     find_package(Nettle REQUIRED)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Visual Studio/MSVC (at least Visual Studio 2019).
 ### Optional 
 
 `ncurses`,
-`libGeoIP`
 
 ### MSYS2
 

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -15,7 +15,6 @@ NASM_VERSION=2.15.05
 ZLIB_VERSION=1.2.11
 GMP_VERSION=6.2.0
 NETTLE_VERSION=3.6
-GEOIP_VERSION=1.6.12
 CURL_VERSION=7.73.0
 SDL2_VERSION=2.0.12
 GLEW_VERSION=2.2.0
@@ -174,26 +173,6 @@ build_nettle() {
 	cd "nettle-${NETTLE_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
 	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]}
-	make
-	make install
-}
-
-# Build GeoIP
-build_geoip() {
-	download "GeoIP-${GEOIP_VERSION}.tar.gz" "https://github.com/maxmind/geoip-api-c/archive/v${GEOIP_VERSION}.tar.gz" geoip
-	cd "geoip-api-c-${GEOIP_VERSION}"
-	autoreconf -vi
-	export ac_cv_func_malloc_0_nonnull=yes
-	export ac_cv_func_realloc_0_nonnull=yes
-	# GeoIP needs -lws2_32 in LDFLAGS
-	local TEMP_LDFLAGS="${LDFLAGS}"
-	case "${PLATFORM}" in
-	mingw*|msvc*)
-		TEMP_LDFLAGS="${LDFLAGS} -lws2_32"
-		;;
-	esac
-	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" LDFLAGS="${TEMP_LDFLAGS}" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]}
 	make
 	make install
 }
@@ -779,7 +758,7 @@ if [ "${#}" -lt "2" ]; then
 	echo "usage: ${0} <platform> <package[s]...>"
 	echo "Script to build dependencies for platforms which do not provide them"
 	echo "Platforms: msvc32 msvc64 mingw32 mingw64 macosx64 linux64"
-	echo "Packages: pkgconfig nasm zlib gmp nettle geoip curl sdl2 glew png jpeg webp freetype openal ogg vorbis speex opus opusfile lua naclsdk naclports wasisdk wasmtime"
+	echo "Packages: pkgconfig nasm zlib gmp nettle curl sdl2 glew png jpeg webp freetype openal ogg vorbis speex opus opusfile lua naclsdk naclports wasisdk wasmtime"
 	echo "Virtual packages:"
 	echo "  install - create a stripped down version of the built packages that CMake can use"
 	echo "  package - create a zip/tarball of the dependencies so they can be distributed"
@@ -787,9 +766,9 @@ if [ "${#}" -lt "2" ]; then
 	echo
 	echo "Packages requires for each platform:"
 	echo "Linux native compile: naclsdk naclports (and possibly others depending on what packages your distribution provides)"
-	echo "Linux to Windows cross-compile: zlib gmp nettle geoip curl sdl2 glew png jpeg webp freetype openal ogg vorbis speex opus opusfile lua naclsdk naclports"
-	echo "Native Windows compile: pkgconfig nasm zlib gmp nettle geoip curl sdl2 glew png jpeg webp freetype openal ogg vorbis speex opus opusfile lua naclsdk naclports"
-	echo "Native Mac OS X compile: pkgconfig nasm gmp nettle geoip sdl2 glew png jpeg webp freetype openal ogg vorbis speex opus opusfile lua naclsdk naclports"
+	echo "Linux to Windows cross-compile: zlib gmp nettle curl sdl2 glew png jpeg webp freetype openal ogg vorbis speex opus opusfile lua naclsdk naclports"
+	echo "Native Windows compile: pkgconfig nasm zlib gmp nettle curl sdl2 glew png jpeg webp freetype openal ogg vorbis speex opus opusfile lua naclsdk naclports"
+	echo "Native Mac OS X compile: pkgconfig nasm gmp nettle sdl2 glew png jpeg webp freetype openal ogg vorbis speex opus opusfile lua naclsdk naclports"
 	exit 1
 fi
 

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -169,10 +169,6 @@ void       NET_LeaveMulticast6();
 
 void       NET_Sleep( int msec );
 
-#ifdef HAVE_GEOIP
-const char *NET_GeoIP_Country( const netadr_t *a );
-#endif
-
 //----(SA)  increased for larger submodel entity counts
 #define MAX_MSGLEN           32768 // max length of a message, which may
 //#define   MAX_MSGLEN              16384       // max length of a message, which may

--- a/src/engine/server/sv_client.cpp
+++ b/src/engine/server/sv_client.cpp
@@ -188,22 +188,7 @@ void SV_DirectConnect( const netadr_t& from, const Cmd::Args& args )
 	memset( new_client, 0, sizeof( client_t ) );
 	int clientNum = new_client - svs.clients;
 
-
-#ifdef HAVE_GEOIP
-		const char * country = NET_GeoIP_Country( &from );
-
-		if ( country )
-		{
-			Log::Notice( "Client %i connecting from %s\n", clientNum, country );
-			userinfo["geoip"] = country;
-		}
-		else
-		{
-			Log::Notice( "Client %i connecting from somewhere unknown\n", clientNum );
-		}
-#else
-		Log::Notice( "Client %i connecting\n", clientNum );
-#endif
+	Log::Notice( "Client %i connecting", clientNum );
 
 	new_client->gentity = SV_GentityNum( clientNum );
 	new_client->gentity->r.svFlags = 0;
@@ -1104,17 +1089,11 @@ void SV_UserinfoChanged( client_t *cl )
 	if ( !NET_IsLocalAddress( cl->netchan.remoteAddress ) )
 	{
 		Info_SetValueForKey( cl->userinfo, "ip", NET_AdrToString( cl->netchan.remoteAddress ), false );
-#ifdef HAVE_GEOIP
-		Info_SetValueForKey( cl->userinfo, "geoip", NET_GeoIP_Country( &cl->netchan.remoteAddress ), false );
-#endif
 	}
 	else
 	{
 		// force the "ip" info key to "loopback" for local clients
 		Info_SetValueForKey( cl->userinfo, "ip", "loopback", false );
-#ifdef HAVE_GEOIP
-		Info_SetValueForKey( cl->userinfo, "geoip", nullptr, false );
-#endif
 	}
 }
 


### PR DESCRIPTION
Fixes #492. I noticed that since the last GeoIP release was in 2018, it is either not working at all, or we are using an ancient database (since no one actually knows how to configure an external database). After realizing this it seems better to nuke it right away instead of after a release.