### PR TITLE
PakPath::ListFiles - don't error on empty result

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -1713,7 +1713,7 @@ bool DirectoryRange::Advance(std::error_code& err)
 	return InternalAdvance();
 }
 
-DirectoryRange ListFiles(Str::StringRef path, std::error_code& err)
+DirectoryRange ListFiles(Str::StringRef path)
 {
 	DirectoryRange state;
 	state.recursive = false;
@@ -1722,14 +1722,11 @@ DirectoryRange ListFiles(Str::StringRef path, std::error_code& err)
 		state.prefix.push_back('/');
 	state.iter = fileMap.begin();
 	state.iter_end = fileMap.end();
-	if (!state.InternalAdvance())
-		SetErrorCodeFilesystem(err, filesystem_error::no_such_directory, path);
-	else
-		ClearErrorCode(err);
+	state.InternalAdvance();
 	return state;
 }
 
-DirectoryRange ListFilesRecursive(Str::StringRef path, std::error_code& err)
+DirectoryRange ListFilesRecursive(Str::StringRef path)
 {
 	DirectoryRange state;
 	state.recursive = true;
@@ -1738,10 +1735,7 @@ DirectoryRange ListFilesRecursive(Str::StringRef path, std::error_code& err)
 		state.prefix.push_back('/');
 	state.iter = fileMap.begin();
 	state.iter_end = fileMap.end();
-	if (!state.InternalAdvance())
-		SetErrorCodeFilesystem(err, filesystem_error::no_such_directory, path);
-	else
-		ClearErrorCode(err);
+	state.InternalAdvance();
 	return state;
 }
 
@@ -1765,11 +1759,7 @@ Cmd::CompletionResult CompleteFilename(Str::StringRef prefix, Str::StringRef roo
 
 	// ListFiles doesn't return directories for PakPath, so use a recursive
 	// search to get directory names.
-	std::error_code err;
-	DirectoryRange range = ListFilesRecursive(Path::Build(root, prefixDir), err);
-	if (err) {
-		return {};
-	}
+	DirectoryRange range = ListFilesRecursive(Path::Build(root, prefixDir));
 
 	Cmd::CompletionResult out;
 
@@ -2804,8 +2794,7 @@ std::set<std::string> GetAvailableMaps(bool allowLegacyPaks)
 
 	if (allowLegacyPaks && UseLegacyPaks()) {
 		const std::string pathSuffix = ".bsp";
-		std::error_code ignored;
-		for (const std::string& path : FS::PakPath::ListFiles("maps/", ignored)) {
+		for (const std::string& path : FS::PakPath::ListFiles("maps/")) {
 			if (Str::IsSuffix(pathSuffix, path) && path.size() > pathSuffix.size()) {
 				maps.insert(path.substr(0, path.size() - pathSuffix.size()));
 			}

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -343,8 +343,8 @@ namespace PakPath {
 	// List all files in the given subdirectory, optionally recursing into subdirectories
 	// Note that unlike RawPath/HomePath, directories are *not* returned by ListFiles
 	class DirectoryRange;
-	DirectoryRange ListFiles(Str::StringRef path, std::error_code& err = throws());
-	DirectoryRange ListFilesRecursive(Str::StringRef path, std::error_code& err = throws());
+	DirectoryRange ListFiles(Str::StringRef path);
+	DirectoryRange ListFilesRecursive(Str::StringRef path);
 
 	// Helper function to complete a filename. The root is prepended to the path but not included
 	// in the completion results.
@@ -368,8 +368,8 @@ namespace PakPath {
 
 	private:
 		friend class DirectoryIterator<DirectoryRange>;
-		friend DirectoryRange ListFiles(Str::StringRef path, std::error_code& err);
-		friend DirectoryRange ListFilesRecursive(Str::StringRef path, std::error_code& err);
+		friend DirectoryRange ListFiles(Str::StringRef path);
+		friend DirectoryRange ListFilesRecursive(Str::StringRef path);
 		bool Advance(std::error_code& err);
 		bool InternalAdvance();
 		std::string current;


### PR DESCRIPTION
FS::PakPath::ListFiles could return a 'no such directory' error. But the pakpath doesn't even have a concept of directories. It was actually just returning an error if the number of files found is zero. So it doesn't make sense to report an error.

Fixes https://github.com/Unvanquished/Unvanquished/issues/2373.