### PR TITLE
tr_shader: add r_lightStyles cvar to disable light styles

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -76,6 +76,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_dynamicLightCastShadows;
 	cvar_t      *r_precomputedLighting;
 	cvar_t      *r_vertexLighting;
+	cvar_t      *r_lightStyles;
 	cvar_t      *r_exportTextures;
 	cvar_t      *r_heatHaze;
 	cvar_t      *r_noMarksOnTrisurfs;
@@ -1103,6 +1104,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_dynamicLightCastShadows = Cvar_Get( "r_dynamicLightCastShadows", "1", 0 );
 		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_LATCH );
 		r_vertexLighting = Cvar_Get( "r_vertexLighting", "0", CVAR_LATCH | CVAR_ARCHIVE );
+		r_lightStyles = Cvar_Get( "r_lightStyles", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_exportTextures = Cvar_Get( "r_exportTextures", "0", 0 );
 		r_heatHaze = Cvar_Get( "r_heatHaze", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_noMarksOnTrisurfs = Cvar_Get( "r_noMarksOnTrisurfs", "1", CVAR_CHEAT );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2931,6 +2931,7 @@ static inline void glFboSetExt()
 	extern cvar_t *r_dynamicLightCastShadows;
 	extern cvar_t *r_precomputedLighting;
 	extern cvar_t *r_vertexLighting;
+	extern cvar_t *r_lightStyles;
 	extern cvar_t *r_exportTextures;
 	extern cvar_t *r_heatHaze;
 	extern cvar_t *r_noMarksOnTrisurfs;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1454,7 +1454,7 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 	So we don't load extra light maps when light styles are not supported.
 
 	The disablement of the stage is done in the ParseShader() function. */
-	if ( r_vertexLighting->integer != 0
+	if ( ( r_vertexLighting->integer != 0 || r_lightStyles->integer == 0 )
 		&& stage->tcGen_Lightmap )
 	{
 		return true;
@@ -3822,7 +3822,7 @@ static bool ParseShader( const char *_text )
 			The first light map stage can be rendered using grid lighting,
 			the other ones have no way to be rendered. */
 			if ( stages[ s ].active 
-				&& r_vertexLighting->integer != 0 )
+				&& ( r_vertexLighting->integer != 0 || r_lightStyles->integer == 0 ) )
 			{
 				if ( stages[ s ].type == stageType_t::ST_LIGHTMAP )
 				{


### PR DESCRIPTION
#750 must be merged first, the target of this branch has to be changed to `master` once #750 is merged.

This allows to set `r_lightStyles 0` to disable light styles.

Light styles are special effects that blends multiple light maps to create fake dynamic lights, like lights of blinking neons.

Every extra light map is a different material stage and can't be collapsed, meaning every extra light map requires an extra render pass.

When extra light map tiles are stored in a light map file not shared with any static light map tile, the option would even prevent the loading of those extra light map files from file system and not upload them to GPU, reducing both load time and memory usage.

The purpose of this option is to be enabled by default but disabled in low graphics presets.