### PR TITLE
Fix the use of lightgrid on BSP surfaces without lightmap

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -855,7 +855,8 @@ static void Render_lightMapping( shaderStage_t *pStage )
 	GLimp_LogComment( "--- Render_lightMapping ---\n" );
 
 	bool enableLightMapping = tr.worldLightMapping
-		&& tess.bspSurface;
+		&& tess.bspSurface
+		&& tess.lightmapNum >= 0 && tess.lightmapNum <= tr.lightmaps.currentElements;
 
 	bool enableDeluxeMapping = tr.worldDeluxeMapping
 		&& tess.bspSurface

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -909,9 +909,6 @@ static void Render_lightMapping( shaderStage_t *pStage )
 
 	if ( noLightMap )
 	{
-		// TODO: do this in a different way so that when lightmapping is disabled,
-		// we could disable building shader permutations with USE_LIGHT_MAPPING.
-		// See https://github.com/DaemonEngine/Daemon/issues/500
 		lightmap = tr.whiteImage;
 		enableLightMapping = true;
 	}


### PR DESCRIPTION
Fix the use of lightgrid on bsp surfaces without lightmap.

It looks like a line was mistakenly deleted in 56d0d83ca64d0712a315d6637a3dfb0ccf74a5ab.

Seems to fix #990:

- https://github.com/DaemonEngine/Daemon/issues/990