### PR TITLE
Compiler: set __SANITIZE_ADDRESS__ on clang if has attribute no_sanitize_address

### DIFF
--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -111,7 +111,7 @@ int CountTrailingZeroes(unsigned long long x);
 #define CONSTEXPR constexpr
 
 // To mark functions which cause issues with address sanitizer
-#if __clang__
+#if defined(__has_feature)
 #if __has_attribute(no_sanitize_address)
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
 // Some parts of the code may rely on thimay rely on thiss

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -114,6 +114,7 @@ int CountTrailingZeroes(unsigned long long x);
 #if __clang__
 #if __has_attribute(no_sanitize_address)
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+# define __SANITIZE_ADDRESS__
 #else
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS
 #endif

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -114,7 +114,6 @@ int CountTrailingZeroes(unsigned long long x);
 #if __clang__
 #if __has_attribute(no_sanitize_address)
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
-# define __SANITIZE_ADDRESS__
 #else
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS
 #endif

--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -114,6 +114,8 @@ int CountTrailingZeroes(unsigned long long x);
 #if __clang__
 #if __has_attribute(no_sanitize_address)
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS __attribute__((no_sanitize_address))
+// Some parts of the code may rely on thimay rely on thiss
+# define __SANITIZE_ADDRESS__
 #else
 # define ATTRIBUTE_NO_SANITIZE_ADDRESS
 #endif

--- a/src/common/System.cpp
+++ b/src/common/System.cpp
@@ -406,10 +406,9 @@ void GenRandomBytes(void* dest, size_t size)
 
 } // namespace Sys
 
-#ifndef __SANITIZE_ADDRESS__
 // Global operator new/delete override to not throw an exception when out of
 // memory. Instead, it is preferable to simply crash with an error.
-void* operator new(size_t n)
+ATTRIBUTE_NO_SANITIZE_ADDRESS void* operator new(size_t n)
 {
 	void* p = malloc(n);
 	if (!p)
@@ -417,13 +416,12 @@ void* operator new(size_t n)
 	return p;
 }
 
-void operator delete(void* p) NOEXCEPT
+ATTRIBUTE_NO_SANITIZE_ADDRESS void operator delete(void* p) NOEXCEPT
 {
 	free(p);
 }
 
-void operator delete(void* p, size_t) NOEXCEPT
+ATTRIBUTE_NO_SANITIZE_ADDRESS void operator delete(void* p, size_t) NOEXCEPT
 {
 	free(p);
 }
-#endif

--- a/src/common/System.cpp
+++ b/src/common/System.cpp
@@ -406,9 +406,10 @@ void GenRandomBytes(void* dest, size_t size)
 
 } // namespace Sys
 
+#ifndef __SANITIZE_ADDRESS__
 // Global operator new/delete override to not throw an exception when out of
 // memory. Instead, it is preferable to simply crash with an error.
-ATTRIBUTE_NO_SANITIZE_ADDRESS void* operator new(size_t n)
+void* operator new(size_t n)
 {
 	void* p = malloc(n);
 	if (!p)
@@ -416,12 +417,13 @@ ATTRIBUTE_NO_SANITIZE_ADDRESS void* operator new(size_t n)
 	return p;
 }
 
-ATTRIBUTE_NO_SANITIZE_ADDRESS void operator delete(void* p) NOEXCEPT
+void operator delete(void* p) NOEXCEPT
 {
 	free(p);
 }
 
-ATTRIBUTE_NO_SANITIZE_ADDRESS void operator delete(void* p, size_t) NOEXCEPT
+void operator delete(void* p, size_t) NOEXCEPT
 {
 	free(p);
 }
+#endif

--- a/src/common/System.cpp
+++ b/src/common/System.cpp
@@ -406,9 +406,10 @@ void GenRandomBytes(void* dest, size_t size)
 
 } // namespace Sys
 
+#ifndef __SANITIZE_ADDRESS__
 // Global operator new/delete override to not throw an exception when out of
 // memory. Instead, it is preferable to simply crash with an error.
-void* operator new(size_t n) ATTRIBUTE_NO_SANITIZE_ADDRESS
+void* operator new(size_t n)
 {
 	void* p = malloc(n);
 	if (!p)
@@ -416,12 +417,13 @@ void* operator new(size_t n) ATTRIBUTE_NO_SANITIZE_ADDRESS
 	return p;
 }
 
-void operator delete(void* p) NOEXCEPT ATTRIBUTE_NO_SANITIZE_ADDRESS
+void operator delete(void* p) NOEXCEPT
 {
 	free(p);
 }
 
-void operator delete(void* p, size_t) NOEXCEPT ATTRIBUTE_NO_SANITIZE_ADDRESS
+void operator delete(void* p, size_t) NOEXCEPT
 {
 	free(p);
 }
+#endif

--- a/src/common/System.cpp
+++ b/src/common/System.cpp
@@ -406,12 +406,9 @@ void GenRandomBytes(void* dest, size_t size)
 
 } // namespace Sys
 
-#ifndef __SANITIZE_ADDRESS__
-#if defined(__has_feature)
-#if !__has_feature(address_sanitizer)
 // Global operator new/delete override to not throw an exception when out of
 // memory. Instead, it is preferable to simply crash with an error.
-void* operator new(size_t n)
+void* operator new(size_t n) ATTRIBUTE_NO_SANITIZE_ADDRESS
 {
 	void* p = malloc(n);
 	if (!p)
@@ -419,15 +416,12 @@ void* operator new(size_t n)
 	return p;
 }
 
-void operator delete(void* p) NOEXCEPT
+void operator delete(void* p) NOEXCEPT ATTRIBUTE_NO_SANITIZE_ADDRESS
 {
 	free(p);
 }
 
-void operator delete(void* p, size_t) NOEXCEPT
+void operator delete(void* p, size_t) NOEXCEPT ATTRIBUTE_NO_SANITIZE_ADDRESS
 {
 	free(p);
 }
-#endif
-#endif
-#endif

--- a/src/common/System.cpp
+++ b/src/common/System.cpp
@@ -407,6 +407,8 @@ void GenRandomBytes(void* dest, size_t size)
 } // namespace Sys
 
 #ifndef __SANITIZE_ADDRESS__
+#if defined(__has_feature)
+#if !__has_feature(address_sanitizer)
 // Global operator new/delete override to not throw an exception when out of
 // memory. Instead, it is preferable to simply crash with an error.
 void* operator new(size_t n)
@@ -426,4 +428,6 @@ void operator delete(void* p, size_t) NOEXCEPT
 {
 	free(p);
 }
+#endif
+#endif
 #endif


### PR DESCRIPTION
This fixes ASAN on clang.

I also modified a bit the code to be less clang-specific and doing [like clang recommends](https://clang.llvm.org/docs/AddressSanitizer.html#id11):

The commits are meant to be squashed, first ones are experiments to do this in other ways, but most of them doesn't work, if you knows how to make `ATTRIBUTE_NO_SANITIZE_ADDRESS` for our `new` and `delete` override, this may be better, but this maybe not possible.