### PR TITLE
A bunch of portal fixes

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -179,6 +179,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_lockpvs;
 	cvar_t      *r_noportals;
 	cvar_t      *r_portalOnly;
+
+	/* Quake3 used 256 as default portal range. */
+	Cvar::Modified<Cvar::Cvar<int>> r_portalDefaultRange(
+		"r_portalDefaultRange", "Default portal range", Cvar::LATCH, 1024 );
+
 	cvar_t      *r_portalSky;
 	cvar_t      *r_max_portal_levels;
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3043,6 +3043,7 @@ static inline void glFboSetExt()
 	extern cvar_t *r_lockpvs;
 	extern cvar_t *r_noportals;
 	extern cvar_t *r_portalOnly;
+	extern Cvar::Modified<Cvar::Cvar<int>> r_portalDefaultRange;
 	extern cvar_t *r_portalSky;
 	extern cvar_t *r_max_portal_levels;
 

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1841,7 +1841,10 @@ static bool R_MirrorViewBySurface(drawSurf_t *drawSurf)
 	if ( tr.viewParms.portalLevel >= r_max_portal_levels->integer &&
 	     tr.viewParms.portalLevel > 0 )
 	{
-		Log::Warn("recursive mirror/portal found");
+		/* Having more than one mirror in a scene is not a bug,
+		we just need to prevent infinite recursion.
+
+		Log::Warn("recursive mirror/portal found"); */
 		return false;
 	}
 
@@ -2071,8 +2074,6 @@ static void R_SortDrawSurfs()
 			{
 				return;
 			}
-
-			break; // only one mirror view at a time
 		}
 	}
 


### PR DESCRIPTION
### tr_main: do not render broken portal
This may happen if, for example, a portal is seen while being outside the map.

There can be other broken ways to reproduce the bug.

The bug can be reproduced with Spacetracks map 1.1.3 from Unvanquished 0.54 and: `/setviewpos 378 -1906 625 80 1`

This would break the render, even loading another map would not fix the render.

To fix the render, one would have to do: `vid_restart` or move to a place where a portal is properly rendered like this: `/setviewpos 27 -1838 668 147 13`

### tr_main: fix recursive portal

The code already supports recursive portals, the maximum recursion
is configured with  `r_max_portal_levels` cvar (set to `5` by default).

### tr_shader: increase default portalRange

`256` seems too low.