### PR TITLE
Use normal max FPS without unfocused/minimized set

### DIFF
--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -912,11 +912,11 @@ void Com_Frame()
 		{
 			int max;
 
-			if ( com_minimized->integer )
+			if ( com_minimized->integer && maxfpsMinimized.Get() != 0 )
 			{
 				max = maxfpsMinimized.Get();
 			}
-			else if ( com_unfocused->integer )
+			else if ( com_unfocused->integer && maxfpsUnfocused.Get() != 0 )
 			{
 				max = maxfpsUnfocused.Get();
 			}


### PR DESCRIPTION
A regression in 443bf08c would cause the FPS to be unlimited when
unfocused/minimized with default settings.