### PR TITLE
Redesign Color::TokenIterator API

### DIFF
--- a/src/common/Color.cpp
+++ b/src/common/Color.cpp
@@ -86,16 +86,16 @@ int StrlenNocolor( const char *string )
 
 char *StripColors( char *string )
 {
-	std::string output;
+	char *out = string;
 
 	for ( const auto& token : Parser( string ) )
 	{
 		Str::StringView text = token.PlainText();
-		output.append( text.begin(), text.end() );
+		memmove( out, text.begin(), text.size() );
+		out += text.size();
 	}
 
-	strcpy( string, output.c_str() );
-
+	*out = '\0';
 	return string;
 }
 
@@ -119,6 +119,7 @@ void StripColors( const char *in, char *out, size_t len )
 std::string StripColors( const std::string& input )
 {
 	std::string output;
+	output.reserve( input.size() );
 
 	for ( const auto& token : Parser( input.c_str() ) )
 	{

--- a/src/common/Color.cpp
+++ b/src/common/Color.cpp
@@ -90,14 +90,8 @@ char *StripColors( char *string )
 
 	for ( const auto& token : Parser( string ) )
 	{
-		if ( token.Type() == Token::TokenType::CHARACTER )
-		{
-			output.append( token.Begin(), token.Size() );
-		}
-		else if ( token.Type() == Token::TokenType::ESCAPE )
-		{
-			output.push_back(Constants::ESCAPE);
-		}
+		Str::StringView text = token.PlainText();
+		output.append( text.begin(), text.end() );
 	}
 
 	strcpy( string, output.c_str() );
@@ -107,29 +101,16 @@ char *StripColors( char *string )
 
 void StripColors( const char *in, char *out, size_t len )
 {
-	--len;
-
 	for ( const auto& token : Parser( in ) )
 	{
-		if ( token.Type() == Token::TokenType::CHARACTER )
+		Str::StringView text = token.PlainText();
+		if ( text.size() >= len )
 		{
-			if ( len < token.Size() )
-			{
-				break;
-			}
-			
-			strncpy( out, token.Begin(), token.Size() );
-			out += token.Size();
-			len -= token.Size();
+			break;
 		}
-		else if ( token.Type() == Token::TokenType::ESCAPE )
-		{
-			if ( len < 1 )
-			{
-				break;
-			}
-			*out++ = Constants::ESCAPE;
-		}
+		memcpy( out, text.begin(), text.size() );
+		out += text.size();
+		len -= text.size();
 	}
 
 	*out = '\0';
@@ -141,14 +122,8 @@ std::string StripColors( const std::string& input )
 
 	for ( const auto& token : Parser( input.c_str() ) )
 	{
-		if ( token.Type() == Token::TokenType::CHARACTER )
-		{
-			output.append( token.Begin(), token.Size() );
-		}
-		else if ( token.Type() == Token::TokenType::ESCAPE )
-		{
-			output.push_back(Constants::ESCAPE);
-		}
+		Str::StringView text = token.PlainText();
+		output.append( text.begin(), text.end() );
 	}
 
 	return output;

--- a/src/common/Color.h
+++ b/src/common/Color.h
@@ -429,6 +429,9 @@ public:
 
 	/*
 	 * Parsed color
+	 * If the token is the reset color code "^*", then the alpha channel is 0 and the RGB comes
+	 * from the Parser's default color. Otherwise, the alpha channel is 1 and the RGB comes from
+	 * parsing the token.
 	 * Pre: Type() == COLOR
 	 */
 	::Color::Color Color() const

--- a/src/common/Color.h
+++ b/src/common/Color.h
@@ -512,15 +512,6 @@ public:
 		return token.Begin() != rhs.token.Begin();
 	}
 
-	// Skips the current token by "count" number of input elements
-	void Skip( difference_type count )
-	{
-		if ( count != 0 )
-		{
-			token = NextToken( token.Begin() + count );
-		}
-	}
-
 private:
 	// Returns the token corresponding to the given input string
 	value_type NextToken(const char* input);

--- a/src/common/String.h
+++ b/src/common/String.h
@@ -204,7 +204,28 @@ namespace Str {
         const T* ptr;
         size_t len;
     };
+
+    // StringRef is a reference to a null-terminated string ("C string") with length included.
     using StringRef = BasicStringRef<char>;
+
+    // std::string_view equivalent - a non-null-terminated sequence of chars.
+    // In most cases you should use StringRef since we have a lot of code that works with C strings.
+    class StringView {
+    private:
+        const char* begin_;
+        const char* end_;
+
+    public:
+        StringView() : begin_(nullptr), end_(nullptr) {}
+        StringView(const char* begin, const char* end) : begin_(begin), end_(end) {}
+
+        const char* begin() const { return begin_; }
+        const char* end() const { return end_; }
+        size_t size() const { return end_ - begin_; }
+
+        const char& operator[] (size_t i) const { return begin_[i]; }
+    };
+
 
     bool ParseInt(int& value, Str::StringRef text);
 

--- a/src/engine/client/cl_scrn.cpp
+++ b/src/engine/client/cl_scrn.cpp
@@ -190,38 +190,17 @@ void SCR_DrawSmallStringExt( int x, int y, const char *string,
 
 	for ( const auto& token : Color::Parser( string, setColor ) )
 	{
-		if ( token.Type() == Color::Token::TokenType::COLOR )
+		if ( !forceColor && token.Type() == Color::Token::TokenType::COLOR )
 		{
-			if ( !forceColor )
-			{
-				Color::Color color = token.Color();
-				color.SetAlpha( setColor.Alpha() );
-				re.SetColor( color );
-			}
-
-			if ( noColorEscape )
-			{
-				for ( const char *c = token.Begin(); c != token.End(); c++ )
-				{
-					SCR_DrawConsoleFontUnichar( xx, y, *c );
-					xx += SCR_ConsoleFontUnicharWidth( *c );
-				}
-			}
+			Color::Color color = token.Color();
+			color.SetAlpha( setColor.Alpha() );
+			re.SetColor( color );
 		}
-		else if ( token.Type() == Color::Token::TokenType::ESCAPE )
-		{
-			SCR_DrawConsoleFontUnichar( xx, y, Color::Constants::ESCAPE );
-			xx += SCR_ConsoleFontUnicharWidth( Color::Constants::ESCAPE );
 
-			if ( noColorEscape )
-			{
-				SCR_DrawConsoleFontUnichar( xx, y, Color::Constants::ESCAPE );
-				xx += SCR_ConsoleFontUnicharWidth( Color::Constants::ESCAPE );
-			}
-		}
-		else
+		Str::StringView text = noColorEscape ? token.RawToken() : token.PlainText();
+		for ( const char *p = text.begin(); p < text.end(); p += Q_UTF8_Width( p ) )
 		{
-			int ch = Q_UTF8_CodePoint( token.Begin() );
+			int ch = Q_UTF8_CodePoint( p );
 			SCR_DrawConsoleFontUnichar( xx, y, ch );
 			xx += SCR_ConsoleFontUnicharWidth( ch );
 		}

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -404,7 +404,10 @@ signed char  ClampChar( int i );
 int          DirToByte( vec3_t const dir );
 void         ByteToDir( int b, vec3_t dir );
 
-#define DotProduct( x,y )            ( ( x )[ 0 ] * ( y )[ 0 ] + ( x )[ 1 ] * ( y )[ 1 ] + ( x )[ 2 ] * ( y )[ 2 ] )
+inline float DotProduct( const vec3_t x, const vec3_t y )
+{
+	return x[ 0 ] * y[ 0 ] + x[ 1 ] * y[ 1 ] + x[ 2 ] * y[ 2 ];
+}
 #define VectorSubtract( a,b,c )      ( ( c )[ 0 ] = ( a )[ 0 ] - ( b )[ 0 ],( c )[ 1 ] = ( a )[ 1 ] - ( b )[ 1 ],( c )[ 2 ] = ( a )[ 2 ] - ( b )[ 2 ] )
 #define VectorAdd( a,b,c )           ( ( c )[ 0 ] = ( a )[ 0 ] + ( b )[ 0 ],( c )[ 1 ] = ( a )[ 1 ] + ( b )[ 1 ],( c )[ 2 ] = ( a )[ 2 ] + ( b )[ 2 ] )
 #define VectorCopy( a,b )            ( ( b )[ 0 ] = ( a )[ 0 ],( b )[ 1 ] = ( a )[ 1 ],( b )[ 2 ] = ( a )[ 2 ] )

--- a/src/engine/renderer/tr_decals.cpp
+++ b/src/engine/renderer/tr_decals.cpp
@@ -131,8 +131,11 @@ static bool MakeTextureMatrix( vec4_t texMat[ 2 ], vec4_t projection, decalVert_
 		}
 	}
 
-	texMat[ 0 ][ 3 ] = a->st[ 0 ] - DotProduct( pa, texMat[ 0 ] );
-	texMat[ 1 ][ 3 ] = a->st[ 1 ] - DotProduct( pa, texMat[ 1 ] );
+	for ( int k : {0, 1} )
+	{
+		float dot = pa[ 0 ] * texMat[ k ][ 0 ] + pa[ 1 ] * texMat[ k ][ 1 ] + pa[ 2 ] * texMat[ k ][ 2 ];
+		texMat[ k ][ 3 ] = a->st[ k ] - dot;
+	}
 
 	/* disco */
 	return true;

--- a/src/engine/sys/con_common.cpp
+++ b/src/engine/sys/con_common.cpp
@@ -31,6 +31,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "con_common.h"
 
 Cvar::Cvar<bool> com_ansiColor("com_ansiColor", "", Cvar::NONE, true);

--- a/src/engine/sys/con_curses.cpp
+++ b/src/engine/sys/con_curses.cpp
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "con_common.h"
 #include "framework/CommandSystem.h"
 #include "framework/ConsoleField.h"
@@ -145,36 +146,24 @@ static void CON_ColorPrint( WINDOW *win, const char *msg, bool stripcodes )
 			{
 				CON_SetColor( win, token.Color() );
 			}
+		}
 
-			if ( !stripcodes )
-			{
-				buffer.append( token.Begin(), token.Size() );
-			}
-		}
-		else if ( token.Type() == Color::Token::TokenType::ESCAPE )
+		if ( *token.RawToken().begin() == '\n' )
 		{
-			if ( !stripcodes )
-			{
-				buffer.append( token.Begin(), token.Size() );
-			}
-			else
-			{
-				buffer += Color::Constants::ESCAPE;
-			}
+			waddstr( win, buffer.c_str() );
+			buffer.clear();
+			Con_ClearColor( win );
+			waddch( win, '\n' );
 		}
-		else if ( token.Type() == Color::Token::TokenType::CHARACTER )
+		else if ( stripcodes )
 		{
-			if ( *token.Begin() == '\n' )
-			{
-				waddstr( win, buffer.c_str() );
-				buffer.clear();
-				Con_ClearColor( win );
-				waddch( win, '\n' );
-			}
-			else
-			{
-				buffer.append( token.Begin(), token.Size() );
-			}
+			Str::StringView text = token.PlainText();
+			buffer.append( text.begin(), text.end() );
+		}
+		else
+		{
+			Str::StringView raw = token.RawToken();
+			buffer.append( raw.begin(), raw.end() );
 		}
 	}
 

--- a/src/engine/sys/con_tty.cpp
+++ b/src/engine/sys/con_tty.cpp
@@ -32,6 +32,7 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "con_common.h"
 
 #include <unistd.h>
@@ -124,13 +125,10 @@ static void CON_AnsiColorPrint( const char *msg )
 				fputs( ansi.c_str(), stderr );
 			}
 		}
-		else if ( token.Type() == Color::Token::TokenType::ESCAPE )
+		else
 		{
-			buffer += Color::Constants::ESCAPE;
-		}
-		else if ( token.Type() == Color::Token::TokenType::CHARACTER )
-		{
-			if ( *token.Begin() == '\n' )
+			Str::StringView text = token.PlainText();
+			if ( text[ 0 ] == '\n' )
 			{
 				fputs( buffer.c_str(), stderr );
 				buffer.clear();
@@ -138,7 +136,7 @@ static void CON_AnsiColorPrint( const char *msg )
 			}
 			else
 			{
-				buffer.append( token.Begin(), token.Size() );
+				buffer.append( text.begin(), text.end() );
 			}
 		}
 	}


### PR DESCRIPTION
Companion: https://github.com/Unvanquished/Unvanquished/pull/2304

The existing API failed to make it easy to do some common tasks, namely converting a color string to plain text and dealing with the possibility of dangling carets at the end of a string.
