### PR TITLE
external_deps: improvements around NASM support

### DIFF
--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -278,8 +278,12 @@ build_png() {
 build_jpeg() {
 	download "libjpeg-turbo-${JPEG_VERSION}.tar.gz" "https://downloads.sourceforge.net/project/libjpeg-turbo/${JPEG_VERSION}/libjpeg-turbo-${JPEG_VERSION}.tar.gz" jpeg
 
-	# Ensure NASM is available
-	"${NASM:-nasm}" --help >/dev/null
+	case "${PLATFORM}" in
+	*-amd64-*|*-i686-*)
+		# Ensure NASM is available
+		"${NASM:-nasm}" --help >/dev/null
+		;;
+	esac
 
 	cd "libjpeg-turbo-${JPEG_VERSION}"
 	case "${PLATFORM}" in

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -281,7 +281,7 @@ build_jpeg() {
 	case "${PLATFORM}" in
 	*-amd64-*|*-i686-*)
 		# Ensure NASM is available
-		"${NASM:-nasm}" --help >/dev/null
+		nasm --help >/dev/null
 		;;
 	esac
 
@@ -717,7 +717,7 @@ common_setup() {
 	BUILD_BASEDIR="build-${PKG_BASEDIR}"
 	BUILD_DIR="${WORK_DIR}/${BUILD_BASEDIR}"
 	PREFIX="${BUILD_DIR}/prefix"
-	PATH="${PATH}:${PREFIX}/bin"
+	PATH="${PREFIX}/bin:${PATH}"
 	PKG_CONFIG="pkg-config"
 	PKG_CONFIG_PATH="${PREFIX}/lib/pkgconfig"
 	CPPFLAGS+=" -I${PREFIX}/include"
@@ -829,7 +829,6 @@ setup_macos-amd64-default() {
 	MACOS_ARCH=x86_64
 	export MACOSX_DEPLOYMENT_TARGET=10.9 # works with CMake
 	common_setup macos x86_64-apple-darwin11
-	export NASM="${PWD}/${BUILD_BASEDIR}/prefix/bin/nasm" # A newer version of nasm is required for 64-bit
 }
 
 # Set up environment for 32-bit i686 Linux


### PR DESCRIPTION
Patches stolen from:

- https://github.com/DaemonEngine/Daemon/pull/857

This makes easier to update libraries requiring NASM.

Actually the `NASM` environment variable used by libjpeg doesn't have the same name in this or that libjpeg (newer versions use another name), and this is specific to libjpeg. Relying on `PATH` mechanism is more reliable, future-proof and library-independent.