### PR TITLE
cmake: Don't make stringop-overflow an a -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,6 +252,7 @@ try_flag(WARNINGS           "-Woverloaded-virtual")
 try_flag(WARNINGS           "-Wstrict-null-sentinel")
 try_flag(WARNINGS           "-Wno-error=sign-promo")
 try_flag(WARNINGS           "-Wno-error=extern-c-compat")
+try_flag(WARNINGS           "-Wno-error=stringop-overflow=")
 # remove
 try_flag(WARNINGS           "-Wno-error=maybe-uninitialized")
 try_flag(WARNINGS           "-W${WARNMODE}missing-field-initializers")


### PR DESCRIPTION
Newer versions of GCC complain about our serialization code and prevent
it from builing under -Werror. Let's disable the warning as Werror for
now.