### PR TITLE
implement workarounds for division by zero

### DIFF
--- a/src/engine/qcommon/q_math.cpp
+++ b/src/engine/qcommon/q_math.cpp
@@ -562,8 +562,14 @@ float ProjectPointOntoRectangleOutwards( vec2_t out, const vec2_t point, const v
 	dsign[ 0 ] = ( dir[ 0 ] < 0.0f );
 	dsign[ 1 ] = ( dir[ 1 ] < 0.0f );
 
-	t = ( bounds[ 1 - dsign[ 0 ] ][ 0 ] - point[ 0 ] ) / dir[ 0 ];
-	ty = ( bounds[ 1 - dsign[ 1 ] ][ 1 ] - point[ 1 ] ) / dir[ 1 ];
+	/* Avoids division-by-zero.
+	Valid values are like 1153.3669 or 0.0027. */
+	vec2_t div;
+	div[ 0 ] = dir[ 0 ] ? dir[ 0 ] : 0.0001f;
+	div[ 1 ] = dir[ 1 ] ? dir[ 1 ] : 0.0001f;
+
+	t = ( bounds[ 1 - dsign[ 0 ] ][ 0 ] - point[ 0 ] ) / div[ 0 ];
+	ty = ( bounds[ 1 - dsign[ 1 ] ][ 1 ] - point[ 1 ] ) / div[ 1 ];
 
 	if( ty < t )
 		t = ty;


### PR DESCRIPTION
This now looks ready to me. This uses `0` as the result of the division if it would be `0/0`.

See for a similar PR on game side:

- https://github.com/Unvanquished/Unvanquished/pull/2533

---

Original message:

This is a draft and work-in-progress.

I dirtily enabled exceptions for divizion by zeros to catch them, and implemented mindless dirty workarounds for some of them.

This needs more thoughts for better workarounds. For now I divided by `1` any time there was a divizion by zero, but some other cases may require better values, like actually returning `1` for the whole division if we do `0/0`, or returning a specific default value for when it cannot be computed.

That's why this PR is marked as work-in-progress.