### PR TITLE
models: convert to MD5 half floats at load time, use VectorNormalizeFast for IQM and MD5

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2269,12 +2269,14 @@ static inline void glFboSetExt()
 		vec4_t      tangent;
 		vec4_t      binormal;
 		vec4_t      normal;
+
+		uint32_t    boneIndexes[ MAX_WEIGHTS ];
+		float       boneWeights[ MAX_WEIGHTS ];
+
 		f16vec2_t texCoords;
 
 		uint32_t    firstWeight;
 		uint32_t    numWeights;
-		uint32_t    boneIndexes[ MAX_WEIGHTS ];
-		float       boneWeights[ MAX_WEIGHTS ];
 	});
 
 	struct md5Surface_t

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2269,7 +2269,7 @@ static inline void glFboSetExt()
 		vec4_t      tangent;
 		vec4_t      binormal;
 		vec4_t      normal;
-		vec2_t      texCoordsF;
+		f16vec2_t texCoords;
 
 		uint32_t    firstWeight;
 		uint32_t    numWeights;

--- a/src/engine/renderer/tr_model_md5.cpp
+++ b/src/engine/renderer/tr_model_md5.cpp
@@ -325,7 +325,9 @@ bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 			for (unsigned k = 0; k < 2; k++ )
 			{
 				token = COM_ParseExt2( &buf_p, false );
-				v->texCoordsF[ k ] = atof( token );
+				// We better want to waste time to convert back and forth when
+				// loading the file than doing it on every frame at render time.
+				v->texCoords[ k ] = floatToHalf( atof( token ) );
 			}
 
 			// skip )
@@ -498,7 +500,7 @@ bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 		// calc tangent spaces
 		{
 			const float *v0, *v1, *v2;
-			const float *t0, *t1, *t2;
+			vec2_t t0, t1, t2;
 			vec3_t      tangent;
 			vec3_t      binormal;
 			vec3_t      normal;
@@ -518,9 +520,14 @@ bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 				v1 = surf->verts[ tri->indexes[ 1 ] ].position;
 				v2 = surf->verts[ tri->indexes[ 2 ] ].position;
 
-				t0 = surf->verts[ tri->indexes[ 0 ] ].texCoordsF;
-				t1 = surf->verts[ tri->indexes[ 1 ] ].texCoordsF;
-				t2 = surf->verts[ tri->indexes[ 2 ] ].texCoordsF;
+				// We better want to waste time to convert back and forth when
+				// loading the file than doing it on every frame at render time.
+				t0[ 0 ] = halfToFloat( surf->verts[ tri->indexes[ 0 ] ].texCoords[ 0 ] );
+				t0[ 1 ] = halfToFloat( surf->verts[ tri->indexes[ 0 ] ].texCoords[ 1 ] );
+				t1[ 0 ] = halfToFloat( surf->verts[ tri->indexes[ 1 ] ].texCoords[ 0 ] );
+				t1[ 1 ] = halfToFloat( surf->verts[ tri->indexes[ 1 ] ].texCoords[ 1 ] );
+				t2[ 0 ] = halfToFloat( surf->verts[ tri->indexes[ 2 ] ].texCoords[ 0 ] );
+				t2[ 1 ] = halfToFloat( surf->verts[ tri->indexes[ 2 ] ].texCoords[ 1 ] );
 
 				R_CalcFaceNormal( normal, v0, v1, v2 );
 				R_CalcTangents( tangent, binormal, v0, v1, v2, t0, t1, t2 );

--- a/src/engine/renderer/tr_model_skel.cpp
+++ b/src/engine/renderer/tr_model_skel.cpp
@@ -168,8 +168,7 @@ void AddSurfaceToVBOSurfacesList( growList_t *vboSurfaces, growList_t *vboTriang
 		R_TBNtoQtangents( surf->verts[ j ].tangent, surf->verts[ j ].binormal,
 				  surf->verts[ j ].normal, data.qtangent[ j ] );
 		
-		data.st[ j ][ 0 ] = floatToHalf( surf->verts[ j ].texCoordsF[ 0 ] );
-		data.st[ j ][ 1 ] = floatToHalf( surf->verts[ j ].texCoordsF[ 1 ] );
+		Vector2Copy( surf->verts[ j ].texCoords, data.st[ j ] );
 
 		for (unsigned k = 0; k < MAX_WEIGHTS; k++ )
 		{

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1147,7 +1147,7 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 
 			VectorCopy( position, tessVertex->xyz );
 
-			floatToHalf( surfaceVertex->texCoordsF, tessVertex->texCoords );
+			Vector2Copy( surfaceVertex->texCoords, tessVertex->texCoords );
 		}
 	}
 	else
@@ -1190,7 +1190,7 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 
 			R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
 
-			floatToHalf( surfaceVertex->texCoordsF, tessVertex->texCoords );
+			Vector2Copy( surfaceVertex->texCoords, tessVertex->texCoords );
 		}
 	}
 

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1183,9 +1183,9 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 				VectorMA( binormal, *boneWeight, tmp, binormal );
 			}
 
-			VectorNormalize( normal );
-			VectorNormalize( tangent );
-			VectorNormalize( binormal );
+			VectorNormalizeFast( normal );
+			VectorNormalizeFast( tangent );
+			VectorNormalizeFast( binormal );
 			VectorCopy( position, tessVertex->xyz );
 
 			R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
@@ -1394,9 +1394,9 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 					VectorMA( binormal, weight, tmp, binormal );
 				}
 
-				VectorNormalize( normal );
-				VectorNormalize( tangent );
-				VectorNormalize( binormal );
+				VectorNormalizeFast( normal );
+				VectorNormalizeFast( tangent );
+				VectorNormalizeFast( binormal );
 				VectorCopy( position, tessVertex->xyz );
 
 				R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );


### PR DESCRIPTION
- renderer/tr_model: spend time in half float conversion at load time, not at render time  
  May also fix bugs since `floatToHalf( const vec4_t in, f16vec4_t out )` is not to convert `vec2_t` to `f16vec2_t`.

- renderer/tr_surface: use vectorNormalizeFast in MD5/IQM code

Most of that code is CPU fallback for processing model when GPU can't. We better want to avoid any useless computation at frame render time. 

I wonder why `floatToHalf( const vec4_t in, f16vec4_t out )` didn't abort the compilation when used with (`vec2_t`, `f16vec2_t`). We may still add the vec2 variant for the places it can be used though.

I also wonder if we can always use `VectorNormalizeFast` any time we use `VectorNormalize` without needing any return value.

The CPU fallback code can be tested with `r_vboVertexSkinning 0`, the human model is MD5, others are IQM. I see no regression.