### PR TITLE
sdl_glimp: also recreate window on resolution change

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -785,20 +785,27 @@ static bool GLimp_CreateContext( const glConfiguration &configuration )
 
 /* GLimp_DestroyWindowIfExists checks if window exists before
 destroying it so we can call GLimp_RecreateWindowWhenChange even
-if no window is created yet.
-
-It is assumed width, height and other things like that are unchanged,
-given vid_restart is called when changing those and then destroying
-the window before calling this. */
+if no window is created yet. */
 static bool GLimp_RecreateWindowWhenChange( const bool fullscreen, const bool bordered, const glConfiguration &configuration )
 {
+	/* Those values doen't contribute to anything
+	when the window isn't created yet. */
 	static bool currentFullscreen = false;
 	static bool currentBordered = false;
+	static int currentWidth = 0;
+	static int currentHeight = 0;
 	static glConfiguration currentConfiguration = {};
 
 	if ( window == nullptr
+		/* We don't care if comparing default values
+		is wrong when the window isn't created yet as
+		the first thing we do is to overwrite them. */
+		|| glConfig.vidWidth != currentWidth
+		|| glConfig.vidHeight != currentHeight
 		|| configuration != currentConfiguration )
 	{
+		currentWidth = glConfig.vidWidth;
+		currentHeight = glConfig.vidHeight;
 		currentConfiguration = configuration;
 
 		GLimp_DestroyWindowIfExists();


### PR DESCRIPTION
Window resolution can also change without calling `vid_restart`: it happens when the window failed to be created and a lower resolution is tried instead.

This replaces:

- https://github.com/DaemonEngine/Daemon/pull/644

This is a fixup for:

- https://github.com/DaemonEngine/Daemon/pull/478

Not recreating the window when the fallback resolution is tried because the context creation failed was a regression.