### PR TITLE
WIP: implement `getcmds` to fetch an array of command backups in one call

### DIFF
--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -136,6 +136,7 @@ enum cgameImport_t
   CG_GETSNAPSHOT,
   CG_GETCURRENTCMDNUMBER,
   CG_GETUSERCMD,
+  CG_GETUSERCMDS,
   CG_SETUSERCMDVALUE,
   CG_GET_ENTITY_TOKEN,
   CG_REGISTER_BUTTON_COMMANDS,
@@ -261,6 +262,10 @@ using GetCurrentCmdNumberMsg = IPC::SyncMessage<
 using GetUserCmdMsg = IPC::SyncMessage<
 	IPC::Message<IPC::Id<VM::QVM, CG_GETUSERCMD>, int>,
 	IPC::Reply<bool, usercmd_t>
+>;
+using GetUserCmdsMsg = IPC::SyncMessage<
+	IPC::Message<IPC::Id<VM::QVM, CG_GETUSERCMDS>, int, int>,
+	IPC::Reply<bool, usercmds_t>
 >;
 using SetUserCmdValueMsg = IPC::Message<IPC::Id<VM::QVM, CG_SETUSERCMDVALUE>, int, int, float>;
 // TODO what?

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -1795,6 +1795,8 @@ union OpaquePlayerState {
 		byte        buttons[ USERCMD_BUTTONS / 8 ];
 	};
 
+	typedef usercmd_t usercmds_t[ 64 ]; // CMD_BACKUP
+
 // Some functions for buttons manipulation & testing
 	inline void usercmdPressButton( byte *buttons, int bit )
 	{


### PR DESCRIPTION
See this thread for details about this:

- https://github.com/DaemonEngine/Daemon/issues/846

This branch doesn't build, I don't know how to write the serializer for this.

I believe merging this would break engine compatibility, so we may want to make this branch target a future branch, like `0.55.0/sync`.