### PR TITLE
Fix shaders not updating without vid_restart

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -332,9 +332,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 			// handle any OpenGL/GLSL brokenness here...
 			// nothing at present
 
-#if defined( GLSL_COMPILE_STARTUP_ONLY )
 			GLSL_InitGPUShaders();
-#endif
 			glConfig.smpActive = false;
 
 			if ( r_smp->integer )
@@ -1417,10 +1415,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			return false;
 		}
 
-#if !defined( GLSL_COMPILE_STARTUP_ONLY )
-		GLSL_InitGPUShaders();
-#endif
-
 		backEndData[ 0 ] = ( backEndData_t * ) ri.Hunk_Alloc( sizeof( *backEndData[ 0 ] ), ha_pref::h_low );
 		backEndData[ 0 ]->polys = ( srfPoly_t * ) ri.Hunk_Alloc( r_maxPolys->integer * sizeof( srfPoly_t ), ha_pref::h_low );
 		backEndData[ 0 ]->polyVerts = ( polyVert_t * ) ri.Hunk_Alloc( r_maxPolyVerts->integer * sizeof( polyVert_t ), ha_pref::h_low );
@@ -1507,10 +1501,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			R_ShutdownVBOs();
 			R_ShutdownFBOs();
 			R_ShutdownVisTests();
-
-#if !defined( GLSL_COMPILE_STARTUP_ONLY )
-			GLSL_ShutdownGPUShaders();
-#endif
 		}
 
 		R_DoneFreeType();
@@ -1518,9 +1508,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		// shut down platform specific OpenGL stuff
 		if ( destroyWindow )
 		{
-#if defined( GLSL_COMPILE_STARTUP_ONLY )
 			GLSL_ShutdownGPUShaders();
-#endif
 			if( glConfig2.glCoreProfile ) {
 				glBindVertexArray( 0 );
 				glDeleteVertexArrays( 1, &backEnd.currentVAO );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -350,6 +350,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 				}
 			}
 		}
+		else
+		{
+			GLSL_ShutdownGPUShaders();
+			GLSL_InitGPUShaders();
+		}
 
 		GL_CheckErrors();
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -170,8 +170,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 
 #define MAX_SHADOWMAPS        5
 
-#define GLSL_COMPILE_STARTUP_ONLY  1
-
 #define MAX_TEXTURE_MIPS      16
 #define MAX_TEXTURE_LAYERS    256
 


### PR DESCRIPTION
GLSL_InitGPUShaders was mistakenly grouped with the code that only runs
if the GL context needs to be recreated. This meant the shader text is
only regenerated if you change something about the window or invoke
/vid_restart. But it should run every time the renderer restarts
(e.g. on map change). It is necessary to regenerate the text because
it may be affected by (latch) cvars.

To see the bug, change the value of `r_dynamicLight` and then change map.
The change will not take effect (despite the cvar being unlatched) and
in some cases the engine will crash (if dynamic light shaders were
never built but are used).

To be clear, this does NOT cause any additional shaders to be built
as long as no cvars were changed. We ALREADY compile or load from cache
each shader on every renderer restart. The performance impact on my
machine is less than 2 ms.