### PR TITLE
cl_input: Fix typing +command in console for repeat key press.

### DIFF
--- a/src/engine/client/cl_input.cpp
+++ b/src/engine/client/cl_input.cpp
@@ -84,7 +84,7 @@ void IN_KeyDown( kbutton_t *b )
 	bool nokey = ( Cmd_Argc() > 1 );
 	Key k = nokey ? Key::NONE : Key_GetKeyNumber(); // NONE if typed manually at the console for continuous down
 
-	if ( k == b->down[ 0 ] || k == b->down[ 1 ] )
+	if ( k.IsValid() && ( k == b->down[ 0 ] || k == b->down[ 1 ] ) )
 	{
 		return; // repeating key
 	}


### PR DESCRIPTION
If someone wants to type a +command like +speed or +attack in console it
doesn't work (even if they add a random arg with it) because this check
will always pass and it returns. However, since +commands in console
never have a key asscoiated with them, check whether the key is valid
first.