### PR TITLE
sdl_glimp: flag the s3tc GL extension as required

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1807,7 +1807,9 @@ static void GLimp_InitExtensions()
 
 	// made required in OpenGL 1.3
 	glConfig.textureCompression = textureCompression_t::TC_NONE;
-	if( LOAD_EXTENSION( ExtFlag_NONE, EXT_texture_compression_s3tc ) )
+	/* ExtFlag_REQUIRED could be turned into ExtFlag_NONE if s3tc-to-rgba is implemented.
+	See https://github.com/DaemonEngine/Daemon/pull/738 */
+	if( LOAD_EXTENSION( ExtFlag_REQUIRED, EXT_texture_compression_s3tc ) )
 	{
 		glConfig.textureCompression = textureCompression_t::TC_S3TC;
 	}


### PR DESCRIPTION
The engine is probably working without a DXT textures, but the only released game (Unvanquished) cannot run without DXT support because almost all textures make usage of it.

The first device that may provide all required features but s3tc extension to be working with the Dæmon engine is the Broadcom  VideoCore IV which was released in 2016 and is well known to be used in the Raspberry Pi 3 that was released in 2018.

This patch only flags the s3tc GL extension as required to avoid an engine crash if it's missing. I intentionally not purged yet the various code that may rely on this extension being there or not to branch on different code (mainly, logging).

I think it would be interesting to have an in-engine crn/DDS to RGBA fallback for the cases where the GPU does not support s3tc or does not support some DXTC variant or even if the engine does not support some variant. For example some old cards may not support the DXTn variant (for normal maps) and some  DXTC variant may require the extension for texture swizzling to properly implement them, which would raise the bar to several GL version. NetRadiant has such code we can port.