### PR TITLE
Factorize some code between basic, specular and physical lighting

### DIFF
--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -116,7 +116,7 @@ void computeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightColor,
   float G = NdotL / (NdotL * (1.0 - k) + k);
   G *= NdotV / (NdotV * (1.0 - k) + k);
 
-  color.rgb += lightColor.rgb * (1.0 - metalness) * NdotL * diffuseColor.rgb;
+  color.rgb += lightColor.rgb * NdotL * diffuseColor.rgb * (1.0 - metalness);
   color.rgb += lightColor.rgb * vec3((D * F * G) / (4.0 * NdotV));
   color.a = mix(diffuseColor.a, 1.0, FexpNV);
 #else // !USE_PHYSICAL_MAPPING
@@ -129,10 +129,10 @@ void computeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightColor,
 	materialColor.rgb *= mix(envColor0, envColor1, u_EnvironmentInterpolation).rgb;
 #endif // USE_REFLECTIVE_SPECULAR
 
-  color.rgb += diffuseColor.rgb * lightColor.rgb * NdotL;
+  color.rgb += lightColor.rgb * NdotL * diffuseColor.rgb;
 #if defined(r_specularMapping)
   // The minimal specular exponent should preferably be nonzero to avoid the undefined pow(0, 0)
-  color.rgb += materialColor.rgb * lightColor.rgb * pow( NdotH, u_SpecularExponent.x * materialColor.a + u_SpecularExponent.y) * r_SpecularScale;
+  color.rgb += lightColor.rgb * materialColor.rgb * pow( NdotH, u_SpecularExponent.x * materialColor.a + u_SpecularExponent.y) * r_SpecularScale;
 #endif // r_specularMapping
 #endif // !USE_PHYSICAL_MAPPING
 }


### PR DESCRIPTION
This is low priority but I just stumbled upon it while reading the code.

Note that it has a computational change as the `NdotL` compute that was only clamped for physical mapping is now clamped in all cases. But I have read in some place that `NdotL` is expected to be `0` for `0°` angle and `1` for `90°` and maybe this value should never go beyond.

I have seen no regression with both light mapping and dynamic lighting (this code is used by both), I tested lighting on basic materials, specular materials and physical materials.

Since it modifies a code that is known to be affected by a bug (see #471), it may be interesting for affected people to test this code to see if by pure luck that makes a difference, I doubt though.