### PR TITLE
Cvar namespaces + unit tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "libs/crunch"]
 	path = libs/crunch
 	url = https://github.com/DaemonEngine/crunch.git
+[submodule "libs/googletest"]
+	path = libs/googletest
+	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,8 @@ if(NOT DAEMON_EXTERNAL_APP)
     option(USE_BREAKPAD "Generate Daemon crash dumps (which require Breakpad tools to read)" OFF)
 endif()
 
+option(BUILD_TESTS "Build unit test applications" OFF)
+
 option(USE_LTO "Use link-time optimization for release builds" OFF)
 cmake_dependent_option(USE_SLIM_LTO "Generate slim LTO objects, improves build times" 1 "USE_LTO AND \"${CMAKE_CXX_COMPILER_ID}\" STREQUAL GNU" 0)
 option(USE_HARDENING "Use stack protection and other hardening flags" OFF)
@@ -491,13 +493,13 @@ if (DEPS_DIR)
     set(CMAKE_FIND_ROOT_PATH ${DEPS_DIR} ${CMAKE_FIND_ROOT_PATH})
     set(CMAKE_INCLUDE_PATH ${DEPS_DIR} ${DEPS_DIR}/include ${CMAKE_INCLUDE_PATH})
     set(CMAKE_FRAMEWORK_PATH ${DEPS_DIR} ${CMAKE_FRAMEWORK_PATH})
-    set(CMAKE_LIBRARY_PATH ${DEPS_DIR}/lib ${CMAKE_LIBRARY_PATH})
+    set(CMAKE_PREFIX_PATH ${DEPS_DIR} ${CMAKE_PREFIX_PATH})
     if (DAEMON_PARENT_SCOPE_DIR)
         # Also set parent scope so the top level CMakeLists can find precompiled deps
         set(CMAKE_FIND_ROOT_PATH ${DEPS_DIR} ${CMAKE_FIND_ROOT_PATH} PARENT_SCOPE)
         set(CMAKE_INCLUDE_PATH ${DEPS_DIR} ${DEPS_DIR}/include ${CMAKE_INCLUDE_PATH} PARENT_SCOPE)
         set(CMAKE_FRAMEWORK_PATH ${DEPS_DIR} ${CMAKE_FRAMEWORK_PATH} PARENT_SCOPE)
-        set(CMAKE_LIBRARY_PATH ${DEPS_DIR}/lib ${CMAKE_LIBRARY_PATH} PARENT_SCOPE)
+        set(CMAKE_PREFIX_PATH ${DEPS_DIR} ${CMAKE_PREFIX_PATH} PARENT_SCOPE)
     endif()
 
     # Force OpenAL Soft on Mac, otherwise the system framework will be selected
@@ -747,26 +749,31 @@ if (BUILD_CLIENT)
     set(LIBS_CLIENT ${LIBS_CLIENT} ${OPENAL_LIBRARY})
 endif()
 
+if (BUILD_TESTS)
+    set(BUILD_GMOCK ON)
+    set(INSTALL_GTEST OFF)
+    set(gtest_force_shared_crt ON)
+    add_subdirectory(${LIB_DIR}/googletest EXCLUDE_FROM_ALL)
+    unset(BUILD_GMOCK CACHE)
+    unset(INSTALL_GTEST CACHE)
+endif()
+
 ################################################################################
 # Engine
 ################################################################################
-function(AddApplication)
-    set(oneValueArgs Target ExecutableName)
-    set(multiValueArgs Definitions Flags Files Libs)
-    cmake_parse_arguments(A "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
-    add_executable(${A_Target} ${A_Files} ${PCH_FILE})
-    target_link_libraries(${A_Target} engine-lib ${A_Libs})
-
-    set_property(TARGET ${A_Target} APPEND PROPERTY COMPILE_OPTIONS ${A_Flags})
-    set_property(TARGET ${A_Target} APPEND PROPERTY INCLUDE_DIRECTORIES ${ENGINE_DIR} ${MOUNT_DIR} ${LIB_DIR})
-    set_property(TARGET ${A_Target} APPEND PROPERTY COMPILE_DEFINITIONS ${A_Definitions})
-    set_target_properties(${A_Target} PROPERTIES OUTPUT_NAME "${A_ExecutableName}" PREFIX "" FOLDER "engine")
+macro(AddApplicationInternal Target Executable)
+    add_executable(${Target} ${Sources})
+    target_link_libraries(${Target} ${A_Target}-objects)
+    add_dependencies(${Target} runtime_deps)
+    set_property(TARGET ${Target} APPEND PROPERTY COMPILE_OPTIONS ${A_Flags})
+    set_property(TARGET ${Target} APPEND PROPERTY INCLUDE_DIRECTORIES ${ENGINE_DIR} ${MOUNT_DIR} ${LIB_DIR})
+    set_property(TARGET ${Target} APPEND PROPERTY COMPILE_DEFINITIONS ${A_Definitions})
+    set_target_properties(${Target} PROPERTIES OUTPUT_NAME "${Executable}" PREFIX "" FOLDER "engine")
 
     # Append Windows specific manifests.
     if (WIN32)
         set(WINDOWS_MANIFESTS_DIR ${ENGINE_DIR}/sys/manifests)
-        target_sources(${A_Target} PRIVATE
+        target_sources(${Target} PRIVATE
             # App is DPI aware, so Windows doesn't try to scale UI.
             ${WINDOWS_MANIFESTS_DIR}/dpi-aware.manifest
             # App supports Windows Vista+, no quirks required.
@@ -774,8 +781,36 @@ function(AddApplication)
         )
     endif()
 
-    message(STATUS ${A_Target})
-    ADD_PRECOMPILED_HEADER(${A_Target})
+    message(STATUS ${Target})
+endmacro()
+
+function(AddApplication)
+    set(oneValueArgs Target ExecutableName)
+    set(multiValueArgs ApplicationMain Definitions Flags Files Libs Tests)
+    cmake_parse_arguments(A "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Reuse object files between the real application and the test one
+    add_library(${A_Target}-objects OBJECT EXCLUDE_FROM_ALL ${A_Files} ${PCH_FILE})
+    target_link_libraries(${A_Target}-objects engine-lib ${A_Libs} ${LIBS_BASE})
+    set_property(TARGET ${A_Target}-objects APPEND PROPERTY COMPILE_OPTIONS ${A_Flags})
+    set_property(TARGET ${A_Target}-objects APPEND PROPERTY INCLUDE_DIRECTORIES ${ENGINE_DIR} ${MOUNT_DIR} ${LIB_DIR})
+    set_property(TARGET ${A_Target}-objects APPEND PROPERTY COMPILE_DEFINITIONS ${A_Definitions})
+
+    set(Sources WIN32 ${A_ApplicationMain})
+    AddApplicationInternal(${A_Target} ${A_ExecutableName})
+    if (BUILD_TESTS)
+        # TODO disable dameon assert macros in test files
+        set(A_Definitions ${A_Definitions} PRODUCE_TEST_APPLICATION DAEMON_SKIP_ASSERT_SHORTHANDS)
+        # Note that unit tests must be added directly as sources to the executable, not via
+        # a static library, because when GCC is linking a library, it drops
+        # object files without a referenced symbol, unless you prevent it with
+        # -Wl,--whole-archive -l<library path> -Wl,--no-whole-archive
+        set(Sources ${A_ApplicationMain} ${A_Tests})
+        AddApplicationInternal(test-${A_Target} test-${A_Target})
+        target_link_libraries(test-${A_Target} GTest::gmock)
+    endif()
+
+    ADD_PRECOMPILED_HEADER(${A_Target}-objects)
 endfunction()
 
 if (NOT NACL)
@@ -791,8 +826,10 @@ if (NOT NACL)
             Target dummyapp
             ExecutableName dummyapp
             Definitions USELESS_DEFINITION_TO_AVOID_PCH_ISSUE
+            ApplicationMain ${ENGINE_DIR}/null/NullApplication.cpp
             Flags ${WARNINGS}
-            Files ${ENGINE_DIR}/null/NullApplication.cpp
+            Files ${COMMON_DIR}/Util.h  # must be nonempty
+            Tests ${ENGINETESTLIST}
         )
     endif()
 endif()
@@ -807,17 +844,19 @@ if (BUILD_CLIENT)
     AddApplication(
         Target client
         ExecutableName daemon
+        ApplicationMain ${ENGINE_DIR}/client/ClientApplication.cpp
         Definitions ${Definitions}
         Flags ${WARNINGS}
-        Files WIN32 ${WIN_RC} ${QCOMMONLIST} ${SERVERLIST} ${CLIENTBASELIST} ${CLIENTLIST}
+        Files ${WIN_RC} ${QCOMMONLIST} ${SERVERLIST} ${CLIENTBASELIST} ${CLIENTLIST}
         Libs ${LIBS_CLIENT} ${LIBS_CLIENTBASE} ${LIBS_ENGINE}
+        Tests ${ENGINETESTLIST}
     )
 
     # generate glsl include files
     set(GLSL_SOURCE_DIR ${ENGINE_DIR}/renderer/glsl_source)
     set(EMBED_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/embed_data)
     file(MAKE_DIRECTORY ${EMBED_INCLUDE_DIR})
-    set_property(TARGET client APPEND PROPERTY INCLUDE_DIRECTORIES ${EMBED_INCLUDE_DIR})
+    set_property(TARGET client-objects APPEND PROPERTY INCLUDE_DIRECTORIES ${EMBED_INCLUDE_DIR})
 
     foreach(res ${GLSLSOURCELIST})
         get_filename_component(filename_no_ext ${res} NAME_WE)
@@ -828,7 +867,7 @@ if (BUILD_CLIENT)
                 "-DVARIABLE_NAME=${filename_no_ext}_glsl" -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/EmbedText.cmake
             MAIN_DEPENDENCY ${res}
         )
-        set_property(TARGET client APPEND PROPERTY SOURCES ${outpath})
+        set_property(TARGET client-objects APPEND PROPERTY SOURCES ${outpath})
     endforeach()
 endif()
 
@@ -836,10 +875,12 @@ if (BUILD_SERVER)
     AddApplication(
         Target server
         ExecutableName daemonded
+        ApplicationMain ${ENGINE_DIR}/server/ServerApplication.cpp
         Definitions BUILD_ENGINE BUILD_SERVER
         Flags ${WARNINGS}
-        Files WIN32 ${WIN_RC} ${QCOMMONLIST} ${SERVERLIST} ${DEDSERVERLIST}
+        Files ${WIN_RC} ${QCOMMONLIST} ${SERVERLIST} ${DEDSERVERLIST}
         Libs ${LIBS_ENGINE}
+        Tests ${ENGINETESTLIST}
     )
 endif()
 
@@ -847,10 +888,12 @@ if (BUILD_TTY_CLIENT)
     AddApplication(
         Target ttyclient
         ExecutableName daemon-tty
+        ApplicationMain ${ENGINE_DIR}/client/ClientApplication.cpp
         Definitions BUILD_ENGINE BUILD_TTY_CLIENT
         Flags ${WARNINGS}
-        Files WIN32 ${WIN_RC} ${QCOMMONLIST} ${SERVERLIST} ${CLIENTBASELIST} ${TTYCLIENTLIST}
+        Files ${WIN_RC} ${QCOMMONLIST} ${SERVERLIST} ${CLIENTBASELIST} ${TTYCLIENTLIST}
         Libs ${LIBS_CLIENTBASE} ${LIBS_ENGINE}
+        Tests ${ENGINETESTLIST}
     )
 endif()
 
@@ -924,15 +967,5 @@ if (BUILD_CLIENT OR BUILD_SERVER OR BUILD_TTY_CLIENT)
                     ${FULL_OUTPUT_DIR}
             )
         endforeach()
-    endif()
-
-    if (BUILD_CLIENT)
-        add_dependencies(client runtime_deps)
-    endif()
-    if (BUILD_SERVER)
-        add_dependencies(server runtime_deps)
-    endif()
-    if (BUILD_TTY_CLIENT)
-        add_dependencies(ttyclient runtime_deps)
     endif()
 endif()

--- a/src.cmake
+++ b/src.cmake
@@ -215,6 +215,7 @@ set(SERVERLIST
 set(ENGINELIST
     ${ENGINE_DIR}/framework/Application.cpp
     ${ENGINE_DIR}/framework/Application.h
+    ${ENGINE_DIR}/framework/ApplicationInternals.h
     ${ENGINE_DIR}/framework/BaseCommands.cpp
     ${ENGINE_DIR}/framework/BaseCommands.h
     ${ENGINE_DIR}/framework/CommandBufferHost.cpp
@@ -261,6 +262,11 @@ else()
     )
 endif()
 
+# Tests for engine-lib
+set(ENGINETESTLIST
+    ${ENGINE_DIR}/framework/CommandSystemTest.cpp
+)
+
 set(QCOMMONLIST
     ${ENGINE_DIR}/qcommon/cmd.cpp
     ${ENGINE_DIR}/qcommon/common.cpp
@@ -305,7 +311,6 @@ set(CLIENTBASELIST
     ${ENGINE_DIR}/client/key_identification.h
     ${ENGINE_DIR}/client/keycodes.h
     ${ENGINE_DIR}/client/keys.h
-    ${ENGINE_DIR}/client/ClientApplication.cpp
 )
 
 set(CLIENTLIST
@@ -345,7 +350,6 @@ set(DEDSERVERLIST
     ${ENGINE_DIR}/null/NullKeyboard.cpp
     ${ENGINE_DIR}/null/null_client.cpp
     ${ENGINE_DIR}/null/null_input.cpp
-    ${ENGINE_DIR}/server/ServerApplication.cpp
 )
 
 set(WIN_RC ${ENGINE_DIR}/sys/daemon.rc)

--- a/src/engine/client/ClientApplication.cpp
+++ b/src/engine/client/ClientApplication.cpp
@@ -28,7 +28,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ===========================================================================
 */
 
-#include "framework/Application.h"
+#include "common/Common.h"
+#include "framework/ApplicationInternals.h"
 #include "framework/CommandSystem.h"
 #include "client.h"
 

--- a/src/engine/framework/Application.cpp
+++ b/src/engine/framework/Application.cpp
@@ -29,11 +29,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "Application.h"
+#include "common/FileSystem.h"
 
 namespace Application {
 
     Traits::Traits()
-    : isClient(false), isTTYClient(false), isServer(false), useCurses(false), supportsUri(false) {
+    : isClient(false), isTTYClient(false), isServer(false),
+      defaultHomepath(FS::DefaultHomePath()), useCurses(false), supportsUri(false) {
     }
 
     // Forward declaration of the function declared by INSTANTIATE_APPLICATION

--- a/src/engine/framework/Application.h
+++ b/src/engine/framework/Application.h
@@ -45,6 +45,7 @@ struct Traits {
     bool isTTYClient;
     bool isServer;
 
+    std::string defaultHomepath;
     std::string uniqueHomepathSuffix;
     bool useCurses;
     bool supportsUri;

--- a/src/engine/framework/ApplicationInternals.h
+++ b/src/engine/framework/ApplicationInternals.h
@@ -1,0 +1,101 @@
+/*
+===========================================================================
+Daemon BSD Source Code
+Copyright (c) 2013-2022, Daemon Developers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Daemon developers nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+===========================================================================
+*/
+
+#ifndef FRAMEWORK_APPLICATION_INTERNALS_H_
+#define FRAMEWORK_APPLICATION_INTERNALS_H_
+
+#ifdef PRODUCE_TEST_APPLICATION
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "common/Cvar.h"
+#include "System.h"
+#endif
+
+#include "Application.h"
+
+namespace Application {
+
+#ifdef PRODUCE_TEST_APPLICATION
+
+template<typename ApplicationT>
+class TestApplication : public ApplicationT
+{
+    static Cvar::Cvar<std::string> gtestFlags;
+
+    void Frame() override
+    {
+        Log::Notice("Running unit tests. You can set Googletest flags via the cvar `testing.flags`."
+                    " Try `-set testing.flags --help`.");
+        std::string flagBuf("programname " + gtestFlags.Get() + " ");
+        std::vector<char*> argv;
+        for (size_t start = 0; start != flagBuf.npos; ) {
+            size_t end = flagBuf.find_first_of(" ", start);
+            flagBuf[end] = '\0';
+            argv.push_back(&flagBuf[start]);
+            start = flagBuf.find_first_not_of(" ", end + 1);
+        }
+        int argc = int(argv.size());
+        testing::InitGoogleMock(&argc, argv.data());
+        if (argc > 1) {
+            Sys::Error("Unknown Googletest flag: '%s'", argv[1]);
+        }
+        bool success = 0 == RUN_ALL_TESTS();
+        if (success) {
+            Sys::Quit("Passed all tests");
+        }
+        else {
+            Sys::Error("One or more tests failed");
+        }
+    }
+};
+
+#define INSTANTIATE_APPLICATION(classname) \
+    template<> Cvar::Cvar<std::string> TestApplication<classname>::gtestFlags( \
+        "testing.flags", "Space-separated flags for Googletest", Cvar::NONE, ""); \
+    Application& GetApp() { \
+        static TestApplication<classname> app; \
+        return app; \
+    }
+
+#else // !PRODUCE_TEST_APPLICATION
+
+#define INSTANTIATE_APPLICATION(classname) \
+    Application& GetApp() { \
+        static classname app; \
+        return app; \
+    }
+
+#endif // PRODUCE_TEST_APPLICATION
+
+#define TRY_SHUTDOWN(code) try {code;} catch (Sys::DropErr&) {}
+
+}
+
+#endif // FRAMEWORK_APPLICATION_INTERNALS_H_

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -409,7 +409,8 @@ static void StartSignalThread()
 // Command line arguments
 struct cmdlineArgs_t {
 	cmdlineArgs_t()
-		: homePath(FS::DefaultHomePath()), libPath(FS::DefaultBasePath()), reset_config(false), use_curses(Application::GetTraits().useCurses) {}
+		: homePath(Application::GetTraits().defaultHomepath), libPath(FS::DefaultBasePath()),
+		  reset_config(false), use_curses(Application::GetTraits().useCurses) {}
 
 	std::string homePath;
 	std::string libPath;

--- a/src/engine/null/NullApplication.cpp
+++ b/src/engine/null/NullApplication.cpp
@@ -31,7 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //TODO(kangz)
 #include "common/Common.h"
 #include "common/System.h"
-#include "framework/Application.h"
+#include "framework/ApplicationInternals.h"
 #include "framework/BaseCommands.h"
 #include "framework/CommandSystem.h"
 #include "qcommon/qcommon.h"

--- a/src/engine/server/ServerApplication.cpp
+++ b/src/engine/server/ServerApplication.cpp
@@ -29,7 +29,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <common/FileSystem.h>
-#include "framework/Application.h"
+#include "framework/ApplicationInternals.h"
 #include "framework/CommandSystem.h"
 #include "qcommon/qcommon.h"
 


### PR DESCRIPTION
1. Add namespace-aware cvar autocompletion (fixes #449). Thanks to @peoro for the original idea.
2. Introduce unit testing using Googletest (a.k.a GTest). To start with there are tests for the cvar namespace collapsing.

Our codebase is not very modular in terms of having independently buildable units; I have worked around this by building the tests directly into the engine binary. A `test` command is used to run the tests. (We could consider a `-test` command line flag instead, but I fear that would run into problems later with things not being initialized.) This approach could be nice for the gamelogic too since it is not easy to make a standalone NaCl binary.

The tests I added are for some `engine/framework` stuff so they are built into all engine binaries including dummyapp. Other tests might be client-specific; they can be built into `daemon` and `daemon-tty`. 

To do before merging:

- [ ] Test external_deps build on Windows and Mac
- [ ] Redirect output to the console functions instead of stdout
- [x] Ensure that configs (autogen, binds) are not read or written