### PR TITLE
Add entity debug field

### DIFF
--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -846,6 +846,8 @@ static netField_t entityStateFields[] =
 	{ NETF( generic1 ),          10             , 0 },
 	{ NETF( misc ),              MAX_MISC       , 0 },
 	{ NETF( weaponAnim ),        ANIM_BITS      , 0 },
+	{ NETF( debugColor ),        32             , 0 },
+	{ NETF( debugNumbers ),      32             , 0 },
 };
 
 static int qsort_entitystatefields( const void *a, const void *b )

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -1962,6 +1962,9 @@ union OpaquePlayerState {
 		int           misc; // bit flags
 		int           generic1;
 		int           weaponAnim; // mask off ANIM_TOGGLEBIT
+
+		int debugColor;
+		int debugNumbers;
 	};
 
 	enum class connstate_t


### PR DESCRIPTION
This will allow for a better implementation of
https://github.com/Unvanquished/Unvanquished/pull/2270

This has [an Unvanquished counterpart too](https://github.com/Unvanquished/Unvanquished/pull/2386), because the intent was to modify entityState_t, and apparently entityState_t has to be kept in sync with playerState_t, and playerState_t lies in Unvanquished. Yep.