### PR TITLE
tr_model_iqm: fix use of uninitialized data

### DIFF
--- a/src/engine/renderer/tr_model_iqm.cpp
+++ b/src/engine/renderer/tr_model_iqm.cpp
@@ -805,6 +805,8 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 					  qtangentbuf[ i ] );
 		}
 
+		memset( &vboData, 0, sizeof( vboData ) );
+
 		vboData.xyz = (vec3_t *)IQModel->positions;
 		vboData.qtangent = qtangentbuf;
 		vboData.numFrames = 0;
@@ -814,7 +816,6 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 		vboData.boneIndexes = (int (*)[4])indexbuf;
 		vboData.boneWeights = (vec4_t *)weightbuf;
 		vboData.numVerts = IQModel->num_vertexes;
-
 
 		vbo = R_CreateStaticVBO( "IQM surface VBO", vboData,
 					 vboLayout_t::VBO_LAYOUT_SKELETAL );


### PR DESCRIPTION
Should fix #880:

- https://github.com/DaemonEngine/Daemon/issues/880

All other similar vboData initialization code already do the same, like:

- `src/engine/renderer/tr_model_skel.cpp` (md5 models)
- `src/engine/renderer/tr_model_md3.cpp`
- `src/engine/renderer/tr_light.cpp`
- `src/engine/renderer/tr_vbo.cpp`
- `src/engine/renderer/tr_bsp.cpp`
