### PR TITLE
renderer/tr_surface: use vectorNormalizeFast in MD5/IQM code

### DIFF
--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1183,9 +1183,9 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 				VectorMA( binormal, *boneWeight, tmp, binormal );
 			}
 
-			VectorNormalize( normal );
-			VectorNormalize( tangent );
-			VectorNormalize( binormal );
+			VectorNormalizeFast( normal );
+			VectorNormalizeFast( tangent );
+			VectorNormalizeFast( binormal );
 			VectorCopy( position, tessVertex->xyz );
 
 			R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
@@ -1394,9 +1394,9 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 					VectorMA( binormal, weight, tmp, binormal );
 				}
 
-				VectorNormalize( normal );
-				VectorNormalize( tangent );
-				VectorNormalize( binormal );
+				VectorNormalizeFast( normal );
+				VectorNormalizeFast( tangent );
+				VectorNormalizeFast( binormal );
 				VectorCopy( position, tessVertex->xyz );
 
 				R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );


### PR DESCRIPTION
This is CPU fallback code for when GPU can't accelerate model, to test this code one can do `set r_vboVertexSkinning 0`.

Continuation of the talk from there:

- https://github.com/DaemonEngine/Daemon/pull/953#discussion_r1382713656

> @slipher: Hmm do you have an argument for why precision isn't needed here? We had that bug with black patches in models due to the GLSL compiler compiling the same code slightly differently in 2 different shaders, so you can't just say that it's graphics so the precision doesn't matter...

> @illwieckz: Unfortunately I don't have an argument for why precision isn't needed here, I only have an argument for why performance is wanted here. 😅️

> @illwieckz: I don't know if that can help, but as far as I know when this code is used, the GLSL compiler is not used (because it is the fallback when that job can't be done on GPU), so we don't have to care about different GLSL compilers behaving differently.