### PR TITLE
renderer: drop unused `r_ext_multisample` and `r_alphabits` cvars

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -103,7 +103,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_depthbits;
 	cvar_t      *r_colorbits;
-	cvar_t      *r_alphabits;
 
 	cvar_t      *r_drawBuffer;
 	cvar_t      *r_shadows;
@@ -1096,7 +1095,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			= Cvar_Get( "r_replaceMaterialMinDimensionIfPresentWithMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_colorMipLevels = Cvar_Get( "r_colorMipLevels", "0", CVAR_LATCH );
 		r_colorbits = Cvar_Get( "r_colorbits", "0",  CVAR_LATCH );
-		r_alphabits = Cvar_Get( "r_alphabits", "0",  CVAR_LATCH );
 		r_depthbits = Cvar_Get( "r_depthbits", "0",  CVAR_LATCH );
 		r_mode = Cvar_Get( "r_mode", "-2", CVAR_LATCH | CVAR_ARCHIVE );
 		r_customwidth = Cvar_Get( "r_customwidth", "1600", CVAR_LATCH | CVAR_ARCHIVE );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -104,7 +104,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_depthbits;
 	cvar_t      *r_colorbits;
 	cvar_t      *r_alphabits;
-	cvar_t      *r_ext_multisample;
 
 	cvar_t      *r_drawBuffer;
 	cvar_t      *r_shadows;
@@ -1099,7 +1098,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_colorbits = Cvar_Get( "r_colorbits", "0",  CVAR_LATCH );
 		r_alphabits = Cvar_Get( "r_alphabits", "0",  CVAR_LATCH );
 		r_depthbits = Cvar_Get( "r_depthbits", "0",  CVAR_LATCH );
-		r_ext_multisample = Cvar_Get( "r_ext_multisample", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_mode = Cvar_Get( "r_mode", "-2", CVAR_LATCH | CVAR_ARCHIVE );
 		r_customwidth = Cvar_Get( "r_customwidth", "1600", CVAR_LATCH | CVAR_ARCHIVE );
 		r_customheight = Cvar_Get( "r_customheight", "1024", CVAR_LATCH | CVAR_ARCHIVE );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2908,8 +2908,6 @@ static inline void glFboSetExt()
 	extern cvar_t *r_colorbits; // number of desired color bits, only relevant for fullscreen
 	extern cvar_t *r_alphabits; // number of desired depth bits
 
-	extern cvar_t *r_ext_multisample;  // desired number of MSAA samples
-
 	extern cvar_t *r_measureOverdraw; // enables stencil buffer overdraw measurement
 
 	extern cvar_t *r_lodBias; // push/pull LOD transitions

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2906,7 +2906,6 @@ static inline void glFboSetExt()
 
 	extern cvar_t *r_depthbits; // number of desired depth bits
 	extern cvar_t *r_colorbits; // number of desired color bits, only relevant for fullscreen
-	extern cvar_t *r_alphabits; // number of desired depth bits
 
 	extern cvar_t *r_measureOverdraw; // enables stencil buffer overdraw measurement
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1238,9 +1238,6 @@ static void GLimp_RegisterConfiguration( const glConfiguration& highestConfigura
 	// alphaBits was used by legacy renderer, do we need it for anything?
 	// int alphaBits = std::max( 0, r_alphabits->integer );
 
-	/* FIXME: It looks like MSAA was only implemented in legacy renderer.
-	int samples = std::max( 0, r_ext_multisample->integer ); */
-
 	{
 		int GLmajor, GLminor;
 		sscanf( ( const char * ) glGetString( GL_VERSION ), "%d.%d", &GLmajor, &GLminor );

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1235,9 +1235,6 @@ static void GLimp_RegisterConfiguration( const glConfiguration& highestConfigura
 		glConfig2.glForwardCompatibleContext = false;
 	}
 
-	// alphaBits was used by legacy renderer, do we need it for anything?
-	// int alphaBits = std::max( 0, r_alphabits->integer );
-
 	{
 		int GLmajor, GLminor;
 		sscanf( ( const char * ) glGetString( GL_VERSION ), "%d.%d", &GLmajor, &GLminor );


### PR DESCRIPTION
renderer: drop unused `r_ext_multisample` and `r_alphabits` cvars

- `r_ext_multisample` belongs to MSAA and MSAA was only implemented in legacy renderer and was never reimplemented since.
- `r_alphabits` was only used in the legacy renderer.
____

Initial message:

We set some `r_ext_multisample` values with Unvanquished graphics preset, but the feature is not implemented yet and then the values aren't tested. It means the day we implement the feature, people may have the bad surprise of a potential performance hit because the variable may have been silently set to an high value before.

This patch ensures that any future released build of the engine will reset the cvar on user's configuration to clean-up them from random untested values.

Deleting the cvar would not reset the bad value in user's config, so if we delete the cvar today and re-add it in the future the day we implement the feature, the untested user's cvar would still be there and used.

See also https://github.com/UnvanquishedAssets/unvanquished_src.dpkdir/pull/169