### PR TITLE
client: add `Hunk_Shutdown()` to make easier to read valgrind output

### DIFF
--- a/src/engine/client/ClientApplication.cpp
+++ b/src/engine/client/ClientApplication.cpp
@@ -110,6 +110,7 @@ class ClientApplication : public Application {
             if (Sys::PedanticShutdown()) {
                 TRY_SHUTDOWN(SV_Shutdown(message.c_str()));
                 TRY_SHUTDOWN(NET_Shutdown());
+                Hunk_Shutdown();
             } else {
                 TRY_SHUTDOWN(SV_QuickShutdown(message.c_str()));
             }

--- a/src/engine/client/hunk_allocator.cpp
+++ b/src/engine/client/hunk_allocator.cpp
@@ -199,6 +199,11 @@ void Hunk_Clear()
 	Log::Debug( "Hunk_Clear: reset the hunk ok" );
 }
 
+void Hunk_Shutdown()
+{
+	Com_Free_Aligned( s_hunkData );
+}
+
 static void Hunk_SwapBanks()
 {
 	hunkUsed_t *swap;

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -612,6 +612,7 @@ static inline void Z_Free(void* ptr)
 #ifndef BUILD_SERVER
 void Hunk_Init();
 void     Hunk_Clear();
+void Hunk_Shutdown();
 void *Hunk_Alloc( int size, ha_pref preference );
 void   *Hunk_AllocateTempMemory( int size );
 void   Hunk_FreeTempMemory( void *buf );


### PR DESCRIPTION
Free the memory allocated by `Hunk_Init()` so that doesn't count as leaked memory.