### PR TITLE
Rewrite some iterators in audio code

### DIFF
--- a/src/engine/audio/Audio.cpp
+++ b/src/engine/audio/Audio.cpp
@@ -147,8 +147,8 @@ namespace Audio {
 
         UpdateListenerGain();
 
-        for (int i = 0; i < MAX_GENTITIES; i++) {
-            entityLoops[i] = {false, nullptr, -1, -1};
+        for (auto &loop : entityLoops) {
+            loop = {false, nullptr, -1, -1};
         }
 
         return true;
@@ -160,11 +160,11 @@ namespace Audio {
         }
 
         // Shuts down the wrapper
-        for (int i = 0; i < MAX_GENTITIES; i++) {
-            if (entityLoops[i].sound) {
-                entityLoops[i].sound->Stop();
+        for (auto &loop : entityLoops) {
+            if (loop.sound) {
+                loop.sound->Stop();
             }
-            entityLoops[i] = {false, nullptr, -1, -1};
+            loop = {false, nullptr, -1, -1};
         }
 
         StopMusic();
@@ -219,17 +219,17 @@ namespace Audio {
         UpdateEmitters();
         UpdateSounds();
 
-        for (int i = 0; i < MAX_GENTITIES; i++) {
-            entityLoops[i].addedThisFrame = false;
+        for (auto &loop : entityLoops) {
+            loop.addedThisFrame = false;
             // if we are the unique owner of a loop pointer, then it means it was stopped, free it.
-            if (entityLoops[i].sound.unique()) {
-                entityLoops[i] = {false, nullptr, -1, -1};
+            if (loop.sound.unique()) {
+                loop = {false, nullptr, -1, -1};
             }
         }
 
-        for (int i = 0; i < N_STREAMS; i++) {
-            if (streams[i] and streams[i].unique()) {
-                streams[i] = nullptr;
+        for (auto &stream : streams) {
+            if (stream and stream.unique()) {
+                stream = nullptr;
             }
         }
     }

--- a/src/engine/audio/Emitter.cpp
+++ b/src/engine/audio/Emitter.cpp
@@ -124,9 +124,7 @@ namespace Audio {
         // Both PositionEmitters and EntityEmitters are ref-counted.
         // If we hold the only reference to them then no sound is still using
         // the Emitter that can be destroyed.
-        for (int i = 0; i < MAX_GENTITIES; i++) {
-            auto emitter = entityEmitters[i];
-
+        for (auto &emitter : entityEmitters) {
             if (not emitter) {
                 continue;
             }
@@ -135,7 +133,7 @@ namespace Audio {
 
             // No sound is using this emitter, destroy it
             if (emitter.unique()) {
-                entityEmitters[i] = nullptr;
+                emitter = nullptr;
             }
         }
 

--- a/src/engine/audio/Emitter.cpp
+++ b/src/engine/audio/Emitter.cpp
@@ -76,13 +76,13 @@ namespace Audio {
         AL::Effect effectParams;
         effectParams.ApplyReverbPreset(*AL::GetPresetByName("generic"));
 
-        for (int i = 0; i < N_REVERB_SLOTS; i++) {
-            reverbSlots[i].effect = new AL::EffectSlot();
-            reverbSlots[i].effect->SetEffect(effectParams);
-            reverbSlots[i].effect->SetGain(1.0f);
-            reverbSlots[i].name = "generic";
-            reverbSlots[i].ratio = 1.0f;
-            reverbSlots[i].askedRatio = 1.0f;
+        for (auto &slot : reverbSlots) {
+            slot.effect = new AL::EffectSlot();
+            slot.effect->SetEffect(effectParams);
+            slot.effect->SetGain(1.0f);
+            slot.name = "generic";
+            slot.ratio = 1.0f;
+            slot.askedRatio = 1.0f;
         }
 
         AL::SetInverseDistanceModel();
@@ -100,14 +100,14 @@ namespace Audio {
 
         localEmitter = nullptr;
 
-        for (int i = 0; i < N_REVERB_SLOTS; i++) {
-            delete reverbSlots[i].effect;
-            reverbSlots[i].effect = nullptr;
+        for (auto &slot : reverbSlots) {
+            delete slot.effect;
+            slot.effect = nullptr;
         }
 
-        for (int i = 0; i < MAX_GENTITIES; i++) {
-            if (entityEmitters[i]) {
-                entityEmitters[i] = nullptr;
+        for (auto &emitter : entityEmitters) {
+            if ( emitter ) {
+                emitter = nullptr;
             }
         }
 
@@ -149,8 +149,8 @@ namespace Audio {
         }
 
         float reverbVolume = reverbIntensity.Get();
-        for (int i = 0; i < N_REVERB_SLOTS; i++) {
-            reverbSlots[i].effect->SetGain(reverbSlots[i].ratio * reverbVolume);
+        for (auto &slot : reverbSlots) {
+            slot.effect->SetGain(slot.ratio * reverbVolume);
         }
 
         AL::SetDopplerExaggerationFactor(dopplerExaggeration.Get());
@@ -384,8 +384,8 @@ namespace Audio {
 
                 if (name == "none") {
                     testingReverb = true;
-                    for (int i = 0; i < N_REVERB_SLOTS; i++) {
-                        reverbSlots[i].effect->SetGain(0.0f);
+                    for (auto &slot : reverbSlots) {
+                        slot.effect->SetGain(0.0f);
                     }
                     return;
                 }


### PR DESCRIPTION
- audio: rewrite an iterator in a code requiring performance

That's the reason why I did this branch first, it's to rewrite a loop in a code that has a critical need for performance (it's one of the hot spot of the engine).

- audio: rewrite some iterators for the sake of more c++ism

This commit is just doing similar changes in less or not critical parts of the code and that's mostly bikeshedding, I just took care of them too while I was around.