### PR TITLE
colors: rewrite in-place color stripping to fix console offset when building with clang

### DIFF
--- a/src/common/Color.cpp
+++ b/src/common/Color.cpp
@@ -86,16 +86,8 @@ int StrlenNocolor( const char *string )
 
 char *StripColors( char *string )
 {
-	char *out = string;
-
-	for ( const auto& token : Parser( string ) )
-	{
-		Str::StringView text = token.PlainText();
-		memmove( out, text.begin(), text.size() );
-		out += text.size();
-	}
-
-	*out = '\0';
+	std::string stripped = StripColors( std::string( string ) );
+	strcpy( string, stripped.c_str() );
 	return string;
 }
 


### PR DESCRIPTION
Rewrite in-place color stripping to fix console offset when building with clang

fix #839:

- https://github.com/DaemonEngine/Daemon/issues/839

While this fixes the issue, I'm afraid we may hide a bug in the compiler.
I'm not skilled enough at C++ to know if the original code is valid.

I need to know if there is a bug in the compiler, because I want to report it to LLVM is that's a compiler bug. This is not the only regression with face with clang (see https://github.com/Unvanquished/Unvanquished/issues/2682 ), so if clang has a bug, we better want to get clang fixed than implementing workarounds one by one.