### PR TITLE
client: set originalDownloadName size to MAX_OSPATH since we copy there downloadName which is size MAX_OSPATH

### DIFF
--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -326,7 +326,7 @@ struct clientStatic_t
 	// if new stuff gets added, CL_ClearStaticDownload code needs to be updated for clear up
 	char     downloadName[ MAX_OSPATH ];
 	char     downloadTempName[ MAX_OSPATH ]; // in wwwdl mode, this is OS path (it's a qpath otherwise)
-	char     originalDownloadName[ MAX_QPATH ]; // if we get a redirect, keep a copy of the original file path
+	char     originalDownloadName[ MAX_OSPATH ]; // if we get a redirect, keep a copy of the original file path
 	bool downloadRestart; // if true, we need to do another FS_Restart because we downloaded a pak
 };
 


### PR DESCRIPTION
Set `originalDownloadName` size to `MAX_OSPATH` since we copy there `downloadName` which is size `MAX_OSPATH`.

We have this code in `src/engine/client/cl_download.cpp`:

```
  Q_strncpyz( cls.originalDownloadName, cls.downloadName, sizeof( cls.originalDownloadName ) );
```

but `sizeof(cls.downloadName)` is `256` (`MAX_OSPATH`) and `sizeof(cls.originalDownloadName)` is `64` (`MAX_QPATH`), meaning the server can tell the client to download a package whose name is longer than what the client string can carry. Let's just enlarge that string.

Large pak names with checksums would be truncated otherwise, letting the client stuck in an infinite download loop because the download of the pak will never succeed.

See:

- https://github.com/DaemonEngine/Daemon/issues/681