### PR TITLE
tr_init: make r_precomputedLighting a cheat cvar

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1101,7 +1101,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_customheight = Cvar_Get( "r_customheight", "1024", CVAR_LATCH | CVAR_ARCHIVE );
 		r_subdivisions = Cvar_Get( "r_subdivisions", "4", CVAR_LATCH );
 		r_dynamicLightCastShadows = Cvar_Get( "r_dynamicLightCastShadows", "1", 0 );
-		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_LATCH );
+		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_vertexLighting = Cvar_Get( "r_vertexLighting", "0", CVAR_LATCH | CVAR_ARCHIVE );
 		r_lightStyles = Cvar_Get( "r_lightStyles", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_exportTextures = Cvar_Get( "r_exportTextures", "0", 0 );


### PR DESCRIPTION
Extracted from:

- https://github.com/DaemonEngine/Daemon/pull/819

Make `r_precomputedLighting` a cheat cvar.

Disabling this cvar disables all precomputed shadows and then makes everything fullbright, which gives
an unbalanced advantage by making everything visible.

_Note:_ to actually get the expected behaviour from this cvar, ones need to also merge:

- https://github.com/DaemonEngine/Daemon/pull/820