### PR TITLE
Rename some symbols consistently with other parts of the code + add some missing switch case

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1279,7 +1279,7 @@ void GLShaderManager::BindAttribLocations( GLuint program ) const
 	}
 }
 
-// reflective specular not implemented for PBR yet
+// Reflective specular not implemented for physically based rendering yet.
 bool GLCompileMacro_USE_REFLECTIVE_SPECULAR::HasConflictingMacros( size_t permutation, const std::vector< GLCompileMacro * > &macros ) const
 {
 	for (const GLCompileMacro* macro : macros)

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -87,15 +87,23 @@ void computeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightColor,
 #endif
 
 #if defined(USE_PHYSICAL_MAPPING)
-  // Daemon PBR packing defaults to ORM like glTF 2.0 defines
-  // https://www.khronos.org/blog/art-pipeline-for-gltf
-  // > ORM texture for Occlusion, Roughness, and Metallic
-  // https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
-  // > The metalness values are sampled from the B channel. The roughness values are sampled from the G channel.
-  // > These values are linear. If other channels are present (R or A), they are ignored for metallic-roughness calculations.
-  // https://docs.blender.org/manual/en/2.80/addons/io_scene_gltf2.html
-  // > glTF stores occlusion in the red (R) channel, allowing it to optionally share the same image
-  // > with the roughness and metallic channels.
+  /* Daemon texture packing for PBR (Physically Based Rendering)
+  defaults to ORM (Occlusion, Roughness, Metallic) like glTF 2.0:
+
+  > ORM texture for Occlusion, Roughness, and Metallic
+  -- https://www.khronos.org/blog/art-pipeline-for-gltf
+
+  > The metalness values are sampled from the B channel.
+  > The roughness values are sampled from the G channel.
+  > These values are linear.
+  > If other channels are present (R or A), they are ignored
+  > for metallic-roughness calculations.
+  -- https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/material.pbrMetallicRoughness.schema.json
+
+  > glTF stores occlusion in the red (R) channel, allowing it
+  > to optionally share the same image with the roughness and
+  > metallic channels.
+  -- https://docs.blender.org/manual/en/2.80/addons/io_scene_gltf2.html */
   float roughness = materialColor.g;
   float metalness = materialColor.b;
 
@@ -122,7 +130,7 @@ void computeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightColor,
 #else // !USE_PHYSICAL_MAPPING
 
 #if defined(USE_REFLECTIVE_SPECULAR)
-	// not implemented for PBR yet
+	// Reflective specular not implemented for physically based rendering yet.
 	vec4 envColor0 = textureCube(u_EnvironmentMap0, reflect(-viewDir, normal));
 	vec4 envColor1 = textureCube(u_EnvironmentMap1, reflect(-viewDir, normal));
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1037,8 +1037,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	  TB_NORMALMAP,
 	  TB_HEIGHTMAP,
 	  TB_MATERIALMAP,
-	  TB_PHYSICALMAP = TB_MATERIALMAP,
 	  TB_SPECULARMAP = TB_MATERIALMAP,
+	  TB_PHYSICALMAP = TB_MATERIALMAP,
 	  TB_GLOWMAP,
 	  MAX_TEXTURE_BUNDLES
 	};
@@ -1061,8 +1061,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	  ST_DIFFUSEMAP,
 	  ST_NORMALMAP,
 	  ST_HEIGHTMAP,
-	  ST_PHYSICALMAP,
 	  ST_SPECULARMAP,
+	  ST_PHYSICALMAP,
 	  ST_REFLECTIONMAP, // cubeMap based reflection
 	  ST_REFRACTIONMAP,
 	  ST_DISPERSIONMAP,
@@ -1072,8 +1072,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	  ST_HEATHAZEMAP, // heatHaze post process effect
 	  ST_LIQUIDMAP,
 	  ST_LIGHTMAP,
-	  ST_COLLAPSE_lighting_PBR,   // map|diffusemap + opt:normalmap + opt:glowmap + opt:physicalmap
-	  ST_COLLAPSE_lighting_PHONG, // map|diffusemap + opt:normalmap + opt:glowmap + specularmap
+	  ST_COLLAPSE_lighting_SPECULAR, // map|diffusemap + opt:normalmap + opt:glowmap + opt:specularmap
+	  ST_COLLAPSE_lighting_PHYSICAL, // map|diffusemap + opt:normalmap + opt:glowmap + physicalmap
 	  ST_COLLAPSE_reflection_CB,  // color cubemap + normalmap
 
 	  // light shader stage types
@@ -1085,8 +1085,8 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 	{
 	  COLLAPSE_none,
 	  COLLAPSE_generic, // used before we know it's another one
-	  COLLAPSE_lighting_PHONG,
-	  COLLAPSE_lighting_PBR,
+	  COLLAPSE_lighting_SPECULAR,
+	  COLLAPSE_lighting_PHYSICAL,
 	  COLLAPSE_reflection_CB,
 	};
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2942,6 +2942,7 @@ void Tess_StageIteratorDepthFill()
 
 			case stageType_t::ST_DIFFUSEMAP:
 			case stageType_t::ST_COLLAPSE_lighting_SPECULAR:
+			case stageType_t::ST_COLLAPSE_lighting_PHYSICAL:
 				{
 					Render_depthFill( stage );
 					break;
@@ -3022,6 +3023,7 @@ void Tess_StageIteratorShadowFill()
 			case stageType_t::ST_LIGHTMAP:
 			case stageType_t::ST_DIFFUSEMAP:
 			case stageType_t::ST_COLLAPSE_lighting_SPECULAR:
+			case stageType_t::ST_COLLAPSE_lighting_PHYSICAL:
 				{
 					Render_shadowFill( stage );
 					break;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2768,8 +2768,8 @@ void Tess_StageIteratorGeneric()
 				}
 
 			case stageType_t::ST_DIFFUSEMAP:
-			case stageType_t::ST_COLLAPSE_lighting_PHONG:
-			case stageType_t::ST_COLLAPSE_lighting_PBR:
+			case stageType_t::ST_COLLAPSE_lighting_SPECULAR:
+			case stageType_t::ST_COLLAPSE_lighting_PHYSICAL:
 				{
 					if ( r_precomputedLighting->integer || r_vertexLighting->integer )
 					{
@@ -2941,7 +2941,7 @@ void Tess_StageIteratorDepthFill()
 				}
 
 			case stageType_t::ST_DIFFUSEMAP:
-			case stageType_t::ST_COLLAPSE_lighting_PHONG:
+			case stageType_t::ST_COLLAPSE_lighting_SPECULAR:
 				{
 					Render_depthFill( stage );
 					break;
@@ -3021,7 +3021,7 @@ void Tess_StageIteratorShadowFill()
 
 			case stageType_t::ST_LIGHTMAP:
 			case stageType_t::ST_DIFFUSEMAP:
-			case stageType_t::ST_COLLAPSE_lighting_PHONG:
+			case stageType_t::ST_COLLAPSE_lighting_SPECULAR:
 				{
 					Render_shadowFill( stage );
 					break;
@@ -3136,8 +3136,8 @@ void Tess_StageIteratorLighting()
 			switch ( pStage->type )
 			{
 				case stageType_t::ST_DIFFUSEMAP:
-				case stageType_t::ST_COLLAPSE_lighting_PBR:
-				case stageType_t::ST_COLLAPSE_lighting_PHONG:
+				case stageType_t::ST_COLLAPSE_lighting_SPECULAR:
+				case stageType_t::ST_COLLAPSE_lighting_PHYSICAL:
 					if ( light->l.rlType == refLightType_t::RL_OMNI )
 					{
 						Render_forwardLighting_DBS_omni( pStage, attenuationXYStage, attenuationZStage, light );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2935,11 +2935,6 @@ void Tess_StageIteratorDepthFill()
 				}
 
 			case stageType_t::ST_LIGHTMAP:
-				{
-					Render_depthFill( stage );
-					break;
-				}
-
 			case stageType_t::ST_DIFFUSEMAP:
 			case stageType_t::ST_COLLAPSE_lighting_SPECULAR:
 			case stageType_t::ST_COLLAPSE_lighting_PHYSICAL:


### PR DESCRIPTION
Some things I noticed while reading the code while trying to fix #677 (those patches don't fix it).

### renderer: name SPECULAR and PHYSICAL consistently with the rest of the code

This patch does not change anything to the logic.

- rename PHONG and PBR as SPECULAR and PHYSICAL to be consistent
  with the rest of the code. The PHONG and PBR names were just
  names I used in my very first commits when rewriting the
  material collapse code refactoring the GLSL code, before I
  had enough knowledge to decide to name the variant specular
  and physical. Now that they are named specular and physical
  everywhere else, it's better to unify back those early
  occurrences.

- I also reordered tests for specular before physical because:
  * specular code is the default if there is no specular or
    physical map (a black specular map is used) or if both
    specular mapping and physical mapping are disabled.
    Physical mapping can also be used with a black physical
    map when there is no specular or physical map but the
    specular code is faster that's why it's the default.
  * there is no game running on Dæmon using PBR textures yet.

Some reordering are just bikeshedding to just make the things
consistent. Specular code is the default anyway.

### renderer: add some missing cases for PHYSICAL in some switches

This one may fix some bugs in PBR code. PHYSICAL and SPECULAR variants are just expected to be usable anywhere where the other is usable, they just compute light effects differently with a different texture. It would even be possible to only use a single type for both and add an extra boolean for the variant but using two types just makes the code simpler everywhere.

### renderer: simplify a switch case

Two switch cases were just doing the same things.