### PR TITLE
cg_api: implement `trap_GetUserCmdArray` to fetch an array of command backups in one call

### DIFF
--- a/src/engine/client/cg_api.h
+++ b/src/engine/client/cg_api.h
@@ -36,12 +36,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #define CGAME_API_VERSION 3
 
-#define CMD_BACKUP               64
-#define CMD_MASK                 ( CMD_BACKUP - 1 )
-// allow a lot of command backups for very fast systems
-// multiple commands may be combined into a single packet, so this
-// needs to be larger than PACKET_BACKUP
-
 #define MAX_ENTITIES_IN_SNAPSHOT 512
 
 // snapshots are a view of the server at a given time
@@ -132,6 +126,7 @@ void            trap_GetCurrentSnapshotNumber( int *snapshotNumber, int *serverT
 bool        trap_GetSnapshot( int snapshotNumber, snapshot_t *snapshot );
 int             trap_GetCurrentCmdNumber();
 bool        trap_GetUserCmd( int cmdNumber, usercmd_t *ucmd );
+int trap_GetUserCmdArray( userCmdArray_t& userCmdArray );
 void            trap_SetUserCmdValue( int stateValue, int flags, float sensitivityScale );
 int             trap_Key_GetCatcher();
 void            trap_Key_SetCatcher( int catcher );

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -136,6 +136,7 @@ enum cgameImport_t
   CG_GETSNAPSHOT,
   CG_GETCURRENTCMDNUMBER,
   CG_GETUSERCMD,
+  CG_GETUSERCMDARRAY,
   CG_SETUSERCMDVALUE,
   CG_GET_ENTITY_TOKEN,
   CG_REGISTER_BUTTON_COMMANDS,
@@ -261,6 +262,10 @@ using GetCurrentCmdNumberMsg = IPC::SyncMessage<
 using GetUserCmdMsg = IPC::SyncMessage<
 	IPC::Message<IPC::Id<VM::QVM, CG_GETUSERCMD>, int>,
 	IPC::Reply<bool, usercmd_t>
+>;
+using GetUserCmdArrayMsg = IPC::SyncMessage<
+	IPC::Message<IPC::Id<VM::QVM, CG_GETUSERCMDARRAY>>,
+	IPC::Reply<int, userCmdArray_t>
 >;
 using SetUserCmdValueMsg = IPC::Message<IPC::Id<VM::QVM, CG_SETUSERCMDVALUE>, int, int, float>;
 // TODO what?

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -97,6 +97,16 @@ int CL_GetCurrentCmdNumber()
 	return cl.cmdNumber;
 }
 
+int CL_GetUserCmdArray( userCmdArray_t& userCmdArray )
+{
+	for ( int i = 0; i < CMD_BACKUP ; i++ )
+	{
+		userCmdArray[ i ] = cl.cmds[ ( cl.cmdNumber - i ) & CMD_MASK ];
+	}
+
+	return cl.cmdNumber;
+}
+
 /*
 =====================
 CL_ConfigstringModified
@@ -1111,6 +1121,12 @@ void CGameVM::QVMSyscall(int syscallNum, Util::Reader& reader, IPC::Channel& cha
 		case CG_GETUSERCMD:
 			IPC::HandleMsg<GetUserCmdMsg>(channel, std::move(reader), [this] (int number, bool& res, usercmd_t& cmd) {
 				res = CL_GetUserCmd(number, &cmd);
+			});
+			break;
+
+		case CG_GETUSERCMDARRAY:
+			IPC::HandleMsg<GetUserCmdArrayMsg>(channel, std::move(reader), [this] (int& number, userCmdArray_t& userCmdArray) {
+				number = CL_GetUserCmdArray(userCmdArray);
 			});
 			break;
 

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -142,6 +142,14 @@ void ignore_result(T) {}
 #define roundf( f ) ( floor( (f) + 0.5 ) )
 #endif
 
+// moved from cg_api.h
+#define CMD_BACKUP 64
+#define CMD_MASK ( CMD_BACKUP - 1 )
+#define CMD_OLDEST ( CMD_BACKUP - 1 )
+// allow a lot of command backups for very fast systems
+// multiple commands may be combined into a single packet, so this
+// needs to be larger than PACKET_BACKUP
+
 //=============================================================
 
 	using byte = uint8_t;
@@ -1794,6 +1802,8 @@ union OpaquePlayerState {
 
 		byte        buttons[ USERCMD_BUTTONS / 8 ];
 	};
+
+	using userCmdArray_t = std::array<usercmd_t, CMD_BACKUP>;
 
 // Some functions for buttons manipulation & testing
 	inline void usercmdPressButton( byte *buttons, int bit )

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -90,6 +90,13 @@ bool trap_GetUserCmd( int cmdNumber, usercmd_t *ucmd )
 	return res;
 }
 
+int trap_GetUserCmdArray( userCmdArray_t& userCmdArray )
+{
+	int number;
+	VM::SendMsg<GetUserCmdArrayMsg>(number, userCmdArray);
+	return number;
+}
+
 void trap_SetUserCmdValue( int stateValue, int flags, float sensitivityScale )
 {
 	VM::SendMsg<SetUserCmdValueMsg>(stateValue, flags, sensitivityScale);


### PR DESCRIPTION
Engine sidecar of:

- https://github.com/Unvanquished/Unvanquished/pull/2660

See this thread for details about this:

- https://github.com/DaemonEngine/Daemon/issues/846

This branch doesn't build, I don't know how to write the serializer for this.

I believe merging this would break engine compatibility, so we may want to make this branch target a future branch, like `0.55.0/sync`.