### PR TITLE
Retries and rate limiting for serverinfo queries

### DIFF
--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -364,6 +364,7 @@ static void LAN_ResetPings( int source )
 	{
 		for ( i = 0; i < count; i++ )
 		{
+			servers[ i ].pingStatus = pingStatus_t::WAITING;
 			servers[ i ].ping = -1;
 		}
 	}

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -365,6 +365,7 @@ static void LAN_ResetPings( int source )
 		for ( i = 0; i < count; i++ )
 		{
 			servers[ i ].pingStatus = pingStatus_t::WAITING;
+			servers[ i ].pingAttempts = 0;
 			servers[ i ].ping = -1;
 		}
 	}

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -248,6 +248,7 @@ struct ping_t
 	netadr_t adr;
 	int      start;
 	int      time;
+	char     challenge[ 9 ]; // 8-character challenge string
 	char     info[ MAX_INFO_STRING ];
 };
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -276,6 +276,7 @@ struct serverInfo_t
 	int      maxPing;
 	pingStatus_t pingStatus;
 	int      ping;
+	int      pingAttempts;
 	bool visible;
 	int      needpass;
 	char     gameName[ MAX_NAME_LENGTH ]; // Arnout

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -252,6 +252,13 @@ struct ping_t
 	char     info[ MAX_INFO_STRING ];
 };
 
+enum class pingStatus_t
+{
+	WAITING,
+	COMPLETE,
+	TIMEOUT,
+};
+
 #define MAX_FEATLABEL_CHARS 32
 struct serverInfo_t
 {
@@ -267,6 +274,7 @@ struct serverInfo_t
 	int      maxClients;
 	int      minPing;
 	int      maxPing;
+	pingStatus_t pingStatus;
 	int      ping;
 	bool visible;
 	int      needpass;
@@ -476,7 +484,6 @@ void        CL_Snd_Restart_f();
 
 void        CL_ReadDemoMessage();
 
-void        CL_GetPing( int n, int *pingtime );
 void        CL_ClearPing( int n );
 int         CL_GetPingQueueCount();
 


### PR DESCRIPTION
The important commit:

> The cvars cl_pingSpacing, cl_pingSpacingRetry1, and cl_pingSpacingRetry2
can be used to configure serverinfo queries (used to populate the server
list) to be attempted up to 3 times, possibly with a minimum delay
between outgoing packets which may be different for each round of
attempts. All first tries must be completed/timed out before starting
2nd attempts, etc.
>
> Default behavior is the same as 0.54 - one attempt with no delays.
>
> Fixes https://github.com/DaemonEngine/Daemon/issues/654.
