### PR TITLE
Really fix specular mapping black patches (#471)

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1084,7 +1084,7 @@ static void Render_lightMapping( int stage )
 		GL_BindToTMU( BIND_MATERIALMAP, pStage->bundle[ TB_MATERIALMAP ].image[ 0 ] );
 	}
 
-	if ( pStage->enableSpecularMapping )
+	if ( !pStage->enablePhysicalMapping && r_specularMapping->integer )
 	{
 		float specExpMin = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
 		float specExpMax = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );


### PR DESCRIPTION

The first attempt #656 is a correct idea in principle, but it doesn't actually do anything on its own because the specular exponent uniform was not even initialized. Apparently it seemed to work due to randomness in an uninitialized value.