### PR TITLE
null_renderer: Fix warning about memsetting non-trival struct.

### DIFF
--- a/src/engine/null/null_renderer.cpp
+++ b/src/engine/null/null_renderer.cpp
@@ -190,10 +190,10 @@ const char *RE_ShaderNameFromHandle( qhandle_t )
 
 bool RE_BeginRegistration( glconfig_t *config, glconfig2_t *glconfig2 )
 {
-	memset( config, 0, sizeof( glconfig_t ) );
+	*config = glconfig_t{};
 	config->vidWidth = 640;
 	config->vidHeight = 480;
-	memset( glconfig2, 0, sizeof( glconfig2_t ) );
+	*glconfig2 = glconfig2_t{};
 
 	return true;
 }
@@ -289,4 +289,3 @@ refexport_t    *GetRefAPI( int, refimport_t* )
 
     return &re;
 }
-


### PR DESCRIPTION
/mnt/media/code/Unvanquished/daemon/src/engine/null/null_renderer.cpp: In function ‘bool RE_BeginRegistration(glconfig_t*, glconfig2_t*)’:
/mnt/media/code/Unvanquished/daemon/src/engine/null/null_renderer.cpp:196:15: error: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct glconfig2_t’ with no trivial copy-assignment; use assignment or value-initialization instead [-Werror=class-memaccess]
  196 |         memset( glconfig2, 0, sizeof( glconfig2_t ) );
      |         ~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~