### PR TITLE
set the error message when disconnected from the server

### DIFF
--- a/src/engine/client/ClientApplication.cpp
+++ b/src/engine/client/ClientApplication.cpp
@@ -95,6 +95,10 @@ class ClientApplication : public Application {
             SV_Shutdown(Str::Format("Server %s: %s", error ? "crashed" : "shutdown", reason).c_str());
             CL_Disconnect(true);
             CL_ShutdownAll();
+            if (error)
+            {
+                Cvar::SetValue("com_errorMessage", Str::Format("^3%s", reason));
+            }
             CL_StartHunkUsers();
         }
 

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -149,9 +149,9 @@ bool CL_HandleServerCommand(Str::StringRef text, std::string& newText) {
 	if (cmd == "disconnect") {
 		// NERVE - SMF - allow server to indicate why they were disconnected
 		if (argc >= 2) {
-			Sys::Drop("Server disconnected: %s", args.Argv(1).c_str());
+			Sys::Drop("^3Server disconnected:\n^7%s", args.Argv(1).c_str());
 		} else {
-			Sys::Drop("Server disconnected");
+			Sys::Drop("^3Server disconnected:\n^7(reason unknown)");
 		}
 	}
 

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -1771,8 +1771,7 @@ void CL_PrintPacket( msg_t *msg )
 	if ( !Q_strnicmp( s, "[err_dialog]", 12 ) )
 	{
 		Q_strncpyz( clc.serverMessage, s + 12, sizeof( clc.serverMessage ) );
-		// Cvar_Set("com_errorMessage", clc.serverMessage );
-		Sys::Drop( "%s", clc.serverMessage );
+		Sys::Drop( "^3Server disconnected:\n^7%s", clc.serverMessage );
 	}
 	else
 	{


### PR DESCRIPTION
This will open an error message to the client's main menu stating why they have been disconnected from the server (whether kicked or otherwise).