### PR TITLE
external_deps: factorize platform definition and other things

### DIFF
--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -696,12 +696,6 @@ common_setup() {
 		export CXXFLAGS="${CXXFLAGS} -msse2"
 		;;
 	esac
-	if [[ "${MSYSTEM:-}" = MINGW* ]]; then
-		# Experimental MSYS2 support. Most packages won't work;
-		# you need to cross-compile from Linux
-		export CMAKE_GENERATOR="MSYS Makefiles"
-		CROSS= # Doing this because there is no ${CROSS}strip
-	fi
 	mkdir -p "${DOWNLOAD_DIR}"
 	mkdir -p "${PREFIX}"
 	mkdir -p "${PREFIX}/bin"

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -34,6 +34,10 @@ NCURSES_VERSION=6.2
 WASISDK_VERSION=16.0
 WASMTIME_VERSION=2.0.2
 
+# Require the compiler names to be explicitly hardcoded, we should not inherit them
+# from environment as we heavily cross-compile.
+export CC='false'
+export CXX='false'
 # Set defaults.
 export LD='ld'
 export AR='ar'

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -144,10 +144,10 @@ build_gmp() {
 	case "${PLATFORM}" in
 	macos-*-*)
 		# The assembler objects are incompatible with PIE
-		CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]} --disable-assembly
+		CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]} --disable-assembly
 		;;
 	*)
-		CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]}
+		CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 		;;
 	esac
 
@@ -167,7 +167,7 @@ build_nettle() {
 	download "nettle-${NETTLE_VERSION}.tar.gz" "https://ftp.gnu.org/gnu/nettle/nettle-${NETTLE_VERSION}.tar.gz" nettle
 	cd "nettle-${NETTLE_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]}
+	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 	make
 	make install
 }
@@ -176,7 +176,7 @@ build_nettle() {
 build_curl() {
 	download "curl-${CURL_VERSION}.tar.bz2" "https://curl.haxx.se/download/curl-${CURL_VERSION}.tar.bz2" curl
 	cd "curl-${CURL_VERSION}"
-	./configure --host="${HOST}" --prefix="${PREFIX}" --without-ssl --without-libssh2 --without-librtmp --without-libidn2 --disable-file --disable-ldap --disable-crypto-auth --disable-gopher --disable-ftp --disable-tftp --disable-dict --disable-imap --disable-mqtt --disable-smtp --disable-pop3 --disable-telnet --disable-rtsp --disable-threaded-resolver --disable-alt-svc ${MSVC_SHARED[@]}
+	./configure --host="${HOST}" --prefix="${PREFIX}" --without-ssl --without-libssh2 --without-librtmp --without-libidn2 --disable-file --disable-ldap --disable-crypto-auth --disable-gopher --disable-ftp --disable-tftp --disable-dict --disable-imap --disable-mqtt --disable-smtp --disable-pop3 --disable-telnet --disable-rtsp --disable-threaded-resolver --disable-alt-svc ${CONFIGURE_SHARED[@]}
 	make
 	make install
 }
@@ -213,7 +213,7 @@ build_sdl2() {
 		download "SDL2-${SDL2_VERSION}.tar.gz" "https://www.libsdl.org/release/SDL2-${SDL2_VERSION}.tar.gz" sdl2
 		cd "SDL2-${SDL2_VERSION}"
 		# The default -O3 is dropped when there's user-provided CFLAGS.
-		CFLAGS="${CFLAGS:-} -O3" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]}
+		CFLAGS="${CFLAGS:-} -O3" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 		make
 		make install
 		;;
@@ -253,7 +253,7 @@ build_png() {
 	download "libpng-${PNG_VERSION}.tar.gz" "https://download.sourceforge.net/libpng/libpng-${PNG_VERSION}.tar.gz" png
 	cd "libpng-${PNG_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]}
+	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 	make
 	make install
 }
@@ -286,7 +286,7 @@ build_webp() {
 	download "libwebp-${WEBP_VERSION}.tar.gz" "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${WEBP_VERSION}.tar.gz" webp
 	cd "libwebp-${WEBP_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --disable-libwebpdemux ${MSVC_SHARED[@]}
+	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --disable-libwebpdemux ${CONFIGURE_SHARED[@]}
 	make
 	make install
 }
@@ -296,7 +296,7 @@ build_freetype() {
 	download "freetype-${FREETYPE_VERSION}.tar.gz" "https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz" freetype
 	cd "freetype-${FREETYPE_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]} --without-bzip2 --without-png --with-harfbuzz=no --with-brotli=no
+	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]} --without-bzip2 --without-png --with-harfbuzz=no --with-brotli=no
 	make
 	make install
 	cp -a "${PREFIX}/include/freetype2" "${PREFIX}/include/freetype"
@@ -350,7 +350,7 @@ build_ogg() {
 	# This header breaks the vorbis and opusfile Mac builds
 	cat <(echo '#include <stdint.h>') include/ogg/os_types.h > os_types.tmp
 	mv os_types.tmp include/ogg/os_types.h
-	./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]}
+	./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 	make
 	make install
 }
@@ -359,7 +359,7 @@ build_ogg() {
 build_vorbis() {
 	download "libvorbis-${VORBIS_VERSION}.tar.gz" "https://downloads.xiph.org/releases/vorbis/libvorbis-${VORBIS_VERSION}.tar.gz" vorbis
 	cd "libvorbis-${VORBIS_VERSION}"
-	./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]} --disable-examples
+	./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]} --disable-examples
 	make
 	make install
 }
@@ -372,10 +372,10 @@ build_opus() {
 	case "${PLATFORM}" in
 	windows-*-*)
 		# With MinGW _FORTIFY_SOURCE (added by configure) can only by used with -fstack-protector enabled.
-		CFLAGS="${CFLAGS:-} -O2 -D_FORTIFY_SOURCE=0" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]}
+		CFLAGS="${CFLAGS:-} -O2 -D_FORTIFY_SOURCE=0" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 		;;
 	*)
-		CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]}
+		CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 		;;
 	esac
 	make
@@ -387,7 +387,7 @@ build_opusfile() {
 	download "opusfile-${OPUSFILE_VERSION}.tar.gz" "https://downloads.xiph.org/releases/opus/opusfile-${OPUSFILE_VERSION}.tar.gz" opusfile
 	cd "opusfile-${OPUSFILE_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${MSVC_SHARED[@]} --disable-http
+	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]} --disable-http
 	make
 	make install
 }
@@ -433,7 +433,7 @@ build_ncurses() {
 	cd "ncurses-${NCURSES_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
 	# Configure terminfo search dirs based on the ones used in Debian. By default it will only look in (only) the install directory.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --enable-widec ${MSVC_SHARED[@]} --with-terminfo-dirs=/etc/terminfo:/lib/terminfo --with-default-terminfo-dir=/usr/share/terminfo
+	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --enable-widec ${CONFIGURE_SHARED[@]} --with-terminfo-dirs=/etc/terminfo:/lib/terminfo --with-default-terminfo-dir=/usr/share/terminfo
 	make
 	make install
 }
@@ -704,7 +704,7 @@ setup_windows-i686-msvc() {
 	HOST=i686-w64-mingw32
 	CROSS="${HOST}-"
 	BITNESS=32
-	MSVC_SHARED=(--enable-shared --disable-static)
+	CONFIGURE_SHARED=(--enable-shared --disable-static)
 	# Libtool bug prevents -static-libgcc from being set in LDFLAGS
 	export CC="i686-w64-mingw32-gcc -static-libgcc"
 	export CXX="i686-w64-mingw32-g++ -static-libgcc"
@@ -726,7 +726,7 @@ setup_windows-amd64-msvc() {
 	HOST=x86_64-w64-mingw32
 	CROSS="${HOST}-"
 	BITNESS=64
-	MSVC_SHARED=(--enable-shared --disable-static)
+	CONFIGURE_SHARED=(--enable-shared --disable-static)
 	# Libtool bug prevents -static-libgcc from being set in LDFLAGS
 	export CC="x86_64-w64-mingw32-gcc -static-libgcc"
 	export CXX="x86_64-w64-mingw32-g++ -static-libgcc"
@@ -739,7 +739,7 @@ setup_windows-i686-mingw() {
 	HOST=i686-w64-mingw32
 	CROSS="${HOST}-"
 	BITNESS=32
-	MSVC_SHARED=(--disable-shared --enable-static)
+	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	export CFLAGS="-m32 -msse2 -D__USE_MINGW_ANSI_STDIO=0"
 	export CXXFLAGS="-m32 -msse2"
 	common_setup
@@ -750,7 +750,7 @@ setup_windows-amd64-mingw() {
 	HOST=x86_64-w64-mingw32
 	CROSS="${HOST}-"
 	BITNESS=64
-	MSVC_SHARED=(--disable-shared --enable-static)
+	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	export CFLAGS="-m64 -D__USE_MINGW_ANSI_STDIO=0"
 	export CXXFLAGS="-m64"
 	common_setup
@@ -760,7 +760,7 @@ setup_windows-amd64-mingw() {
 setup_macos-amd64-default() {
 	HOST=x86_64-apple-darwin11
 	CROSS=
-	MSVC_SHARED=(--disable-shared --enable-static)
+	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	export MACOSX_DEPLOYMENT_TARGET=10.9 # works with CMake
 	export CC=clang
 	export CXX=clang++
@@ -776,7 +776,7 @@ setup_macos-amd64-default() {
 setup_linux-i686-default() {
 	HOST=i386-unknown-linux-gnu
 	CROSS=
-	MSVC_SHARED=(--disable-shared --enable-static)
+	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	export CC='i686-linux-gnu-gcc'
 	export CXX='i686-linux-gnu-g++'
 	export CFLAGS='-fPIC'
@@ -789,7 +789,7 @@ setup_linux-i686-default() {
 setup_linux-amd64-default() {
 	HOST=x86_64-unknown-linux-gnu
 	CROSS=
-	MSVC_SHARED=(--disable-shared --enable-static)
+	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	export CC='x86_64-linux-gnu-gcc'
 	export CXX='x86_64-linux-gnu-g++'
 	export CFLAGS="-m64 -fPIC"
@@ -802,7 +802,7 @@ setup_linux-amd64-default() {
 setup_linux-armhf-default() {
 	HOST=arm-unknown-linux-gnueabihf
 	CROSS=
-	MSVC_SHARED=(--disable-shared --enable-static)
+	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	export CC='arm-linux-gnueabihf-gcc'
 	export CXX='arm-linux-gnueabihf-g++'
 	export CFLAGS="-fPIC"
@@ -815,7 +815,7 @@ setup_linux-armhf-default() {
 setup_linux-arm64-default() {
 	HOST=aarch64-unknown-linux-gnu
 	CROSS=
-	MSVC_SHARED=(--disable-shared --enable-static)
+	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	export CC='aarch64-linux-gnu-gcc'
 	export CXX='aarch64-linux-gnu-g++'
 	export CFLAGS="-fPIC"

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -740,8 +740,8 @@ setup_windows-i686-mingw() {
 	CROSS="${HOST}-"
 	BITNESS=32
 	CONFIGURE_SHARED=(--disable-shared --enable-static)
-	export CFLAGS="-m32 -msse2 -D__USE_MINGW_ANSI_STDIO=0"
-	export CXXFLAGS="-m32 -msse2"
+	export CFLAGS="-msse2 -D__USE_MINGW_ANSI_STDIO=0"
+	export CXXFLAGS="-msse2"
 	common_setup
 }
 
@@ -751,8 +751,7 @@ setup_windows-amd64-mingw() {
 	CROSS="${HOST}-"
 	BITNESS=64
 	CONFIGURE_SHARED=(--disable-shared --enable-static)
-	export CFLAGS="-m64 -D__USE_MINGW_ANSI_STDIO=0"
-	export CXXFLAGS="-m64"
+	export CFLAGS="-D__USE_MINGW_ANSI_STDIO=0"
 	common_setup
 }
 
@@ -791,9 +790,8 @@ setup_linux-amd64-default() {
 	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	export CC='x86_64-linux-gnu-gcc'
 	export CXX='x86_64-linux-gnu-g++'
-	export CFLAGS="-m64 -fPIC"
-	export CXXFLAGS="-m64 -fPIC"
-	export LDFLAGS="-m64"
+	export CFLAGS="-fPIC"
+	export CXXFLAGS="-fPIC"
 	common_setup
 }
 

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -712,7 +712,6 @@ common_setup() {
 		;;
 	esac
 	mkdir -p "${DOWNLOAD_DIR}"
-	mkdir -p "${PREFIX}"
 	mkdir -p "${PREFIX}/bin"
 	mkdir -p "${PREFIX}/include"
 	mkdir -p "${PREFIX}/lib"

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -110,7 +110,7 @@ build_zlib() {
 	cd "zlib-${ZLIB_VERSION}"
 	case "${PLATFORM}" in
 	windows-*-*)
-		LOC="${CFLAGS:-}" make -f win32/Makefile.gcc PREFIX="${CROSS}"
+		LOC="${CFLAGS}" make -f win32/Makefile.gcc PREFIX="${CROSS}"
 		make -f win32/Makefile.gcc install BINARY_PATH="${PREFIX}/bin" LIBRARY_PATH="${PREFIX}/lib" INCLUDE_PATH="${PREFIX}/include" SHARED_MODE=1
 		;;
 	linux-*-*)
@@ -144,10 +144,10 @@ build_gmp() {
 	case "${PLATFORM}" in
 	macos-*-*)
 		# The assembler objects are incompatible with PIE
-		CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]} --disable-assembly
+		CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]} --disable-assembly
 		;;
 	*)
-		CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
+		CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 		;;
 	esac
 
@@ -167,7 +167,7 @@ build_nettle() {
 	download "nettle-${NETTLE_VERSION}.tar.gz" "https://ftp.gnu.org/gnu/nettle/nettle-${NETTLE_VERSION}.tar.gz" nettle
 	cd "nettle-${NETTLE_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
+	CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 	make
 	make install
 }
@@ -213,7 +213,7 @@ build_sdl2() {
 		download "SDL2-${SDL2_VERSION}.tar.gz" "https://www.libsdl.org/release/SDL2-${SDL2_VERSION}.tar.gz" sdl2
 		cd "SDL2-${SDL2_VERSION}"
 		# The default -O3 is dropped when there's user-provided CFLAGS.
-		CFLAGS="${CFLAGS:-} -O3" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
+		CFLAGS="${CFLAGS} -O3" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 		make
 		make install
 		;;
@@ -226,20 +226,20 @@ build_glew() {
 	cd "glew-${GLEW_VERSION}"
 	case "${PLATFORM}" in
 	windows-*-*)
-		make SYSTEM="linux-mingw${BITNESS}" GLEW_DEST="${PREFIX}" CC="${CROSS}gcc" AR="${CROSS}ar" RANLIB="${CROSS}ranlib" STRIP="${CROSS}strip" LD="${CROSS}ld" CFLAGS.EXTRA="${CFLAGS:-}" LDFLAGS.EXTRA="${LDFLAGS:-}"
-		make install SYSTEM="linux-mingw${BITNESS}" GLEW_DEST="${PREFIX}" CC="${CROSS}gcc" AR="${CROSS}ar" RANLIB="${CROSS}ranlib" STRIP="${CROSS}strip" LD="${CROSS}ld" CFLAGS.EXTRA="${CFLAGS:-}" LDFLAGS.EXTRA="${LDFLAGS:-}"
+		make SYSTEM="linux-mingw${BITNESS}" GLEW_DEST="${PREFIX}" CC="${CROSS}gcc" AR="${CROSS}ar" RANLIB="${CROSS}ranlib" STRIP="${CROSS}strip" LD="${CROSS}ld" CFLAGS.EXTRA="${CFLAGS}" LDFLAGS.EXTRA="${LDFLAGS}"
+		make install SYSTEM="linux-mingw${BITNESS}" GLEW_DEST="${PREFIX}" CC="${CROSS}gcc" AR="${CROSS}ar" RANLIB="${CROSS}ranlib" STRIP="${CROSS}strip" LD="${CROSS}ld" CFLAGS.EXTRA="${CFLAGS}" LDFLAGS.EXTRA="${LDFLAGS}"
 		mv "${PREFIX}/lib/glew32.dll" "${PREFIX}/bin/"
 		rm "${PREFIX}/lib/libglew32.a"
 		cp lib/libglew32.dll.a "${PREFIX}/lib/"
 		;;
 	macos-*-*)
-		make SYSTEM=darwin GLEW_DEST="${PREFIX}" CC="${CC}" LD="${CC}" CFLAGS.EXTRA="${CFLAGS:-} -dynamic -fno-common" LDFLAGS.EXTRA="${LDFLAGS:-}"
-		make install SYSTEM=darwin GLEW_DEST="${PREFIX}" CC="${CC}" LD="${CC}" CFLAGS.EXTRA="${CFLAGS:-} -dynamic -fno-common" LDFLAGS.EXTRA="${LDFLAGS:-}"
+		make SYSTEM=darwin GLEW_DEST="${PREFIX}" CC="${CC}" LD="${CC}" CFLAGS.EXTRA="${CFLAGS} -dynamic -fno-common" LDFLAGS.EXTRA="${LDFLAGS}"
+		make install SYSTEM=darwin GLEW_DEST="${PREFIX}" CC="${CC}" LD="${CC}" CFLAGS.EXTRA="${CFLAGS} -dynamic -fno-common" LDFLAGS.EXTRA="${LDFLAGS}"
 		install_name_tool -id "@rpath/libGLEW.${GLEW_VERSION}.dylib" "${PREFIX}/lib/libGLEW.${GLEW_VERSION}.dylib"
 		;;
 	linux-*-*)
-		make GLEW_DEST="${PREFIX}" CC="${CC}" LD="${CC}" CFLAGS.EXTRA="${CFLAGS:-}" LDFLAGS.EXTRA="${LDFLAGS:-}"
-		make install GLEW_DEST="${PREFIX}" CC="${CC}" LD="${CC}" CFLAGS.EXTRA="${CFLAGS:-}" LDFLAGS.EXTRA="${LDFLAGS:-}"
+		make GLEW_DEST="${PREFIX}" CC="${CC}" LD="${CC}" CFLAGS.EXTRA="${CFLAGS}" LDFLAGS.EXTRA="${LDFLAGS}"
+		make install GLEW_DEST="${PREFIX}" CC="${CC}" LD="${CC}" CFLAGS.EXTRA="${CFLAGS}" LDFLAGS.EXTRA="${LDFLAGS}"
 		;;
 	*)
 		echo "Unsupported platform for GLEW"
@@ -253,7 +253,7 @@ build_png() {
 	download "libpng-${PNG_VERSION}.tar.gz" "https://download.sourceforge.net/libpng/libpng-${PNG_VERSION}.tar.gz" png
 	cd "libpng-${PNG_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
+	CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 	make
 	make install
 }
@@ -271,7 +271,7 @@ build_jpeg() {
 		cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="${SCRIPT_DIR}/../cmake/cross-toolchain-mingw${BITNESS}.cmake" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DWITH_JPEG8=1 -DENABLE_SHARED=0
 		;;
 	windows-*-msvc)
-		CFLAGS="${CFLAGS:-} " cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="${SCRIPT_DIR}/../cmake/cross-toolchain-mingw${BITNESS}.cmake" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DWITH_JPEG8=1 -DENABLE_SHARED=1
+		CFLAGS="${CFLAGS} " cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE="${SCRIPT_DIR}/../cmake/cross-toolchain-mingw${BITNESS}.cmake" -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DWITH_JPEG8=1 -DENABLE_SHARED=1
 		;;
 	macos-*-*)
 		cmake -S . -B build -DCMAKE_INSTALL_PREFIX="${PREFIX}" -DWITH_JPEG8=1 -DENABLE_SHARED=0
@@ -286,7 +286,7 @@ build_webp() {
 	download "libwebp-${WEBP_VERSION}.tar.gz" "https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-${WEBP_VERSION}.tar.gz" webp
 	cd "libwebp-${WEBP_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --disable-libwebpdemux ${CONFIGURE_SHARED[@]}
+	CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --disable-libwebpdemux ${CONFIGURE_SHARED[@]}
 	make
 	make install
 }
@@ -296,7 +296,7 @@ build_freetype() {
 	download "freetype-${FREETYPE_VERSION}.tar.gz" "https://download.savannah.gnu.org/releases/freetype/freetype-${FREETYPE_VERSION}.tar.gz" freetype
 	cd "freetype-${FREETYPE_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]} --without-bzip2 --without-png --with-harfbuzz=no --with-brotli=no
+	CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]} --without-bzip2 --without-png --with-harfbuzz=no --with-brotli=no
 	make
 	make install
 	cp -a "${PREFIX}/include/freetype2" "${PREFIX}/include/freetype"
@@ -372,10 +372,10 @@ build_opus() {
 	case "${PLATFORM}" in
 	windows-*-*)
 		# With MinGW _FORTIFY_SOURCE (added by configure) can only by used with -fstack-protector enabled.
-		CFLAGS="${CFLAGS:-} -O2 -D_FORTIFY_SOURCE=0" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
+		CFLAGS="${CFLAGS} -O2 -D_FORTIFY_SOURCE=0" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 		;;
 	*)
-		CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
+		CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]}
 		;;
 	esac
 	make
@@ -387,7 +387,7 @@ build_opusfile() {
 	download "opusfile-${OPUSFILE_VERSION}.tar.gz" "https://downloads.xiph.org/releases/opus/opusfile-${OPUSFILE_VERSION}.tar.gz" opusfile
 	cd "opusfile-${OPUSFILE_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]} --disable-http
+	CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" ${CONFIGURE_SHARED[@]} --disable-http
 	make
 	make install
 }
@@ -412,7 +412,7 @@ build_lua() {
 		exit 1
 		;;
 	esac
-	make "${LUA_PLATFORM}" CC="${CC:-${CROSS}gcc}" AR="${CROSS}ar rcu" RANLIB="${CROSS}ranlib" MYCFLAGS="${CFLAGS:-}" MYLDFLAGS="${LDFLAGS}"
+	make "${LUA_PLATFORM}" CC="${CC:-${CROSS}gcc}" AR="${CROSS}ar rcu" RANLIB="${CROSS}ranlib" MYCFLAGS="${CFLAGS}" MYLDFLAGS="${LDFLAGS}"
 	case "${PLATFORM}" in
 	windows-*-mingw)
 		make install TO_BIN="lua.exe luac.exe" TO_LIB="liblua.a" INSTALL_TOP="${PREFIX}"
@@ -433,7 +433,7 @@ build_ncurses() {
 	cd "ncurses-${NCURSES_VERSION}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
 	# Configure terminfo search dirs based on the ones used in Debian. By default it will only look in (only) the install directory.
-	CFLAGS="${CFLAGS:-} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --enable-widec ${CONFIGURE_SHARED[@]} --with-terminfo-dirs=/etc/terminfo:/lib/terminfo --with-default-terminfo-dir=/usr/share/terminfo
+	CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --enable-widec ${CONFIGURE_SHARED[@]} --with-terminfo-dirs=/etc/terminfo:/lib/terminfo --with-default-terminfo-dir=/usr/share/terminfo
 	make
 	make install
 }
@@ -684,6 +684,8 @@ common_setup() {
 	export PATH="${PATH}:${PREFIX}/bin"
 	export PKG_CONFIG="pkg-config"
 	export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
+	export CFLAGS="${CFLAGS:-}"
+	export CXXFLAGS="${CXXFLAGS:-}"
 	export CPPFLAGS="${CPPFLAGS:-} -I${PREFIX}/include"
 	export LDFLAGS="${LDFLAGS:-} -L${PREFIX}/lib"
 	if [[ "${MSYSTEM:-}" = MINGW* ]]; then

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -38,6 +38,12 @@ WASMTIME_VERSION=2.0.2
 export LD='ld'
 export AR='ar'
 export RANLIB='ranlib'
+# Always reset flags, we heavily cross-compile and must not inherit any stray flag
+# from environment.
+export CFLAGS=''
+export CXXFLAGS=''
+export CPPFLAGS=''
+export LDFLAGS=''
 
 # Extract an archive into the given subdirectory of the build dir and cd to it
 # Usage: extract <filename> <directory>
@@ -691,10 +697,10 @@ common_setup() {
 	export PATH="${PATH}:${PREFIX}/bin"
 	export PKG_CONFIG="pkg-config"
 	export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
-	export CFLAGS="${CFLAGS:-}"
-	export CXXFLAGS="${CXXFLAGS:-}"
-	export CPPFLAGS="${CPPFLAGS:-} -I${PREFIX}/include"
-	export LDFLAGS="${LDFLAGS:-} -L${PREFIX}/lib"
+	export CFLAGS
+	export CXXFLAGS
+	export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
+	export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
 	case "${PLATFORM}" in
 	*-i686)
 		export CFLAGS="${CFLAGS} -msse2"

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -688,6 +688,12 @@ common_setup() {
 	export CXXFLAGS="${CXXFLAGS:-}"
 	export CPPFLAGS="${CPPFLAGS:-} -I${PREFIX}/include"
 	export LDFLAGS="${LDFLAGS:-} -L${PREFIX}/lib"
+	case "${PLATFORM}" in
+	*-i686)
+		export CFLAGS="${CFLAGS} -msse2"
+		export CXXFLAGS="${CXXFLAGS} -msse2"
+		;;
+	esac
 	if [[ "${MSYSTEM:-}" = MINGW* ]]; then
 		# Experimental MSYS2 support. Most packages won't work;
 		# you need to cross-compile from Linux
@@ -710,8 +716,8 @@ setup_windows-i686-msvc() {
 	# Libtool bug prevents -static-libgcc from being set in LDFLAGS
 	export CC="i686-w64-mingw32-gcc -static-libgcc"
 	export CXX="i686-w64-mingw32-g++ -static-libgcc"
-	export CFLAGS="-msse2 -mpreferred-stack-boundary=2 -D__USE_MINGW_ANSI_STDIO=0"
-	export CXXFLAGS="-msse2 -mpreferred-stack-boundary=2"
+	export CFLAGS='-mpreferred-stack-boundary=2 -D__USE_MINGW_ANSI_STDIO=0'
+	export CXXFLAGS='-mpreferred-stack-boundary=2'
 	common_setup
 }
 
@@ -742,8 +748,7 @@ setup_windows-i686-mingw() {
 	CROSS="${HOST}-"
 	BITNESS=32
 	CONFIGURE_SHARED=(--disable-shared --enable-static)
-	export CFLAGS="-msse2 -D__USE_MINGW_ANSI_STDIO=0"
-	export CXXFLAGS="-msse2"
+	export CFLAGS="-D__USE_MINGW_ANSI_STDIO=0"
 	common_setup
 }
 

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -781,7 +781,6 @@ setup_linux-i686-default() {
 	export CXX='i686-linux-gnu-g++'
 	export CFLAGS='-fPIC'
 	export CXXFLAGS='-fPIC'
-	export LDFLAGS=''
 	common_setup
 }
 
@@ -807,7 +806,6 @@ setup_linux-armhf-default() {
 	export CXX='arm-linux-gnueabihf-g++'
 	export CFLAGS="-fPIC"
 	export CXXFLAGS="-fPIC"
-	export LDFLAGS=""
 	common_setup
 }
 
@@ -820,7 +818,6 @@ setup_linux-arm64-default() {
 	export CXX='aarch64-linux-gnu-g++'
 	export CFLAGS="-fPIC"
 	export CXXFLAGS="-fPIC"
-	export LDFLAGS=""
 	common_setup
 }
 

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -42,6 +42,7 @@ CXX='false'
 LD='ld'
 AR='ar'
 RANLIB='ranlib'
+CONFIGURE_SHARED=(--disable-shared --enable-static)
 # Always reset flags, we heavily cross-compile and must not inherit any stray flag
 # from environment.
 CFLAGS=''
@@ -733,7 +734,6 @@ common_setup_msvc() {
 }
 
 common_setup_mingw() {
-	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	CC="${HOST}-gcc"
 	CXX="${HOST}-g++"
 	LD="${HOST}-ld"
@@ -743,7 +743,6 @@ common_setup_mingw() {
 }
 
 common_setup_macos() {
-	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	CC='clang'
 	CXX='clang++'
 	CFLAGS+=" -arch ${MACOS_ARCH}"
@@ -753,7 +752,6 @@ common_setup_macos() {
 }
 
 common_setup_linux() {
-	CONFIGURE_SHARED=(--disable-shared --enable-static)
 	CC="${HOST/-unknown-/-}-gcc"
 	CXX="${HOST/-unknown-/-}-g++"
 	CFLAGS+=' -fPIC'

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -36,18 +36,18 @@ WASMTIME_VERSION=2.0.2
 
 # Require the compiler names to be explicitly hardcoded, we should not inherit them
 # from environment as we heavily cross-compile.
-export CC='false'
-export CXX='false'
+CC='false'
+CXX='false'
 # Set defaults.
-export LD='ld'
-export AR='ar'
-export RANLIB='ranlib'
+LD='ld'
+AR='ar'
+RANLIB='ranlib'
 # Always reset flags, we heavily cross-compile and must not inherit any stray flag
 # from environment.
-export CFLAGS=''
-export CXXFLAGS=''
-export CPPFLAGS=''
-export LDFLAGS=''
+CFLAGS=''
+CXXFLAGS=''
+CPPFLAGS=''
+LDFLAGS=''
 
 # Extract an archive into the given subdirectory of the build dir and cd to it
 # Usage: extract <filename> <directory>
@@ -698,23 +698,22 @@ common_setup() {
 	BUILD_BASEDIR="build-${PKG_BASEDIR}"
 	BUILD_DIR="${WORK_DIR}/${BUILD_BASEDIR}"
 	PREFIX="${BUILD_DIR}/prefix"
-	export PATH="${PATH}:${PREFIX}/bin"
-	export PKG_CONFIG="pkg-config"
-	export PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
-	export CFLAGS
-	export CXXFLAGS
-	export CPPFLAGS="${CPPFLAGS} -I${PREFIX}/include"
-	export LDFLAGS="${LDFLAGS} -L${PREFIX}/lib"
+	PATH="${PATH}:${PREFIX}/bin"
+	PKG_CONFIG="pkg-config"
+	PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
+	CPPFLAGS+=" -I${PREFIX}/include"
+	LDFLAGS+=" -L${PREFIX}/lib"
 	case "${PLATFORM}" in
 	*-i686)
-		export CFLAGS="${CFLAGS} -msse2"
-		export CXXFLAGS="${CXXFLAGS} -msse2"
+		CFLAGS+=" -msse2"
+		CXXFLAGS+=" -msse2"
 		;;
 	esac
 	mkdir -p "${DOWNLOAD_DIR}"
 	mkdir -p "${PREFIX}/bin"
 	mkdir -p "${PREFIX}/include"
 	mkdir -p "${PREFIX}/lib"
+	export CC CXX LD AR RANLIB PKG_CONFIG PKG_CONFIG_PATH PATH CFLAGS CXXFLAGS CPPFLAGS LDFLAGS
 }
 
 # -D__USE_MINGW_ANSI_STDIO=0 instructs MinGW to *not* use its own implementation
@@ -728,44 +727,44 @@ common_setup() {
 common_setup_msvc() {
 	CONFIGURE_SHARED=(--enable-shared --disable-static)
 	# Libtool bug prevents -static-libgcc from being set in LDFLAGS
-	export CC="${HOST}-gcc -static-libgcc"
-	export CXX="${HOST}-g++ -static-libgcc"
-	export CFLAGS="${CFLAGS} -D__USE_MINGW_ANSI_STDIO=0"
+	CC="${HOST}-gcc -static-libgcc"
+	CXX="${HOST}-g++ -static-libgcc"
+	CFLAGS+=' -D__USE_MINGW_ANSI_STDIO=0'
 }
 
 common_setup_mingw() {
 	CONFIGURE_SHARED=(--disable-shared --enable-static)
-	export CC="${HOST}-gcc"
-	export CXX="${HOST}-g++"
-	export LD="${HOST}-ld"
-	export AR="${HOST}-ar"
-	export RANLIB="${HOST}-ranlib"
-	export CFLAGS="${CFLAGS} -D__USE_MINGW_ANSI_STDIO=0"
+	CC="${HOST}-gcc"
+	CXX="${HOST}-g++"
+	LD="${HOST}-ld"
+	AR="${HOST}-ar"
+	RANLIB="${HOST}-ranlib"
+	CFLAGS+=' -D__USE_MINGW_ANSI_STDIO=0'
 }
 
 common_setup_macos() {
 	CONFIGURE_SHARED=(--disable-shared --enable-static)
-	export CC='clang'
-	export CXX='clang++'
-	export CFLAGS="-arch ${MACOS_ARCH}"
-	export CXXFLAGS="-arch ${MACOS_ARCH}"
-	export LDFLAGS="-arch ${MACOS_ARCH}"
+	CC='clang'
+	CXX='clang++'
+	CFLAGS+=" -arch ${MACOS_ARCH}"
+	CXXFLAGS+=" -arch ${MACOS_ARCH}"
+	LDFLAGS+=" -arch ${MACOS_ARCH}"
 	export CMAKE_OSX_ARCHITECTURES="${MACOS_ARCH}"
 }
 
 common_setup_linux() {
 	CONFIGURE_SHARED=(--disable-shared --enable-static)
-	export CC="${HOST/-unknown-/-}-gcc"
-	export CXX="${HOST/-unknown-/-}-g++"
-	export CFLAGS='-fPIC'
-	export CXXFLAGS='-fPIC'
+	CC="${HOST/-unknown-/-}-gcc"
+	CXX="${HOST/-unknown-/-}-g++"
+	CFLAGS+=' -fPIC'
+	CXXFLAGS+=' -fPIC'
 }
 
 # Set up environment for 32-bit i686 Windows for Visual Studio (compile all as .dll)
 setup_windows-i686-msvc() {
 	BITNESS=32
-	export CFLAGS='-mpreferred-stack-boundary=2'
-	export CXXFLAGS='-mpreferred-stack-boundary=2'
+	CFLAGS+=' -mpreferred-stack-boundary=2'
+	CXXFLAGS+=' -mpreferred-stack-boundary=2'
 	common_setup msvc i686-w64-mingw32
 }
 


### PR DESCRIPTION
Some various changes:

- factorize platform definition

Right now adding a linux platform would be as easy as adding a one-line function, this way:

```bash
setup_linux-amd64-default() {
	common_setup linux x86_64-unknown-linux-gnu
}
```

- rename `MSVC_SHARED` as `CONFIGURE_SHARED`

It makes the name more relevant.

- remove `-m32` and `-m64` flags

We already hardcode the 32-bit and 64-bit compilers anyway.

- always reset flags from the environment and require compiler names to be hardcoded

We heavily cross-compile and must not inherit any stray flag from environment.

Require the compiler names to be explicitly hardcoded, we should not inherit them from environment as we heavily cross-compile. They are already all hardcoded, make sure to get an error when adding a new platform without writing down in the script the compiler to use for that platform.

- always set -msse2 on i686 whatever the system or compiler

This is actually the only change that should produce different binaries when building deps with that new version of the script, as I forgot to add it to `linux-i686`. There is now no need to set this flag per platform, it's just set to all i686 platforms.

- various rewrites, especially simplifies some variable usage as some being always set, we don't need to clutter the code with syntax to catch undefined variables, and delete some variables that are now useless.