### PR TITLE
client: Drop early server commands.

### DIFF
--- a/src/engine/client/cl_parse.cpp
+++ b/src/engine/client/cl_parse.cpp
@@ -491,6 +491,11 @@ void CL_ParseCommandString( msg_t *msg )
 	clc.serverCommandSequence = seq;
 
 	index = seq & ( MAX_RELIABLE_COMMANDS - 1 );
+	if ( cls.state < connstate_t::CA_LOADING )
+	{
+		Log::Debug( "Dropping early server command: %s", s );
+		return;
+	}
 	Q_strncpyz( clc.serverCommands[ index ], s, sizeof( clc.serverCommands[ index ] ) );
 }
 


### PR DESCRIPTION
These server commands don't get processed until we have loaded the game. By then, they will be stale and can lead to bad state as in the stuck scoreboard bug.