### PR TITLE
Make feature disablement more consistent and move some compute at stage configuration

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -446,7 +446,6 @@ static std::vector<std::string> R_LoadExternalLightmaps( const char *mapName )
 R_LoadLightmaps
 ===============
 */
-static const int LIGHTMAP_SIZE = 128;
 static void R_LoadLightmaps( lump_t *l, const char *bspName )
 {
 	tr.worldLightMapping = r_precomputedLighting->integer && !r_vertexLighting->integer;
@@ -591,8 +590,10 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 		// we are about to upload textures
 		R_SyncRenderThread();
 
+		const int internalLightMapSize = 128;
+
 		// create all the lightmaps
-		int numLightmaps = len / ( LIGHTMAP_SIZE * LIGHTMAP_SIZE * 3 );
+		int numLightmaps = len / ( internalLightMapSize * internalLightMapSize * 3 );
 
 		if ( numLightmaps == 1 )
 		{
@@ -609,21 +610,21 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 		for ( int i = 0; i < numLightmaps; i++ )
 		{
-			byte *lightMapBuffer = (byte*) ri.Hunk_AllocateTempMemory( sizeof( byte ) * LIGHTMAP_SIZE * LIGHTMAP_SIZE * 4 );
+			byte *lightMapBuffer = (byte*) ri.Hunk_AllocateTempMemory( sizeof( byte ) * internalLightMapSize * internalLightMapSize * 4 );
 
-			memset( lightMapBuffer, 128, LIGHTMAP_SIZE * LIGHTMAP_SIZE * 4 );
+			memset( lightMapBuffer, 128, internalLightMapSize * internalLightMapSize * 4 );
 
 			// expand the 24 bit on-disk to 32 bit
-			byte *buf_p = buf + i * LIGHTMAP_SIZE * LIGHTMAP_SIZE * 3;
+			byte *buf_p = buf + i * internalLightMapSize * internalLightMapSize * 3;
 
-			for ( int y = 0; y < LIGHTMAP_SIZE; y++ )
+			for ( int y = 0; y < internalLightMapSize; y++ )
 			{
-				for ( int x = 0; x < LIGHTMAP_SIZE; x++ )
+				for ( int x = 0; x < internalLightMapSize; x++ )
 				{
-					int index = x + ( y * LIGHTMAP_SIZE );
-					lightMapBuffer[( index * 4 ) + 0 ] = buf_p[( ( x + ( y * LIGHTMAP_SIZE ) ) * 3 ) + 0 ];
-					lightMapBuffer[( index * 4 ) + 1 ] = buf_p[( ( x + ( y * LIGHTMAP_SIZE ) ) * 3 ) + 1 ];
-					lightMapBuffer[( index * 4 ) + 2 ] = buf_p[( ( x + ( y * LIGHTMAP_SIZE ) ) * 3 ) + 2 ];
+					int index = x + ( y * internalLightMapSize );
+					lightMapBuffer[( index * 4 ) + 0 ] = buf_p[( ( x + ( y * internalLightMapSize ) ) * 3 ) + 0 ];
+					lightMapBuffer[( index * 4 ) + 1 ] = buf_p[( ( x + ( y * internalLightMapSize ) ) * 3 ) + 1 ];
+					lightMapBuffer[( index * 4 ) + 2 ] = buf_p[( ( x + ( y * internalLightMapSize ) ) * 3 ) + 2 ];
 					lightMapBuffer[( index * 4 ) + 3 ] = 255;
 
 					R_ColorShiftLightingBytes( &lightMapBuffer[( index * 4 ) + 0 ], &lightMapBuffer[( index * 4 ) + 0 ] );
@@ -635,7 +636,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 			imageParams.filterType = filterType_t::FT_DEFAULT;
 			imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
 
-			image_t *internalLightMap = R_CreateImage( va( "_internalLightMap%d", i ), (const byte **)&lightMapBuffer, LIGHTMAP_SIZE, LIGHTMAP_SIZE, 1, imageParams );
+			image_t *internalLightMap = R_CreateImage( va( "_internalLightMap%d", i ), (const byte **)&lightMapBuffer, internalLightMapSize, internalLightMapSize, 1, imageParams );
 			Com_AddToGrowList( &tr.lightmaps, internalLightMap );
 
 			ri.Hunk_FreeTempMemory( lightMapBuffer );

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -449,7 +449,11 @@ R_LoadLightmaps
 static const int LIGHTMAP_SIZE = 128;
 static void R_LoadLightmaps( lump_t *l, const char *bspName )
 {
-	if ( r_vertexLighting->integer != 0 )
+	tr.worldLightMapping = r_precomputedLighting->integer && !r_vertexLighting->integer;
+
+	/* All lightmaps will be loaded if either light mapping
+	or deluxe mapping is enabled. */
+	if ( !tr.worldLightMapping && !tr.worldDeluxeMapping )
 	{
 		return;
 	}
@@ -482,6 +486,8 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 			if ( hdrFiles.empty() )
 			{
 				Log::Warn("no lightmap files found");
+				tr.worldLightMapping = false;
+				tr.worldDeluxeMapping = false;
 				return;
 			}
 			std::sort( hdrFiles.begin(), hdrFiles.end(), LightmapNameLess );
@@ -505,11 +511,13 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 				ri.Free( ldrImage );
 			}
 
-			if (tr.worldDeluxeMapping && r_deluxeMapping->integer != 0) {
+			if (tr.worldDeluxeMapping) {
 				// load deluxemaps
 				std::vector<std::string> lightmapFiles = R_LoadExternalLightmaps(mapName);
 				if (lightmapFiles.empty()) {
 					Log::Warn("no lightmap files found");
+					tr.worldLightMapping = false;
+					tr.worldDeluxeMapping = false;
 					return;
 				}
 
@@ -533,6 +541,8 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 			std::vector<std::string> lightmapFiles = R_LoadExternalLightmaps(mapName);
 			if (lightmapFiles.empty()) {
 				Log::Warn("no lightmap files found");
+				tr.worldLightMapping = false;
+				tr.worldDeluxeMapping = false;
 				return;
 			}
 
@@ -553,7 +563,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 					auto image = R_FindImageFile(va("%s/%s", mapName, lightmapFiles[i].c_str()), imageParams);
 					Com_AddToGrowList(&tr.lightmaps, image);
 				}
-				else if (r_deluxeMapping->integer != 0)
+				else if (tr.worldDeluxeMapping)
 				{
 					imageParams_t imageParams = {};
 					imageParams.bits = IF_NOPICMIP | IF_NORMALMAP;
@@ -570,6 +580,9 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 		if ( !len )
 		{
+			Log::Warn("no lightmap files found");
+			tr.worldLightMapping = false;
+			tr.worldDeluxeMapping = false;
 			return;
 		}
 
@@ -825,7 +838,7 @@ static void ParseFace( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf, in
 	// get lightmap
 	realLightmapNum = LittleLong( ds->lightmapNum );
 
-	if ( r_precomputedLighting->integer && ( !r_vertexLighting->integer || ( r_deluxeMapping->integer && tr.worldDeluxeMapping ) ) )
+	if ( tr.worldLightMapping || tr.worldDeluxeMapping )
 	{
 		surf->lightmapNum = realLightmapNum;
 	}
@@ -1033,7 +1046,7 @@ static void ParseMesh( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf )
 	// get lightmap
 	realLightmapNum = LittleLong( ds->lightmapNum );
 
-	if ( r_precomputedLighting->integer && ( !r_vertexLighting->integer || ( r_deluxeMapping->integer && tr.worldDeluxeMapping ) ) )
+	if ( tr.worldLightMapping || tr.worldDeluxeMapping )
 	{
 		surf->lightmapNum = realLightmapNum;
 	}
@@ -4224,7 +4237,8 @@ void R_LoadEntities( lump_t *l )
 		if ( !Q_stricmp( keyname, "deluxeMapping" ) && !Q_stricmp( value, "1" ) )
 		{
 			Log::Debug("map features directional light mapping" );
-			tr.worldDeluxeMapping = true;
+			// This will be disabled if the engine fails to load the lightmaps.
+			tr.worldDeluxeMapping = r_deluxeMapping->integer != 0;
 			continue;
 		}
 
@@ -4242,7 +4256,8 @@ void R_LoadEntities( lump_t *l )
 			if ( s )
 			{
 				Log::Debug("map features directional light mapping" );
-				tr.worldDeluxeMapping = true;
+				// This will be disabled if the engine fails to load the lightmaps.
+				tr.worldDeluxeMapping = r_deluxeMapping->integer != 0;
 			}
 
 			continue;
@@ -6013,7 +6028,7 @@ void R_PrecacheInteractions()
 	{
 		light = &s_worldData.lights[ i ];
 
-		if ( ( r_precomputedLighting->integer || r_vertexLighting->integer ) && !light->noRadiosity )
+		if ( tr.worldLightMapping && !light->noRadiosity )
 		{
 			continue;
 		}
@@ -6721,6 +6736,8 @@ void RE_LoadWorldMap( const char *name )
 	// try will not look at the partially loaded version
 	tr.world = nullptr;
 
+	// tr.worldDeluxeMapping will be set by R_LoadLightmaps()
+	tr.worldLightMapping = false;
 	// tr.worldDeluxeMapping will be set by R_LoadEntities()
 	tr.worldDeluxeMapping = false;
 	tr.worldHDR_RGBE = false;

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1101,7 +1101,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_customheight = Cvar_Get( "r_customheight", "1024", CVAR_LATCH | CVAR_ARCHIVE );
 		r_subdivisions = Cvar_Get( "r_subdivisions", "4", CVAR_LATCH );
 		r_dynamicLightCastShadows = Cvar_Get( "r_dynamicLightCastShadows", "1", 0 );
-		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_LATCH );
+		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_vertexLighting = Cvar_Get( "r_vertexLighting", "0", CVAR_LATCH | CVAR_ARCHIVE );
 		r_lightStyles = Cvar_Get( "r_lightStyles", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_exportTextures = Cvar_Get( "r_exportTextures", "0", 0 );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1222,6 +1222,9 @@ static inline void glFboSetExt()
 		alphaGen_t      alphaGen;
 		expression_t    alphaExp;
 
+		colorGen_t computedColorGen;
+		alphaGen_t computedAlphaGen;
+
 		expression_t    alphaTestExp;
 
 		bool        tcGen_Environment;
@@ -1296,6 +1299,7 @@ static inline void glFboSetExt()
 	};
 
 	void SetShaderStageRenderers( shader_t*, shaderStage_t* );
+	void SetShaderStageColorAlphaGen( shaderStage_t* );
 
 	enum cullType_t : int
 	{

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1187,6 +1187,11 @@ static inline void glFboSetExt()
 	  COLLAPSE_reflection_CB,
 	};
 
+	struct shaderStage_t;
+
+	using shaderRendererFunc_t = void( shaderStage_t* );
+	using shaderForwardRendererFunc_t = void( shaderStage_t*, shaderStage_t*, shaderStage_t*, trRefLight_t* );
+
 	struct shaderStage_t
 	{
 		stageType_t     type;
@@ -1196,6 +1201,11 @@ static inline void glFboSetExt()
 		bool        active;
 
 		bool            dpMaterial;
+
+		shaderRendererFunc_t *genericRenderer;
+		shaderRendererFunc_t *depthFillRenderer;
+		shaderRendererFunc_t *shadowFillRenderer;
+		shaderForwardRendererFunc_t *forwardRenderer;
 
 		textureBundle_t bundle[ MAX_TEXTURE_BUNDLES ];
 
@@ -1284,6 +1294,8 @@ static inline void glFboSetExt()
 
 		bool        noFog; // used only for shaders that have fog disabled, so we can enable it for individual stages
 	};
+
+	void SetShaderStageRenderers( shader_t*, shaderStage_t* );
 
 	enum cullType_t : int
 	{

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2713,6 +2713,7 @@ static inline void glFboSetExt()
 		int        frameSceneNum; // zeroed at RE_BeginFrame
 
 		bool   worldMapLoaded;
+		bool   worldLightMapping;
 		bool   worldDeluxeMapping;
 		bool   worldHDR_RGBE;
 		world_t    *world;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1285,8 +1285,6 @@ static inline void glFboSetExt()
 		bool        noFog; // used only for shaders that have fog disabled, so we can enable it for individual stages
 	};
 
-	struct shaderCommands_t;
-
 	enum cullType_t : int
 	{
 		CT_FRONT_SIDED = 0,

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -862,13 +862,12 @@ static void Render_lightMapping( int stage )
 
 	shaderStage_t *pStage = tess.surfaceStages[ stage ];
 
-	bool enableLightMapping = !r_vertexLighting->integer
-		&& tess.bspSurface
-		&& tess.lightmapNum >= 0 && tess.lightmapNum <= tr.lightmaps.currentElements;
+	bool enableLightMapping = tr.worldLightMapping
+		&& tess.bspSurface;
 
-	bool enableDeluxeMapping = pStage->enableDeluxeMapping
+	bool enableDeluxeMapping = tr.worldDeluxeMapping
 		&& tess.bspSurface
-		&& tr.worldDeluxeMapping;
+		&& pStage->enableDeluxeMapping;
 
 	bool noLightMap = !pStage->implicitLightmap
 		&& (tess.surfaceShader->surfaceFlags & SURF_NOLIGHTMAP)
@@ -2826,7 +2825,7 @@ void Tess_StageIteratorGeneric()
 			case stageType_t::ST_COLLAPSE_lighting_PHONG:
 			case stageType_t::ST_COLLAPSE_lighting_PBR:
 				{
-					if ( r_precomputedLighting->integer || r_vertexLighting->integer )
+					if ( r_precomputedLighting->integer )
 					{
 						Render_lightMapping( stage );
 					}

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2816,23 +2816,11 @@ void Tess_StageIteratorGeneric()
 				}
 
 			case stageType_t::ST_LIGHTMAP:
-				{
-					Render_lightMapping( stage );
-					break;
-				}
-
 			case stageType_t::ST_DIFFUSEMAP:
 			case stageType_t::ST_COLLAPSE_lighting_PHONG:
 			case stageType_t::ST_COLLAPSE_lighting_PBR:
 				{
-					if ( r_precomputedLighting->integer )
-					{
-						Render_lightMapping( stage );
-					}
-					else
-					{
-						Render_depthFill( stage );
-					}
+					Render_lightMapping( stage );
 					break;
 				}
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -693,6 +693,12 @@ static void Render_generic2D( int stage )
 
 static void Render_generic( int stage )
 {
+	if ( backEnd.projection2D )
+	{
+		Render_generic2D( stage );
+		return;
+	}
+
 	shaderStage_t *pStage;
 	colorGen_t    rgbGen;
 	alphaGen_t    alphaGen;
@@ -2804,14 +2810,7 @@ void Tess_StageIteratorGeneric()
 		{
 			case stageType_t::ST_COLORMAP:
 				{
-					if ( backEnd.projection2D )
-					{
-						Render_generic2D( stage );
-					}
-					else
-					{
-						Render_generic( stage );
-					}
+					Render_generic( stage );
 					break;
 				}
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4992,6 +4992,9 @@ static void CollapseStages()
 				stage->normalScale[ i ] = 1.0;
 			}
 		}
+
+		// Set shader stage renderer functions.
+		SetShaderStageRenderers( &shader, stage );
 	}
 }
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4995,6 +4995,9 @@ static void CollapseStages()
 
 		// Set shader stage renderer functions.
 		SetShaderStageRenderers( &shader, stage );
+
+		// Set shader stage colorGen and alphaGen.
+		SetShaderStageColorAlphaGen( stage );
 	}
 }
 


### PR DESCRIPTION
The PR was split, please review those PR before reviewing this one:

- https://github.com/DaemonEngine/Daemon/pull/820
- https://github.com/DaemonEngine/Daemon/pull/821
- https://github.com/DaemonEngine/Daemon/pull/822
- https://github.com/DaemonEngine/Daemon/pull/823
- https://github.com/DaemonEngine/Daemon/pull/824

Once those other PRs are merged, the remaining commits to review will be:

- `tr_shade: Render_generic() calls Render_generic2D() if 2D`
- `tr_shade,tr_shader: set colorGen and alphaGen only once`

---

_Original message:_

- Make feature disablement more consistent: various combinations of disabled `r_precomputedLight` where wrong.
- Make possible to load deluxe maps even if light mapping is disabled, as deluxe mapping with grid lighting is possible.
- Do not load lightgrid if precomputed lighting is disabled, the same way lightmap loading is already disabled.
- Call `Render_lightMapping()` on every related shader stages because that function knows how to render in all cases.
- `Render_generic()` calls `Render_generic2D()` if 2D, This allows to move the function from `Tess_StageIteratorGeneric()` which means many tests from `Tess_StageIteratorGeneric()` can be moved to shader stage configuration.
- Select shader stage render function only once. Introduce `SetShaderStageRenderers()` and call it at shader stage configuration. Not only factorise the code, but makes sure the Render function as selected once and only once, if possible when finalizing the shader stage, instead of running it on every frame
- Set `colorGen` and `alphaGen` only once. Factorise the code, do it only once per shader stage, and do it when finalizing the shader stage if possible.
- Make `r_precomputedLighting` a cheat cvar. Disabling this cvar disables all precomputed shadows and then makes everything fullbright, which gives an unbalanced advantage by making everything visible.
