### PR TITLE
Do not require pthread, cursesw, minizip and zlib when only building the game code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,24 +602,26 @@ if (DAEMON_PARENT_SCOPE_DIR)
 endif()
 
 # Curses, pdcurses on Windows and ncursesw on Unix
-if (USE_CURSES AND NOT NACL)
-    if (WIN32)
-        set(LIBS_ENGINE_BASE ${LIBS_ENGINE_BASE} gdi32 comdlg32)
+if (BUILD_CLIENT OR BUILD_TTY_CLIENT OR BUILD_SERVER OR BUILD_DUMMY_AP)
+    if (USE_CURSES)
+        if (WIN32)
+            set(LIBS_ENGINE_BASE ${LIBS_ENGINE_BASE} gdi32 comdlg32)
 
-        add_definitions(-DPDC_WIDE -DPDC_FORCE_UTF8 -DUSE_CURSES)
-        add_library(srclibs-pdcurses EXCLUDE_FROM_ALL ${PDCURSESLIST})
-        if (MSVC)
-            target_compile_options(srclibs-pdcurses PRIVATE "/W2") # decrease warning level
+            add_definitions(-DPDC_WIDE -DPDC_FORCE_UTF8 -DUSE_CURSES)
+            add_library(srclibs-pdcurses EXCLUDE_FROM_ALL ${PDCURSESLIST})
+            if (MSVC)
+                target_compile_options(srclibs-pdcurses PRIVATE "/W2") # decrease warning level
+            endif()
+            set_target_properties(srclibs-pdcurses PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
+            set(LIBS_ENGINE_BASE ${LIBS_ENGINE_BASE} srclibs-pdcurses)
+            include_directories(${LIB_DIR}/pdcurses)
+        else ()
+            add_definitions(-DUSE_CURSES)
+            set(CURSES_NEED_NCURSES 1) # Tells FindCurses that ncurses is required
+            find_package(CursesW REQUIRED)
+            set(LIBS_ENGINE_BASE ${LIBS_ENGINE_BASE} ${CURSESW_LIBRARIES})
+            include_directories(${CURSESW_INCLUDE_DIR})
         endif()
-        set_target_properties(srclibs-pdcurses PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
-        set(LIBS_ENGINE_BASE ${LIBS_ENGINE_BASE} srclibs-pdcurses)
-        include_directories(${LIB_DIR}/pdcurses)
-    else ()
-        add_definitions(-DUSE_CURSES)
-        set(CURSES_NEED_NCURSES 1) # Tells FindCurses that ncurses is required
-        find_package(CursesW REQUIRED)
-        set(LIBS_ENGINE_BASE ${LIBS_ENGINE_BASE} ${CURSESW_LIBRARIES})
-        include_directories(${CURSESW_INCLUDE_DIR})
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -563,11 +563,13 @@ else()
 endif()
 
 # Minizip
-add_library(srclibs-minizip EXCLUDE_FROM_ALL ${MINIZIPLIST})
-set_target_properties(srclibs-minizip PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
-set(LIBS_BASE ${LIBS_BASE} srclibs-minizip)
-if (MSVC)
-    target_compile_options(srclibs-minizip PRIVATE "/wd4100") # disable "unreferenced formal parameter"
+if (BUILD_CLIENT OR BUILD_TTY_CLIENT OR BUILD_SERVER)
+    add_library(srclibs-minizip EXCLUDE_FROM_ALL ${MINIZIPLIST})
+    set_target_properties(srclibs-minizip PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
+    set(LIBS_BASE ${LIBS_BASE} srclibs-minizip)
+    if (MSVC)
+        target_compile_options(srclibs-minizip PRIVATE "/wd4100") # disable "unreferenced formal parameter"
+    endif()
 endif()
 
 # Look for OpenGL here before we potentially switch to looking for static libs.
@@ -586,16 +588,18 @@ endif()
 
 
 # zlib
-if (NOT NACL)
-    find_package(ZLIB REQUIRED)
-else()
-    add_library(srclibs-zlib EXCLUDE_FROM_ALL ${ZLIBLIST})
-    set_target_properties(srclibs-zlib PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
-    set(ZLIB_INCLUDE_DIRS ${LIB_DIR}/zlib)
-    set(ZLIB_LIBRARIES srclibs-zlib)
+if (BUILD_CLIENT OR BUILD_TTY_CLIENT OR BUILD_SERVER OR NACL)
+    if (NOT NACL)
+        find_package(ZLIB REQUIRED)
+    else()
+        add_library(srclibs-zlib EXCLUDE_FROM_ALL ${ZLIBLIST})
+        set_target_properties(srclibs-zlib PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
+        set(ZLIB_INCLUDE_DIRS ${LIB_DIR}/zlib)
+        set(ZLIB_LIBRARIES srclibs-zlib)
+    endif()
+    set(LIBS_BASE ${LIBS_BASE} ${ZLIB_LIBRARIES})
+    include_directories(${ZLIB_INCLUDE_DIRS})
 endif()
-set(LIBS_BASE ${LIBS_BASE} ${ZLIB_LIBRARIES})
-include_directories(${ZLIB_INCLUDE_DIRS})
 
 if (DAEMON_PARENT_SCOPE_DIR)
     set(LIBS_BASE ${LIBS_BASE} PARENT_SCOPE)

--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -28,7 +28,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ===========================================================================
 */
 
+#if defined(BUILD_ENGINE)
 #include "minizip/unzip.h"
+#endif
 
 #ifdef BUILD_VM
 #include "shared/VMMain.h"
@@ -298,6 +300,7 @@ inline intptr_t my_pread(int fd, void* buf, size_t count, offset_t offset)
 #endif
 }
 
+#if defined(BUILD_ENGINE)
 // std::error_code support for minizip
 class minizip_category_impl: public std::error_category
 {
@@ -333,6 +336,7 @@ static const minizip_category_impl& minizip_category()
 	static minizip_category_impl instance;
 	return instance;
 }
+#endif // defined(BUILD_ENGINE)
 
 class filesystem_category_impl: public std::error_category
 {
@@ -417,6 +421,7 @@ static void SetErrorCodeFilesystem(std::error_code& err, filesystem_error ec, St
 		SetErrorCodeFilesystem(err, ec);
 	}
 }
+#if defined(BUILD_ENGINE)
 static void SetErrorCodeZlib(std::error_code& err, int num)
 {
 	if (num == UNZ_ERRNO)
@@ -424,6 +429,7 @@ static void SetErrorCodeZlib(std::error_code& err, int num)
 	else
 		SetErrorCode(err, num, minizip_category());
 }
+#endif // defined(BUILD_ENGINE)
 
 // Determine whether a character is a OS-dependent path separator
 inline bool isdirsep(unsigned int c)
@@ -674,6 +680,7 @@ void File::SetLineBuffered(bool enable, std::error_code& err) const
 		ClearErrorCode(err);
 }
 
+#if defined(BUILD_ENGINE)
 // Workaround for GCC 4.7.2 bug: http://gcc.gnu.org/bugzilla/show_bug.cgi?id=55015
 namespace {
 
@@ -886,11 +893,7 @@ public:
 	offset_t OpenFileWithSymlinkResolution(Str::StringRef name, offset_t offset, std::error_code& err)
 	{
 		int depth = 0;
-#ifdef BUILD_ENGINE
 		int maxDepth = fs_maxSymlinkDepth.Get();
-#else
-		int maxDepth = 0; // TODO(slipher): Stop building unzip code in the gamelogic.
-#endif
 		std::string resolvedName;
 		std::error_code ignored;
 		for (;;) {
@@ -1038,6 +1041,7 @@ private:
 };
 
 } // GCC bug workaround
+#endif // defined(BUILD_ENGINE)
 
 namespace PakPath {
 


### PR DESCRIPTION
Do not require pthread, cursesw, minizip and zlib when only building the game code.

Note: for some reasons zlib is still needed when building nacl game code.

We may be able to disable more code in `Fileystem.cpp` that may be unused when building game code, but at least the zlib-specific code is disabled and then not linked against.

This is motivated by some work-in-progress changes I'm doing to the release scripts.