### PR TITLE
sdl_glimp,tr_fbo: also require EXT_framebuffer_blit if EXT_framebuffer_object, catch EXT errors

### DIFF
--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -67,6 +67,18 @@ bool R_CheckFBO( const FBO_t *fbo )
 			Log::Warn("R_CheckFBO: (%s) Framebuffer incomplete, missing read buffer", fbo->name );
 			break;
 
+		/* Errors specific to EXT_framebuffer_object. Some headers may also define
+		the names without _EXT suffix but that's for GLES so those names may only
+		be available when GLES is available. The GL/glext.h header for desktop
+		OpenGL uses _EXT suffixed names. */
+		case GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS_EXT:
+			Log::Warn("R_CheckFBO: (%s) Framebuffer incomplete, attached images must have same dimensions", fbo->name );
+			break;
+
+		case GL_FRAMEBUFFER_INCOMPLETE_FORMATS_EXT:
+			Log::Warn("R_CheckFBO: (%s) Framebuffer incomplete, attached images must have same format", fbo->name );
+			break;
+
 		default:
 			Log::Warn("R_CheckFBO: (%s) unknown error 0x%X", fbo->name, code );
 			break;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -196,6 +196,7 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 struct glFboShim_t
 {
 	/* Functions with same signature and similar purpose can be provided by:
+
 	- ARB_framebuffer_object
 	- EXT_framebuffer_object
 	- OES_framebuffer_object
@@ -227,14 +228,18 @@ struct glFboShim_t
 	// void (*glRenderbufferStorage) (GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
 	PFNGLRENDERBUFFERSTORAGEPROC glRenderbufferStorage;
 
-	/* Unused for now:
+	/* Unused for now, part of GL_EXT_framebuffer_multisample:
 	// void (*glRenderbufferStorageMultisample) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
 	PFNGLRENDERBUFFERSTORAGEMULTISAMPLEPROC glRenderbufferStorageMultisample; */
 
 	/* Those three values are the same:
+
 	- GL_FRAMEBUFFER_COMPLETE
 	- GL_FRAMEBUFFER_COMPLETE_EXT
 	- GL_FRAMEBUFFER_COMPLETE_OES
+
+	The same happens with other GL_FRAMEBUFFER_* defines, we can expect the
+	various names for various the extension variants to share the same values.
 
 	So there is no need to abstract them and GL_FRAMEBUFFER_COMPLETE can be
 	used in all cases. */
@@ -256,7 +261,7 @@ static inline void glFboSetArb()
 	GL_fboShim.glGenRenderbuffers = glGenRenderbuffers;
 	GL_fboShim.glRenderbufferStorage = glRenderbufferStorage;
 
-	/* Unused for now:
+	/* Unused for now, part of GL_EXT_framebuffer_multisample:
 	GL_fboShim.glRenderbufferStorageMultisample = glRenderbufferStorageMultisample; */
 }
 
@@ -274,7 +279,7 @@ static inline void glFboSetExt()
 	GL_fboShim.glGenRenderbuffers = glGenRenderbuffersEXT;
 	GL_fboShim.glRenderbufferStorage = glRenderbufferStorageEXT;
 
-	/* Unused for now:
+	/* Unused for now, part of GL_EXT_framebuffer_multisample:
 	GL_fboShim.glRenderbufferStorageMultisample = glRenderbufferStorageMultisampleEXT; */
 }
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1841,6 +1841,20 @@ static void GLimp_InitExtensions()
 	else
 	{
 		LOAD_EXTENSION( ExtFlag_REQUIRED, EXT_framebuffer_object );
+
+		/* Both EXT_framebuffer_object and EXT_framebuffer_blit are said to be
+		parts of ARB_framebuffer_object:
+
+		> So there may be hardware that supports EXT_FBO and not ARB_FBO,
+		> even thought they support things like EXT_FBO_blit and other parts
+		> of ARB_FBO.
+		-- https://www.khronos.org/opengl/wiki/Framebuffer_Object
+
+		Our code is known to require EXT_framebuffer_blit so if we don't find
+		ARB_framebuffer_object but find EXT_framebuffer_object we must
+		check for EXT_framebuffer_blit too. */
+		LOAD_EXTENSION( ExtFlag_REQUIRED, EXT_framebuffer_blit );
+
 		glFboSetExt();
 	}
 


### PR DESCRIPTION
Follow-up of #727. This also the proof our engine can perfectly works with `EXT_framebuffer_object` as it was written against it, then EXT_fbo functions were replaced with ARB_fbo ones.

Before `EXT_framebuffer_object` was replaced by `ARB_framebuffer_object`
in c122d65c626f0b45507f044c4edae73af3709508, `EXT_framebuffer_blit`
was also required (now part of `ARB_framebuffer_object`) and two extra
errors specific to `EXT_framebuffer_object` were caught.
    
This enforces the requirement of `EXT_framebuffer_blit` if `EXT_framebuffer_object`
is available but not `ARB_framebuffer_object`, and restore catching for those
`EXT_framebuffer_object` errors.

An extra commit do some bikeshedding on comment wording.