### PR TITLE
CommandSystem: free all commands on exit

### DIFF
--- a/src/engine/framework/CommandSystem.cpp
+++ b/src/engine/framework/CommandSystem.cpp
@@ -115,8 +115,8 @@ namespace Cmd {
     // can be registered before main. The first time this function is called the command map
     // is initialized so we are sure it is initialized as soon as we need it.
     CommandMap& GetCommandMap() {
-        static CommandMap* commands = new CommandMap();
-        return *commands;
+        static CommandMap commands;
+        return commands;
     }
 
     // Used to emulate the C API


### PR DESCRIPTION
Partially frees some cvar leaks:

- https://github.com/DaemonEngine/Daemon/issues/885

It looks like all cvars spawn a command, those commands are never freed.

This only _partially_ fixes the problem because:

- Cvar code is still leaking a lot because CvarProxy code is leaking a lot too.