### PR TITLE
cg_api: implement `trap_S_UpdateEntityPositionVelocity` to set position and velocity in one call

### DIFF
--- a/src/engine/client/cg_api.h
+++ b/src/engine/client/cg_api.h
@@ -189,6 +189,7 @@ void            trap_R_GetShaderNameFromHandle( const qhandle_t shader, char *ou
 void            trap_PrepareKeyUp();
 void            trap_R_SetAltShaderTokens( const char * );
 void            trap_S_UpdateEntityVelocity( int entityNum, const vec3_t velocity );
+void trap_S_UpdateEntityPositionVelocity( int entityNum, const vec3_t position, const vec3_t velocity );
 void            trap_S_SetReverb( int slotNum, const char* presetName, float ratio );
 void            trap_S_BeginRegistration();
 void            trap_S_EndRegistration();

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -155,6 +155,7 @@ enum cgameImport_t
   CG_S_STARTBACKGROUNDTRACK,
   CG_S_STOPBACKGROUNDTRACK,
   CG_S_UPDATEENTITYVELOCITY,
+  CG_S_UPDATEENTITYPOSITIONVELOCITY,
   CG_S_SETREVERB,
   CG_S_BEGINREGISTRATION,
   CG_S_ENDREGISTRATION,
@@ -301,6 +302,7 @@ namespace Audio {
 	using StartBackgroundTrackMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_STARTBACKGROUNDTRACK>, std::string, std::string>;
 	using StopBackgroundTrackMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_STOPBACKGROUNDTRACK>>;
 	using UpdateEntityVelocityMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_UPDATEENTITYVELOCITY>, int, Vec3>;
+	using UpdateEntityPositionVelocityMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_UPDATEENTITYPOSITIONVELOCITY>, int, Vec3, Vec3>;
 	using SetReverbMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_SETREVERB>, int, std::string, float>;
 	using BeginRegistrationMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_BEGINREGISTRATION>>;
 	using EndRegistrationMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_ENDREGISTRATION>>;

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1536,6 +1536,13 @@ void CGameVM::CmdBuffer::HandleCommandBufferSyscall(int major, int minor, Util::
 				});
 				break;
 
+			case CG_S_UPDATEENTITYPOSITIONVELOCITY:
+				HandleMsg<Audio::UpdateEntityPositionVelocityMsg>(std::move(reader), [this] (int entityNum, Vec3 position, Vec3 velocity) {
+					Audio::UpdateEntityPosition(entityNum, position);
+					Audio::UpdateEntityVelocity(entityNum, velocity);
+				});
+				break;
+
 			case CG_S_SETREVERB:
 				HandleMsg<Audio::SetReverbMsg>(std::move(reader), [this] (int slotNum, const std::string& name, float ratio) {
 					Audio::SetReverb(slotNum, name, ratio);

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -207,6 +207,11 @@ void trap_S_UpdateEntityVelocity( int entityNum, const vec3_t velocity )
 	cmdBuffer.SendMsg<Audio::UpdateEntityVelocityMsg>(entityNum, Vec3::Load(velocity));
 }
 
+void trap_S_UpdateEntityPositionVelocity( int entityNum, const vec3_t origin, const vec3_t velocity )
+{
+	cmdBuffer.SendMsg<Audio::UpdateEntityPositionVelocityMsg>(entityNum, Vec3::Load(origin), Vec3::Load(velocity));
+}
+
 void trap_S_SetReverb( int slotNum, const char* name, float ratio )
 {
 	cmdBuffer.SendMsg<Audio::SetReverbMsg>(slotNum, name, ratio);


### PR DESCRIPTION
Implement `trap_S_UpdateEntityPositionVelocity` to set position and velocity in one call.

Engine sidecar of:

- https://github.com/Unvanquished/Unvanquished/pull/2680