### PR TITLE
cm: call `CM_FreeAll()` when doing `CM_ClearMap()`

### DIFF
--- a/src/common/cm/cm_load.cpp
+++ b/src/common/cm/cm_load.cpp
@@ -918,8 +918,7 @@ void CM_LoadMap(Str::StringRef name)
 		Sys::Drop("Could not load %s", mapFile.c_str());
 	}
 
-	// free old stuff
-	CM_FreeAll();
+	// clear collision map data
 	CM_ClearMap();
 
 	if ( !name[ 0 ] )
@@ -975,6 +974,7 @@ CM_ClearMap
 */
 void CM_ClearMap()
 {
+	CM_FreeAll();
 	memset( &cm, 0, sizeof( cm ) );
 	CM_ClearLevelPatches();
 }

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -726,9 +726,6 @@ void CL_ShutdownAll()
 	{
 		void SV_ShutdownGameProgs();
 		SV_ShutdownGameProgs();
-
-		// clear collision map data
-		CM_ClearMap();
 	}
 
 	Hunk_Clear();

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -734,6 +734,9 @@ void SV_Shutdown( const char *finalmsg )
 	// free current level
 	SV_ClearServer();
 
+	// clear collision map data
+	CM_ClearMap();
+
 	// free server static data
 	if ( svs.clients )
 	{


### PR DESCRIPTION
I've noticed a lot of stuff allocated with `CM_Alloc` were remaining on shutdown.

Previously it was only done on map load.

So I made sure `CM_FreeAll()` is also called on shutdown.

Also don't call `CM_ClearMap` in `CL_ShutdownAll`.