### PR TITLE
cm: Silence invalid bevel warnings.

### DIFF
--- a/src/common/cm/cm_plane.cpp
+++ b/src/common/cm/cm_plane.cpp
@@ -622,7 +622,7 @@ void CM_AddFacetBevels( cFacet_t *facet )
 
 					if ( !w2 )
 					{
-						cmLog.Warn( "CM_AddFacetBevels... invalid bevel" );
+						cmLog.Debug( "CM_AddFacetBevels... invalid bevel" );
 						continue;
 					}
 					else


### PR DESCRIPTION
ioq3 has it as a debug print. ET:Legacy has it commented it out all together. It seems this check doesn't apply anymore.
 - ioq3: https://github.com/ioquake/ioq3/blob/main/code/qcommon/cm_patch.c#L966
 - et:l: https://github.com/etlegacy/etlegacy/blob/master/src/qcommon/cm_patch.c#L1175


Fixes https://github.com/Unvanquished/Unvanquished/issues/2109

