### PR TITLE
navedit: less flickering

### DIFF
--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -2696,7 +2696,7 @@ static void RunBotDebugDrawCommands()
 	}
 
 	Util::Reader r;
-	std::swap( r.GetData(), botDebugDrawCommands );
+	r.GetData() = botDebugDrawCommands;
 	while ( true )
 	{
 		debugDrawMode_t mode;


### PR DESCRIPTION
This makes navmesh flickering less jaggering, even if there are still some weirdness.

The problem this fixes is that the botDebugDrawCommands buffer was cleared after every rendering frame, while the server frame which did set the value (calling RE_SendBotDebugDrawCommands) did run less often, likely at a rate of sv_fps.

A good way to show how this change is useful is to notice how the flickering was much more annoying at /timescale 0.1, but is now not any worse.

@bmorel I think you'd be interested in that one too, since you complained loudly about that flickering before.