### PR TITLE
cmake: make mumblelink optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,11 @@ if(NOT DAEMON_EXTERNAL_APP)
     else()
         option(USE_CURSES "Enable fancy colors in terminal's output" ON)
     endif()
+
+    if (BUILD_CLIENT OR BUILD_TTY_CLIENT)
+        option(USE_MUMBLE "Build Daemon with mumblelink sumpport" ON)
+    endif()
+
     cmake_dependent_option(USE_SMP "Compile with support for running the renderer in a separate thread" 1 BUILD_CLIENT 0)
     option(USE_BREAKPAD "Generate Daemon crash dumps (which require Breakpad tools to read)" OFF)
 endif()
@@ -667,10 +672,12 @@ if (BUILD_CLIENT OR BUILD_TTY_CLIENT)
     include_directories(${CURL_INCLUDE_DIRS})
     set(LIBS_CLIENTBASE ${LIBS_CLIENTBASE} ${CURL_LIBRARIES})
 
-    # Mumble link
-    add_library(srclibs-mumblelink EXCLUDE_FROM_ALL ${MUMBLELINKLIST})
-    set_target_properties(srclibs-mumblelink PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
-    set(LIBS_CLIENTBASE ${LIBS_CLIENTBASE} srclibs-mumblelink)
+    if (USE_MUMBLE)
+        # Mumble link
+        add_library(srclibs-mumblelink EXCLUDE_FROM_ALL ${MUMBLELINKLIST})
+        set_target_properties(srclibs-mumblelink PROPERTIES POSITION_INDEPENDENT_CODE 1 FOLDER "libs")
+        set(LIBS_CLIENTBASE ${LIBS_CLIENTBASE} srclibs-mumblelink)
+    endif()
 endif()
 
 # SDL, required for all targets on win32 because of iconv and SDL_SetHint(SDL_TIMER_RESOLUTION, 0)

--- a/src.cmake
+++ b/src.cmake
@@ -1,3 +1,7 @@
+if (USE_MUMBLE)
+    add_definitions("-DUSE_MUMBLE")
+endif()
+
 if (DAEMON_PARENT_SCOPE_DIR)
     set(SHAREDLIST
         ${MOUNT_DIR}/shared/CommandBufferClient.cpp

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -38,7 +38,11 @@ Maryland 20850 USA.
 #include "cg_msgdef.h"
 
 #include "key_identification.h"
+
+#if defined(USE_MUMBLE)
 #include "mumblelink/libmumblelink.h"
+#endif
+
 #include "qcommon/crypto.h"
 #include "qcommon/sys.h"
 
@@ -780,11 +784,13 @@ void CL_FirstSnapshot()
 		Cvar_Set( "activeAction", "" );
 	}
 
+#if defined(USE_MUMBLE)
 	if ( ( cl_useMumble->integer ) && !mumble_islinked() )
 	{
 		int ret = mumble_link( CLIENT_WINDOW_TITLE );
 		Log::Notice(ret == 0 ? "Mumble: Linking to Mumble application okay" : "Mumble: Linking to Mumble application failed" );
 	}
+#endif
 
 	// resend userinfo upon entering the game, as some cvars may
     // not have had the CVAR_USERINFO flag set until loading cgame

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -43,7 +43,10 @@ Maryland 20850 USA.
 #include "framework/CommandSystem.h"
 #include "framework/CvarSystem.h"
 
+#if defined(USE_MUMBLE)
 #include "mumblelink/libmumblelink.h"
+#endif
+
 #include "qcommon/crypto.h"
 #include "framework/Rcon.h"
 #include "framework/Crypto.h"
@@ -58,8 +61,10 @@ Maryland 20850 USA.
 
 static Log::Logger serverInfoLog("client.serverinfo", "");
 
+#if defined(USE_MUMBLE)
 cvar_t *cl_useMumble;
 cvar_t *cl_mumbleScale;
+#endif
 
 cvar_t *cl_nodelta;
 
@@ -179,6 +184,7 @@ void        CL_ShowIP_f();
 void        CL_ServerStatus_f();
 void        CL_ServerStatusResponse( const netadr_t& from, msg_t *msg );
 
+#if defined(USE_MUMBLE)
 static void CL_UpdateMumble()
 {
 	vec3_t pos, forward, up;
@@ -215,6 +221,7 @@ static void CL_UpdateMumble()
 
 	mumble_update_coordinates( pos, forward, up );
 }
+#endif
 
 /*
 =======================================================================
@@ -821,11 +828,13 @@ void CL_Disconnect( bool showMainMenu )
 
 	CL_SendDisconnect();
 
+#if defined(USE_MUMBLE)
 	if ( cl_useMumble->integer && mumble_islinked() )
 	{
 		Log::Notice("Mumble: Unlinking from Mumble application" );
 		mumble_unlink();
 	}
+#endif
 
 	if ( clc.download )
 	{
@@ -2546,7 +2555,9 @@ void CL_Frame( int msec )
 	// update the sound
 	Audio::Update();
 
+#if defined(USE_MUMBLE)
 	CL_UpdateMumble();
+#endif
 
 	Con_RunConsole();
 
@@ -2900,8 +2911,11 @@ void CL_Init()
 
 	Cvar_Get( "password", "", CVAR_USERINFO );
 
+#if defined(USE_MUMBLE)
 	cl_useMumble = Cvar_Get( "cl_useMumble", "0",  CVAR_LATCH );
 	cl_mumbleScale = Cvar_Get( "cl_mumbleScale", "0.0254", 0 );
+#endif
+
 	cl_cgameSyscallStats = Cvar_Get( "cl_cgameSyscallStats", "0", 0 );
 
 	//

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -454,8 +454,10 @@ extern cvar_t *cl_aviFrameRate;
 extern cvar_t *cl_aviMotionJpeg;
 // XreaL END
 
+#if defined(USE_MUMBLE)
 extern cvar_t *cl_useMumble;
 extern cvar_t *cl_mumbleScale;
+#endif
 
 //=================================================
 

--- a/srclibs.cmake
+++ b/srclibs.cmake
@@ -14,10 +14,12 @@ set(MINIZIPLIST
     ${LIB_DIR}/minizip/unzip.h
 )
 
+if (USE_MUMBLE)
 set(MUMBLELINKLIST
     ${LIB_DIR}/mumblelink/libmumblelink.cpp
     ${LIB_DIR}/mumblelink/libmumblelink.h
 )
+endif()
 
 set(NACLLIST_MODULE
     ${LIB_DIR}/nacl/native_client/src/shared/imc/nacl/nacl_imc.cc


### PR DESCRIPTION
This makes possible to build the engine without mumblelink, by setting `USE_MUMBLE` cmake option to `OFF`.

I was too lazy to fix mumblelink on Android, and since it's not required to play the game, why not making possible to disable it on platform that doesn't build that code?

Borrowed from:

- https://github.com/DaemonEngine/Daemon/pull/799