### PR TITLE
tr_shader: update comment about standalone lightmap blending

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1033,21 +1033,27 @@ static void Render_lightMapping( int stage )
 	This is needed to be able to blend two multitextured collapsed
 	stage like when doing terrain blending (blending rock and sand).
 
-	But we should not do it with standalone lightmap stages,
-	otherwise it would break q3map2 light styles, likely
-	because in such situation we do not blend a lightmap
-	on a diffusemap but we blend a white texture passed as
-	a lightmap on the lightmap passed as a diffusemap and
-	then we would not multiply a diffuse but a lightmap.
-
-	To avoid the lightmap-as-a-diffuse being multiplied
-	by some values intended for diffuse maps, we can simply
-	set the color to white as diffuse * 1.0  == diffuse.
+	But doing this with standalone lightmap stages breaks q3map2 light
+	styles. To prevent the multiplication we we can simply set the
+	color to white as diffuse * 1.0  == diffuse.
 
 	But we should still pass the color and do the multiplication
 	if the rgbGen is const as in such situation the mapper
 	explicitly requested the lightmap stage to be multiplied by
-	the values the mapper have set when creating the materials. */
+	the values the mapper have set when creating the materials.
+
+	FIXME: It is possible that preventing the multiplication to be
+	done in some cases may prevent some extra lightmaps to be blend
+	but if this happens it will never prevent the default lightmap
+	to be blend so the surface will never look bad. On the contrary
+	not preventing the multiplication to be done produces many very
+	visible glitches affecting dozens of textures.
+
+	More investigations are needed. For now those tests takes care
+	of only allowing operations that are known to not glitch.
+
+	We may also investigate about processing all standalone lightmap
+	stages with Render_generic() instead. */
 
 	if ( pStage->type == stageType_t::ST_LIGHTMAP )
 	{


### PR DESCRIPTION
The statement saying standalone lightmaps are passed as
diffuse with white lightmap was wrong, standalone lightmaps
are already passed as lightmaps on white diffuse.

This updates the comment and tells the code may disable some
standalone lightmaps in some corner cases and also says this
is better wanted as it would never prevent default lightmaps
to be applied (and then it would looks good) while this code
is known to fix many other glitches.

The comment now contains an explicit FIXME to recommend
further investigations and states that the tests currently
take care of only allowing operations that are actually
known to not glitch.

This rewrites ba9ad6d71db2c8f95c017b702eda2c1b1e776c4f better.