### PR TITLE
common/FileSystem: introduce `FS::DefaultTempPath()`

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -2353,6 +2353,18 @@ std::string DefaultHomePath()
 #endif
 }
 
+// Determine path to temporary directory
+#ifndef _WIN32
+std::string DefaultTempPath()
+{
+	const char* tmpDir = getenv("TMPDIR");
+	if (!tmpDir || !tmpDir[0]) {
+		tmpDir = "/tmp";
+	}
+	return tmpDir;
+}
+#endif
+
 #endif // BUILD_VM
 
 #ifdef BUILD_VM

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -509,6 +509,9 @@ void Initialize();
 #else
 std::string DefaultBasePath();
 std::string DefaultHomePath();
+#ifndef _WIN32
+std::string DefaultTempPath();
+#endif
 void Initialize(Str::StringRef homePath, Str::StringRef libPath, const std::vector<std::string>& paths);
 #endif
 

--- a/src/engine/framework/ApplicationInternals.h
+++ b/src/engine/framework/ApplicationInternals.h
@@ -88,9 +88,7 @@ public:
         this->traits.defaultHomepath = name;
         free(name);
 #else
-        const char* tmpdir = getenv("TMPDIR");
-        tmpdir = tmpdir ? tmpdir : "/tmp";
-        std::string name = FS::Path::Build(tmpdir, "daemon-test-homepath.XXXXXX");
+        std::string name = FS::Path::Build(FS::DefaultTempPath(), "daemon-test-homepath.XXXXXX");
         // mktempd creates the directory
         if (mkdtemp(&name[0]) == nullptr) {
             Sys::Error("Couldn't create temp dir for test: %s", strerror(errno));

--- a/src/engine/framework/ApplicationInternals.h
+++ b/src/engine/framework/ApplicationInternals.h
@@ -89,7 +89,7 @@ public:
         free(name);
 #else
         std::string name = FS::Path::Build(FS::DefaultTempPath(), "daemon-test-homepath.XXXXXX");
-        // mktempd creates the directory
+        // mkdtemp creates the directory
         if (mkdtemp(&name[0]) == nullptr) {
             Sys::Error("Couldn't create temp dir for test: %s", strerror(errno));
         }

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -72,13 +72,14 @@ std::string GetSingletonSocketPath()
 	char homePathHash[33] = "";
 	Com_MD5Buffer(homePath.data(), homePath.size(), homePathHash, sizeof(homePathHash));
 #ifdef _WIN32
-	return std::string("\\\\.\\pipe\\" PRODUCT_NAME) + suffix + "-" + homePathHash;
+	std::string base = "\\\\.\\pipe\\" PRODUCT_NAME;
 #else
 	// We use a temporary directory rather that using the homepath because
 	// socket paths are limited to about 100 characters. This also avoids issues
 	// when the homepath is on a network filesystem.
-	return std::string("/tmp/." PRODUCT_NAME_LOWER) +  suffix + "-" + homePathHash + "/socket";
+	std::string base = FS::Path::Build(FS::DefaultTempPath(), "." PRODUCT_NAME_LOWER);
 #endif
+	return base + suffix + "-" + homePathHash;
 }
 
 // Create a socket to listen for commands from other instances


### PR DESCRIPTION
Introduce `FS::DefaultTempPath()`
    
Make sure `TMPDIR` is always used when needing a temporary file
outside of Windows.
    
`TMPDIR` is a standard variable, for example it is used by `mktemp`.
Android doesn't give access to `/tmp` but Termux sets `TMPDIR`.

This is needed by:

- https://github.com/DaemonEngine/Daemon/pull/799

This fixes this error on systems not allowing to write in `/tmp` but setting `TMPDIR` instead:

> `Warn: Could not bind singleton socket: No such file or directory`