### PR TITLE
Log: replace DoDebugCode(lambda) with if statement

### DIFF
--- a/src/common/Log.h
+++ b/src/common/Log.h
@@ -64,7 +64,7 @@ namespace Log {
      *
      *   // However functions calls will still be performed.
      *   // To run code depending on the logger state use the following:
-     *   fooLog.DoNoticeCode([&](){
+     *   if (fooLog.ShowNotice()) {
      *       ExpensiveCall();
      *       fooLog.Notice("Printing the expensive expression %s", <the expression>);
      *   });
@@ -95,17 +95,21 @@ namespace Log {
             template<typename ... Args>
             void Debug(Str::StringRef format, Args&& ... args);
 
-            template<typename F>
-            void DoWarnCode(F&& code);
+            bool ShowWarn() const {
+                return filterLevel->Get() >= Level::WARNING;
+            }
 
-            template<typename F>
-            void DoNoticeCode(F&& code);
+            bool ShowNotice() const {
+                return filterLevel->Get() >= Level::NOTICE;
+            }
 
-            template<typename F>
-            void DoVerboseCode(F&& code);
+            bool ShowVerbose() const {
+                return filterLevel->Get() >= Level::VERBOSE;
+            }
 
-            template<typename F>
-            void DoDebugCode(F&& code);
+            bool ShowDebug() const {
+                return filterLevel->Get() >= Level::DEBUG;
+            }
 
             Logger WithoutSuppression();
 
@@ -218,34 +222,6 @@ namespace Log {
     void Logger::Debug(Str::StringRef format, Args&& ... args) {
         if (filterLevel->Get() <= Level::DEBUG) {
             this->Dispatch(Prefix(Str::Format(format, std::forward<Args>(args) ...)), Level::DEBUG, format);
-        }
-    }
-
-    template<typename F>
-    inline void Logger::DoWarnCode(F&& code) {
-        if (filterLevel->Get() <= Level::WARNING) {
-            code();
-        }
-    }
-
-    template<typename F>
-    inline void Logger::DoNoticeCode(F&& code) {
-        if (filterLevel->Get() <= Level::NOTICE) {
-            code();
-        }
-    }
-
-    template<typename F>
-    inline void Logger::DoVerboseCode(F&& code) {
-        if (filterLevel->Get() <= Level::VERBOSE) {
-            code();
-        }
-    }
-
-    template<typename F>
-    inline void Logger::DoDebugCode(F&& code) {
-        if (filterLevel->Get() <= Level::DEBUG) {
-            code();
         }
     }
 

--- a/src/engine/framework/CommandSystem.cpp
+++ b/src/engine/framework/CommandSystem.cpp
@@ -223,9 +223,9 @@ namespace Cmd {
     CompletionResult CompleteArgument(const Args& args, int argNum) {
         CommandMap& commands = GetCommandMap();
 
-        commandLog.DoDebugCode([&]() {
+        if (commandLog.ShowDebug()) {
             commandLog.Debug("Completing argument %i of '%s'", argNum, args.ConcatArgs(0));
-        });
+        }
 
         if (args.Argc() == 0) {
             return {};

--- a/src/engine/framework/Network.cpp
+++ b/src/engine/framework/Network.cpp
@@ -210,14 +210,14 @@ private:
                 if (result.ipv4.type == netadrtype_t::NA_BAD && result.ipv6.type == netadrtype_t::NA_BAD) {
                     netLog.Notice("Failed to resolve hostname %s", hostname);
                 } else {
-                    netLog.DoVerboseCode([&hostname, &result] {
+                    if (netLog.ShowVerbose()) {
                         if (result.ipv4.type != netadrtype_t::NA_BAD) {
                             netLog.Verbose("Resolved %s (IPv4) to %s", hostname, AddressToString(result.ipv4));
                         }
                         if (result.ipv6.type != netadrtype_t::NA_BAD) {
                             netLog.Verbose("Resolved %s (IPv6) to %s", hostname, AddressToString(result.ipv6));
                         }
-                    });
+                    }
                 }
                 lock.lock();
                 if (hostname == queries_[next].hostname && mask == queries_[next].protocolMask) {

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1632,7 +1632,8 @@ static void ParseNormalMapDetectHeightMap( shaderStage_t *stage, const char **te
 		&& stage->bundle[ bundleIndex ].image[ 0 ]->bits & IF_NORMALMAP
 		&& stage->bundle[ bundleIndex ].image[ 0 ]->bits & IF_ALPHA )
 	{
-		Log::defaultLogger.DoDebugCode([&] {
+		if ( Log::defaultLogger.ShowDebug() )
+		{
 			char buffer[ 1024 ];
 			buffer[ 0 ] = '\0';
 			if ( !ParseMap( &initialText, buffer, sizeof( buffer ) ) )
@@ -1640,7 +1641,7 @@ static void ParseNormalMapDetectHeightMap( shaderStage_t *stage, const char **te
 				ASSERT( false );
 			}
 			Log::Debug("Found heightmap embedded in normalmap '%s'", buffer);
-		});
+		}
 
 		stage->isHeightMapInNormalMap = true;
 	}


### PR DESCRIPTION
Instead of having Logger::DoDebugCode, DoVerboseCode etc. that conditionally execute a function based on the log level (to avoid evaluating expensive expressions for disabled messages), provide functions returning a bool that tell whether that level would currently be printed: Logger::ShowDebug(), ShowVerbose() etc. I don't see any benefit to the lambda; if (logger.ShowDebug()) { ... } is easier to type and more flexible.

Draft to remind me to make the gamelogic side before merging

What do you guys thing of the ShowDebug/ShowVerbose/etc. name? Is there anything better?