### PR TITLE
renderer: fallback on `EXT_framebuffer_object` if `ARB_framebuffer_object` is missing

### DIFF
--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -34,13 +34,13 @@ bool R_CheckFBO( const FBO_t *fbo )
 	int id;
 
 	glGetIntegerv( GL_FRAMEBUFFER_BINDING, &id );
-	glBindFramebuffer( GL_FRAMEBUFFER, fbo->frameBuffer );
+	GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, fbo->frameBuffer );
 
-	code = glCheckFramebufferStatus( GL_FRAMEBUFFER );
+	code = GL_fboShim.glCheckFramebufferStatus( GL_FRAMEBUFFER );
 
 	if ( code == GL_FRAMEBUFFER_COMPLETE )
 	{
-		glBindFramebuffer( GL_FRAMEBUFFER, id );
+		GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, id );
 		return true;
 	}
 
@@ -72,7 +72,7 @@ bool R_CheckFBO( const FBO_t *fbo )
 			break;
 	}
 
-	glBindFramebuffer( GL_FRAMEBUFFER, id );
+	GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, id );
 
 	return false;
 }
@@ -112,7 +112,7 @@ FBO_t          *R_CreateFBO( const char *name, int width, int height )
 	fbo->width = width;
 	fbo->height = height;
 
-	glGenFramebuffers( 1, &fbo->frameBuffer );
+	GL_fboShim.glGenFramebuffers( 1, &fbo->frameBuffer );
 
 	return fbo;
 }
@@ -140,15 +140,15 @@ void R_CreateFBOColorBuffer( FBO_t *fbo, int format, int index )
 
 	if ( absent )
 	{
-		glGenRenderbuffers( 1, &fbo->colorBuffers[ index ] );
+		GL_fboShim.glGenRenderbuffers( 1, &fbo->colorBuffers[ index ] );
 	}
 
-	glBindRenderbuffer( GL_RENDERBUFFER, fbo->colorBuffers[ index ] );
-	glRenderbufferStorage( GL_RENDERBUFFER, format, fbo->width, fbo->height );
+	GL_fboShim.glBindRenderbuffer( GL_RENDERBUFFER, fbo->colorBuffers[ index ] );
+	GL_fboShim.glRenderbufferStorage( GL_RENDERBUFFER, format, fbo->width, fbo->height );
 
 	if ( absent )
 	{
-		glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, GL_RENDERBUFFER,
+		GL_fboShim.glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, GL_RENDERBUFFER,
 					   fbo->colorBuffers[ index ] );
 	}
 
@@ -177,15 +177,15 @@ void R_CreateFBODepthBuffer( FBO_t *fbo, int format )
 
 	if ( absent )
 	{
-		glGenRenderbuffers( 1, &fbo->depthBuffer );
+		GL_fboShim.glGenRenderbuffers( 1, &fbo->depthBuffer );
 	}
 
-	glBindRenderbuffer( GL_RENDERBUFFER, fbo->depthBuffer );
-	glRenderbufferStorage( GL_RENDERBUFFER, fbo->depthFormat, fbo->width, fbo->height );
+	GL_fboShim.glBindRenderbuffer( GL_RENDERBUFFER, fbo->depthBuffer );
+	GL_fboShim.glRenderbufferStorage( GL_RENDERBUFFER, fbo->depthFormat, fbo->width, fbo->height );
 
 	if ( absent )
 	{
-		glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, fbo->depthBuffer );
+		GL_fboShim.glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, fbo->depthBuffer );
 	}
 
 	GL_CheckErrors();
@@ -214,16 +214,16 @@ void R_CreateFBOStencilBuffer( FBO_t *fbo, int format )
 
 	if ( absent )
 	{
-		glGenRenderbuffers( 1, &fbo->stencilBuffer );
+		GL_fboShim.glGenRenderbuffers( 1, &fbo->stencilBuffer );
 	}
 
-	glBindRenderbuffer( GL_RENDERBUFFER, fbo->stencilBuffer );
-	glRenderbufferStorage( GL_RENDERBUFFER, fbo->stencilFormat, fbo->width, fbo->height );
+	GL_fboShim.glBindRenderbuffer( GL_RENDERBUFFER, fbo->stencilBuffer );
+	GL_fboShim.glRenderbufferStorage( GL_RENDERBUFFER, fbo->stencilFormat, fbo->width, fbo->height );
 	GL_CheckErrors();
 
 	if ( absent )
 	{
-		glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, fbo->stencilBuffer );
+		GL_fboShim.glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, fbo->stencilBuffer );
 	}
 
 	GL_CheckErrors();
@@ -250,18 +250,18 @@ void R_CreateFBOPackedDepthStencilBuffer( FBO_t *fbo, int format )
 
 	if ( absent )
 	{
-		glGenRenderbuffers( 1, &fbo->packedDepthStencilBuffer );
+		GL_fboShim.glGenRenderbuffers( 1, &fbo->packedDepthStencilBuffer );
 	}
 
-	glBindRenderbuffer( GL_RENDERBUFFER, fbo->packedDepthStencilBuffer );
-	glRenderbufferStorage( GL_RENDERBUFFER, fbo->packedDepthStencilFormat, fbo->width, fbo->height );
+	GL_fboShim.glBindRenderbuffer( GL_RENDERBUFFER, fbo->packedDepthStencilBuffer );
+	GL_fboShim.glRenderbufferStorage( GL_RENDERBUFFER, fbo->packedDepthStencilFormat, fbo->width, fbo->height );
 	GL_CheckErrors();
 
 	if ( absent )
 	{
-		glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER,
+		GL_fboShim.glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER,
 					   fbo->packedDepthStencilBuffer );
-		glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER,
+		GL_fboShim.glFramebufferRenderbuffer( GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER,
 					   fbo->packedDepthStencilBuffer );
 	}
 
@@ -303,7 +303,7 @@ void R_AttachFBOTexture2D( int target, int texId, int index )
 		return;
 	}
 
-	glFramebufferTexture2D( GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, target, texId, 0 );
+	GL_fboShim.glFramebufferTexture2D( GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, target, texId, 0 );
 }
 
 /*
@@ -329,7 +329,7 @@ R_AttachFBOTextureDepth
 */
 void R_AttachFBOTextureDepth( int texId )
 {
-	glFramebufferTexture2D( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texId, 0 );
+	GL_fboShim.glFramebufferTexture2D( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texId, 0 );
 }
 
 /*
@@ -339,8 +339,8 @@ R_AttachFBOTexturePackedDepthStencil
 */
 void R_AttachFBOTexturePackedDepthStencil( int texId )
 {
-	glFramebufferTexture2D( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texId, 0 );
-	glFramebufferTexture2D( GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, texId, 0 );
+	GL_fboShim.glFramebufferTexture2D( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texId, 0 );
+	GL_fboShim.glFramebufferTexture2D( GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, texId, 0 );
 }
 
 /*
@@ -364,7 +364,7 @@ void R_BindFBO( FBO_t *fbo )
 
 	if ( glState.currentFBO != fbo )
 	{
-		glBindFramebuffer( GL_FRAMEBUFFER, fbo->frameBuffer );
+		GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, fbo->frameBuffer );
 
 		glState.currentFBO = fbo;
 	}
@@ -384,8 +384,8 @@ void R_BindNullFBO()
 
 	if ( glState.currentFBO )
 	{
-		glBindFramebuffer( GL_FRAMEBUFFER, 0 );
-		glBindRenderbuffer( GL_RENDERBUFFER, 0 );
+		GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, 0 );
+		GL_fboShim.glBindRenderbuffer( GL_RENDERBUFFER, 0 );
 		glState.currentFBO = nullptr;
 	}
 }
@@ -570,23 +570,23 @@ void R_ShutdownFBOs()
 		{
 			if ( fbo->colorBuffers[ j ] )
 			{
-				glDeleteRenderbuffers( 1, &fbo->colorBuffers[ j ] );
+				GL_fboShim.glDeleteRenderbuffers( 1, &fbo->colorBuffers[ j ] );
 			}
 		}
 
 		if ( fbo->depthBuffer )
 		{
-			glDeleteRenderbuffers( 1, &fbo->depthBuffer );
+			GL_fboShim.glDeleteRenderbuffers( 1, &fbo->depthBuffer );
 		}
 
 		if ( fbo->stencilBuffer )
 		{
-			glDeleteRenderbuffers( 1, &fbo->stencilBuffer );
+			GL_fboShim.glDeleteRenderbuffers( 1, &fbo->stencilBuffer );
 		}
 
 		if ( fbo->frameBuffer )
 		{
-			glDeleteFramebuffers( 1, &fbo->frameBuffer );
+			GL_fboShim.glDeleteFramebuffers( 1, &fbo->frameBuffer );
 		}
 	}
 }

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1127,7 +1127,7 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 			if ( image->filterType == filterType_t::FT_DEFAULT )
 			{
 				if( image->type != GL_TEXTURE_CUBE_MAP || i == 5 ) {
-					glGenerateMipmap( image->type );
+					GL_fboShim.glGenerateMipmap( image->type );
 					glTexParameteri( image->type, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR );  // default to trilinear
 				}
 			}

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -852,8 +852,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		   bound.
 		 */
 
-		glBindFramebuffer( GL_FRAMEBUFFER, 0 );
-		glBindRenderbuffer( GL_RENDERBUFFER, 0 );
+		GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, 0 );
+		GL_fboShim.glBindRenderbuffer( GL_RENDERBUFFER, 0 );
 		glState.currentFBO = nullptr;
 
 		GL_PolygonMode( GL_FRONT_AND_BACK, GL_FILL );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -193,6 +193,91 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 // max. 16 dynamic lights per plane
 #define LIGHT_PLANES ( MAX_REF_LIGHTS / 16 )
 
+struct glFboShim_t
+{
+	/* Functions with same signature and similar purpose can be provided by:
+	- ARB_framebuffer_object
+	- EXT_framebuffer_object
+	- OES_framebuffer_object
+
+	They are not 100% equivalent, for example the ARB fbo provides more
+	features than the EXT fbo, but the EXT fbo subset of the ARB fbo looks
+	to be enough for us. */
+
+	// void (*glBindFramebuffer) (GLenum target, GLuint framebuffer);
+	PFNGLBINDFRAMEBUFFERPROC glBindFramebuffer;
+	// void (*glBindRenderbuffer) (GLenum target, GLuint renderbuffer);
+	PFNGLBINDRENDERBUFFERPROC glBindRenderbuffer;
+	// GLenum (*glCheckFramebufferStatus) (GLenum target);
+	PFNGLCHECKFRAMEBUFFERSTATUSPROC glCheckFramebufferStatus;
+	// void (*glDeleteFramebuffers) (GLsizei n, const GLuint *framebuffers);
+	PFNGLDELETEFRAMEBUFFERSPROC glDeleteFramebuffers;
+	// void (*glDeleteRenderbuffers) (GLsizei n, const GLuint *renderbuffers);
+	PFNGLDELETERENDERBUFFERSPROC glDeleteRenderbuffers;
+	// void (*glFramebufferRenderbuffer) (GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
+	PFNGLFRAMEBUFFERRENDERBUFFERPROC glFramebufferRenderbuffer;
+	// void (*glFramebufferTexture2D) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
+	PFNGLFRAMEBUFFERTEXTURE2DPROC glFramebufferTexture2D;
+	// void (*glGenerateMipmap) (GLenum target);
+	PFNGLGENERATEMIPMAPPROC glGenerateMipmap;
+	// void (*glGenFramebuffers) (GLsizei n, GLuint *framebuffers);
+	PFNGLGENFRAMEBUFFERSPROC glGenFramebuffers;
+	// void (*glGenRenderbuffers) (GLsizei n, GLuint *renderbuffers);
+	PFNGLGENRENDERBUFFERSPROC glGenRenderbuffers;
+	// void (*glRenderbufferStorage) (GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
+	PFNGLRENDERBUFFERSTORAGEPROC glRenderbufferStorage;
+
+	/* Unused for now:
+	// void (*glRenderbufferStorageMultisample) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
+	PFNGLRENDERBUFFERSTORAGEMULTISAMPLEPROC glRenderbufferStorageMultisample; */
+
+	/* Those three values are the same:
+	- GL_FRAMEBUFFER_COMPLETE
+	- GL_FRAMEBUFFER_COMPLETE_EXT
+	- GL_FRAMEBUFFER_COMPLETE_OES
+
+	So there is no need to abstract them and GL_FRAMEBUFFER_COMPLETE can be
+	used in all cases. */
+};
+
+extern glFboShim_t GL_fboShim;
+
+static inline void glFboSetArb()
+{
+	GL_fboShim.glBindFramebuffer =  glBindFramebuffer;
+	GL_fboShim.glBindRenderbuffer = glBindRenderbuffer;
+	GL_fboShim.glCheckFramebufferStatus = glCheckFramebufferStatus;
+	GL_fboShim.glDeleteFramebuffers = glDeleteFramebuffers;
+	GL_fboShim.glDeleteRenderbuffers = glDeleteRenderbuffers;
+	GL_fboShim.glFramebufferRenderbuffer = glFramebufferRenderbuffer;
+	GL_fboShim.glFramebufferTexture2D = glFramebufferTexture2D;
+	GL_fboShim.glGenerateMipmap = glGenerateMipmap;
+	GL_fboShim.glGenFramebuffers = glGenFramebuffers;
+	GL_fboShim.glGenRenderbuffers = glGenRenderbuffers;
+	GL_fboShim.glRenderbufferStorage = glRenderbufferStorage;
+
+	/* Unused for now:
+	GL_fboShim.glRenderbufferStorageMultisample = glRenderbufferStorageMultisample; */
+}
+
+static inline void glFboSetExt()
+{
+	GL_fboShim.glBindFramebuffer = glBindFramebufferEXT;
+	GL_fboShim.glBindRenderbuffer = glBindRenderbufferEXT;
+	GL_fboShim.glCheckFramebufferStatus = glCheckFramebufferStatusEXT;
+	GL_fboShim.glDeleteFramebuffers = glDeleteFramebuffersEXT;
+	GL_fboShim.glDeleteRenderbuffers = glDeleteRenderbuffersEXT;
+	GL_fboShim.glFramebufferRenderbuffer = glFramebufferRenderbufferEXT;
+	GL_fboShim.glFramebufferTexture2D = glFramebufferTexture2DEXT;
+	GL_fboShim.glGenerateMipmap = glGenerateMipmapEXT;
+	GL_fboShim.glGenFramebuffers = glGenFramebuffersEXT;
+	GL_fboShim.glGenRenderbuffers = glGenRenderbuffersEXT;
+	GL_fboShim.glRenderbufferStorage = glRenderbufferStorageEXT;
+
+	/* Unused for now:
+	GL_fboShim.glRenderbufferStorageMultisample = glRenderbufferStorageMultisampleEXT; */
+}
+
 	enum class renderSpeeds_t
 	{
 	  RSPEEDS_GENERAL = 1,

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1829,7 +1829,6 @@ static void GLimp_InitExtensions()
 
 	// VAO and VBO
 	// made required in OpenGL 3.0
-
 	LOAD_EXTENSION( ExtFlag_REQUIRED | ExtFlag_CORE, ARB_half_float_vertex );
 
 	// made required in OpenGL 3.0

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1551,7 +1551,7 @@ static bool GLimp_StartDriverAndSetMode( int mode, bool fullscreen, bool bordere
 				"OpenGL is not available.\n\n"
 				"You need a graphic card with drivers supporting\n"
 				"at least OpenGL 3.2 or OpenGL 2.1 with\n"
-				"ARB_half_float_vertex and ARB_framebuffer_object." );
+				"ARB_half_float_vertex and EXT_framebuffer_object." );
 
 			// Sys:Error calls OSExit() so the break and the return is unreachable.
 			break;
@@ -1561,7 +1561,7 @@ static bool GLimp_StartDriverAndSetMode( int mode, bool fullscreen, bool bordere
 				"OpenGL %d.%d is too old.\n\n"
 				"You need a graphic card with drivers supporting\n"
 				"at least OpenGL 3.2 or OpenGL 2.1 with\n"
-				"ARB_half_float_vertex and ARB_framebuffer_object." );
+				"ARB_half_float_vertex and EXT_framebuffer_object." );
 
 			// Sys:Error calls OSExit() so the break and the return is unreachable.
 			break;
@@ -1723,6 +1723,8 @@ static bool LoadExt( int flags, bool hasExt, const char* name, bool test = true 
 
 #define LOAD_EXTENSION_WITH_TEST(flags, ext, test) LoadExt(flags, GLEW_##ext, #ext, test)
 
+glFboShim_t GL_fboShim;
+
 static void GLimp_InitExtensions()
 {
 	logger.Notice("Initializing OpenGL extensions" );
@@ -1832,7 +1834,15 @@ static void GLimp_InitExtensions()
 	LOAD_EXTENSION( ExtFlag_REQUIRED | ExtFlag_CORE, ARB_half_float_vertex );
 
 	// made required in OpenGL 3.0
-	LOAD_EXTENSION( ExtFlag_REQUIRED | ExtFlag_CORE, ARB_framebuffer_object );
+	if ( LOAD_EXTENSION( ExtFlag_CORE, ARB_framebuffer_object ) )
+	{
+		glFboSetArb();
+	}
+	else
+	{
+		LOAD_EXTENSION( ExtFlag_REQUIRED, EXT_framebuffer_object );
+		glFboSetExt();
+	}
 
 	// FBO
 	glGetIntegerv( GL_MAX_RENDERBUFFER_SIZE, &glConfig2.maxRenderbufferSize );


### PR DESCRIPTION
Fallback on `EXT_framebuffer_object` if `ARB_framebuffer_object` is missing.

`ARB_framebuffer_object` does more things than `EXT_framebuffer_object` so hardware supporting `EXT_framebuffer_object` may not support `ARB_framebuffer_object` but it looks like our game does not do crazy things enough and `EXT_framebuffer_object` seems to be usable as a fallback for missing `ARB_framebuffer_object`.

This makes the engine run on all Nvidia NV40 (Curie) on Linux with nouveau nv30 driver.

The proprietary nvidia 304 driver emulated `ARB_framebuffer_object` over `EXT_framebuffer_object` but nouveau doesn't, and the proprietary nvidia 304 driver isn't provided on Linux distributions anymore, leaving nouveau the only driver for this range of hardware.

I first tried to enable `ARB_framebuffer_object` on Mesa directly, but it looks like the hardware doesn't support everything required for it and I don't have enough knowledge to emulate it over `EXT_framebuffer_object`:

- https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/19513

This is implemented in the form of a struct of OpenGL functions pointers, setting the ones from `ARB_framebuffer_object` or `EXT_framebuffer_object` given what extension is provided, and calling them through the struct.

Before this PR is merged and the engine rebuilt and released, people can do the same as this PR with the `MESA_EXTENSION_OVERRIDE=GL_ARB_framebuffer_object` environment variable.

Note that running the Dæmon engine over a nv40 hardware will suffer from an nouveau nv30 driver bug related to vbo model skinning. One can workaround this bug by setting `r_vboVertexSkinning 0` to force the CPU code path for this task:

- https://gitlab.freedesktop.org/mesa/mesa/-/issues/7631