### PR TITLE
tr_local: cleanup an useless declaration

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1285,8 +1285,6 @@ static inline void glFboSetExt()
 		bool        noFog; // used only for shaders that have fog disabled, so we can enable it for individual stages
 	};
 
-	struct shaderCommands_t;
-
 	enum cullType_t : int
 	{
 		CT_FRONT_SIDED = 0,


### PR DESCRIPTION
Extracted from:

- https://github.com/DaemonEngine/Daemon/pull/819

Cleanup an useless declaration.

This would have been useful if a struct or a function declaration used that type before that type was declared, but this is not happening.