### PR TITLE
bump `MAX_IMAGE_ANIMATIONS` to `32`

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1124,7 +1124,7 @@ static inline void glFboSetExt()
 		expression_t rExp;
 	};
 
-#define MAX_IMAGE_ANIMATIONS 24
+#define MAX_IMAGE_ANIMATIONS 32
 
 	enum
 	{


### PR DESCRIPTION
Bump `MAX_IMAGE_ANIMATIONS` to `32` (from `24`)

On game side, the particle system has `MAX_PS_SHADER_FRAMES` set to `32`, so let's unify this number.

There may be animations with 25 images around or more, like the new Unvanquished groundfire:

- https://github.com/UnvanquishedAssets/res-weapons_src.dpkdir/pull/15

Without this patch, it was expected the engine only loaded `24` images instead of `25`.


