### PR TITLE
Validate shader cache binary size

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -962,6 +962,12 @@ bool GLShaderManager::LoadShaderBinary( GLShader *shader, size_t programNum )
 	if ( shaderHeader.checkSum != shader->_checkSum )
 		return false;
 
+	if ( shaderHeader.binaryLength != shaderData.size() - sizeof( shaderHeader ) )
+	{
+		Log::Warn( "Shader cache %s has wrong size", shaderFilename );
+		return false;
+	}
+
 	// load the shader
 	shaderProgram_t *shaderProgram = &shader->_shaderPrograms[ programNum ];
 	shaderProgram->program = glCreateProgram();

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -57,7 +57,7 @@ struct GLBinaryHeader
 	unsigned int numMacros;
 
 	GLenum binaryFormat; // argument to glProgramBinary
-	GLint  binaryLength; // argument to glProgramBinary
+	uint32_t binaryLength; // argument to glProgramBinary
 };
 
 class GLUniform;


### PR DESCRIPTION
We shouldn't just believe what the shader cache file says the size of its binary program is. If the file were truncated, believing it would cause an out-of-bounds read.

On my machine the Nvidia driver crashed even when incorrectly told that the length of the shader binary is 0, which would seem fairly innocuous...