### PR TITLE
common: some optimizations in tracing code

### DIFF
--- a/src/common/cm/cm_test.cpp
+++ b/src/common/cm/cm_test.cpp
@@ -196,10 +196,8 @@ CM_PointContents
 int CM_PointContents( const vec3_t p, clipHandle_t model )
 {
 	int      leafnum;
-	int      i;
 	cLeaf_t  *leaf;
 	int      contents;
-	float    d;
 	cmodel_t *clipm;
 
 	if ( !cm.numNodes )
@@ -246,19 +244,22 @@ int CM_PointContents( const vec3_t p, clipHandle_t model )
 		// XreaL END
 
 		// see if the point is in the brush
-		for ( i = 0; i < b->numsides; i++ )
+		const cbrushside_t *firstSide = b->sides;
+		const cbrushside_t *endSide = firstSide + b->numsides;
+		const cbrushside_t *side;
+		for ( side = firstSide; side < endSide; side++ )
 		{
-			d = DotProduct( p, b->sides[ i ].plane->normal );
+			float d = DotProduct( p, side->plane->normal );
 
 // FIXME test for Cash
-//          if ( d >= b->sides[i].plane->dist ) {
-			if ( d > b->sides[ i ].plane->dist )
+//          if ( d >= side->plane->dist ) {
+			if ( d > side->plane->dist )
 			{
 				break;
 			}
 		}
 
-		if ( i == b->numsides )
+		if ( side == endSide )
 		{
 			contents |= b->contents;
 		}

--- a/src/common/cm/cm_test.cpp
+++ b/src/common/cm/cm_test.cpp
@@ -507,17 +507,12 @@ CM_BoundsIntersect
 */
 bool CM_BoundsIntersect( const vec3_t mins, const vec3_t maxs, const vec3_t mins2, const vec3_t maxs2 )
 {
-	if ( maxs[ 0 ] < mins2[ 0 ] - SURFACE_CLIP_EPSILON ||
-	     maxs[ 1 ] < mins2[ 1 ] - SURFACE_CLIP_EPSILON ||
-	     maxs[ 2 ] < mins2[ 2 ] - SURFACE_CLIP_EPSILON ||
-	     mins[ 0 ] > maxs2[ 0 ] + SURFACE_CLIP_EPSILON ||
-	     mins[ 1 ] > maxs2[ 1 ] + SURFACE_CLIP_EPSILON ||
-	     mins[ 2 ] > maxs2[ 2 ] + SURFACE_CLIP_EPSILON )
-	{
-		return false;
-	}
-
-	return true;
+	return ( maxs[ 0 ] >= mins2[ 0 ] - SURFACE_CLIP_EPSILON &&
+	     maxs[ 1 ] >= mins2[ 1 ] - SURFACE_CLIP_EPSILON &&
+	     maxs[ 2 ] >= mins2[ 2 ] - SURFACE_CLIP_EPSILON &&
+	     mins[ 0 ] <= maxs2[ 0 ] + SURFACE_CLIP_EPSILON &&
+	     mins[ 1 ] <= maxs2[ 1 ] + SURFACE_CLIP_EPSILON &&
+	     mins[ 2 ] <= maxs2[ 2 ] + SURFACE_CLIP_EPSILON );
 }
 
 /*
@@ -527,17 +522,12 @@ CM_BoundsIntersectPoint
 */
 bool CM_BoundsIntersectPoint( const vec3_t mins, const vec3_t maxs, const vec3_t point )
 {
-	if ( maxs[ 0 ] < point[ 0 ] - SURFACE_CLIP_EPSILON ||
-	     maxs[ 1 ] < point[ 1 ] - SURFACE_CLIP_EPSILON ||
-	     maxs[ 2 ] < point[ 2 ] - SURFACE_CLIP_EPSILON ||
-	     mins[ 0 ] > point[ 0 ] + SURFACE_CLIP_EPSILON ||
-	     mins[ 1 ] > point[ 1 ] + SURFACE_CLIP_EPSILON ||
-	     mins[ 2 ] > point[ 2 ] + SURFACE_CLIP_EPSILON )
-	{
-		return false;
-	}
-
-	return true;
+	return ( maxs[ 0 ] >= point[ 0 ] - SURFACE_CLIP_EPSILON &&
+	     maxs[ 1 ] >= point[ 1 ] - SURFACE_CLIP_EPSILON &&
+	     maxs[ 2 ] >= point[ 2 ] - SURFACE_CLIP_EPSILON &&
+	     mins[ 0 ] <= point[ 0 ] + SURFACE_CLIP_EPSILON &&
+	     mins[ 1 ] <= point[ 1 ] + SURFACE_CLIP_EPSILON &&
+	     mins[ 2 ] <= point[ 2 ] + SURFACE_CLIP_EPSILON );
 }
 
 // XreaL END

--- a/src/common/cm/cm_test.cpp
+++ b/src/common/cm/cm_test.cpp
@@ -196,10 +196,8 @@ CM_PointContents
 int CM_PointContents( const vec3_t p, clipHandle_t model )
 {
 	int      leafnum;
-	int      i, k;
-	int      brushnum;
+	int      i;
 	cLeaf_t  *leaf;
-	cbrush_t *b;
 	int      contents;
 	float    d;
 	cmodel_t *clipm;
@@ -233,10 +231,11 @@ int CM_PointContents( const vec3_t p, clipHandle_t model )
 
 	contents = 0;
 
-	for ( k = 0; k < leaf->numLeafBrushes; k++ )
+	const int *firstBrushNum = leaf->firstLeafBrush;
+	const int *endBrushNum = firstBrushNum + leaf->numLeafBrushes;
+	for ( const int *brushNum = firstBrushNum; brushNum < endBrushNum; brushNum++ )
 	{
-		brushnum = leaf->firstLeafBrush[ k ];
-		b = &cm.brushes[ brushnum ];
+		cbrush_t *b = &cm.brushes[ *brushNum ];
 
 		// XreaL BEGIN
 		if ( !CM_BoundsIntersectPoint( b->bounds[ 0 ], b->bounds[ 1 ], p ) )

--- a/src/common/cm/cm_trace.cpp
+++ b/src/common/cm/cm_trace.cpp
@@ -162,11 +162,8 @@ CM_TestBoxInBrush
 */
 static void CM_TestBoxInBrush( traceWork_t *tw, cbrush_t *brush )
 {
-	int          i;
-	cplane_t     *plane;
 	float        dist;
 	float        d1;
-	cbrushside_t *side;
 	float        t;
 	vec3_t       startp;
 
@@ -186,14 +183,18 @@ static void CM_TestBoxInBrush( traceWork_t *tw, cbrush_t *brush )
 		return;
 	}
 
+	const cbrushside_t *firstSide = brush->sides;
+	const cbrushside_t *endSide = firstSide + brush->numsides;
+	
+	// the first six planes are the axial planes, so we only
+	// need to test the remainder
+	firstSide += 6;
+
 	if ( tw->type == traceType_t::TT_CAPSULE )
 	{
-		// the first six planes are the axial planes, so we only
-		// need to test the remainder
-		for ( i = 6; i < brush->numsides; i++ )
+		for ( const cbrushside_t *side = firstSide; side < endSide; side++ )
 		{
-			side = brush->sides + i;
-			plane = side->plane;
+			const cplane_t *plane = side->plane;
 
 			// adjust the plane distance appropriately for radius
 			dist = plane->dist + tw->sphere.radius;
@@ -220,12 +221,9 @@ static void CM_TestBoxInBrush( traceWork_t *tw, cbrush_t *brush )
 	}
 	else
 	{
-		// the first six planes are the axial planes, so we only
-		// need to test the remainder
-		for ( i = 6; i < brush->numsides; i++ )
+		for ( const cbrushside_t *side = firstSide; side < endSide; side++ )
 		{
-			side = brush->sides + i;
-			plane = side->plane;
+			const cplane_t *plane = side->plane;
 
 			// adjust the plane distance appropriately for mins/maxs
 			dist = plane->dist - DotProduct( tw->offsets[ plane->signbits ], plane->normal );
@@ -1017,21 +1015,17 @@ CM_TraceThroughBrush
 */
 void CM_TraceThroughBrush( traceWork_t *tw, cbrush_t *brush )
 {
-	int          i;
-	cplane_t     *plane, *clipplane;
 	float        dist;
 	float        enterFrac, leaveFrac;
 	float        d1, d2;
 	bool     getout, startout;
 	float        f;
-	cbrushside_t *side, *leadside;
 	float        t;
 	vec3_t       startp;
 	vec3_t       endp;
 
 	enterFrac = -1.0f;
 	leaveFrac = 1.0f;
-	clipplane = nullptr;
 
 	if ( !brush->numsides )
 	{
@@ -1043,7 +1037,11 @@ void CM_TraceThroughBrush( traceWork_t *tw, cbrush_t *brush )
 	getout = false;
 	startout = false;
 
-	leadside = nullptr;
+	const cplane_t *clipplane = nullptr;
+	const cbrushside_t *leadside = nullptr;
+
+	const cbrushside_t *firstSide = brush->sides;
+	const cbrushside_t *endSide = firstSide + brush->numsides;
 
 	if ( tw->type == traceType_t::TT_BISPHERE )
 	{
@@ -1052,10 +1050,9 @@ void CM_TraceThroughBrush( traceWork_t *tw, cbrush_t *brush )
 		// find the latest time the trace crosses a plane towards the interior
 		// and the earliest time the trace crosses a plane towards the exterior
 		//
-		for ( i = 0; i < brush->numsides; i++ )
+		for ( const cbrushside_t *side = firstSide; side < endSide; side++ )
 		{
-			side = brush->sides + i;
-			plane = side->plane;
+			const cplane_t *plane = side->plane;
 
 			// adjust the plane distance appropriately for radius
 			d1 = DotProduct( tw->start, plane->normal ) - ( plane->dist + tw->biSphere.startRadius );
@@ -1127,10 +1124,9 @@ void CM_TraceThroughBrush( traceWork_t *tw, cbrush_t *brush )
 		// find the latest time the trace crosses a plane towards the interior
 		// and the earliest time the trace crosses a plane towards the exterior
 		//
-		for ( i = 0; i < brush->numsides; i++ )
+		for ( const cbrushside_t *side = firstSide; side < endSide; side++ )
 		{
-			side = brush->sides + i;
-			plane = side->plane;
+			const cplane_t *plane = side->plane;
 
 			// adjust the plane distance appropriately for radius
 			dist = plane->dist + tw->sphere.radius;
@@ -1218,10 +1214,9 @@ void CM_TraceThroughBrush( traceWork_t *tw, cbrush_t *brush )
 		// find the latest time the trace crosses a plane towards the interior
 		// and the earliest time the trace crosses a plane towards the exterior
 		//
-		for ( i = 0; i < brush->numsides; i++ )
+		for ( const cbrushside_t *side = firstSide; side < endSide; side++ )
 		{
-			side = brush->sides + i;
-			plane = side->plane;
+			const cplane_t *plane = side->plane;
 
 			// adjust the plane distance appropriately for mins/maxs
 			dist = plane->dist - DotProduct( tw->offsets[ plane->signbits ], plane->normal );
@@ -2553,21 +2548,19 @@ void CM_TransformedBiSphereTrace( trace_t *results, const vec3_t start, const ve
 
 static float CM_DistanceToBrush( const vec3_t loc, cbrush_t *brush )
 {
-	int          i;
-	cplane_t     *plane;
 	float        dist = -999999.0f;
 	float        d1;
-	cbrushside_t *side;
 
 	if ( !brush->numsides )
 	{
 		return 999999.0f;
 	}
 
-	for ( i = 0; i < brush->numsides; i++ )
+	const cbrushside_t *firstSide = brush->sides;
+	const cbrushside_t *endSide = firstSide + brush->numsides;
+	for ( const cbrushside_t *side = firstSide; side < endSide; side++ )
 	{
-		side = brush->sides + i;
-		plane = side->plane;
+		const cplane_t *plane = side->plane;
 
 		d1 = DotProduct( loc, plane->normal ) - plane->dist;
 

--- a/src/common/cm/cm_trace.cpp
+++ b/src/common/cm/cm_trace.cpp
@@ -465,7 +465,6 @@ a tangent sphere at the top and the bottom that has the same radius.
 */
 void CM_TestCapsuleInCapsule( traceWork_t *tw, clipHandle_t model )
 {
-	int    i;
 	vec3_t mins, maxs;
 	vec3_t top, bottom;
 	vec3_t p1, p2, tmp;
@@ -477,11 +476,18 @@ void CM_TestCapsuleInCapsule( traceWork_t *tw, clipHandle_t model )
 	VectorAdd( tw->start, tw->sphere.offset, top );
 	VectorSubtract( tw->start, tw->sphere.offset, bottom );
 
-	for ( i = 0; i < 3; i++ )
 	{
-		offset[ i ] = ( mins[ i ] + maxs[ i ] ) * 0.5;
-		symetricSize[ 0 ][ i ] = mins[ i ] - offset[ i ];
-		symetricSize[ 1 ][ i ] = maxs[ i ] - offset[ i ];
+		offset[ 0 ] = ( mins[ 0 ] + maxs[ 0 ] ) * 0.5;
+		offset[ 1 ] = ( mins[ 1 ] + maxs[ 1 ] ) * 0.5;
+		offset[ 2 ] = ( mins[ 2 ] + maxs[ 2 ] ) * 0.5;
+
+		symetricSize[ 0 ][ 0 ] = mins[ 0 ] - offset[ 0 ];
+		symetricSize[ 0 ][ 1 ] = mins[ 1 ] - offset[ 1 ];
+		symetricSize[ 0 ][ 2 ] = mins[ 2 ] - offset[ 2 ];
+
+		symetricSize[ 1 ][ 0 ] = maxs[ 0 ] - offset[ 0 ];
+		symetricSize[ 1 ][ 1 ] = maxs[ 1 ] - offset[ 1 ];
+		symetricSize[ 1 ][ 2 ] = maxs[ 2 ] - offset[ 2 ];
 	}
 
 	halfwidth = symetricSize[ 1 ][ 0 ];
@@ -555,19 +561,31 @@ void CM_TestBoundingBoxInCapsule( traceWork_t *tw, clipHandle_t model )
 	vec3_t       mins, maxs, offset, size[ 2 ];
 	clipHandle_t h;
 	cmodel_t     *cmod;
-	int          i;
 
 	// mins maxs of the capsule
 	CM_ModelBounds( model, mins, maxs );
 
 	// offset for capsule center
-	for ( i = 0; i < 3; i++ )
 	{
-		offset[ i ] = ( mins[ i ] + maxs[ i ] ) * 0.5;
-		size[ 0 ][ i ] = mins[ i ] - offset[ i ];
-		size[ 1 ][ i ] = maxs[ i ] - offset[ i ];
-		tw->start[ i ] -= offset[ i ];
-		tw->end[ i ] -= offset[ i ];
+		offset[ 0 ] = ( mins[ 0 ] + maxs[ 0 ] ) * 0.5;
+		offset[ 1 ] = ( mins[ 1 ] + maxs[ 1 ] ) * 0.5;
+		offset[ 2 ] = ( mins[ 2 ] + maxs[ 2 ] ) * 0.5;
+
+		size[ 0 ][ 0 ] = mins[ 0 ] - offset[ 0 ];
+		size[ 0 ][ 1 ] = mins[ 1 ] - offset[ 1 ];
+		size[ 0 ][ 2 ] = mins[ 2 ] - offset[ 2 ];
+
+		size[ 1 ][ 0 ] = maxs[ 0 ] - offset[ 0 ];
+		size[ 1 ][ 1 ] = maxs[ 1 ] - offset[ 1 ];
+		size[ 1 ][ 2 ] = maxs[ 2 ] - offset[ 2 ];
+
+		tw->start[ 0 ] -= offset[ 0 ];
+		tw->start[ 1 ] -= offset[ 1 ];
+		tw->start[ 2 ] -= offset[ 2 ];
+
+		tw->end[ 0 ] -= offset[ 0 ];
+		tw->end[ 1 ] -= offset[ 1 ];
+		tw->end[ 2 ] -= offset[ 2 ];
 	}
 
 	// replace the bounding box with the capsule
@@ -599,10 +617,14 @@ void CM_PositionTest( traceWork_t *tw )
 	VectorAdd( tw->start, tw->size[ 0 ], ll.bounds[ 0 ] );
 	VectorAdd( tw->start, tw->size[ 1 ], ll.bounds[ 1 ] );
 
-	for ( i = 0; i < 3; i++ )
 	{
-		ll.bounds[ 0 ][ i ] -= 1;
-		ll.bounds[ 1 ][ i ] += 1;
+		ll.bounds[ 0 ][ 0 ] -= 1;
+		ll.bounds[ 0 ][ 1 ] -= 1;
+		ll.bounds[ 0 ][ 2 ] -= 1;
+
+		ll.bounds[ 1 ][ 0 ] += 1;
+		ll.bounds[ 1 ][ 1 ] += 1;
+		ll.bounds[ 1 ][ 2 ] += 1;
 	}
 
 	ll.count = 0;
@@ -1800,7 +1822,6 @@ capsule vs. capsule collision (not rotated)
 */
 void CM_TraceCapsuleThroughCapsule( traceWork_t *tw, clipHandle_t model )
 {
-	int    i;
 	vec3_t mins, maxs;
 	vec3_t top, bottom, starttop, startbottom, endtop, endbottom;
 	vec3_t offset, symetricSize[ 2 ];
@@ -1825,11 +1846,18 @@ void CM_TraceCapsuleThroughCapsule( traceWork_t *tw, clipHandle_t model )
 	VectorSubtract( tw->end, tw->sphere.offset, endbottom );
 
 	// calculate top and bottom of the capsule spheres to collide with
-	for ( i = 0; i < 3; i++ )
 	{
-		offset[ i ] = ( mins[ i ] + maxs[ i ] ) * 0.5;
-		symetricSize[ 0 ][ i ] = mins[ i ] - offset[ i ];
-		symetricSize[ 1 ][ i ] = maxs[ i ] - offset[ i ];
+		offset[ 0 ] = ( mins[ 0 ] + maxs[ 0 ] ) * 0.5;
+		offset[ 1 ] = ( mins[ 1 ] + maxs[ 1 ] ) * 0.5;
+		offset[ 2 ] = ( mins[ 2 ] + maxs[ 2 ] ) * 0.5;
+
+		symetricSize[ 0 ][ 0 ] = mins[ 0 ] - offset[ 0 ];
+		symetricSize[ 0 ][ 1 ] = mins[ 1 ] - offset[ 1 ];
+		symetricSize[ 0 ][ 2 ] = mins[ 2 ] - offset[ 2 ];
+
+		symetricSize[ 1 ][ 0 ] = maxs[ 0 ] - offset[ 0 ];
+		symetricSize[ 1 ][ 1 ] = maxs[ 1 ] - offset[ 1 ];
+		symetricSize[ 1 ][ 2 ] = maxs[ 2 ] - offset[ 2 ];
 	}
 
 	halfwidth = symetricSize[ 1 ][ 0 ];
@@ -1874,19 +1902,31 @@ void CM_TraceBoundingBoxThroughCapsule( traceWork_t *tw, clipHandle_t model )
 	vec3_t       mins, maxs, offset, size[ 2 ];
 	clipHandle_t h;
 	cmodel_t     *cmod;
-	int          i;
 
 	// mins maxs of the capsule
 	CM_ModelBounds( model, mins, maxs );
 
 	// offset for capsule center
-	for ( i = 0; i < 3; i++ )
 	{
-		offset[ i ] = ( mins[ i ] + maxs[ i ] ) * 0.5;
-		size[ 0 ][ i ] = mins[ i ] - offset[ i ];
-		size[ 1 ][ i ] = maxs[ i ] - offset[ i ];
-		tw->start[ i ] -= offset[ i ];
-		tw->end[ i ] -= offset[ i ];
+		offset[ 0 ] = ( mins[ 0 ] + maxs[ 0 ] ) * 0.5;
+		offset[ 1 ] = ( mins[ 1 ] + maxs[ 1 ] ) * 0.5;
+		offset[ 2 ] = ( mins[ 2 ] + maxs[ 2 ] ) * 0.5;
+
+		size[ 0 ][ 0 ] = mins[ 0 ] - offset[ 0 ];
+		size[ 0 ][ 1 ] = mins[ 1 ] - offset[ 1 ];
+		size[ 0 ][ 2 ] = mins[ 2 ] - offset[ 2 ];
+
+		size[ 1 ][ 0 ] = maxs[ 0 ] - offset[ 0 ];
+		size[ 1 ][ 1 ] = maxs[ 1 ] - offset[ 1 ];
+		size[ 1 ][ 2 ] = maxs[ 2 ] - offset[ 2 ];
+
+		tw->start[ 0 ] -= offset[ 0 ];
+		tw->start[ 1 ] -= offset[ 1 ];
+		tw->start[ 2 ] -= offset[ 2 ];
+
+		tw->end[ 0 ] -= offset[ 0 ];
+		tw->end[ 1 ] -= offset[ 1 ];
+		tw->end[ 2 ] -= offset[ 2 ];
 	}
 
 	// replace the bounding box with the capsule
@@ -2095,13 +2135,26 @@ static void CM_Trace( trace_t *results, const vec3_t start, const vec3_t end, co
 	// adjust so that mins and maxs are always symmetric, which
 	// avoids some complications with plane expanding of rotated
 	// bmodels
-	for ( i = 0; i < 3; i++ )
 	{
-		offset[ i ] = ( mins[ i ] + maxs[ i ] ) * 0.5;
-		tw.size[ 0 ][ i ] = mins[ i ] - offset[ i ];
-		tw.size[ 1 ][ i ] = maxs[ i ] - offset[ i ];
-		tw.start[ i ] = start[ i ] + offset[ i ];
-		tw.end[ i ] = end[ i ] + offset[ i ];
+		offset[ 0 ] = ( mins[ 0 ] + maxs[ 0 ] ) * 0.5;
+		offset[ 1 ] = ( mins[ 1 ] + maxs[ 1 ] ) * 0.5;
+		offset[ 2 ] = ( mins[ 2 ] + maxs[ 2 ] ) * 0.5;
+
+		tw.size[ 0 ][ 0 ] = mins[ 0 ] - offset[ 0 ];
+		tw.size[ 0 ][ 1 ] = mins[ 1 ] - offset[ 1 ];
+		tw.size[ 0 ][ 2 ] = mins[ 2 ] - offset[ 2 ];
+
+		tw.size[ 1 ][ 0 ] = maxs[ 0 ] - offset[ 0 ];
+		tw.size[ 1 ][ 1 ] = maxs[ 1 ] - offset[ 1 ];
+		tw.size[ 1 ][ 2 ] = maxs[ 2 ] - offset[ 2 ];
+
+		tw.start[ 0 ] = start[ 0 ] + offset[ 0 ];
+		tw.start[ 1 ] = start[ 1 ] + offset[ 1 ];
+		tw.start[ 2 ] = start[ 2 ] + offset[ 2 ];
+
+		tw.end[ 0 ] = end[ 0 ] + offset[ 0 ];
+		tw.end[ 1 ] = end[ 1 ] + offset[ 1 ];
+		tw.end[ 2 ] = end[ 2 ] + offset[ 2 ];
 	}
 
 	// if a sphere is already specified
@@ -2333,7 +2386,6 @@ void CM_TransformedBoxTrace( trace_t *results, const vec3_t start, const vec3_t 
 	vec3_t   offset;
 	vec3_t   symetricSize[ 2 ];
 	vec3_t   matrix[ 3 ], transpose[ 3 ];
-	int      i;
 	float    halfwidth;
 	float    halfheight;
 	float    t;
@@ -2352,13 +2404,26 @@ void CM_TransformedBoxTrace( trace_t *results, const vec3_t start, const vec3_t 
 	// adjust so that mins and maxs are always symmetric, which
 	// avoids some complications with plane expanding of rotated
 	// bmodels
-	for ( i = 0; i < 3; i++ )
 	{
-		offset[ i ] = ( mins[ i ] + maxs[ i ] ) * 0.5;
-		symetricSize[ 0 ][ i ] = mins[ i ] - offset[ i ];
-		symetricSize[ 1 ][ i ] = maxs[ i ] - offset[ i ];
-		start_l[ i ] = start[ i ] + offset[ i ];
-		end_l[ i ] = end[ i ] + offset[ i ];
+		offset[ 0 ] = ( mins[ 0 ] + maxs[ 0 ] ) * 0.5;
+		offset[ 1 ] = ( mins[ 1 ] + maxs[ 1 ] ) * 0.5;
+		offset[ 2 ] = ( mins[ 2 ] + maxs[ 2 ] ) * 0.5;
+
+		symetricSize[ 0 ][ 0 ] = mins[ 0 ] - offset[ 0 ];
+		symetricSize[ 0 ][ 1 ] = mins[ 1 ] - offset[ 1 ];
+		symetricSize[ 0 ][ 2 ] = mins[ 2 ] - offset[ 2 ];
+
+		symetricSize[ 1 ][ 0 ] = maxs[ 0 ] - offset[ 0 ];
+		symetricSize[ 1 ][ 1 ] = maxs[ 1 ] - offset[ 1 ];
+		symetricSize[ 1 ][ 2 ] = maxs[ 2 ] - offset[ 2 ];
+
+		start_l[ 0 ] = start[ 0 ] + offset[ 0 ];
+		start_l[ 1 ] = start[ 1 ] + offset[ 1 ];
+		start_l[ 2 ] = start[ 2 ] + offset[ 2 ];
+
+		end_l[ 0 ] = end[ 0 ] + offset[ 0 ];
+		end_l[ 1 ] = end[ 1 ] + offset[ 1 ];
+		end_l[ 2 ] = end[ 2 ] + offset[ 2 ];
 	}
 
 	// subtract origin offset
@@ -2509,10 +2574,9 @@ void CM_BiSphereTrace( trace_t *results, const vec3_t start, const vec3_t end, f
 	}
 	else
 	{
-		for ( i = 0; i < 3; i++ )
-		{
-			tw.trace.endpos[ i ] = start[ i ] + tw.trace.fraction * ( end[ i ] - start[ i ] );
-		}
+		tw.trace.endpos[ 0 ] = start[ 0 ] + tw.trace.fraction * ( end[ 0 ] - start[ 0 ] );
+		tw.trace.endpos[ 1 ] = start[ 1 ] + tw.trace.fraction * ( end[ 1 ] - start[ 1 ] );
+		tw.trace.endpos[ 2 ] = start[ 2 ] + tw.trace.fraction * ( end[ 2 ] - start[ 2 ] );
 	}
 
 	*results = tw.trace;

--- a/src/common/cm/cm_trace.cpp
+++ b/src/common/cm/cm_trace.cpp
@@ -1834,7 +1834,8 @@ void CM_TraceCapsuleThroughCapsule( traceWork_t *tw, clipHandle_t model )
 	     || tw->bounds[ 0 ][ 1 ] > maxs[ 1 ] + RADIUS_EPSILON
 	     || tw->bounds[ 0 ][ 2 ] > maxs[ 2 ] + RADIUS_EPSILON
 	     || tw->bounds[ 1 ][ 0 ] < mins[ 0 ] - RADIUS_EPSILON
-	     || tw->bounds[ 1 ][ 1 ] < mins[ 1 ] - RADIUS_EPSILON || tw->bounds[ 1 ][ 2 ] < mins[ 2 ] - RADIUS_EPSILON )
+	     || tw->bounds[ 1 ][ 1 ] < mins[ 1 ] - RADIUS_EPSILON
+	     || tw->bounds[ 1 ][ 2 ] < mins[ 2 ] - RADIUS_EPSILON )
 	{
 		return;
 	}

--- a/src/common/cm/cm_trace.cpp
+++ b/src/common/cm/cm_trace.cpp
@@ -368,16 +368,12 @@ CM_TestInLeaf
 */
 void CM_TestInLeaf( traceWork_t *tw, cLeaf_t *leaf )
 {
-	int        k;
-	int        brushnum;
-	cbrush_t   *b;
-	cSurface_t *surface;
-
 	// test box position against all brushes in the leaf
-	for ( k = 0; k < leaf->numLeafBrushes; k++ )
+	const int *firstBrushNum = leaf->firstLeafBrush;
+	const int *endBrushNum = firstBrushNum + leaf->numLeafBrushes;
+	for ( const int *brushNum = firstBrushNum; brushNum < endBrushNum; brushNum++ )
 	{
-		brushnum = leaf->firstLeafBrush[ k ];
-		b = &cm.brushes[ brushnum ];
+		cbrush_t *b = &cm.brushes[ *brushNum ];
 
 		if ( b->checkcount == cm.checkcount )
 		{
@@ -405,9 +401,11 @@ void CM_TestInLeaf( traceWork_t *tw, cLeaf_t *leaf )
 	}
 
 	// test against all surfaces
-	for ( k = 0; k < leaf->numLeafSurfaces; k++ )
+	const int *firstSurfaceNum = leaf->firstLeafSurface;
+	const int *endSurfaceNum = firstSurfaceNum + leaf->numLeafSurfaces;
+	for ( const int *surfaceNum = firstSurfaceNum; surfaceNum < endSurfaceNum; surfaceNum++ )
 	{
-		surface = cm.surfaces[ leaf->firstLeafSurface[ k ] ];
+		cSurface_t *surface = cm.surfaces[ *surfaceNum ];
 
 		if ( !surface )
 		{
@@ -1433,17 +1431,12 @@ CM_TraceThroughLeaf
 */
 void CM_TraceThroughLeaf( traceWork_t *tw, cLeaf_t *leaf )
 {
-	int        k;
-	int        brushnum;
-	cbrush_t   *b;
-	cSurface_t *surface;
-
 	// trace line against all brushes in the leaf
-	for ( k = 0; k < leaf->numLeafBrushes; k++ )
+	const int *firstBrushNum = leaf->firstLeafBrush;
+	const int *endBrushNum = firstBrushNum + leaf->numLeafBrushes;
+	for ( const int *brushNum = firstBrushNum; brushNum < endBrushNum; brushNum++ )
 	{
-		brushnum = leaf->firstLeafBrush[ k ];
-
-		b = &cm.brushes[ brushnum ];
+		cbrush_t *b = &cm.brushes[ *brushNum ];
 
 		if ( b->checkcount == cm.checkcount )
 		{
@@ -1479,9 +1472,11 @@ void CM_TraceThroughLeaf( traceWork_t *tw, cLeaf_t *leaf )
 	}
 
 	// trace line against all surfaces in the leaf
-	for ( k = 0; k < leaf->numLeafSurfaces; k++ )
+	const int *firstSurfaceNum = leaf->firstLeafSurface;
+	const int *endSurfaceNum = firstSurfaceNum + leaf->numLeafSurfaces;
+	for ( const int *surfaceNum = firstSurfaceNum; surfaceNum < endSurfaceNum; surfaceNum++ )
 	{
-		surface = cm.surfaces[ leaf->firstLeafSurface[ k ] ];
+		cSurface_t *surface = cm.surfaces[ *surfaceNum ];
 
 		if ( !surface )
 		{
@@ -1521,11 +1516,9 @@ void CM_TraceThroughLeaf( traceWork_t *tw, cLeaf_t *leaf )
 
 	if ( tw->testLateralCollision && tw->trace.fraction < 1.0f )
 	{
-		for ( k = 0; k < leaf->numLeafBrushes; k++ )
+		for ( const int *brushNum = firstBrushNum; brushNum < endBrushNum; brushNum++ )
 		{
-			brushnum = leaf->firstLeafBrush[ k ];
-
-			b = &cm.brushes[ brushnum ];
+			cbrush_t *b = &cm.brushes[ *brushNum ];
 
 			// This brush never collided, so don't bother
 			if ( !b->collided )
@@ -1551,9 +1544,9 @@ void CM_TraceThroughLeaf( traceWork_t *tw, cLeaf_t *leaf )
 			}
 		}
 
-		for ( k = 0; k < leaf->numLeafSurfaces; k++ )
+		for ( const int *surfaceNum = firstSurfaceNum; surfaceNum < endSurfaceNum; surfaceNum++ )
 		{
-			surface = cm.surfaces[ leaf->firstLeafSurface[ k ] ];
+			cSurface_t *surface = cm.surfaces[ *surfaceNum ];
 
 			if ( !surface )
 			{
@@ -2592,19 +2585,18 @@ static float CM_DistanceToBrush( const vec3_t loc, cbrush_t *brush )
 
 float CM_DistanceToModel( const vec3_t loc, clipHandle_t model ) {
 	cmodel_t    *cmod;
-	int        k;
-	int        brushnum;
-	cbrush_t   *b;
 	float      dist = 999999.0f;
 	float      d1;
 
 	cmod = CM_ClipHandleToModel( model );
 
 	// test box position against all brushes in the leaf
-	for ( k = 0; k < cmod->leaf.numLeafBrushes; k++ )
+	const cLeaf_t *leaf = &cmod->leaf;
+	const int *firstBrushNum = leaf->firstLeafBrush;
+	const int *endBrushNum = firstBrushNum + leaf->numLeafBrushes;
+	for ( const int *brushNum = firstBrushNum; brushNum < endBrushNum; brushNum++ )
 	{
-		brushnum = cmod->leaf.firstLeafBrush[ k ];
-		b = &cm.brushes[ brushnum ];
+		cbrush_t *b = &cm.brushes[ *brushNum ];
 
 		d1 = CM_DistanceToBrush( loc, b );
 		if( d1 < dist )

--- a/src/common/cm/cm_trace.cpp
+++ b/src/common/cm/cm_trace.cpp
@@ -73,15 +73,17 @@ TransposeMatrix
 */
 void TransposeMatrix( const vec3_t matrix[ 3 ], vec3_t transpose[ 3 ] )
 {
-	int i, j;
+	transpose[ 0 ][ 0 ] = matrix[ 0 ][ 0 ];
+	transpose[ 0 ][ 1 ] = matrix[ 1 ][ 0 ];
+	transpose[ 0 ][ 2 ] = matrix[ 2 ][ 0 ];
 
-	for ( i = 0; i < 3; i++ )
-	{
-		for ( j = 0; j < 3; j++ )
-		{
-			transpose[ i ][ j ] = matrix[ j ][ i ];
-		}
-	}
+	transpose[ 1 ][ 0 ] = matrix[ 0 ][ 1 ];
+	transpose[ 1 ][ 1 ] = matrix[ 1 ][ 1 ];
+	transpose[ 1 ][ 2 ] = matrix[ 2 ][ 1 ];
+
+	transpose[ 2 ][ 0 ] = matrix[ 0 ][ 2 ];
+	transpose[ 2 ][ 1 ] = matrix[ 1 ][ 2 ];
+	transpose[ 2 ][ 2 ] = matrix[ 2 ][ 2 ];
 }
 
 /*


### PR DESCRIPTION
When spamming grenades, some parts of the tracing codes is iterated millions time. For example the `CM_TestInLeaf` function can count for 10 or 15% of the CPU time spent by the game, not because the compute is heavy, but because it is done so many time. In this case even simple things are costly, like dereferencing a pointer of pointer instead of deferencing a pointer, because it is done millions time.

So I turned some array index iterators into pointer iterators in those precious functions. While I was at it and for completeness, I also did it for every leaf brush, leaf surface, and brush side in both `tr_trace.cpp` and `tr_test.cpp`.

This PR also brings some commits unrolling some loops, helping the compiler to vectorize them, for similar reasons: small speedup can become large when done millions time.

I added an extra commit rewriting basically `if test; return true; else; return false;` into `return test`.
