### PR TITLE
say which file failed when checking socket

### DIFF
--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -124,10 +124,10 @@ static void CreateSingletonSocket()
 	addr.sun_family = AF_UNIX;
 	Q_strncpyz(addr.sun_path, singletonSocketPath.c_str(), sizeof(addr.sun_path));
 	if (bind(singletonSocket, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) == -1)
-		Sys::Error("Could not bind singleton socket: %s", strerror(errno));
+		Sys::Error("Could not bind singleton socket at file: \"%s\", error: \"%s\"", singletonSocketPath, strerror(errno) );
 
 	if (listen(singletonSocket, SOMAXCONN) == -1)
-		Sys::Error("Could not listen on singleton socket: %s", strerror(errno));
+		Sys::Error("Could not listen on singleton socket file \"%s\", error: \"%s\"", singletonSocketPath, strerror(errno) );
 #endif
 }
 


### PR DESCRIPTION
Currently when daemon fails to create a socket, it does not says what it tries to do, making it a pain to know which file to clean. This PR gives this information in logs.

I got annoyed by the lack of info about which file to remove after a crash, hence this PR.