### PR TITLE
Don't archive language cvar

### DIFF
--- a/src/engine/qcommon/translation.cpp
+++ b/src/engine/qcommon/translation.cpp
@@ -39,7 +39,7 @@ extern "C" {
     #include "findlocale/findlocale.h"
 }
 
-static Cvar::Cvar<std::string> language("language", "language for UI text", Cvar::ARCHIVE, "");
+static Cvar::Cvar<std::string> language("language", "language for UI text", Cvar::NONE, "");
 
 void Trans_LoadDefaultLanguage()
 {


### PR DESCRIPTION
The auto-detected language will no longer by archived by default. It will only be archived if you use `seta` or choose a language from a (not yet existing) menu in the UI.

Fixes https://github.com/Unvanquished/Unvanquished/issues/2165.