### PR TITLE
Fix crash with r_vertexLighting

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -748,7 +748,7 @@ std::string     GLShaderManager::BuildGPUShaderText( Str::StringRef mainShaderNa
 	return shaderText;
 }
 
-bool GLShaderManager::buildPermutation( GLShader *shader, int macroIndex, int deformIndex )
+void GLShaderManager::buildPermutation( GLShader *shader, int macroIndex, int deformIndex )
 {
 	std::string compileMacros;
 	int  startTime = ri.Milliseconds();
@@ -759,7 +759,7 @@ bool GLShaderManager::buildPermutation( GLShader *shader, int macroIndex, int de
 	if ( i < shader->_shaderPrograms.size() &&
 	     shader->_shaderPrograms[ i ].program )
 	{
-		return false;
+		return;
 	}
 
 	if( shader->GetCompileMacrosString( macroIndex, compileMacros ) )
@@ -782,7 +782,7 @@ bool GLShaderManager::buildPermutation( GLShader *shader, int macroIndex, int de
 
 			if ( baseShader->unusedPermutation )
 			{
-				return true;
+				return;
 			}
 
 			glAttachShader( shaderProgram->program, baseShader->VS );
@@ -798,7 +798,7 @@ bool GLShaderManager::buildPermutation( GLShader *shader, int macroIndex, int de
 
 			if ( shaderProgram->unusedPermutation )
 			{
-				return true;
+				return;
 			}
 
 			SaveShaderBinary( shader, i );
@@ -813,9 +813,7 @@ bool GLShaderManager::buildPermutation( GLShader *shader, int macroIndex, int de
 
 		endTime = ri.Milliseconds();
 		_totalBuildTime += ( endTime - startTime );
-		return true;
 	}
-	return false;
 }
 
 void GLShaderManager::buildAll()

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1035,15 +1035,6 @@ void GLShaderManager::CompileGPUShaders( GLShader *shader, shaderProgram_t *prog
 			{
 				break;
 			}
-
-			/* FIXME: add this test: ( strcmp( token, "USE_TCGEN_LIGHTMAP" ) == 0 && r_lightMapping->integer == 0 )
-			when lightmaps are never used when lightmapping is disabled
-			see https://github.com/DaemonEngine/Daemon/issues/296 is fixed */
-			if ( strcmp( token, "USE_LIGHT_MAPPING" ) == 0 && r_vertexLighting->integer != 0 )
-			{
-				program->unusedPermutation = true;
-				return;
-			}
 			else if ( strcmp( token, "USE_NORMAL_MAPPING" ) == 0 && r_normalMapping->integer == 0 )
 			{
 				program->unusedPermutation = true;

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -770,8 +770,6 @@ void GLShaderManager::buildPermutation( GLShader *shader, int macroIndex, int de
 			shader->_shaderPrograms.resize( (deformIndex + 1) << shader->_compileMacros.size() );
 
 		shaderProgram_t *shaderProgram = &shader->_shaderPrograms[ i ];
-
-		shaderProgram->program = glCreateProgram();
 		shaderProgram->attribs = shader->_vertexAttribsRequired; // | _vertexAttribsOptional;
 
 		if( deformIndex > 0 )
@@ -785,6 +783,7 @@ void GLShaderManager::buildPermutation( GLShader *shader, int macroIndex, int de
 				return;
 			}
 
+			shaderProgram->program = glCreateProgram();
 			glAttachShader( shaderProgram->program, baseShader->VS );
 			glAttachShader( shaderProgram->program, _deformShaders[ deformIndex ] );
 			glAttachShader( shaderProgram->program, baseShader->FS );
@@ -939,6 +938,7 @@ bool GLShaderManager::LoadShaderBinary( GLShader *shader, size_t programNum )
 
 	// load the shader
 	shaderProgram_t *shaderProgram = &shader->_shaderPrograms[ programNum ];
+	shaderProgram->program = glCreateProgram();
 	glProgramBinary( shaderProgram->program, shaderHeader.binaryFormat, binaryptr, shaderHeader.binaryLength );
 	glGetProgramiv( shaderProgram->program, GL_LINK_STATUS, &success );
 
@@ -1117,6 +1117,7 @@ void GLShaderManager::CompileAndLinkGPUShaderProgram( GLShader *shader, shaderPr
 		return;
 	}
 
+	program->program = glCreateProgram();
 	glAttachShader( program->program, program->VS );
 	glAttachShader( program->program, _deformShaders[ deformIndex ] );
 	glAttachShader( program->program, program->FS );

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -311,7 +311,7 @@ public:
 
 	int getDeformShaderIndex( deformStage_t *deforms, int numDeforms );
 
-	bool buildPermutation( GLShader *shader, int macroIndex, int deformIndex );
+	void buildPermutation( GLShader *shader, int macroIndex, int deformIndex );
 	void buildAll();
 private:
 	bool LoadShaderBinary( GLShader *shader, size_t permutation );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -804,6 +804,9 @@ static void Render_lightMapping( int stage )
 
 	if ( noLightMap )
 	{
+		// TODO: do this in a different way so that when lightmapping is disabled,
+		// we could disable building shader permutations with USE_LIGHT_MAPPING.
+		// See https://github.com/DaemonEngine/Daemon/issues/500
 		lightmap = tr.whiteImage;
 		enableLightMapping = true;
 	}


### PR DESCRIPTION
Also show a useful error message when crashing from this class of bug (using an "unused" permutation).