### PR TITLE
tr_model: Fix typo when reading md3 models

### DIFF
--- a/src/engine/renderer/tr_model.cpp
+++ b/src/engine/renderer/tr_model.cpp
@@ -184,7 +184,7 @@ qhandle_t RE_RegisterModel( const char *name )
 		filename[ strlen( filename ) - 1 ] = '3';  // try MD3 first
 
 		std::error_code err;
-		std::string buffer = FS::PakPath::ReadFile( name, err );
+		std::string buffer = FS::PakPath::ReadFile( filename, err );
 
 		// LoDs are optional
 		if ( err )


### PR DESCRIPTION
MD3 models do some extra processing so it copies `name` to `filename`. We were loading `name` which was causing crashes when trying to view md3 models.

Fixes https://github.com/Unvanquished/Unvanquished/issues/2371