### PR TITLE
Better detect incompatible versions of game VMs

### DIFF
--- a/src/common/IPC/Common.h
+++ b/src/common/IPC/Common.h
@@ -70,6 +70,19 @@ namespace IPC {
         void Close() const;
 	};
 
+    // Version of the protocol for detecting what ABI version the VM has upon startup
+    constexpr uint32_t ABI_VERSION_DETECTION_ABI_VERSION = 4;
+
+    // Version for the syscall signatures between engine and VM. This must change if the syscall
+    // IDs, argument types, or return types change, or if serialization procedures change.
+    // Follows Daemon major versions.
+    // This should be updated only by update-version-number.py when a "major" release is indicated
+    constexpr const char* SYSCALL_ABI_VERSION = "0.54.0";
+
+    // This should be manually set to true when starting a 'for-X.Y.Z/sync' branch.
+    // This should be set to false by update-version-number.py when a (major) release is created.
+    constexpr bool DAEMON_HAS_COMPATIBILITY_BREAKING_SYSCALL_CHANGES = true;
+
     /*
      * The messages sent between the VM and the engine are defined by a numerical
      * ID used for dispatch, a list of input types and an optional list of return

--- a/src/engine/client/cg_api.h
+++ b/src/engine/client/cg_api.h
@@ -34,8 +34,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "shared/bg_public.h"
 #endif
 
-#define CGAME_API_VERSION 3
-
 #define CMD_BACKUP               64
 #define CMD_MASK                 ( CMD_BACKUP - 1 )
 // allow a lot of command backups for very fast systems

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -963,10 +963,7 @@ CGameVM::CGameVM(): VM::VMBase("cgame", Cvar::CHEAT), services(nullptr), cmdBuff
 void CGameVM::Start()
 {
 	services = std::unique_ptr<VM::CommonVMServices>(new VM::CommonVMServices(*this, "CGame", FS::Owner::CGAME, Cmd::CGAME_VM));
-	uint32_t version = this->Create();
-	if ( version != CGAME_API_VERSION ) {
-		Sys::Drop( "CGame ABI mismatch, expected %d, got %d", CGAME_API_VERSION, version );
-	}
+	this->Create();
 	this->CGameStaticInit();
 }
 

--- a/src/engine/framework/VirtualMachine.h
+++ b/src/engine/framework/VirtualMachine.h
@@ -113,9 +113,8 @@ public:
 	VMBase(std::string name, int vmTypeCvarFlags)
 		: processHandle(Sys::INVALID_HANDLE), name(name), type(TYPE_NACL), params(name, vmTypeCvarFlags) {}
 
-	// Create the VM for the named module. Returns the ABI version reported
-	// by the module. This will automatically free any existing VM.
-	uint32_t Create();
+	// Create the VM for the named module. This will automatically free any existing VM.
+	void Create();
 
 	// Free the VM
 	void Free();

--- a/src/engine/server/sg_api.h
+++ b/src/engine/server/sg_api.h
@@ -25,8 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include "engine/qcommon/q_shared.h"
 
-#define GAME_API_VERSION          3
-
 #define SVF_NOCLIENT              0x00000001
 #define SVF_CLIENTMASK            0x00000002
 #define SVF_VISDUMMY              0x00000004

--- a/src/engine/server/sv_sgame.cpp
+++ b/src/engine/server/sv_sgame.cpp
@@ -338,11 +338,7 @@ void GameVM::Start()
 {
 	services = std::unique_ptr<VM::CommonVMServices>(new VM::CommonVMServices(*this, "SGame", FS::Owner::SGAME, Cmd::SGAME_VM));
 
-	uint32_t version = this->Create();
-	if ( version != GAME_API_VERSION ) {
-		Sys::Drop( "SGame ABI mismatch, expected %d, got %d", GAME_API_VERSION, version );
-	}
-
+	this->Create();
 	this->GameStaticInit();
 }
 

--- a/src/shared/VMMain.cpp
+++ b/src/shared/VMMain.cpp
@@ -51,9 +51,11 @@ static void CommonInit(Sys::OSHandle rootSocket)
 {
 	VM::rootChannel = IPC::Channel(IPC::Socket::FromHandle(rootSocket));
 
-	// Send syscall ABI version, also acts as a sign that the module loaded
+	// Send ABI version information, also acts as a sign that the module loaded
 	Util::Writer writer;
-	writer.Write<uint32_t>(VM::VM_API_VERSION);
+	writer.Write<uint32_t>(IPC::ABI_VERSION_DETECTION_ABI_VERSION);
+	writer.Write<std::string>(IPC::SYSCALL_ABI_VERSION);
+	writer.Write<bool>(IPC::DAEMON_HAS_COMPATIBILITY_BREAKING_SYSCALL_CHANGES);
 	VM::rootChannel.SendMsg(writer);
 
 	// Start the main loop

--- a/src/shared/VMMain.h
+++ b/src/shared/VMMain.h
@@ -42,7 +42,6 @@ namespace VM {
 	void VMInit();
 	void VMHandleSyscall(uint32_t id, Util::Reader reader);
 	void GetNetcodeTables(NetcodeTable& playerStateTable, int& playerStateSize);
-	extern int VM_API_VERSION;
 
 	// Send a message to the engine
 	template<typename Msg, typename... Args> void SendMsg(Args&&... args) {


### PR DESCRIPTION
Companion: https://github.com/Unvanquished/Unvanquished/pull/2874

The previous mechanism was that one should update some constants CGAME_API_VERSION and GAME_API_VERSION, but no one ever did it. The counters only got to 3 in 10 years of development.

Instead tie gamelogic ABI versioning to "major" Unvanquished releases. The assumption is that in each major release there will always be a few compatibility-breaking changes, while a point release definitely should not have any such changes or else the previous gamelogic can't run.

This will help users get an informative error message when they try to replay a demo or run a mod that is not compatible with the current Daemon.

Additionally there is a constant defined for whether the gamelogic ABI contains breaking changes intended for an upcoming release. This should be set on the next-release branch, for-X.Y.Z/sync. The detection of discrepancies in the compat break bit will help developers keep things straight when they are switching between the upcoming release branch and other branches, forget to rebuild stuff, set the wrong vm type flags etc. This can also be useful when bisecting the engine as you could try to avoid commits from the compat-breaking branch to avoid having to rebuild gamelogic every time.

Updates to Unvanquished's update-version-number.sh will help to automatically update the ABI version and compat break bit.