### PR TITLE
framework: include Common.h in Application.cpp

### DIFF
--- a/src/engine/framework/Application.cpp
+++ b/src/engine/framework/Application.cpp
@@ -28,6 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ===========================================================================
 */
 
+#include "common/Common.h"
 #include "Application.h"
 #include "common/FileSystem.h"
 


### PR DESCRIPTION
Fixes this error on Intel ICX 2023.2.2:

```
In file included from Unvanquished/daemon/src/engine/framework/Application.cpp:31: In file included from Unvanquished/daemon/src/engine/framework/Application.h:35: Unvanquished/daemon/src/common/String.h:287:20: error: unknown type name 'uint8_t'
  287 |     char HexDigit( uint8_t digit );
      |                    ^
1 error generated.
```

Replaces:

- https://github.com/DaemonEngine/Daemon/pull/968