### PR TITLE
Honor nan and inf

### DIFF
--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -173,6 +173,7 @@ elseif (NACL)
     set_cxx_flag("-std=gnu++14")
 
     set_c_cxx_flag("-ffast-math")
+    set_c_cxx_flag("-fno-finite-math-only")
     set_c_cxx_flag("-fvisibility=hidden")
     set_c_cxx_flag("-stdlib=libc++")
     set_c_cxx_flag("--pnacl-allow-exceptions")
@@ -183,6 +184,7 @@ elseif (NACL)
     set_c_cxx_flag("-O0          -g3"   DEBUG)
 else()
     set_c_cxx_flag("-ffast-math")
+    set_c_cxx_flag("-fno-finite-math-only")
     set_c_cxx_flag("-fno-strict-aliasing")
 
     # Set arch on x86 to SSE2 minimum and enable CMPXCHG16B

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -353,6 +353,11 @@ static void LAN_ResetPings( int source )
 			servers = &cls.globalServers[ 0 ];
 			count = MAX_GLOBAL_SERVERS;
 			break;
+
+		case AS_FAVORITES:
+			servers = &cls.favoriteServers[ 0 ];
+			count = MAX_OTHER_SERVERS;
+			break;
 	}
 
 	if ( servers )
@@ -378,6 +383,9 @@ static int LAN_GetServerCount( int source )
 
 		case AS_GLOBAL:
 			return cls.numglobalservers;
+
+		case AS_FAVORITES:
+			return cls.numfavoriteservers;
 	}
 
 	return 0;
@@ -409,6 +417,14 @@ static void LAN_GetServerInfo( int source, int n, char *buf, int buflen )
 			if ( n >= 0 && n < MAX_GLOBAL_SERVERS )
 			{
 				server = &cls.globalServers[ n ];
+			}
+
+			break;
+
+		case AS_FAVORITES:
+			if ( n >= 0 && n < MAX_OTHER_SERVERS )
+			{
+				server = &cls.favoriteServers[ n ];
 			}
 
 			break;
@@ -469,6 +485,14 @@ static int LAN_GetServerPing( int source, int n )
 			}
 
 			break;
+
+		case AS_FAVORITES:
+			if ( n >= 0 && n < MAX_OTHER_SERVERS )
+			{
+				server = &cls.favoriteServers[ n ];
+			}
+
+			break;
 	}
 
 	if ( server )
@@ -501,6 +525,10 @@ static void LAN_MarkServerVisible( int source, int n, bool visible )
 				server = &cls.globalServers[ 0 ];
 				count = MAX_GLOBAL_SERVERS;
 				break;
+
+			case AS_FAVORITES:
+				server = &cls.favoriteServers[ 0 ];
+				break;
 		}
 
 		if ( server )
@@ -530,6 +558,14 @@ static void LAN_MarkServerVisible( int source, int n, bool visible )
 				}
 
 				break;
+
+			case AS_FAVORITES:
+				if ( n >= 0 && n < MAX_OTHER_SERVERS )
+				{
+					cls.favoriteServers[ n ].visible = visible;
+				}
+
+				break;
 		}
 	}
 }
@@ -555,6 +591,14 @@ static int LAN_ServerIsVisible( int source, int n )
 			if ( n >= 0 && n < MAX_GLOBAL_SERVERS )
 			{
 				return cls.globalServers[ n ].visible;
+			}
+
+			break;
+
+		case AS_FAVORITES:
+			if ( n >= 0 && n < MAX_OTHER_SERVERS )
+			{
+				return cls.favoriteServers[ n ].visible;
 			}
 
 			break;

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -3065,6 +3065,14 @@ static void CL_SetServerInfoByAddress( const netadr_t& from, const char *info, i
 			CL_SetServerInfo( &cls.globalServers[ i ], info, ping );
 		}
 	}
+
+	for ( i = 0; i < MAX_OTHER_SERVERS; i++ )
+	{
+		if ( NET_CompareAdr( from, cls.favoriteServers[ i ].adr ) )
+		{
+			CL_SetServerInfo( &cls.favoriteServers[ i ], info, ping );
+		}
+	}
 }
 
 /*
@@ -3787,7 +3795,7 @@ bool CL_UpdateVisiblePings_f( int source )
 	int      max;
 	bool status = false;
 
-	if ( source < 0 || source >= AS_NUM_TYPES )
+	if ( source < 0 || source > AS_FAVORITES )
 	{
 		return false;
 	}
@@ -3812,6 +3820,11 @@ bool CL_UpdateVisiblePings_f( int source )
 			case AS_GLOBAL:
 				server = &cls.globalServers[ 0 ];
 				max = cls.numglobalservers;
+				break;
+
+			case AS_FAVORITES:
+				server = &cls.favoriteServers[ 0 ];
+				max = cls.numfavoriteservers;
 				break;
 		}
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -307,6 +307,9 @@ struct clientStatic_t
 	unsigned     numserverLinks;
 	netadr_t     serverLinks[ MAX_GLOBAL_SERVERS ];
 
+	int          numfavoriteservers;
+	serverInfo_t favoriteServers[ MAX_OTHER_SERVERS ];
+
 	int          pingUpdateSource; // source currently pinging or updating
 
 	int          masterNum;

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -2046,7 +2046,7 @@ int        Com_GMTime( qtime_t *qtime );
 // server browser sources
 #define AS_LOCAL     0
 #define AS_GLOBAL    1 // NERVE - SMF - modified
-#define AS_NUM_TYPES 2
+#define AS_FAVORITES 2
 
 #define MAX_GLOBAL_SERVERS       4096
 #define MAX_OTHER_SERVERS        128

--- a/src/engine/sys/con_tty.cpp
+++ b/src/engine/sys/con_tty.cpp
@@ -85,9 +85,9 @@ void WriteToStdout(const char* text) {
 
 	if (ret < 0) {
 		// Do not log to stdout
-		Log::Dispatch( Str::Format("Error writing to the terminal: %d", errno),
+		Log::Dispatch( Str::Format("Error writing to the terminal: %s", strerror(errno)),
                         ((1<<Log::MAX_TARGET_ID)-1) & ~(1<<Log::TTY_CONSOLE)
-                    );
+		);
 	}
 }
 


### PR DESCRIPTION
This changes the compiler flags so that gcc and clang don't assume NaN and Inf cannot exist

This change applies to both Daemon and Unvanquished, and fixes https://github.com/Unvanquished/Unvanquished/issues/2299 and fixes https://github.com/Unvanquished/Unvanquished/issues/2311.

This also includes a tiny logging change.