### PR TITLE
Platform code touchup

### DIFF
--- a/src/common/Endian.h
+++ b/src/common/Endian.h
@@ -84,13 +84,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  define Q3_BYTE_ORDER 1234
 # endif // __ARMEB__
 
-#elif defined( _XBOX )
-//
-// XBox is always big endian??
-//
-# define Q3_BIG_ENDIAN
-# define Q3_BYTE_ORDER 4321
-
 #elif defined(_BIG_ENDIAN) && !defined(_LITTLE_ENDIAN) || \
     defined(__BIG_ENDIAN__) && !defined(__LITTLE_ENDIAN__) || \
     defined(__BIGENDIAN__) && !defined(__LITTLEENDIAN__) || \

--- a/src/common/Platform.h
+++ b/src/common/Platform.h
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DLL_EXT ".so"
 #define EXE_EXT ""
 #define PATH_SEP '/'
-#define PLATFORM_STRING "Mac OS X"
+#define PLATFORM_STRING "macOS"
 #elif defined(__linux__)
 #define DLL_EXT ".so"
 #define EXE_EXT ""


### PR DESCRIPTION
1. common/Endian: remove Xbox 360 code

Only Xbox 360 is big-endian (PowerPC). Original Xbox, Xbox One and Xbox Series are little-endian (i686 for the Original,
amd64 for others). We don't build for Xbox anyway.

2. common/Platform: unify macOS wording

Rename _Mac OS X_ as _macOS_ following current Apple naming conventions.

Moved from:

- https://github.com/DaemonEngine/Daemon/pull/799