### PR TITLE
CvarSystem: free all cvars on exit

### DIFF
--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -161,8 +161,8 @@ namespace Cvar {
     // can be registered before main. The first time this function is called the cvar map
     // is initialized so we are sure it is initialized as soon as we need it.
     CvarMap& GetCvarMap() {
-        static CvarMap* cvars = new CvarMap();
-        return *cvars;
+        static CvarMap cvars;
+        return cvars;
     }
 
 	void Shutdown() {

--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -169,27 +169,30 @@ namespace Cvar {
 		CvarMap &cvars = GetCvarMap();
 
 		for (const auto &it: cvars) {
-			cvar_t &cvar = it.second->ccvar;
+			cvarRecord_t *cvar = it.second;
+			cvar_t &ccvar = cvar->ccvar;
 
-			if (cvar.name)
+			if (ccvar.name)
 			{
-				Z_Free(cvar.name);
+				Z_Free(ccvar.name);
 			}
 
-			if (cvar.resetString)
+			if (ccvar.resetString)
 			{
-				Z_Free(cvar.resetString);
+				Z_Free(ccvar.resetString);
 			}
 
-			if (cvar.latchedString)
+			if (ccvar.latchedString)
 			{
-				Z_Free(cvar.latchedString);
+				Z_Free(ccvar.latchedString);
 			}
 
-			if (cvar.string)
+			if (ccvar.string)
 			{
-				Z_Free(cvar.string);
+				Z_Free(ccvar.string);
 			}
+
+			delete cvar;
 		}
 
 		cvars.clear();


### PR DESCRIPTION
Continuation of:

- https://github.com/DaemonEngine/Daemon/pull/896

Finishes to fix #885:

- https://github.com/DaemonEngine/Daemon/issues/885

First commit fixes that (valgrind):

```
==00:00:00:59.515 213477== 24 bytes in 1 blocks are possibly lost in loss record 23 of 535
==00:00:00:59.515 213477==    at 0x4845013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==00:00:00:59.515 213477==    by 0x38940D: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*, std::forward_iterator_tag) (basic_string.tcc:225)
==00:00:00:59.515 213477==    by 0x4226CD: Cvar::InternalSetValue(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, bool, bool) (CvarSystem.cpp:300)
==00:00:00:59.515 213477==    by 0x423082: Cvar::SetValue(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (CvarSystem.cpp:304)
```

Second commit fixes that (valgrind):

```
==00:00:01:01.979 202365== 56 bytes in 1 blocks are still reachable in loss record 45 of 198
==00:00:01:01.979 202365==    at 0x4845013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==00:00:01:01.979 202365==    by 0x422228: Cvar::GetCvarMap[abi:cxx11]() (CvarSystem.cpp:164)
==00:00:01:01.979 202365==    by 0x4232FC: Cvar::Register(Cvar::CvarProxy*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (CvarSystem.cpp:327)
```

Before first commit (heapusage):

```
==172694== HEAP SUMMARY:
==172694==     in use at exit: 687184 bytes in 6210 blocks
==172694==   total heap usage: 5352272 allocs, 6291123 frees, 3972108898 bytes allocated
==172694==    peak heap usage: 726631131 bytes allocated
```

After first commit (heapusage):

```
==174804== HEAP SUMMARY:
==174804==     in use at exit: 532043 bytes in 5436 blocks
==174804==   total heap usage: 13920522 allocs, 14892807 frees, 7503304735 bytes allocated
==174804==    peak heap usage: 726048167 bytes allocated
```

After second commit (heapusage):

```
==215460== HEAP SUMMARY:
==215460==     in use at exit: 491787 bytes in 4956 blocks
==215460==   total heap usage: 5126293 allocs, 6066770 frees, 4055135774 bytes allocated
==215460==    peak heap usage: 726633073 bytes allocated
```