### PR TITLE
OpusCodec: free buffer after use

### DIFF
--- a/src/engine/audio/OpusCodec.cpp
+++ b/src/engine/audio/OpusCodec.cpp
@@ -156,6 +156,7 @@ AudioData LoadOpusCodec(std::string filename)
 		std::copy_n(buffer, samplesPerChannelRead * numberOfChannels, std::back_inserter(samples));
 	}
 
+	delete[] buffer;
 	op_free(opusFile);
 
 	char* rawSamples = new char[sampleWidth * samples.size()];


### PR DESCRIPTION
OpusCodec: free buffer after use.

Fixes #881:

- https://github.com/DaemonEngine/Daemon/issues/881