### PR TITLE
external_deps: do not prevent i686, and minor touchup (almost bikeshedding)

### DIFF
--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -550,8 +550,8 @@ build_naclsdk() {
 		# TODO(0.54): Unify all arch strings using i686 and amd64 strings.
 		cp pepper_*"/tools/irt_core_x86_64.nexe" "${PREFIX}/irt_core-x86_64.nexe"
 		;;
-	linux-amd64-*)
-		cp pepper_*"/tools/nacl_helper_bootstrap_x86_64" "${PREFIX}/nacl_helper_bootstrap"
+	linux-amd64-*|linux-i686-*)
+		cp pepper_*"/tools/nacl_helper_bootstrap_${NACLSDK_ARCH}" "${PREFIX}/nacl_helper_bootstrap"
 		# Fix permissions on a few files which deny access to non-owner
 		chmod 644 "${PREFIX}/irt_core-${DAEMON_ARCH}.nexe"
 		chmod 755 "${PREFIX}/nacl_helper_bootstrap" "${PREFIX}/sel_ldr"
@@ -757,6 +757,19 @@ setup_macos-amd64-default() {
 	export CMAKE_OSX_ARCHITECTURES="x86_64"
 	common_setup
 	export NASM="${PWD}/${BUILD_BASEDIR}/prefix/bin/nasm" # A newer version of nasm is required for 64-bit
+}
+
+# Set up environment for 32-bit i686 Linux
+setup_linux-i686-default() {
+	HOST=i386-unknown-linux-gnu
+	CROSS=
+	MSVC_SHARED=(--disable-shared --enable-static)
+	export CC='i686-linux-gnu-gcc'
+	export CXX='i686-linux-gnu-g++'
+	export CFLAGS='-fPIC'
+	export CXXFLAGS='-fPIC'
+	export LDFLAGS=''
+	common_setup
 }
 
 # Set up environment for 64-bit amd64 Linux

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -31,8 +31,8 @@ OPUSFILE_VERSION=0.12
 LUA_VERSION=5.4.4
 NACLSDK_VERSION=44.0.2403.155
 NCURSES_VERSION=6.2
-WASISDK_VERSION=12.0
-WASMTIME_VERSION=0.28.0
+WASISDK_VERSION=16.0
+WASMTIME_VERSION=2.0.2
 
 # Extract an archive into the given subdirectory of the build dir and cd to it
 # Usage: extract <filename> <directory>
@@ -451,6 +451,14 @@ build_wasisdk() {
 		local WASISDK_PLATFORM=linux
 		;;
 	esac
+	case "${PLATFORM}" in
+	*-amd64-*)
+		;;
+	*)
+		echo "wasi doesn't have release for ${PLATFORM}"
+		exit 1
+		;;
+	esac
 	local WASISDK_VERSION_MAJOR="$(echo "${WASISDK_VERSION}" | cut -f1 -d'.')"
 	download "wasi-sdk_${WASISDK_PLATFORM}.tar.gz" "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASISDK_VERSION_MAJOR}/wasi-sdk-${WASISDK_VERSION}-${WASISDK_PLATFORM}.tar.gz" wasisdk
 	cp -r "wasi-sdk-${WASISDK_VERSION}" "${PREFIX}/wasi-sdk"
@@ -473,16 +481,21 @@ build_wasmtime() {
 		;;
 	esac
 	case "${PLATFORM}" in
-	*-i686-*)
-		echo "wasmtime doesn't have release for x86"
-		exit 1
-		;;
 	*-amd64-*)
 		local WASMTIME_ARCH=x86_64
 		;;
+	linux-arm64-*|macos-arm64-*)
+		local WASMTIME_ARCH=aarch64
+		;;
+	*)
+		echo "wasmtime doesn't have release for ${PLATFORM}"
+		exit 1
+		;;
 	esac
-	download "wasmtime_${WASMTIME_PLATFORM}.${ARCHIVE_EXT}" "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-${WASMTIME_PLATFORM}-c-api.${ARCHIVE_EXT}" wasmtime
-	cd "wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-${WASMTIME_PLATFORM}-c-api"
+	local folder_name="wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-${WASMTIME_PLATFORM}-c-api"
+	local archive_name="${folder_name}.${ARCHIVE_EXT}"
+	download "${archive_name}" "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/${archive_name}" wasmtime
+	cd "${folder_name}"
 	cp -r include/* "${PREFIX}/include"
 	cp -r lib/* "${PREFIX}/lib"
 }


### PR DESCRIPTION
- linux-i686 cost is null

Now that the toolchain is fully cross-compilation compliant, building the engine for i686 is just a matter of setting `CC` to `i686-linux-gnu-gcc`. So the cost of it is null.

There is no change to be done on engine code neither on engine cmake to build a linux i686 engine as we already take care of engine i686 compatibility for Windows.

While the oldest supported amd64 CPU is 21 years old and the oldest supported GPU is 20 years old, Intel introduced new 32-bit-only processors until 2011 _included_, so the more recent 32-bit only Intel CPU is 11 years old. Also Intel sold amd64 compatible CPUs as 32-bit CPUs hiding the fact they were 64-bit compatible. I myself hosted linux network services for companies I worked for on such hardware, given I was _aware_ of it I ran amd64 distros on them, but other people may run i686 distros on them because the hardware is officially advertised as i686 only. Those would be perfect to run unvanquished servers.

The same way [people asked for arm support to host servers](https://github.com/Unvanquished/Unvanquished/issues/1015), there is no reason a low-end intel CPU can't host a server. On Via side, Via C7 seems to provide all features to run a server. Those kind of Atom/Via CPUs are very common in devices like light clients, nettop, NAS, and things like that, which are perfect as low-consumption servers and cost nothing on second hand market.

Even running the more recent amd64-compatible Atom/Via CPUs as 32-bit may be a wise choice for hosting a server, with hardware just costing 20$ to host a home server.

I myself hosted my Unvanquished server on a low-end Via CPU for years. I assume the only reason why we didn't get any request for this is that our user base is small. The same way our user base is known to not have reached yet less developed countries, or we don't know about it.

We know from SourceForge we have lots of downloads from South-American countries without never seeing the players, except once when some Brazilian people came to troubleshoot problems when hosting LAN servers (so we know we have users we never see online).

We also received reports last year from a French non-profit organization refurbishing old computers to play LAN games with children, including reports for Via GPUs from 2005 and Intel GPUs from 2007, which gives a glance on the kind of hardware they refurbish for playing LAN games.

Given the cost of linux-i686 is null, I see no reason to prevent the building of it.

- more wasmtime and wasisdk care

I added more switch/case stuff to correctly report errors on newly supported platforms like arm64. I updated versions so the knowledge baked in the script matches an actual release.

I noticed Wasmtime doesn't provide 32-bit i686 build at all so that would be very problematic when moving to Wasm as this would phase out windows-i686 build, which is believed to still be used a lot (average people don't reinstall their preinstalled Windows). That would also phase out 32-bit arm support which is still the default and recommended download for Raspberry Pi, the first cause of request for arm and rapsberry pi support being servers.

I noticed the Wasi SDK only provides amd64 build, which is similar to the NaCl SDK that only provided amd64 and i686 build if I'm right (no arm NaCl SDK for sure).