### PR TITLE
Import and rewrite a fix from ioq3

### DIFF
--- a/src/engine/server/sv_client.cpp
+++ b/src/engine/server/sv_client.cpp
@@ -1402,7 +1402,7 @@ void SV_ExecuteClientMessage( client_t *cl, msg_t *msg )
 	// NOTE: when the client message is fux0red the acknowledgement numbers
 	// can be out of range, this could cause the server to send thousands of server
 	// commands which the server thinks are not yet acknowledged in SV_UpdateServerCommandsToClient
-	if ( cl->reliableAcknowledge < cl->reliableSequence - MAX_RELIABLE_COMMANDS )
+	if ( cl->reliableAcknowledge < 0 || cl->reliableAcknowledge < cl->reliableSequence - MAX_RELIABLE_COMMANDS || cl->reliableAcknowledge > cl->reliableSequence )
 	{
 		// usually only hackers create messages like this
 		// it is more annoying for them to let them hanging


### PR DESCRIPTION
Original patch by @ineedbots

See:

- https://github.com/ioquake/ioq3/pull/596
- https://github.com/callofduty4x/CoD4x_Server/pull/336

Commit message:

> Fix bad client reliableAcknowledge DOS exploit
>
> Having a reliableAcknowledge of 0x7FFFFFFF causes a massive loop to be executed in SV_UpdateServerCommandsToClient due to the + 1 overflow.

Rewritten from a suggestion by @slipher