### PR TITLE
tr_bsp: do not load deluxemap if deluxemapping is disabled

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -494,7 +494,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 				ri.Free( ldrImage );
 			}
 
-			if (tr.worldDeluxeMapping) {
+			if (tr.worldDeluxeMapping && r_deluxeMapping->integer != 0) {
 				// load deluxemaps
 				lightmapFiles = R_LoadExternalLightmaps(mapName, &numLightmaps);
 				if (!lightmapFiles || !numLightmaps) {
@@ -542,7 +542,9 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i]), imageParams);
 					Com_AddToGrowList(&tr.lightmaps, image);
-				} else {
+				}
+				else if (r_deluxeMapping->integer != 0)
+				{
 					imageParams_t imageParams = {};
 					imageParams.bits = IF_NOPICMIP | IF_NORMALMAP;
 					imageParams.filterType = filterType_t::FT_LINEAR;

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -446,7 +446,7 @@ R_LoadLightmaps
 static const int LIGHTMAP_SIZE = 128;
 static void R_LoadLightmaps( lump_t *l, const char *bspName )
 {
-	if ( r_vertexLighting->integer )
+	if ( r_vertexLighting->integer != 0 )
 	{
 		return;
 	}


### PR DESCRIPTION
Note: _the engine already not loads light maps when light mapping is disabled: d2624fe9bb9d729629ef13dfcf5a152f342d82d1 from #358._

This makes the engine not loads deluxe maps when deluxe mapping is disabled. For example thunder has 7 deluxe maps that are 1024×1024 RGB textures. Before when deluxe mapping was disabled we still uploaded 7×1024×1024×3 bytes (25.9MB) to GPU for nothing.

---

Original message:

First purpose of this is to _not_ load deluxe maps when deluxe mapping is disabled, saving loading time from file system, uploading time to GPU and GPU memory  when using low presets. This is expected to divide by two the GPU memory used by light maps on low presets, which can be a big deal since light maps don't use DXT compressed format. Until now those deluxe maps were loaded in all cases but never used when deluxe mapping was disabled.

For example thunder has 7 light maps and 7 deluxe maps, both are 1024×1024 RGB textures. Before when deluxe mapping was disabled we uploaded 14×1024×1024×3 bytes (51.8 MB) to the GPU, now we upload 7×1024×1024×3 bytes (25.9MB)

While I was at it, I also made sure light maps are not loaded when light mapping is disabled. Though, disabling light mapping is mostly a debug mode to check for the grid lighting renderer on every surface (usually only used for models and world surfaces without light maps). Because deluxe maps are sidecars for light maps, deluxe maps are also not loaded if light mapping is disabled. It means disabling light mapping is now expected to upload 0 bytes of light maps to the GPU.