### PR TITLE
files: implement fs_pakprefixes

### DIFF
--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -703,6 +703,7 @@ static void Init(int argc, char** argv)
 	// TODO: cvar names and FS_* stuff needs to be properly integrated
 	EarlyCvar("fs_basepak", cmdlineArgs);
 	EarlyCvar("fs_extrapaks", cmdlineArgs);
+	EarlyCvar("fs_pakprefixes", cmdlineArgs);
 
     Application::LoadInitialConfig(cmdlineArgs.reset_config);
 	Cmd::ExecuteCommandBuffer();


### PR DESCRIPTION
The idea is to allow to provide a complete tree of dpk archives in an subfolder and get them loaded first.

This will be useful for the nightly server, or for any mod.

Basically by running the game like this:

```sh
./daemon -set fs_pakprefixes 'dev'
```

The engine will look for `pkg/dev/unvanquished` dpk before the `pkg/unvanquished` one, and load it if exists.

It means we can host a whole copy of upcoming Unvanquished dpk archives in `pkg/dev` and get clients download it from `pkg/dev`, not breaking default installs on user side.

Like `fs_extrapaks`, the `fs_pakprefixs` cvar can gets a space-separated list of folders, so for example one can set `race dev` and the engine is expected to look first in `pkg/race`, then in `pkg/dev`, then in `pkg`.

First prefix to have a package for the given name gets the priority to load the package, even if an higher version of it exists in the next prefix (or base folder) to look for. I consider this is good enough and it makes sense anyway.

Right now I only tested with dpkdir, but I verified that only the server has to set the prefix, the client gets the list of translated paths (for example `dev/unvanquished`) from the server as expected.