### PR TITLE
Read various files from pakpath only (not homepath)

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -264,6 +264,7 @@ endif()
 
 # Tests for engine-lib
 set(ENGINETESTLIST
+    ${COMMON_DIR}/StringTest.cpp
     ${ENGINE_DIR}/framework/CommandSystemTest.cpp
 )
 

--- a/src/common/String.cpp
+++ b/src/common/String.cpp
@@ -118,8 +118,17 @@ namespace Str {
         return res;
     }
 
+    static bool CharIEqual(char a, char b) {
+        return ctolower(a) == ctolower(b);
+    }
+
     bool IsPrefix(Str::StringRef prefix, Str::StringRef text) {
         auto res = std::mismatch(prefix.begin(), prefix.end(), text.begin());
+        return res.first == prefix.end();
+    }
+
+    bool IsIPrefix(Str::StringRef prefix, Str::StringRef text) {
+        auto res = std::mismatch(prefix.begin(), prefix.end(), text.begin(), CharIEqual);
         return res.first == prefix.end();
     }
 
@@ -129,22 +138,20 @@ namespace Str {
         return std::equal(text.begin() + text.size() - suffix.size(), text.end(), suffix.begin());
     }
 
+    bool IsISuffix(Str::StringRef suffix, Str::StringRef text) {
+        if (text.size() < suffix.size())
+            return false;
+        return std::equal(text.begin() + text.size() - suffix.size(), text.end(), suffix.begin(), CharIEqual);
+    }
+
     int LongestPrefixSize(Str::StringRef text1, Str::StringRef text2) {
         auto res = std::mismatch(text1.begin(), text1.end(), text2.begin());
-
         return res.first - text1.begin();
     }
 
-    bool IsIPrefix(Str::StringRef prefix, Str::StringRef text) {
-        return IsPrefix(ToLower(prefix), ToLower(text));
-    }
-
-    bool IsISuffix(Str::StringRef suffix, Str::StringRef text) {
-        return IsSuffix(ToLower(suffix), ToLower(text));
-    }
-
     int LongestIPrefixSize(Str::StringRef text1, Str::StringRef text2) {
-        return LongestPrefixSize(ToLower(text1), ToLower(text2));
+        auto res = std::mismatch(text1.begin(), text1.end(), text2.begin(), CharIEqual);
+        return res.first - text1.begin();
     }
 
     bool IsIEqual(Str::StringRef text1, Str::StringRef text2) {

--- a/src/common/String.cpp
+++ b/src/common/String.cpp
@@ -139,6 +139,10 @@ namespace Str {
         return IsPrefix(ToLower(prefix), ToLower(text));
     }
 
+    bool IsISuffix(Str::StringRef suffix, Str::StringRef text) {
+        return IsSuffix(ToLower(suffix), ToLower(text));
+    }
+
     int LongestIPrefixSize(Str::StringRef text1, Str::StringRef text2) {
         return LongestPrefixSize(ToLower(text1), ToLower(text2));
     }

--- a/src/common/String.h
+++ b/src/common/String.h
@@ -296,6 +296,7 @@ namespace Str {
 
     // Case insensitive versions
     bool IsIPrefix(Str::StringRef prefix, Str::StringRef text);
+    bool IsISuffix(Str::StringRef suffix, Str::StringRef text);
     int LongestIPrefixSize(Str::StringRef text1, Str::StringRef text2);
     bool IsIEqual(Str::StringRef text1, Str::StringRef text2);
 

--- a/src/common/StringTest.cpp
+++ b/src/common/StringTest.cpp
@@ -1,0 +1,105 @@
+/*
+===========================================================================
+Daemon BSD Source Code
+Copyright (c) 2022, Daemon Developers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Daemon developers nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+===========================================================================
+*/
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "String.h"
+
+namespace Str {
+namespace {
+using ::testing::Eq;
+
+TEST(IsIPrefix, EqualArguments)
+{
+    // The case with two literals could behave differently, since the pointers are the same
+    EXPECT_TRUE(IsIPrefix("", ""));
+    EXPECT_TRUE(IsIPrefix("", std::string()));
+    EXPECT_TRUE(IsIPrefix("DIRECT, indirect, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES",
+                          "DIRECT, INDIRECT, INCIDENTAL, SPECIAL, exemplary, OR CONSEQUENTIAL DAMAGES"));
+}
+
+TEST(IsIPrefix, NotPrefix)
+{
+    EXPECT_FALSE(IsIPrefix("tnhhtnshtnshtns", ""));
+    EXPECT_FALSE(IsIPrefix("Redistributions in binary form must", "redistributions in binary form mus"));
+    EXPECT_FALSE(IsIPrefix("IN NO EVENT SHALL DAEMON DEVELOPERS", "IN NO EVENT SHALL DAEMON DE.................."));
+}
+
+TEST(IsIPrefix, ProperPrefix)
+{
+    EXPECT_TRUE(IsIPrefix("", "%"));
+    EXPECT_TRUE(IsIPrefix("proCUREMENT OF SUBSTITUTE", "PROCUREMENT of SUBSTITUTE GOODS"));
+}
+
+TEST(IsISuffix, EqualArguments)
+{
+    // The case with two literals could behave differently, since the pointers are the same
+    EXPECT_TRUE(IsISuffix("", ""));
+    EXPECT_TRUE(IsISuffix("", std::string()));
+    EXPECT_TRUE(IsIPrefix("DIRECT, indirect, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES",
+                          "DIRECT, INDIRECT, INCIDENTAL, SPECIAL, exemplary, OR CONSEQUENTIAL DAMAGES"));
+}
+
+TEST(IsISuffix, NotSuffix)
+{
+    EXPECT_FALSE(IsISuffix("tnhhtnshtnshtns", ""));
+    EXPECT_FALSE(IsISuffix("Redistributions in binary form must", "redistributions in binary form mus"));
+    EXPECT_FALSE(IsISuffix("daemon DEVELOPERS", "IN NO EVENT SHALL DEVELOPERS"));
+}
+
+TEST(IsISuffix, ProperSuffix)
+{
+    EXPECT_TRUE(IsISuffix("", "%"));
+    EXPECT_TRUE(IsISuffix("of SUBSTITUTE GOODS", "PROCUREMENT OF SUBSTITUTE goodS"));
+}
+
+TEST(LongestIPrefixSize, EqualArguments)
+{
+    EXPECT_THAT(LongestIPrefixSize("", ""), Eq(0));
+    EXPECT_THAT(LongestIPrefixSize("ITNESS for A PARTICULAR", "ITNESS FOR A parTICULAR"), Eq(23));
+}
+
+TEST(LongestIPrefixSize, OneArgumentIsPrefix)
+{
+    EXPECT_THAT(LongestIPrefixSize("", "dh"), Eq(0));
+    EXPECT_THAT(LongestIPrefixSize("dh", ""), Eq(0));
+    EXPECT_THAT(LongestIPrefixSize("EVEN IF ADVISED OF", "even if advised"), Eq(15));
+    EXPECT_THAT(LongestIPrefixSize("even if advised", "EVEN IF ADVISED OF"), Eq(15));
+}
+
+TEST(LongestIPrefixSize, MismatchedArguments)
+{
+    EXPECT_THAT(LongestIPrefixSize("cat", "mat"), Eq(0));
+    EXPECT_THAT(LongestIPrefixSize("granger", "GRavity"), Eq(3));
+}
+
+} // namespace
+} // namespace Cmd
+

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2742,7 +2742,6 @@ static bool CL_InitRef()
 	ri.FS_WriteFile = FS_WriteFile;
 	ri.FS_FreeFileList = FS_FreeFileList;
 	ri.FS_ListFiles = FS_ListFiles;
-	ri.FS_FileExists = FS_FileExists;
 	ri.FS_Seek = FS_Seek;
 	ri.FS_FTell = FS_FTell;
 	ri.FS_Read = FS_Read;

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -87,15 +87,10 @@ static void FS_CheckHandle(fileHandle_t handle, bool write)
 		Sys::Drop("FS_CheckHandle: writing to file in pak");
 }
 
-bool FS_FileExists(const char* path)
-{
-	return FS::PakPath::FileExists(path) || FS::HomePath::FileExists(path);
-}
-
 int FS_FOpenFileRead(const char* path, fileHandle_t* handle)
 {
 	if (!handle)
-		return FS_FileExists(path);
+		return FS::PakPath::FileExists(path) || FS::HomePath::FileExists(path);
 
 	*handle = FS_AllocHandle();
 	int length = -1;

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -360,8 +360,6 @@ char **FS_ListFiles( const char *directory, const char *extension, int *numfiles
 
 void         FS_FreeFileList( char **list );
 
-bool     FS_FileExists( const char *file );
-
 int          FS_GetFileList( const char *path, const char *extension, char *listbuf, int bufsize );
 int          FS_GetFileListRecursive( const char* path, const char* extension, char* listBuf, int bufSize );
 

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -381,14 +381,6 @@ void FS_SetOwner( fileHandle_t f, FS::Owner owner );
 void FS_CheckOwnership( fileHandle_t f, FS::Owner owner );
 void FS_CloseAllForOwner( FS::Owner owner );
 
-/*
-if uniqueFILE is true, then a new FILE will be fopened even if the file
-is found in an already open pak file.  If uniqueFILE is false, you must call
-FS_FCloseFile instead of fclose, otherwise the pak FILE would be improperly closed
-It is generally safe to always set uniqueFILE to true, because the majority of
-file IO goes through FS_ReadFile, which Does The Right Thing already.
-*/
-
 int FS_Delete( const char *filename );  // only works inside the 'save' directory (for deleting savegames/images)
 
 int FS_Write( const void *buffer, int len, fileHandle_t f );

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -6684,7 +6684,6 @@ void RE_LoadWorldMap( const char *name )
 {
 	int       i;
 	dheader_t *header;
-	byte      *buffer;
 	byte      *startMarker;
 
 	if ( tr.worldMapLoaded )
@@ -6710,9 +6709,10 @@ void RE_LoadWorldMap( const char *name )
 	tr.worldMapLoaded = true;
 
 	// load it
-	ri.FS_ReadFile( name, ( void ** ) &buffer );
+	std::error_code err;
+	std::string buffer = FS::PakPath::ReadFile( name, err );
 
-	if ( !buffer )
+	if ( err )
 	{
 		Sys::Drop( "RE_LoadWorldMap: %s not found", name );
 	}
@@ -6733,14 +6733,13 @@ void RE_LoadWorldMap( const char *name )
 
 	startMarker = (byte*) ri.Hunk_Alloc( 0, ha_pref::h_low );
 
-	header = ( dheader_t * ) buffer;
+	header = ( dheader_t * ) buffer.data();
 	fileBase = ( byte * ) header;
 
 	i = LittleLong( header->version );
 
 	if ( i != BSP_VERSION && i != BSP_VERSION_Q3 )
 	{
-		ri.FS_FreeFile( buffer );
 		Sys::Drop( "RE_LoadWorldMap: %s has wrong version number (%i should be %i for ET or %i for Q3)",
 		           name, i, BSP_VERSION, BSP_VERSION_Q3 );
 	}
@@ -6790,6 +6789,4 @@ void RE_LoadWorldMap( const char *name )
 
 	// build cubemaps after the necessary vbo stuff is done
 	//R_BuildCubeMaps();
-
-	ri.FS_FreeFile( buffer );
 }

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1690,7 +1690,7 @@ static void R_LoadImage( const char **buffer, byte **pic, int *width, int *heigh
 				// that, and by the way if there is no alternative an error will be raised
 				// because of missing texture so we don't have to let the ImageLoader says
 				// it failed to read the file using this filename
-				if (FS_FileExists( filename ))
+				if ( FS::PakPath::FileExists( filename ) )
 				{
 					// load
 					imageLoaders[ i ].ImageLoader( filename, pic, width, height, numLayers, numMips, bits, alphaByte );

--- a/src/engine/renderer/tr_image_crn.cpp
+++ b/src/engine/renderer/tr_image_crn.cpp
@@ -66,7 +66,7 @@ std::string CRNFormatToString(crn_format format)
   }
 }
 
-bool LoadInMemoryCRN(const char* name, void* buff, size_t buffLen, byte **data, int *width, int *height,
+bool LoadInMemoryCRN(const char* name, const void* buff, size_t buffLen, byte **data, int *width, int *height,
                      int *numLayers, int *numMips, int *bits)
 {
     if (crnd::crnd_validate_file(buff, buffLen, nullptr)) { // Checks the header, not the whole file.
@@ -153,17 +153,16 @@ bool LoadInMemoryCRN(const char* name, void* buff, size_t buffLen, byte **data, 
 void LoadCRN(const char* name, byte **data, int *width, int *height,
              int *numLayers, int *numMips, int *bits, byte)
 {
-    void* buff;
-    size_t buffLen = ri.FS_ReadFile(name, &buff);
+    std::error_code err;
+    std::string buff = FS::PakPath::ReadFile( name, err );
     *numLayers = 0;
-    if (!buff) {
+    if ( err ) {
         return;
     }
-    if (!LoadInMemoryCRN(name, buff, buffLen, data, width, height, numLayers, numMips, bits)) {
+    if (!LoadInMemoryCRN(name, buff.data(), buff.size(), data, width, height, numLayers, numMips, bits)) {
         if (*data) {
             ri.Free(*data);
             *data = nullptr; // This signals failure.
         }
     }
-    ri.FS_FreeFile(buff);
 }

--- a/src/engine/renderer/tr_image_dds.cpp
+++ b/src/engine/renderer/tr_image_dds.cpp
@@ -137,7 +137,7 @@ struct DDSHEADER_t
 #define FOURCC_BC4U             MAKEFOURCC( 'B', 'C', '4', 'U' )
 #define FOURCC_BC5U             MAKEFOURCC( 'B', 'C', '5', 'U' )
 
-void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
+void R_LoadDDSImageData( const void *pImageData, const char *name, byte **data,
 			 int *width, int *height, int *numLayers,
 			 int *numMips, int *bits )
 {
@@ -358,17 +358,14 @@ void R_LoadDDSImageData( void *pImageData, const char *name, byte **data,
 void LoadDDS( const char *name, byte **data, int *width, int *height,
 	      int *numLayers, int *numMips, int *bits, byte )
 {
-	byte    *buff;
+	std::error_code err;
+	std::string buff = FS::PakPath::ReadFile( name, err );
 
-	ri.FS_ReadFile( name, ( void ** ) &buff );
-
-	if ( !buff )
+	if ( err )
 	{
 		return;
 	}
 
-	R_LoadDDSImageData( buff, name, data, width, height,
+	R_LoadDDSImageData( buff.data(), name, data, width, height,
 			    numLayers, numMips, bits );
-
-	ri.FS_FreeFile( buff );
 }

--- a/src/engine/renderer/tr_image_ktx.cpp
+++ b/src/engine/renderer/tr_image_ktx.cpp
@@ -753,18 +753,17 @@ void LoadKTX( const char *name, byte **pic, int *width, int *height,
 	*pic = nullptr;
 	*numLayers = 0;
 
-	void *ktxData{ nullptr };
-	const size_t ktxSize = ri.FS_ReadFile( name, &ktxData );
-	if (!ktxData) {
+	std::error_code err;
+	std::string ktxData = FS::PakPath::ReadFile( name, err );
+	if ( err ) {
 		return;
 	}
-	if ( !LoadInMemoryKTX( name, ktxData, ktxSize, pic, width, height, numLayers, numMips, bits ) ) {
+	if ( !LoadInMemoryKTX( name, &ktxData[0], ktxData.size(), pic, width, height, numLayers, numMips, bits ) ) {
 		if (*pic) {
 			ri.Free(*pic);
 		}
 		*pic = nullptr; // This signals failure.
 	}
-	ri.FS_FreeFile( ktxData );
 }
 
 void SaveImageKTX( const char *path, image_t *img )

--- a/src/engine/renderer/tr_image_png.cpp
+++ b/src/engine/renderer/tr_image_png.cpp
@@ -66,13 +66,13 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 	png_infop    info;
 	png_structp  png;
 	png_bytep    *row_pointers;
-	byte         *data;
 	byte         *out;
 
 	// load png
-	ri.FS_ReadFile( name, ( void ** ) &data );
+	std::error_code err;
+	std::string data = FS::PakPath::ReadFile(name, err);
 
-	if ( !data )
+	if ( err )
 	{
 		return;
 	}
@@ -83,7 +83,6 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 	{
 		Log::Warn("PNG image '%s' has failed png_create_write_struct() [libpng v.'%s']",
 			name, PNG_LIBPNG_VER_STRING );
-		ri.FS_FreeFile( data );
 		return;
 	}
 
@@ -94,7 +93,6 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 	{
 		Log::Warn("PNG image '%s' has failed png_create_info_struct() [libpng v.'%s']",
 			name, PNG_LIBPNG_VER_STRING );
-		ri.FS_FreeFile( data );
 		png_destroy_read_struct( &png, ( png_infopp ) nullptr, ( png_infopp ) nullptr );
 		return;
 	}
@@ -109,12 +107,11 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 		// if we get here, we had a problem reading the file
 		Log::Warn("PNG image '%s' has first exception handler called [libpng v.'%s']",
 			name, PNG_LIBPNG_VER_STRING );
-		ri.FS_FreeFile( data );
 		png_destroy_read_struct( &png, ( png_infopp ) & info, ( png_infopp ) nullptr );
 		return;
 	}
 
-	png_set_read_fn( png, data, png_read_data );
+	png_set_read_fn( png, &data[ 0 ], png_read_data );
 
 	png_set_sig_bytes( png, 0 );
 
@@ -179,7 +176,6 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 		Log::Warn("PNG image '%s' has second exception handler called [libpng v.'%s']",
 			name, PNG_LIBPNG_VER_STRING );
 		ri.Hunk_FreeTempMemory( row_pointers );
-		ri.FS_FreeFile( data );
 		png_destroy_read_struct( &png, ( png_infopp ) & info, ( png_infopp ) nullptr );
 		return;
 	}
@@ -199,7 +195,6 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 	png_destroy_read_struct( &png, &info, ( png_infopp ) nullptr );
 
 	ri.Hunk_FreeTempMemory( row_pointers );
-	ri.FS_FreeFile( data );
 }
 
 /*

--- a/src/engine/renderer/tr_image_webp.cpp
+++ b/src/engine/renderer/tr_image_webp.cpp
@@ -60,14 +60,13 @@ void LoadWEBP( const char *path, byte **pic, int *width, int *height, int *, int
 {
 	*pic = nullptr;
 	
-	void *webpData{ nullptr };
-	const size_t webpSize = ri.FS_ReadFile( path, &webpData );
-	if (!webpData) {
+	std::error_code err;
+	std::string webpData = FS::PakPath::ReadFile( path, err );
+	if ( err ) {
 		return;
 	}
-	if ( !LoadInMemoryWEBP( path, static_cast<const uint8_t*>(webpData), webpSize, pic, width, height ) ) {
+	if ( !LoadInMemoryWEBP( path, reinterpret_cast<const uint8_t*>(webpData.data()), webpData.size(), pic, width, height ) ) {
 		ri.Free( *pic );
 		*pic = nullptr; // This signals failure.
 	}
-	ri.FS_FreeFile( webpData );
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -694,7 +694,7 @@ public:
 				fileName = Str::Format( "screenshots/" PRODUCT_NAME_LOWER "_%04d-%02d-%02d_%02d%02d%02d_%03d.%s",
 					                    1900 + t.tm_year, t.tm_mon + 1, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec, lastNumber, fileExtension );
 
-				if ( !ri.FS_FileExists( fileName.c_str() ) )
+				if ( !FS::HomePath::FileExists( fileName.c_str() ) )
 				{
 					break; // file doesn't exist
 				}

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef TR_LOCAL_H
 #define TR_LOCAL_H
 
+#include "common/FileSystem.h"
 #include "qcommon/q_shared.h"
 #include "qcommon/qfiles.h"
 #include "qcommon/qcommon.h"

--- a/src/engine/renderer/tr_model.cpp
+++ b/src/engine/renderer/tr_model.cpp
@@ -168,7 +168,6 @@ qhandle_t RE_RegisterModel( const char *name )
 		}
 	}
 
-	bool isOptional = false;
 	for ( lod = MD3_MAX_LODS - 1; lod >= 0; lod-- )
 	{
 		char filename[ 1024 ];
@@ -186,19 +185,13 @@ qhandle_t RE_RegisterModel( const char *name )
 
 			sprintf( namebuf, "_%d.md3", lod );
 			strcat( filename, namebuf );
-			isOptional = true;
 		}
 
 		filename[ strlen( filename ) - 1 ] = '3';  // try MD3 first
 
-		// LoD are optionals
-		if (isOptional && !ri.FS_FileExists( filename ))
-		{
-			continue;
-		}
-
 		ri.FS_ReadFile( filename, ( void ** ) &buffer );
 
+		// LoDs are optional
 		if ( !buffer )
 		{
 			continue;

--- a/src/engine/renderer/tr_model.cpp
+++ b/src/engine/renderer/tr_model.cpp
@@ -26,9 +26,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define LL(x) x = LittleLong(x)
 #define LF(x) x = LittleFloat(x)
 
-bool R_LoadMD3( model_t *mod, int lod, void *buffer, const char *name );
-bool R_LoadMD5( model_t *mod, void *buffer, const char *name );
-bool R_LoadIQModel( model_t *mod, void *buffer, int bufferSize, const char *name );
+bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *name );
+bool R_LoadMD5( model_t *mod, const char *buffer, const char *name );
+bool R_LoadIQModel( model_t *mod, const void *buffer, int bufferSize, const char *name );
 
 /*
 ** R_GetModelByHandle
@@ -86,10 +86,7 @@ asked for again.
 qhandle_t RE_RegisterModel( const char *name )
 {
 	model_t   *mod;
-	unsigned  *buffer;
-	int       bufferLen = 0;
 	int       lod;
-	int       ident;
 	bool  loaded;
 	qhandle_t hModel;
 	int       numLoaded;
@@ -145,21 +142,18 @@ qhandle_t RE_RegisterModel( const char *name )
 		// try loading skeletal file
 
 		loaded = false;
-		bufferLen = ri.FS_ReadFile( name, ( void ** ) &buffer );
+		std::error_code err;
+		std::string buffer = FS::PakPath::ReadFile( name, err );
 
-		if ( buffer )
+		if ( !err )
 		{
-			ident = LittleLong( * ( unsigned * ) buffer );
-
-			if ( !Q_strnicmp( ( const char * ) buffer, "MD5Version", 10 ) )
+			if ( Str::IsIPrefix( "MD5Version", buffer ) )
 			{
-				loaded = R_LoadMD5( mod, buffer, name );
+				loaded = R_LoadMD5( mod, buffer.c_str(), name );
 			}
-			else if ( !Q_strnicmp( ( const char * ) buffer, "INTERQUAKEMODEL", 15 ) ) {
-				loaded = R_LoadIQModel( mod, buffer, bufferLen, name );
+			else if ( Str::IsIPrefix( "INTERQUAKEMODEL", buffer ) ) {
+				loaded = R_LoadIQModel( mod, buffer.data(), buffer.size(), name );
 			}
-
-			ri.FS_FreeFile( buffer );
 		}
 
 		if ( loaded )
@@ -189,25 +183,21 @@ qhandle_t RE_RegisterModel( const char *name )
 
 		filename[ strlen( filename ) - 1 ] = '3';  // try MD3 first
 
-		ri.FS_ReadFile( filename, ( void ** ) &buffer );
+		std::error_code err;
+		std::string buffer = FS::PakPath::ReadFile( name, err );
 
 		// LoDs are optional
-		if ( !buffer )
+		if ( err )
 		{
 			continue;
 		}
 
-		ident = LittleLong( * ( unsigned * ) buffer );
-
-		if ( ident == MD3_IDENT )
+		if ( Str::IsPrefix( "IDP3", buffer ) )
 		{
-			loaded = R_LoadMD3( mod, lod, buffer, name );
-			ri.FS_FreeFile( buffer );
+			loaded = R_LoadMD3( mod, lod, buffer.data(), name );
 		}
 		else
 		{
-			ri.FS_FreeFile( buffer );
-
 			Log::Warn("RE_RegisterModel: unknown fileid for %s", name );
 			goto fail;
 		}

--- a/src/engine/renderer/tr_model_iqm.cpp
+++ b/src/engine/renderer/tr_model_iqm.cpp
@@ -78,7 +78,7 @@ static bool IQM_CheckRange( iqmHeader_t *header, int offset,
 	return false;
 }
 
-static bool LoadIQMFile( void *buffer, unsigned filesize, const char *mod_name,
+static bool LoadIQMFile( const void *buffer, unsigned filesize, const char *mod_name,
 			     size_t *len_names )
 {
 	iqmHeader_t		*header;
@@ -440,7 +440,7 @@ R_LoadIQModel
 Load an IQM model and compute the joint matrices for every frame.
 =================
 */
-bool R_LoadIQModel( model_t *mod, void *buffer, int filesize,
+bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 			const char *mod_name ) {
 	iqmHeader_t		*header;
 	iqmVertexArray_t	*vertexarray;

--- a/src/engine/renderer/tr_model_md3.cpp
+++ b/src/engine/renderer/tr_model_md3.cpp
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 R_LoadMD3
 =================
 */
-bool R_LoadMD3( model_t *mod, int lod, void *buffer, const char *modName )
+bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 {
 	int            i, j, k; //, l;
 

--- a/src/engine/renderer/tr_model_md5.cpp
+++ b/src/engine/renderer/tr_model_md5.cpp
@@ -30,7 +30,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 R_LoadMD5
 =================
 */
-bool R_LoadMD5( model_t *mod, void *buffer, const char *modName )
+bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 {
 	md5Model_t    *md5;
 	md5Bone_t     *bone;

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -275,7 +275,6 @@ struct refimport_t
 	char           **( *FS_ListFiles )( const char *name, const char *extension, int *numfilesfound );
 	void ( *FS_FreeFileList )( char **filelist );
 	void ( *FS_WriteFile )( const char *qpath, const void *buffer, int size );
-	bool( *FS_FileExists )( const char *file );
 	int ( *FS_Seek )( fileHandle_t f, long offset, fsOrigin_t origin );
 	int ( *FS_FTell )( fileHandle_t f );
 	int ( *FS_Read )( void *buffer, int len, fileHandle_t f );

--- a/src/engine/renderer/tr_skin.cpp
+++ b/src/engine/renderer/tr_skin.cpp
@@ -41,10 +41,10 @@ This is unfortunate, but the skin files aren't
 compatible with our engine's main script/source parsing rules.
 ==================
 */
-static const char *CommaParse( char **data_p )
+static const char *CommaParse( const char **data_p )
 {
 	int         c = 0, len;
-	char        *data;
+	const char  *data;
 	static char com_token[ MAX_TOKEN_CHARS ];
 
 	data = *data_p;
@@ -166,7 +166,7 @@ qhandle_t RE_RegisterSkin( const char *name )
 	skin_t        *skin;
 	skinSurface_t *surf;
 	skinModel_t   *model; //----(SA) added
-	char          *text, *text_p;
+	const char    *text_p;
 	const char    *token;
 	char          surfName[ MAX_QPATH ];
 
@@ -213,9 +213,10 @@ qhandle_t RE_RegisterSkin( const char *name )
 	R_SyncRenderThread();
 
 	// load and parse the skin file
-	ri.FS_ReadFile( name, ( void ** ) &text );
+	std::error_code err;
+	std::string text = FS::PakPath::ReadFile( name, err );
 
-	if ( !text )
+	if ( err )
 	{
 		return 0;
 	}
@@ -229,7 +230,7 @@ qhandle_t RE_RegisterSkin( const char *name )
 
 //----(SA)  end
 
-	text_p = text;
+	text_p = text.c_str();
 
 	while ( text_p && *text_p )
 	{
@@ -281,8 +282,6 @@ qhandle_t RE_RegisterSkin( const char *name )
 		surf->shader = R_FindShader( token, shaderType_t::SHADER_3D_DYNAMIC, RSF_DEFAULT );
 		skin->numSurfaces++;
 	}
-
-	ri.FS_FreeFile( text );
 
 	// never let a skin have 0 shaders
 	if ( skin->numSurfaces == 0 )


### PR DESCRIPTION
A lot of places in the engine are using a file opening function that checks both VFS and homepath for stuff that should really only come from the VFS. For example if q3shaders are read from the homepath then you could cheat by adding a shader that makes walls invisible or something.