### PR TITLE
Avoid catching fatal exceptions under NaCl

### DIFF
--- a/src/shared/VMMain.cpp
+++ b/src/shared/VMMain.cpp
@@ -139,14 +139,19 @@ int main(int argc, char** argv)
 	// sent back to the engine and reported to the user.
 	Sys::SetupCrashHandler();
 
+	// For NaCl avoid catching the exceptions so we can get a crash dump. You get have either
+	// the exception message or a crash dump with a useful backtrace, not both. The trace
+	// seems more informative on average.
 	try {
 		CommonInit(rootSocket);
 	} catch (Sys::DropErr& err) {
 		Sys::Error(err.what());
+#ifndef __native_client__
 	} catch (std::exception& err) {
 		Sys::Error("Unhandled exception (%s): %s", typeid(err).name(), err.what());
 	} catch (...) {
 		Sys::Error("Unhandled exception of unknown type");
+#endif
 	}
 }
 


### PR DESCRIPTION
This lets us get a crash dump with the stack trace, albeit at the cost of not being able to read a std::exception's message().

The trace can look like this (I programmed the `rocket` command to throw an exception):
```
Thread 0 (crashed)
 0  main.nexe!abort [abort.c : 21 + 0x0]
    rax = 0x0000000000000000   rdx = 0x0000000000000000
    rcx = 0x000000000ffc13e0   rbx = 0x0000000000000000
    rsi = 0x0000000000000000   rdi = 0x00000000fffe4d68
    rbp = 0x00000000fffeff80   rsp = 0x00000000fffe4d90
     r8 = 0x0000000000000000    r9 = 0x0000000000000000
    r10 = 0x0000000000000000   r11 = 0x0000019000585860
    r12 = 0x0000000000000037   r13 = 0x0000000000000288
    r14 = 0x00000000100944c5   r15 = 0x0000019000000000
    rip = 0x0000000000585896
    Found by: given as instruction pointer in context
 1  main.nexe!abort_message + 0xa0
    rbx = 0x00000000fefe0008   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe4db0   r12 = 0x0000000000000037
    r13 = 0x0000000000000288   r14 = 0x00000000100944c5
    r15 = 0x0000019000000000   rip = 0x000000000057f6c0
    Found by: call frame info
 2  main.nexe!default_terminate_handler() [cxa_default_handlers.cpp : 63 + 0x20]
    rbx = 0x00000000100712b0   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe4de0   r12 = 0x0000000000000037
    r13 = 0x0000000000000288   r14 = 0x00000000100944bc
    r15 = 0x0000019000000000   rip = 0x000000000057de00
    Found by: call frame info
 3  main.nexe!std::__terminate(void (*)()) [cxa_handlers.cpp : 68 + 0x40]
    rbx = 0x00000000feeb9a10   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe4e30   r12 = 0x0000000000000037
    r13 = 0x0000000000000288   r14 = 0x00000000feeb99f0
    r15 = 0x0000019000000000   rip = 0x000000000057bca0
    Found by: call frame info
 4  main.nexe!__cxa_throw [cxa_exception.cpp : 149 + 0x20]
    rbx = 0x00000000feeb9a10   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe4e50   r12 = 0x0000000000000037
    r13 = 0x0000000000000288   r14 = 0x00000000feeb99f0
    r15 = 0x0000019000000000   rip = 0x000000000057c080
    Found by: call frame info
 5  main.nexe!Rocket_Rocket_f() + 0x140
    rbx = 0x0000000000000000   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe4e70   r12 = 0x0000000000000037
    r13 = 0x0000000000000288   r14 = 0x0000000000000036
    r15 = 0x0000019000000000   rip = 0x0000000000110f60
    Found by: call frame info
 6  main.nexe!TrapProxyCommand::Run(Cmd::Args const&) const + 0x140
    rbx = 0x0000000000000036   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe4e90   r12 = 0x0000000000000037
    r13 = 0x0000000000000288   r14 = 0x0000000000000036
    r15 = 0x0000019000000000   rip = 0x00000000001d6860
    Found by: call frame info
 7  main.nexe!Cmd::ExecuteSyscall(Util::Reader&, IPC::Channel&) + 0x3c0
    rbx = 0x0000000000000000   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe6ef0   r12 = 0x0000000000000000
    r13 = 0x0000000000000064   r14 = 0x0000000000000000
    r15 = 0x0000019000000000   rip = 0x00000000001c2480
    Found by: call frame info
 8  main.nexe!VM::VMHandleSyscall(unsigned int, Util::Reader) + 0x160
    rbx = 0x0000000000000000   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe6ff0   r12 = 0x00000000fffefec0
    r13 = 0x0000000000000064   r14 = 0x0000000000000000
    r15 = 0x0000019000000000   rip = 0x0000000000026880
    Found by: call frame info
 9  main.nexe!main + 0x8a0
    rbx = 0x00000000fd5dc240   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffefe80   r12 = 0x00000000fffefec0
    r13 = 0x0000000000000064   r14 = 0x00000000fffefea0
    r15 = 0x0000019000000000   rip = 0x00000000001d9080
    Found by: call frame info
10  main.nexe!_start [start.c : 68 + 0x39]
    rbx = 0x0000000000000024   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffeff30   r12 = 0x00000000fffeffbc
    r13 = 0x00000000fffeffc8   r14 = 0x0000000000000024
    r15 = 0x0000019000000000   rip = 0x0000000000586040
    Found by: call frame info
```