### PR TITLE
Remove unused git revision info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -296,42 +296,6 @@ try_flag(WARNINGS           "-Wstrict-null-sentinel")
 try_flag(WARNINGS           "-W${WARNMODE}sign-compare")
 
 ################################################################################
-# Git revision info
-################################################################################
-
-if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
-    find_package(Git)
-    if (GIT_FOUND)
-        execute_process(
-            COMMAND ${GIT_EXECUTABLE} describe --tags --long --match v* --dirty=+dirty
-            OUTPUT_VARIABLE GIT_DESCRIBE_REPORT
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        )
-        message(STATUS "git reported ${GIT_DESCRIBE_REPORT}")
-        # this may fail with annotated non-release tags
-        if (GIT_DESCRIBE_REPORT MATCHES "-0-g.......$")
-            set(GIT_DESCRIBE_REPORT)
-        endif()
-    endif()
-endif()
-
-if (GIT_DESCRIBE_REPORT)
-    set(DESIRED_REVISION_H_CONTENTS "#define REVISION \"${GIT_DESCRIBE_REPORT}\"\n")
-endif()
-
-if (EXISTS "${OBJ_DIR}/revision.h")
-    file(READ "${OBJ_DIR}/revision.h" ACTUAL_REVISION_H_CONTENTS)
-    if (NOT "${ACTUAL_REVISION_H_CONTENTS}" STREQUAL "${DESIRED_REVISION_H_CONTENTS}")
-        file(WRITE "${OBJ_DIR}/revision.h" "${DESIRED_REVISION_H_CONTENTS}")
-    endif()
-else()
-    file(WRITE "${OBJ_DIR}/revision.h" "${DESIRED_REVISION_H_CONTENTS}")
-endif()
-
-include_directories("${OBJ_DIR}")
-
-################################################################################
 # Group the sources by folder to have folder show in Visual Studio
 ################################################################################
 

--- a/src/engine/client/cl_console.cpp
+++ b/src/engine/client/cl_console.cpp
@@ -34,7 +34,6 @@ Maryland 20850 USA.
 
 // console.c
 
-#include "revision.h"
 #include "client.h"
 #include "qcommon/q_unicode.h"
 #include "framework/LogSystem.h"

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -34,7 +34,6 @@ Maryland 20850 USA.
 
 // common.c -- misc functions used in client and server
 
-#include "revision.h"
 #include "qcommon/q_shared.h"
 #include "qcommon/sys.h"
 #include "q_unicode.h"

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -51,11 +51,7 @@ Maryland 20850 USA.
 #define ENGINE_NAME             "Daemon Engine"
 #define ENGINE_VERSION          PRODUCT_VERSION
 
-#ifdef REVISION
-# define Q3_VERSION             PRODUCT_NAME " " PRODUCT_VERSION " " REVISION
-#else
-# define Q3_VERSION             PRODUCT_NAME " " PRODUCT_VERSION
-#endif
+#define Q3_VERSION              PRODUCT_NAME " " PRODUCT_VERSION
 
 #define Q3_ENGINE               ENGINE_NAME " " ENGINE_VERSION
 #define Q3_ENGINE_DATE          __DATE__


### PR DESCRIPTION
There was only one reference to REVISION, in qcommon.h, but it was never used because the relevant header was not included.

It's not implemented reliably anyway. The revision detection only reruns at random times (when cmake stuff is modified), so it is only reliable for a freshly created build dir, like for a release. But for releases we just hard-code the version with update-version-number.sh. The revision could be made always correct by forcing the revision header to be re-created on every build but that's ugly since it slows down incremental builds.