### PR TITLE
fix for network port > 2 power 15

### DIFF
--- a/src/common/Endian.h
+++ b/src/common/Endian.h
@@ -149,6 +149,28 @@ inline int64_t Swap64(int64_t x)
 	        (x >> 56);
 }
 
+inline uint16_t USwap16(uint16_t x)
+{
+	return (x >> 8) | (x << 8);
+}
+
+inline uint32_t USwap32(uint32_t x)
+{
+	return (x << 24) | ((x << 8) & 0xff0000) | ((x >> 8) & 0xff00) | (x >> 24);
+}
+
+inline uint64_t USwap64(uint64_t x)
+{
+	return  (x << 56) |
+	       ((x << 40) & 0xff000000000000ULL) |
+	       ((x << 24) & 0xff0000000000ULL) |
+	       ((x <<  8) & 0xff00000000ULL) |
+	       ((x >>  8) & 0xff000000ULL) |
+	       ((x >> 24) & 0xff0000ULL) |
+	       ((x >> 40) & 0xff00ULL) |
+	        (x >> 56);
+}
+
 inline float SwapFloat(float x)
 {
 	union
@@ -173,6 +195,13 @@ inline float SwapFloat(float x)
 #define Big64(x) Swap64(x)
 #define BigFloat(x) SwapFloat(x)
 
+#define ULittleShort(x) (x)
+#define ULittleLong(x) (x)
+#define ULittle64(x) (x)
+#define UBigShort(x) USwap16(x)
+#define UBigLong(x) USwap32(x)
+#define UBig64(x) USwap64(x)
+
 #elif defined(Q3_BIG_ENDIAN)
 
 #define LittleShort(x) Swap16(x)
@@ -183,6 +212,13 @@ inline float SwapFloat(float x)
 #define BigLong(x) (x)
 #define Big64(x) (x)
 #define BigFloat(x) (x)
+
+#define ULittleShort(x) USwap16(x)
+#define ULittleLong(x) USwap32(x)
+#define ULittle64(x) USwap64(x)
+#define UBigShort(x) (x)
+#define UBigLong(x) (x)
+#define UBig64(x) (x)
 
 #else
 

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -1070,7 +1070,7 @@ void CL_Connect_f()
 
 	if ( clc.serverAddress.port == 0 )
 	{
-		clc.serverAddress.port = BigShort( PORT_SERVER );
+		clc.serverAddress.port = UBigShort( PORT_SERVER );
 	}
 
 	serverString = NET_AdrToStringwPort( clc.serverAddress );
@@ -1238,7 +1238,7 @@ static netadr_t CL_RconDestinationAddress()
 
 	if ( to.port == 0 )
 	{
-		to.port = BigShort( PORT_SERVER );
+		to.port = UBigShort( PORT_SERVER );
 	}
 
 	return to;
@@ -1897,7 +1897,7 @@ CL_ServerLinksResponsePacket
 */
 void CL_ServerLinksResponsePacket( msg_t *msg )
 {
-	int      port;
+	unsigned short      port;
 	byte      *buffptr;
 	byte      *buffend;
 
@@ -1923,13 +1923,13 @@ void CL_ServerLinksResponsePacket( msg_t *msg )
 		// IPv4 address
 		memcpy( cls.serverLinks[ cls.numserverLinks ].ip, buffptr, 4 );
 		port = buffptr[ 4 ] << 8 | buffptr[ 5 ];
-		cls.serverLinks[ cls.numserverLinks ].port4 = BigShort( port );
+		cls.serverLinks[ cls.numserverLinks ].port4 = UBigShort( port );
 		buffptr += 6;
 
 		// IPv4 address
 		memcpy( cls.serverLinks[ cls.numserverLinks ].ip6, buffptr, 16 );
 		port = buffptr[ 16 ] << 8 | buffptr[ 17 ];
-		cls.serverLinks[ cls.numserverLinks ].port6 = BigShort( port );
+		cls.serverLinks[ cls.numserverLinks ].port6 = UBigShort( port );
 		buffptr += 18;
 
 		++cls.numserverLinks;
@@ -2013,7 +2013,7 @@ void CL_ServersResponsePacket( const netadr_t *from, msg_t *msg, bool extended )
 		bool duplicate = false;
 		byte ip6[16];
 		byte ip[4];
-		short port;
+		unsigned short port;
 
 		// IPv4 address
 		if ( *buffptr == '\\' )
@@ -2032,7 +2032,7 @@ void CL_ServersResponsePacket( const netadr_t *from, msg_t *msg, bool extended )
 			// parse out port
 			port = ( *buffptr++ ) << 8;
 			port += *buffptr++;
-			port = BigShort( port );;
+			port = UBigShort( port );;
 
 			// deduplicate server list, do not add known server
 			for ( int i = 0; i < cls.numglobalservers; i++ )
@@ -2102,7 +2102,7 @@ void CL_ServersResponsePacket( const netadr_t *from, msg_t *msg, bool extended )
 			// parse out port
 			port = ( *buffptr++ ) << 8;
 			port += *buffptr++;
-			port = BigShort( port );;
+			port = UBigShort( port );;
 
 			// deduplicate server list, do not add known server
 			for ( int i = 0; i < cls.numglobalservers; i++ )
@@ -3467,7 +3467,7 @@ void CL_LocalServers_f()
 		// can nicely run multiple servers
 		for ( j = 0; j < NUM_SERVER_PORTS; j++ )
 		{
-			to.port = BigShort( ( short )( PORT_SERVER + j ) );
+			to.port = UBigShort( ( short )( PORT_SERVER + j ) );
 
 			to.type = netadrtype_t::NA_BROADCAST;
 			NET_SendPacket( netsrc_t::NS_CLIENT, messageLen, message, to );
@@ -3545,7 +3545,7 @@ void CL_GlobalServers_f()
 		}
 		else if ( i == 2 )
 		{
-			to.port = BigShort( PORT_MASTER );
+			to.port = UBigShort( PORT_MASTER );
 		}
 
 		Log::Debug( "CL_GlobalServers_f: %s resolved to %s", masteraddress,

--- a/src/engine/qcommon/net_chan.cpp
+++ b/src/engine/qcommon/net_chan.cpp
@@ -650,12 +650,12 @@ int NET_StringToAdr( const char *s, netadr_t *a, netadrtype_t family )
 
 	if ( port )
 	{
-		a->port = BigShort( ( short ) atoi( port ) );
+		a->port = UBigShort( ( unsigned short ) atoi( port ) );
 		return 1;
 	}
 	else
 	{
-		a->port = BigShort( PORT_SERVER );
+		a->port = UBigShort( PORT_SERVER );
 		return 2;
 	}
 }

--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -386,7 +386,7 @@ void SV_MasterHeartbeat( const char *hbname )
 		if ( adrs.ipv4.type != netadrtype_t::NA_BAD )
 		{
 			if (adrs.ipv4.port == 0) {
-				adrs.ipv4.port = BigShort( PORT_MASTER );
+				adrs.ipv4.port = UBigShort( PORT_MASTER );
 			}
 			netLog.Notice( "Sending heartbeat (IPv4) to %s", master.addressCvar.Get() );
 			// this command should be changed if the server info / status format
@@ -397,7 +397,7 @@ void SV_MasterHeartbeat( const char *hbname )
 		if ( adrs.ipv6.type != netadrtype_t::NA_BAD )
 		{
 			if (adrs.ipv6.port == 0) {
-				adrs.ipv6.port = BigShort( PORT_MASTER );
+				adrs.ipv6.port = UBigShort( PORT_MASTER );
 			}
 			netLog.Notice( "Sending heartbeat (IPv6) to %s", master.addressCvar.Get() );
 			// this command should be changed if the server info / status format


### PR DESCRIPTION
The engine can't use network port > 2 power 15 because of the signedness of the endianness functions and some bad cast in the code.

This pull request fix these problems by:
- adding unsigned endianness functions UBigShort/USwap16 and others for coherency (the same code with unsigned type in the function's signatures).
- editing code who takes and converts network port number in the engine to use these new functions and rectify some broken casts and types.

I built and tested the game with this fix and it works.