### PR TITLE
tr_image: avoid a copy when iterating an array of struct

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2048,7 +2048,7 @@ image_t *R_FindCubeImage( const char *imageName, imageParams_t &imageParams )
 	char cubeMapBaseName[ MAX_QPATH ];
 	COM_StripExtension3( buffer, cubeMapBaseName, sizeof( cubeMapBaseName ) );
 
-	for ( const cubeMapLoader_t loader : cubeMapLoaders )
+	for ( const cubeMapLoader_t &loader : cubeMapLoaders )
 	{
 		std::string cubeMapName = Str::Format( "%s.%s", cubeMapBaseName, loader.ext );
 		if( R_FindImageLoader( cubeMapName.c_str() ) >= 0 )


### PR DESCRIPTION
tr_image: avoid a copy when iterating an array of struct