### PR TITLE
Render all dynamic lights, not a random 25%

### DIFF
--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -215,13 +215,7 @@ void computeDLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4 mater
 
       if( idx >= u_numLights )
       {
-#if defined(r_showLightTiles)
-        if (numLights > 0.0)
-        {
-          color = vec4(numLights/(lightsPerLayer*numLayers), numLights/(lightsPerLayer*numLayers), numLights/(lightsPerLayer*numLayers), 1.0);
-        }
-#endif
-        return;
+        break;
       }
 
       computeDLight( idx, P, normal, viewDir, diffuse, material, color );


### PR DESCRIPTION
The dynamic lights are evenly divided into four "layers". Due to the typo of 'return' instead of 'break' (unnoticed since the original tiled renderer commit), only lights assigned to the first layer were being rendered.

This seems to fix https://github.com/Unvanquished/Unvanquished/issues/2351, although it doesn't makes sense. The bug fixed here is that we skip rendering some lights, which should make things dimmer, not brighter. (With the NVidia bug the light is far brighter than what you get from just rendering all lights correctly.) If I change the `return;` to `layer = 9; break;`, which should not change the meaning of the existing code, then the excessive brightness go away. So it seems that we have some sort of compiler bug or optimization quirk with Nvidia drivers.
 

It was not as easy as it sounds to notice 3 out of 4 lights not being rendered because many of our use cases for dynamic lights spawn a lot of small lights rather than a single light. For example, a pulse rifle shot seems to contain 5 lights. So despite the bug you would always see at least some light. 

We probably need to rework some assets before merging this since many more lights may now be displayed. For example, the blaster impact site lights seem excessive now with this fixed.