### PR TITLE
don't use the same cache file for the generic and generic2D GLSL shader, etc.

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -173,7 +173,6 @@ set(GLSLSOURCELIST
     ${ENGINE_DIR}/renderer/glsl_source/fxaa_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/fxaa_vp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/fxaa3_11_fp.glsl
-    ${ENGINE_DIR}/renderer/glsl_source/generic2D_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/generic_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/generic_vp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/heatHaze_fp.glsl

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1500,9 +1500,9 @@ void GLShader_generic2D::BuildShaderVertexLibNames( std::string& vertexInlines )
 	vertexInlines += "vertexSimple vertexSkinning vertexAnimation vertexSprite ";
 }
 
-void GLShader_generic2D::BuildShaderFragmentLibNames( std::string& fragmentInlines )
+void GLShader_generic2D::BuildShaderCompileMacros( std::string& compileMacros )
 {
-	fragmentInlines += "generic2D";
+	compileMacros += "GENERIC_2D ";
 }
 
 void GLShader_generic2D::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1481,7 +1481,7 @@ void GLShader::SetRequiredVertexPointers()
 }
 
 GLShader_generic2D::GLShader_generic2D( GLShaderManager *manager ) :
-	GLShader( "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
+	GLShader( "generic2D", "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
 	u_TextureMatrix( this ),
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2213,7 +2213,7 @@ class GLShader_generic2D :
 public:
 	GLShader_generic2D( GLShaderManager *manager );
 	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
-	void BuildShaderFragmentLibNames( std::string& vertexInlines ) override;
+	void BuildShaderCompileMacros( std::string& compileMacros ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
 

--- a/src/engine/renderer/glsl_source/generic2D_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic2D_fp.glsl
@@ -1,3 +1,0 @@
-/* generic2D_fp.glsl */
-
-#define GENERIC_2D 1

--- a/src/engine/renderer/shaders.cpp
+++ b/src/engine/renderer/shaders.cpp
@@ -34,7 +34,6 @@
 #include "fxaa_fp.glsl.h"
 #include "fxaa_vp.glsl.h"
 #include "fxaa3_11_fp.glsl.h"
-#include "generic2D_fp.glsl.h"
 #include "generic_fp.glsl.h"
 #include "generic_vp.glsl.h"
 #include "heatHaze_fp.glsl.h"
@@ -88,7 +87,6 @@ std::unordered_map<std::string, std::string> shadermap({
 	{ "glsl/fxaa3_11_fp.glsl", std::string(reinterpret_cast<const char*>(fxaa3_11_fp_glsl), sizeof(fxaa3_11_fp_glsl)) },
 	{ "glsl/fxaa_fp.glsl", std::string(reinterpret_cast<const char*>(fxaa_fp_glsl), sizeof(fxaa_fp_glsl)) },
 	{ "glsl/fxaa_vp.glsl", std::string(reinterpret_cast<const char*>(fxaa_vp_glsl), sizeof(fxaa_vp_glsl)) },
-	{ "glsl/generic2D_fp.glsl", std::string(reinterpret_cast<const char*>(generic2D_fp_glsl), sizeof(generic2D_fp_glsl)) },
 	{ "glsl/generic_fp.glsl", std::string(reinterpret_cast<const char*>(generic_fp_glsl), sizeof(generic_fp_glsl)) },
 	{ "glsl/generic_vp.glsl", std::string(reinterpret_cast<const char*>(generic_vp_glsl), sizeof(generic_vp_glsl)) },
 	{ "glsl/heatHaze_fp.glsl", std::string(reinterpret_cast<const char*>(heatHaze_fp_glsl), sizeof(heatHaze_fp_glsl)) },


### PR DESCRIPTION
- Don't use the same cache file for the generic and generic2D GLSL shader
  Do not rebuild generic GLSL shaders on every map load.
- set `GENERIC_2D` define without relying on an extra file.

Fixes #889:

- https://github.com/DaemonEngine/Daemon/issues/889