### PR TITLE
cmake/DaemonCBSE: find python again if currently cached python path is invalid

### DIFF
--- a/cmake/DaemonCBSE.cmake
+++ b/cmake/DaemonCBSE.cmake
@@ -26,7 +26,7 @@
 
 # Allow overriding the python path with a cached variable.
 set(DAEMON_CBSE_PYTHON_PATH "NOTFOUND" CACHE FILEPATH "Python executable for CBSE code generation")
-if (NOT DAEMON_CBSE_PYTHON_PATH)
+if (NOT DAEMON_CBSE_PYTHON_PATH OR NOT EXISTS DAEMON_CBSE_PYTHON_PATH)
     find_package(Python REQUIRED)
     set(DAEMON_CBSE_PYTHON_PATH "${Python_EXECUTABLE}" CACHE FILEPATH "Python executable for CBSE code generation" FORCE)
 endif()


### PR DESCRIPTION
I got this issue:

```
-- git reported v0.53.2-5-gfb3d55449
-- Using CBSE Python executable: /usr/bin/python3.8
CMake Error at Daemon/cmake/DaemonCBSE.cmake:48 (message):
  Missing dependences for CBSE generation.  Please ensure you have python ≥
  2, python-yaml, and python-jinja installed.

                               Use pip install -r src/utils/cbse/requirements.txt to install
Call Stack (most recent call first):
  CMakeLists.txt:153 (CBSE)
```

But I had the required python modules:

```
$ python3 -c 'import jinja2, yaml, collections, argparse, sys, os.path, re' && echo ok
ok
```

But I recently upgraded my distro and the python binary path changed:

```
$ /usr/bin/python3.8
bash: /usr/bin/python3.8: No such file or directory
```

```
$ realpath "$(command -v python3)"
/usr/bin/python3.10
```

So this PR attempts to force cmake to find python again if the python binary path disappeared.

On a side note, I wonder why we have a CBSE cmake script in Dæmon instead of Unvanquished.