### PR TITLE
tr_bsp,tr_shade: rework precomputed light, light map, deluxe map enablement

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2711,6 +2711,7 @@ static inline void glFboSetExt()
 		int        frameSceneNum; // zeroed at RE_BeginFrame
 
 		bool   worldMapLoaded;
+		bool   worldLightMapping;
 		bool   worldDeluxeMapping;
 		bool   worldHDR_RGBE;
 		world_t    *world;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -862,13 +862,12 @@ static void Render_lightMapping( int stage )
 
 	shaderStage_t *pStage = tess.surfaceStages[ stage ];
 
-	bool enableLightMapping = !r_vertexLighting->integer
-		&& tess.bspSurface
-		&& tess.lightmapNum >= 0 && tess.lightmapNum <= tr.lightmaps.currentElements;
+	bool enableLightMapping = tr.worldLightMapping
+		&& tess.bspSurface;
 
-	bool enableDeluxeMapping = pStage->enableDeluxeMapping
+	bool enableDeluxeMapping = tr.worldDeluxeMapping
 		&& tess.bspSurface
-		&& tr.worldDeluxeMapping;
+		&& pStage->enableDeluxeMapping;
 
 	bool noLightMap = !pStage->implicitLightmap
 		&& (tess.surfaceShader->surfaceFlags & SURF_NOLIGHTMAP)
@@ -2826,7 +2825,7 @@ void Tess_StageIteratorGeneric()
 			case stageType_t::ST_COLLAPSE_lighting_PHONG:
 			case stageType_t::ST_COLLAPSE_lighting_PBR:
 				{
-					if ( r_precomputedLighting->integer || r_vertexLighting->integer )
+					if ( r_precomputedLighting->integer )
 					{
 						Render_lightMapping( stage );
 					}

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2816,23 +2816,11 @@ void Tess_StageIteratorGeneric()
 				}
 
 			case stageType_t::ST_LIGHTMAP:
-				{
-					Render_lightMapping( stage );
-					break;
-				}
-
 			case stageType_t::ST_DIFFUSEMAP:
 			case stageType_t::ST_COLLAPSE_lighting_PHONG:
 			case stageType_t::ST_COLLAPSE_lighting_PBR:
 				{
-					if ( r_precomputedLighting->integer )
-					{
-						Render_lightMapping( stage );
-					}
-					else
-					{
-						Render_depthFill( stage );
-					}
+					Render_lightMapping( stage );
 					break;
 				}
 


### PR DESCRIPTION
Extracted from:

- https://github.com/DaemonEngine/Daemon/pull/819

The render is now as expected not only when `r_precomputedLighting` is enabled but also when it is disabled.

Disabling lightmapping while keeping deluxemapping enabled now still loads the deluxemaps to use them with gridlighting.

A variable named `tr.worldLightMapping` is used to know when light mapping is enabled instead of redoing all the tests
with potential mistakes. The is similar to the already existing `tr.worldDeluxeMapping` variable.

`Render_LightMapping()` always knows how to render, there are fallback everywhere.

Rendering with depth fill when there is no lighting is simply wrong, it was probably a very early workaround from before then engine was setting up a fallback lighting.