### PR TITLE
get rid of almost all qcommon.h cvar_t

### DIFF
--- a/src/engine/audio/Audio.cpp
+++ b/src/engine/audio/Audio.cpp
@@ -408,7 +408,7 @@ namespace Audio {
     }
 
     void UpdateListenerGain() {
-        if ((muteWhenMinimized.Get() and com_minimized->integer) or (muteWhenUnfocused.Get() and com_unfocused->integer)) {
+        if ((muteWhenMinimized.Get() and com_minimized.Get()) or (muteWhenUnfocused.Get() and com_unfocused.Get())) {
             AL::SetListenerGain(0.0f);
         } else {
             AL::SetListenerGain(SliderToAmplitude(masterVolume.Get()));

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -732,7 +732,7 @@ void CL_AdjustTimeDelta()
 		// if any of the frames between this and the previous snapshot
 		// had to be extrapolated, nudge our sense of time back a little
 		// the granularity of +1 / -2 is too high for timescale modified frametimes
-		if ( com_timescale->value == 0 || com_timescale->value == 1 )
+		if ( com_timescale.Get() == 0.0f || com_timescale.Get() == 1.0f )
 		{
 			if ( cl.extrapolatedSnapshot )
 			{

--- a/src/engine/client/cl_console.cpp
+++ b/src/engine/client/cl_console.cpp
@@ -1289,7 +1289,7 @@ void Con_JumpUp()
 
 void Con_Close()
 {
-	if ( !com_cl_running->integer )
+	if ( !com_cl_running.Get() )
 	{
 		return;
 	}

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -133,7 +133,6 @@ cvar_t *cl_inGameVideo;
 cvar_t *cl_serverStatusResendTime;
 
 cvar_t                 *cl_packetloss; //bani
-cvar_t                 *cl_packetdelay; //bani
 
 cvar_t                 *cl_consoleFont;
 cvar_t                 *cl_consoleFontSize;
@@ -722,7 +721,7 @@ void CL_ShutdownAll()
 	// Gordon: stop recording on map change etc, demos aren't valid over map changes anyway
 	CL_StopRecord();
 
-	if ( !com_sv_running->integer )
+	if ( !com_sv_running.Get() )
 	{
 		void SV_ShutdownGameProgs();
 		SV_ShutdownGameProgs();
@@ -745,7 +744,7 @@ memory on the hunk from cgame, ui, and renderer
 */
 void CL_MapLoading()
 {
-	if ( !com_cl_running->integer )
+	if ( !com_cl_running.Get() )
 	{
 		return;
 	}
@@ -809,7 +808,7 @@ static void CL_SendDisconnect()
 {
 	// send a disconnect message to the server
 	// send it a few times in case one is dropped
-	if ( com_cl_running && com_cl_running->integer && cls.state >= connstate_t::CA_CONNECTED )
+	if ( com_cl_running.Get() && cls.state >= connstate_t::CA_CONNECTED )
 	{
 		CL_AddReliableCommand( "disconnect" );
 		CL_WritePacket();
@@ -820,7 +819,7 @@ static void CL_SendDisconnect()
 
 void CL_Disconnect( bool showMainMenu )
 {
-	if ( !com_cl_running || !com_cl_running->integer )
+	if ( !com_cl_running.Get() )
 	{
 		return;
 	}
@@ -1051,7 +1050,7 @@ void CL_Connect_f()
 	// clear any previous "server full" type messages
 	clc.serverMessage[ 0 ] = 0;
 
-	if ( com_sv_running->integer && !strcmp( server, "loopback" ) )
+	if ( com_sv_running.Get() && !strcmp( server, "loopback" ) )
 	{
 		// if running a local server, kill it
 		SV_Shutdown( "Server quit" );
@@ -2492,7 +2491,7 @@ CL_Frame
 */
 void CL_Frame( int msec )
 {
-	if ( !com_cl_running->integer )
+	if ( !com_cl_running.Get() )
 	{
 		return;
 	}
@@ -2506,7 +2505,7 @@ void CL_Frame( int msec )
 			CL_TakeVideoFrame();
 
 			// fixed time for next frame
-			msec = ( int ) ceil( ( 1000.0f / cl_aviFrameRate->value ) * com_timescale->value );
+			msec = ( int ) ceil( ( 1000.0f / cl_aviFrameRate->value ) * com_timescale.Get() );
 
 			if ( msec == 0 )
 			{
@@ -2650,12 +2649,7 @@ Only the renderer is really a hunk user.
 */
 void CL_StartHunkUsers()
 {
-	if ( !com_cl_running )
-	{
-		return;
-	}
-
-	if ( !com_cl_running->integer )
+	if ( !com_cl_running.Get() )
 	{
 		return;
 	}
@@ -2712,7 +2706,7 @@ void CL_RefTagFree()
 
 int CL_ScaledMilliseconds()
 {
-	return Sys::Milliseconds() * com_timescale->value;
+	return Sys::Milliseconds() * com_timescale.Get();
 }
 
 extern refexport_t *GetRefAPI( int apiVersion, refimport_t *rimp );
@@ -2899,7 +2893,6 @@ void CL_Init()
 
 	//bani
 	cl_packetloss = Cvar_Get( "cl_packetloss", "0", CVAR_CHEAT );
-	cl_packetdelay = Cvar_Get( "cl_packetdelay", "0", CVAR_CHEAT );
 
 	Cvar_Get( "cl_maxPing", "800", 0 );
 	// userinfo
@@ -2960,7 +2953,7 @@ void CL_Shutdown()
 	static bool recursive = false;
 
 	// check whether the client is running at all.
-	if ( !( com_cl_running && com_cl_running->integer ) )
+	if ( !com_cl_running.Get() )
 	{
 		return;
 	}

--- a/src/engine/client/cl_parse.cpp
+++ b/src/engine/client/cl_parse.cpp
@@ -352,7 +352,7 @@ void CL_SystemInfoChanged()
 	cl.serverId = atoi( Info_ValueForKey( systemInfo, "sv_serverid" ) );
 
 	// load paks sent by the server, but not if we are running a local server
-	if (!com_sv_running->integer) {
+	if (!com_sv_running.Get()) {
 		FS::PakPath::ClearPaks();
 		if (!FS_LoadServerPaks(Info_ValueForKey(systemInfo, "sv_paks"), clc.demoplaying)) {
 			if (!cl_allowDownload->integer) {

--- a/src/engine/client/cl_scrn.cpp
+++ b/src/engine/client/cl_scrn.cpp
@@ -318,7 +318,7 @@ void SCR_UpdateScreen()
 		SCR_DrawScreenField();
 		SCR_DrawConsoleAndPointer();
 
-		if ( com_speeds->integer )
+		if ( com_speeds.Get() )
 		{
 			re.EndFrame( &time_frontend, &time_backend );
 		}

--- a/src/engine/qcommon/net_chan.cpp
+++ b/src/engine/qcommon/net_chan.cpp
@@ -59,6 +59,9 @@ to the new value before sending out any replies.
 
 */
 
+static Cvar::Cvar<bool> sv_packetdelay = Cvar::Cvar<bool>( "sv_packetdelay", "", CVAR_CHEAT, false );
+static Cvar::Cvar<int> cl_packetdelay = Cvar::Cvar<int>( "cl_packetdelay", "", Cvar::CHEAT, 0 );
+
 static const int MAX_PACKETLEN = 1400; // max size of a network packet
 
 static const int FRAGMENT_SIZE = ( MAX_PACKETLEN - 100 );
@@ -518,7 +521,7 @@ static void NET_QueuePacket( int length, const void *data, const netadr_t& to,
 	memcpy( newp->data, data, length );
 	newp->length = length;
 	newp->to = to;
-	newp->release = Sys::Milliseconds() + ( int )( ( float ) offset / com_timescale->value );
+	newp->release = Sys::Milliseconds() + ( int )( ( float ) offset / com_timescale.Get() );
 	newp->next = nullptr;
 
 	if ( !packetQueue )
@@ -564,15 +567,15 @@ void NET_SendPacket( netsrc_t sock, int length, const void *data, const netadr_t
 	}
 
 #ifndef BUILD_SERVER
-	if ( sock == netsrc_t::NS_CLIENT && cl_packetdelay->integer > 0 )
+	if ( sock == netsrc_t::NS_CLIENT && cl_packetdelay.Get() > 0 )
 	{
-		NET_QueuePacket( length, data, to, cl_packetdelay->integer );
+		NET_QueuePacket( length, data, to, cl_packetdelay.Get() );
 	}
 	else
 #endif
-	if ( sock == netsrc_t::NS_SERVER && sv_packetdelay->integer > 0 )
+	if ( sock == netsrc_t::NS_SERVER && sv_packetdelay.Get() > 0 )
 	{
-		NET_QueuePacket( length, data, to, sv_packetdelay->integer );
+		NET_QueuePacket( length, data, to, sv_packetdelay.Get() );
 	}
 	else
 	{

--- a/src/engine/qcommon/net_chan.cpp
+++ b/src/engine/qcommon/net_chan.cpp
@@ -573,7 +573,7 @@ void NET_SendPacket( netsrc_t sock, int length, const void *data, const netadr_t
 	}
 	else
 #endif
-	if ( sock == netsrc_t::NS_SERVER && sv_packetdelay.Get() > 0 )
+	if ( sock == netsrc_t::NS_SERVER && sv_packetdelay.Get() )
 	{
 		NET_QueuePacket( length, data, to, sv_packetdelay.Get() );
 	}

--- a/src/engine/qcommon/net_ip.cpp
+++ b/src/engine/qcommon/net_ip.cpp
@@ -1779,7 +1779,7 @@ void NET_Config( bool enableNetworking )
 	// get any latched changes to cvars
 	modified = NET_GetCvars();
 #ifndef BUILD_SERVER
-	svRunning = !!com_sv_running->integer;
+	svRunning = com_sv_running.Get();
 	modified |= ( svRunning != serverMode );
 #endif
 

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -532,22 +532,18 @@ bool       Com_ServerRunning();
 // if match is nullptr, all set commands will be executed, otherwise
 // only a set with the exact name.  Only used during startup.
 
-extern cvar_t       *com_developer;
-extern cvar_t       *com_speeds;
-extern cvar_t       *com_timescale;
-extern cvar_t       *com_sv_running;
-extern cvar_t       *com_cl_running;
+extern Cvar::Cvar<int> com_speeds;
+extern Cvar::Cvar<float> com_timescale;
 extern cvar_t       *com_version;
+extern Cvar::Cvar<bool> com_sv_running;
+extern Cvar::Cvar<bool> com_cl_running;
 
 extern Cvar::Cvar<std::string> com_consoleCommand;
 
 extern Cvar::Cvar<bool> com_ansiColor;
 
-extern cvar_t       *com_unfocused;
-extern cvar_t       *com_minimized;
-
-extern cvar_t       *cl_packetdelay;
-extern cvar_t       *sv_packetdelay;
+extern Cvar::Cvar<bool> com_unfocused;
+extern Cvar::Cvar<bool> com_minimized;
 
 // com_speeds times
 extern int          time_game;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -324,9 +324,6 @@ extern Cvar::Cvar<bool> sv_wwwDownload;
 extern Cvar::Cvar<std::string> sv_wwwBaseURL;
 extern Cvar::Cvar<std::string> sv_wwwFallbackURL;
 
-//bani
-extern cvar_t *sv_packetdelay;
-
 //fretn
 extern cvar_t *sv_fullmsg;
 

--- a/src/engine/server/sv_ccmds.cpp
+++ b/src/engine/server/sv_ccmds.cpp
@@ -153,7 +153,7 @@ static void SV_MapRestart_f()
 	}
 
 	// make sure server is running
-	if ( !com_sv_running->integer )
+	if ( !com_sv_running.Get() )
 	{
 		Log::Notice( "Server is not running.\n" );
 		return;
@@ -261,7 +261,7 @@ public:
 	void Run(const Cmd::Args&) const override
 	{
 		// make sure server is running
-		if ( !com_sv_running->integer )
+		if ( !com_sv_running.Get() )
 		{
 			Log::Notice( "Server is not running.\n" );
 			return;
@@ -368,7 +368,7 @@ Examine the serverinfo string
 static void SV_Serverinfo_f()
 {
 	// make sure server is running
-	if ( !com_sv_running->integer )
+	if ( !com_sv_running.Get() )
 	{
 		Log::Notice( "Server is not running.\n" );
 		return;
@@ -388,7 +388,7 @@ Examine the systeminfo string
 static void SV_Systeminfo_f()
 {
 	// make sure server is running
-	if ( !com_sv_running->integer )
+	if ( !com_sv_running.Get() )
 	{
 		Log::Notice( "Server is not running.\n" );
 		return;
@@ -429,7 +429,7 @@ SV_AddOperatorCommands
 */
 void SV_AddOperatorCommands()
 {
-	if ( com_sv_running->integer )
+	if ( com_sv_running.Get() )
 	{
 		// These commands should only be available while the server is running.
 		Cmd_AddCommand( "fieldinfo",   SV_FieldInfo_f );

--- a/src/engine/server/sv_client.cpp
+++ b/src/engine/server/sv_client.cpp
@@ -1227,7 +1227,7 @@ static bool SV_ClientCommand( client_t *cl, msg_t *msg, bool premaprestart )
 	// but not other people
 	// We don't do this when the client hasn't been active yet, since it is
 	// by protocol to spam a lot of commands when downloading
-	if ( !com_cl_running->integer && cl->state >= clientState_t::CS_ACTIVE && // (SA) this was commented out in Wolf.  Did we do that?
+	if ( !com_cl_running.Get() && cl->state >= clientState_t::CS_ACTIVE && // (SA) this was commented out in Wolf.  Did we do that?
 	     sv_floodProtect->integer && svs.time < cl->nextReliableTime && floodprotect )
 	{
 		// ignore any other text messages from this client but let them keep playing

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -636,9 +636,6 @@ void SV_Init()
 	// the download netcode tops at 18/20 kb/s, no need to make you think you can go above
 	sv_dl_maxRate = Cvar_Get( "sv_dl_maxRate", "42000", 0 );
 
-	//bani
-	sv_packetdelay = Cvar_Get( "sv_packetdelay", "0", CVAR_CHEAT );
-
 	// fretn - note: redirecting of clients to other servers relies on this,
 	// ET://someserver.com
 	sv_fullmsg = Cvar_Get( "sv_fullmsg", "Server is full.", 0 );
@@ -695,7 +692,7 @@ void SV_FinalCommand( char *cmd, bool disconnect )
 // Used instead of SV_Shutdown when Daemon is exiting
 void SV_QuickShutdown( const char *finalmsg )
 {
-	if ( !com_sv_running || !com_sv_running->integer )
+	if ( !com_sv_running.Get() )
 	{
 		return;
 	}
@@ -720,7 +717,7 @@ Called to shut down the sgame VM, or to clean up after the VM shut down on its o
 */
 void SV_Shutdown( const char *finalmsg )
 {
-	if ( !com_sv_running || !com_sv_running->integer )
+	if ( !com_sv_running.Get() )
 	{
 		return;
 	}

--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -73,9 +73,6 @@ cvar_t         *sv_dl_maxRate;
 
 cvar_t *sv_showAverageBPS; // NERVE - SMF - net debugging
 
-//bani
-cvar_t *sv_packetdelay;
-
 // fretn
 cvar_t *sv_fullmsg;
 
@@ -486,7 +483,7 @@ if a user is interested in a server to do a full status
 */
 static void SVC_Info( const netadr_t& from, const Cmd::Args& args )
 {
-	if ( SV_Private(ServerPrivate::NoStatus) || !com_sv_running || !com_sv_running->integer )
+	if ( SV_Private(ServerPrivate::NoStatus) || !com_sv_running.Get() )
 	{
 		return;
 	}
@@ -1284,7 +1281,7 @@ void SV_Frame( int msec )
 		return;
 	}
 
-	if ( !com_sv_running->integer )
+	if ( !com_sv_running.Get() )
 	{
 		return;
 	}
@@ -1354,7 +1351,7 @@ void SV_Frame( int msec )
 		cvar_modifiedFlags &= ~CVAR_SYSTEMINFO;
 	}
 
-	if ( com_speeds->integer )
+	if ( com_speeds.Get() )
 	{
 		startTime = Sys::Milliseconds();
 	}
@@ -1377,7 +1374,7 @@ void SV_Frame( int msec )
 		gvm.GameRunFrame( sv.time );
 	}
 
-	if ( com_speeds->integer )
+	if ( com_speeds.Get() )
 	{
 		time_game = Sys::Milliseconds() - startTime;
 	}

--- a/src/engine/sys/sdl_input.cpp
+++ b/src/engine/sys/sdl_input.cpp
@@ -1216,12 +1216,12 @@ void IN_Frame()
 		// Console is down in windowed mode
 		IN_SetFocus( false );
 	}
-	else if ( com_unfocused->integer )
+	else if ( com_unfocused.Get() )
 	{
 		// Window doesn't have focus
 		IN_SetFocus( false );
 	}
-	else if ( com_minimized->integer )
+	else if ( com_minimized.Get() )
 	{
 		// Minimized
 		IN_SetFocus( false );


### PR DESCRIPTION
Does not builds yet because I don't know how to fix:

> daemon/src/engine/qcommon/net_ip.cpp:1708:15: error: no member named 'modified' in 'Cvar::Cvar<int>'
        net_enabled->modified = false;

The only remaining cvar_t in that header file will then be `com_version` because I'm even less sure of how to migrate it. Maybe I'll just avoir migrating net_enabled, though. Dunno yet.