### PR TITLE
Fix disappearing cursor during load on Mac

### DIFF
--- a/src/engine/sys/sdl_input.cpp
+++ b/src/engine/sys/sdl_input.cpp
@@ -437,6 +437,10 @@ void IN_SetMouseMode(MouseMode newMode)
 		}
 		mouse_mode = newMode;
 	}
+#ifdef __APPLE__
+	// This prevents the system cursor from disappearing in the loading screen
+	SDL_PumpEvents();
+#endif
 }
 
 static bool in_focus = false;


### PR DESCRIPTION
When combined with a call to trap_SetMouseMode(MouseMode::SystemCursor) during CG_Init, this fixes #866.