### PR TITLE
common/String: include cstdint to define uint8_t

### DIFF
--- a/src/common/String.h
+++ b/src/common/String.h
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
 #include <limits>
+#include <cstdint>
 #include "Compiler.h"
 
 namespace Str {


### PR DESCRIPTION
Reported by Intel ICX 2023.2.2:

```
Unvanquished/daemon/src/common/String.h:287:20: error: unknown type name 'uint8_t'
    char HexDigit( uint8_t digit );
                   ^
1 error generated.
```