### PR TITLE
cmake/DaemonGame: make code more reusable for other toolchains

### DIFF
--- a/cmake/DaemonGame.cmake
+++ b/cmake/DaemonGame.cmake
@@ -129,17 +129,7 @@ function(GAMEMODULE)
 
         # Generate NaCl executables for supported architectures.
         foreach(NACL_TARGET ${NACL_TARGETS})
-            if (NACL_TARGET STREQUAL "i686")
-                set(PNACL_ARCH "i686")
-            elseif (NACL_TARGET STREQUAL "amd64")
-                set(PNACL_ARCH "x86-64")
-            elseif (NACL_TARGET STREQUAL "armhf")
-                set(PNACL_ARCH "arm")
-            else()
-                message(FATAL_ERROR "Unknown NaCl architecture ${NACL_TARGET}")
-            endif()
-
-            pnacl_finalize(${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${GAMEMODULE_NAME} ${PNACL_ARCH} ${NACL_TARGET})
+            pnacl_finalize(${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${GAMEMODULE_NAME} ${NACL_TARGET})
         endforeach()
     endif()
 endfunction()

--- a/cmake/DaemonGame.cmake
+++ b/cmake/DaemonGame.cmake
@@ -114,8 +114,10 @@ function(GAMEMODULE)
 
         add_executable(${GAMEMODULE_NAME}-nacl ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${COMMONLIST})
         target_link_libraries(${GAMEMODULE_NAME}-nacl ${GAMEMODULE_LIBS} ${LIBS_BASE})
+        # PLATFORM_EXE_SUFFIX is .pexe when building with PNaCl
+        # as translating to .nexe is a separate task.
         set_target_properties(${GAMEMODULE_NAME}-nacl PROPERTIES
-            OUTPUT_NAME ${GAMEMODULE_NAME}.pexe
+            OUTPUT_NAME ${GAMEMODULE_NAME}${PLATFORM_EXE_SUFFIX}
             COMPILE_DEFINITIONS "VM_NAME=${GAMEMODULE_NAME};${GAMEMODULE_DEFINITIONS};BUILD_VM"
             COMPILE_OPTIONS "${GAMEMODULE_FLAGS}"
             FOLDER ${GAMEMODULE_NAME}

--- a/cmake/DaemonNacl.cmake
+++ b/cmake/DaemonNacl.cmake
@@ -52,7 +52,7 @@ else()
   elseif( NACL_ARCH STREQUAL "armhf" )
     add_definitions( -DNACL_BUILD_ARCH=arm )
   else()
-    message(FATAL_ERROR "Unsupported architecture ${ARCH}")
+    message(FATAL_ERROR "Unsupported architecture ${NACL_ARCH}")
   endif()
 endif()
 

--- a/cmake/toolchain-pnacl.cmake
+++ b/cmake/toolchain-pnacl.cmake
@@ -86,16 +86,6 @@ set(NACL ON)
 set(CMAKE_C_FLAGS "")
 set(CMAKE_CXX_FLAGS "")
 
-function(pnacl_finalize target)
-    add_custom_command(TARGET ${target} POST_BUILD
-        COMMENT "Finalising ${target}"
-        COMMAND
-            ${PNACLPYTHON_PREFIX2}
-            "${PLATFORM_PREFIX}/${PLATFORM_TRIPLET}-finalize${PNACL_BIN_EXT}"
-            "$<TARGET_FILE:${target}>"
-    )
-endfunction()
-
 set(PNACL_TRANSLATE_OPTIONS
     --allow-llvm-bitcode-input # FIXME: finalize as part of the build process
     --pnacl-allow-exceptions

--- a/cmake/toolchain-pnacl.cmake
+++ b/cmake/toolchain-pnacl.cmake
@@ -96,10 +96,20 @@ set(PNACL_TRANSLATE_OPTIONS
     $<$<CONFIG:MinSizeRel>:-O2>
 )
 
-function(pnacl_finalize dir module pnacl_arch arch)
+function(pnacl_finalize dir module arch)
     set(PEXE ${dir}/${module}.pexe)
     set(NEXE ${dir}/${module}-${arch}.nexe)
     set(STRIPPED_NEXE ${dir}/${module}-${arch}-stripped.nexe)
+
+    if (arch STREQUAL "i686")
+        set(PNACL_ARCH "i686")
+    elseif (arch STREQUAL "amd64")
+        set(PNACL_ARCH "x86-64")
+    elseif (arch STREQUAL "armhf")
+        set(PNACL_ARCH "arm")
+    else()
+        message(FATAL_ERROR "Unknown NaCl architecture ${arch}")
+    endif()
 
     add_custom_command(
         OUTPUT ${NEXE}
@@ -109,7 +119,7 @@ function(pnacl_finalize dir module pnacl_arch arch)
             ${PNACLPYTHON_PREFIX2}
             "${PNACL_TRANSLATE}"
             ${PNACL_TRANSLATE_OPTIONS}
-            -arch ${pnacl_arch}
+            -arch ${PNACL_ARCH}
             ${PEXE}
             -o ${NEXE}
     )


### PR DESCRIPTION
Very minor.

When toying with Saigo I noticed this code could be factored: the `PLATFORM_EXE_SUFFIX` is set in the toolchain file so there is no need to hardcode the value there. The same code would probably work for `.pexe`, direct `.nexe` or even `.wasm` as long as the toolchain properly sets `PLATFORM_EXE_SUFFIX`.