### PR TITLE
use saner defaults for console colours

### DIFF
--- a/src/engine/client/cl_console.cpp
+++ b/src/engine/client/cl_console.cpp
@@ -396,9 +396,9 @@ void Con_Init()
 
 	con_height = Cvar_Get( "con_height", "55", 0 );
 	con_colorRed = Cvar_Get( "con_colorRed", "0", 0 );
-	con_colorBlue = Cvar_Get( "con_colorBlue", "0.3", 0 );
-	con_colorGreen = Cvar_Get( "con_colorGreen", "0.18", 0 );
-	con_colorAlpha = Cvar_Get( "con_colorAlpha", "0.5", 0 );
+	con_colorBlue = Cvar_Get( "con_colorBlue", "0.0", 0 );
+	con_colorGreen = Cvar_Get( "con_colorGreen", "0.0", 0 );
+	con_colorAlpha = Cvar_Get( "con_colorAlpha", "0.75", 0 );
 
 	con_margin = Cvar_Get( "con_margin", "10", 0 );
 	con_horizontalPadding = Cvar_Get( "con_horizontalPadding", "0", 0 );

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2592,7 +2592,7 @@ bool CL_InitRenderer()
 
 	cl_consoleFont = Cvar_Get( "cl_consoleFont", "fonts/unifont.ttf",  CVAR_LATCH );
 	cl_consoleFontSize = Cvar_Get( "cl_consoleFontSize", "16",  CVAR_LATCH );
-	cl_consoleFontScaling = Cvar_Get( "cl_consoleFontScaling", "1", CVAR_LATCH );
+	cl_consoleFontScaling = Cvar_Get( "cl_consoleFontScaling", "0", CVAR_LATCH );
 
 	// load character sets
 	cls.charSetShader = re.RegisterShader( "gfx/2d/bigchars", RSF_DEFAULT );


### PR DESCRIPTION
![2023-05-25](https://github.com/DaemonEngine/Daemon/assets/1316300/b09c2cb5-ab37-4049-a911-bd54a3ab86e6)

2nd half for fixing definitely https://github.com/Unvanquished/Unvanquished/issues/2441

This one is probably more a matter of tastes, so I consider it optional for fixing the issue, but those defaults (proposed by @cu-kai ) are imo much, much more readable than current colours.