### PR TITLE
deps: SDL2 CMake requires the bin/ dir to exist even when not using anything from it

### DIFF
--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -242,6 +242,11 @@ build_sdl2() {
 		CFLAGS="${CFLAGS} -O3" ./configure --host="${HOST}" --prefix="${PREFIX}" --libdir="${PREFIX}/lib" "${CONFIGURE_SHARED[@]}"
 		make
 		make install
+		# Workaround for an SDL2 CMake bug, we need to provide
+		# a bin/ directory even when nothing is used from it.
+		mkdir -p "${PREFIX}/bin"
+		# We don't keep empty folders.
+		touch "${PREFIX}/bin/.keep"
 		;;
 	esac
 }
@@ -744,7 +749,7 @@ build_install() {
 	rm -rf "${PKG_PREFIX}/def"
 	rm -rf "${PKG_PREFIX}/share"
 	rm -rf "${PKG_PREFIX}/lib/pkgconfig"
-	find "${PKG_PREFIX}/bin" -not -type d -not -name '*.dll' -execdir rm -f -- {} \;
+	find "${PKG_PREFIX}/bin" -not -type d -not -name '*.dll' -not -name '.keep' -execdir rm -f -- {} \;
 	find "${PKG_PREFIX}/lib" -name '*.la' -execdir rm -f -- {} \;
 	find "${PKG_PREFIX}/lib" -name '*.dll.a' -execdir bash -c 'rm -f -- "$(basename "{}" .dll.a).a"' \;
 	find "${PKG_PREFIX}/lib" -name '*.dylib' -execdir bash -c 'rm -f -- "$(basename "{}" .dylib).a"' \;


### PR DESCRIPTION
SDL2 CMake requires the `bin/` dir to exist even when not using anything from it

Fixes #946:

- https://github.com/DaemonEngine/Daemon/issues/946

This also fixes doing release builds for Linux (yay!).