### PR TITLE
quick fix #1002

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -867,7 +867,7 @@ static void RB_RenderDrawSurfaces( shaderSort_t fromSort, shaderSort_t toSort,
 		if( entity == &tr.worldEntity ) {
 			if( !( drawSurfFilter & DRAWSURFACES_WORLD ) )
 				continue;
-		} else if( !( entity->e.renderfx & RF_DEPTHHACK ) ) {
+		} else if( !( entity && entity->e.renderfx & RF_DEPTHHACK ) ) {
 			if( !( drawSurfFilter & DRAWSURFACES_FAR_ENTITIES ) )
 				continue;
 		} else {
@@ -875,7 +875,7 @@ static void RB_RenderDrawSurfaces( shaderSort_t fromSort, shaderSort_t toSort,
 				continue;
 		}
 
-		if ( entity == oldEntity && shader == oldShader && lightmapNum == oldLightmapNum && fogNum == oldFogNum )
+		if ( entity == oldEntity && shader == oldShader && lightmapNum == oldLightmapNum && fogNum == oldFogNum && drawSurf->surface )
 		{
 			// fast path, same as previous sort
 			rb_surfaceTable[Util::ordinal(*drawSurf->surface)](drawSurf->surface );
@@ -916,7 +916,7 @@ static void RB_RenderDrawSurfaces( shaderSort_t fromSort, shaderSort_t toSort,
 				// set up the transformation matrix
 				R_RotateEntityForViewParms( backEnd.currentEntity, &backEnd.viewParms, &backEnd.orientation );
 
-				if ( backEnd.currentEntity->e.renderfx & RF_DEPTHHACK )
+				if ( backEnd.currentEntity && backEnd.currentEntity->e.renderfx & RF_DEPTHHACK )
 				{
 					// hack the depth range to prevent view model from poking into walls
 					depthRange = true;
@@ -949,7 +949,10 @@ static void RB_RenderDrawSurfaces( shaderSort_t fromSort, shaderSort_t toSort,
 		}
 
 		// add the triangles for this surface
-		rb_surfaceTable[Util::ordinal(*drawSurf->surface)](drawSurf->surface );
+		if ( drawSurf->surface )
+		{
+			rb_surfaceTable[Util::ordinal(*drawSurf->surface)](drawSurf->surface );
+		}
 	}
 
 	// draw the contents of the last shader batch

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -632,6 +632,10 @@ Called by both the front end and the back end
 */
 void R_RotateEntityForViewParms( const trRefEntity_t *ent, const viewParms_t *viewParms, orientationr_t * orientation )
 {
+	if ( ent == nullptr )
+	{
+		return;
+	}
 	vec3_t delta;
 	float  axisLength;
 


### PR DESCRIPTION
bmorel sent me this patch, on my end it fixes:

- https://github.com/DaemonEngine/Daemon/issues/1002

Quick deepl translation of his words:

> it fixes the crashes in theory. But it doesn't solve the bugs, and it's a very naive patch.
> in concrete terms, drawSurface_t is the equivalent of: memset( &drawSurface, 0, sizeof( drawSurface_t ) );
> i think grangermaze triggers this because of the intensive use of func_misc which appear and disappear quickly
> possibly linked to the fact that portals are used to see them

I have not reviewed the code, only tested that it builds and fixes the bug.