### PR TITLE
external_deps: re-add a case “;;” mistakenly removed

### DIFF
--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -136,6 +136,7 @@ build_zlib() {
 		CFLAGS="${CFLAGS} -O3" ./configure --prefix="${PREFIX}" --libdir="${PREFIX}/lib" --static --const
 		make
 		make install
+		;;
 	esac
 }
 


### PR DESCRIPTION
It looks to have been mistakenly removed in 93d4c3e7eaea03eea2cf854f4197681461f88970, likely a rebase error.