### PR TITLE
tr_shader: disable extra lightmap stages when lightmapping is disabled

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1448,6 +1448,18 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 		return true;
 	}
 
+	/* Light styles are only compatible with light mapping as light styles
+	are just extra light map stages with special effects.
+
+	So we don't load extra light maps when light styles are not supported.
+
+	The disablement of the stage is done in the ParseShader() function. */
+	if ( r_vertexLighting->integer != 0
+		&& stage->tcGen_Lightmap )
+	{
+		return true;
+	}
+
 	imageParams_t imageParams = {};
 	imageParams.minDimension = shader.imageMinDimension;
 	imageParams.maxDimension = shader.imageMaxDimension;
@@ -3213,14 +3225,6 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 	// compute state bits
 	stage->stateBits = colorMaskBits | depthMaskBits | blendSrcBits | blendDstBits | atestBits | depthFuncBits | polyModeBits;
 
-	/* If light style external light map and light mapping is disabled,
-	do not load the image and disable the stage */
-	if ( r_vertexLighting->integer && stage->tcGen_Lightmap == true )
-	{
-		stage->active = false;
-		return true;
-	}
-
 	// load image
 	if ( loadMap && !LoadMap( stage, buffer ) )
 	{
@@ -3777,6 +3781,8 @@ static bool ParseShader( const char *_text )
 		return false;
 	}
 
+	bool lightmap_found = false;
+
 	while ( true )
 	{
 		token = COM_ParseExt2( text, true );
@@ -3807,6 +3813,34 @@ static bool ParseShader( const char *_text )
 			}
 
 			stages[ s ].active = true;
+
+			/* Light styles are only compatible with light mapping as light styles
+			are just extra light map stages with special effects.
+
+			So we disable extra light map stages when light styles are not supported.
+
+			The first light map stage can be rendered using grid lighting,
+			the other ones have no way to be rendered. */
+			if ( stages[ s ].active 
+				&& r_vertexLighting->integer != 0 )
+			{
+				if ( stages[ s ].type == stageType_t::ST_LIGHTMAP )
+				{
+					if ( !lightmap_found )
+					{
+						lightmap_found = true;
+					}
+					else
+					{
+						stages[ s ].active = false;
+					}
+				}
+				else if ( stages[ s ].tcGen_Lightmap )
+				{
+					stages[ s ].active = false;
+				}
+			}
+
 			s++;
 			continue;
 		}


### PR DESCRIPTION
_Note:_ It also removes a previous implementation that revealed itself to be broken.

_Note:_ It would be very easy to add a cvar to reuse this code to disable light styles when light mapping is enabled. This can be useful for getting better performances on low presets.

Light styles are only compatible with light mapping as light styles are just extra light map stages with blend effects.

So we disable extra light map stages when light styles are not supported.

The first light map stage can be rendered using grid lighting, the other ones have no way to be rendered.

When light mapping is disabled, this:

```c
gloom2/7C9AD47A87BC98CCA1FF30C4D788DD47
{ // Q3Map2 defaulted
	{
		map $lightmap
		rgbGen identity
	}
	// Q3Map2 custom lightstyle stage(s)
	{
		map $lightmap
		blendFunc GL_SRC_ALPHA GL_ONE
		rgbGen wave noise 1 .75 1.6 4.2 // style 2
		tcGen lightmap
		tcMod transform 1 0 0 1 0.54492 0.10156
	}
	{
		map $lightmap
		blendFunc GL_SRC_ALPHA GL_ONE
		rgbGen wave noise 1 .5 3.7 4.9 // style 3
		tcGen lightmap
		tcMod transform 1 0 0 1 -0.38672 0.19043
	}
	{
		map $lightmap
		blendFunc GL_SRC_ALPHA GL_ONE
		rgbGen wave noise 1 1 2.6 1.3 // style 4
		tcGen lightmap
		tcMod transform 1 0 0 1 0.24023 0.19043
	}
	{
		map textures/gloom2/e8clangfloor05c.tga
		blendFunc GL_DST_COLOR GL_ZERO
		rgbGen identity
	}
}
```

or this:

```c
gloom2/7C9AD47A87BC98CCA1FF30C4D788DD47
{ // Q3Map2 defaulted
	{
		map $lightmap
		rgbGen identity
	}
	// Q3Map2 custom lightstyle stage(s)
	{
		map maps/gloom2/lm_0000.tga
		blendFunc GL_SRC_ALPHA GL_ONE
		rgbGen wave noise 1 .75 1.6 4.2 // style 2
		tcGen lightmap
		tcMod transform 1 0 0 1 0.54492 0.10156
	}
	{
		map maps/gloom2/lm_0000.tga
		blendFunc GL_SRC_ALPHA GL_ONE
		rgbGen wave noise 1 .5 3.7 4.9 // style 3
		tcGen lightmap
		tcMod transform 1 0 0 1 -0.38672 0.19043
	}
	{
		map maps/gloom2/lm_0000.tga
		blendFunc GL_SRC_ALPHA GL_ONE
		rgbGen wave noise 1 1 2.6 1.3 // style 4
		tcGen lightmap
		tcMod transform 1 0 0 1 0.24023 0.19043
	}
	{
		map textures/gloom2/e8clangfloor05c.tga
		blendFunc GL_DST_COLOR GL_ZERO
		rgbGen identity
	}
}
```

will be translated to:

```c
gloom2/7C9AD47A87BC98CCA1FF30C4D788DD47
{ // Q3Map2 defaulted
	{
		map $lightmap
		rgbGen identity
	}
	{
		map textures/gloom2/e8clangfloor05c.tga
		blendFunc GL_DST_COLOR GL_ZERO
		rgbGen identity
	}
}
```