### PR TITLE
external_deps: add our own mirror, and options to only download or prefer our own mirror

### DIFF
--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -99,11 +99,9 @@ extract() {
 	cd "${2}"
 }
 
-# Download a file if it doesn't exist yet, and extract it into the build dir
-# Usage: download <filename> <URL> <dir>
 download() {
-	local extract_dir="${BUILD_DIR}/${1}"; shift
-	local tarball_file="${DOWNLOAD_DIR}/${1}"; shift
+	local tarball_file="${1}"; shift
+
 	while [ ! -f "${tarball_file}" ]; do
 		if [ -z "${1:-}" ]
 		then
@@ -117,6 +115,21 @@ download() {
 			rm -f "${tarball_file}"
 		fi
 	done
+}
+
+# Download a file if it doesn't exist yet, and extract it into the build dir
+# Usage: download <filename> <URL> <dir>
+download_extract() {
+	local extract_dir="${BUILD_DIR}/${1}"; shift
+	local our_mirror="https://dl.unvanquished.net/deps/original/${1}"
+	local tarball_file="${DOWNLOAD_DIR}/${1}"; shift
+
+	if "${prefer_ours}"
+	then
+		download "${tarball_file}" "${our_mirror}" "${@}"
+	else
+		download "${tarball_file}" "${@}" "${our_mirror}"
+	fi
 
 	"${download_only}" && return
 
@@ -128,7 +141,7 @@ build_pkgconfig() {
 	local dir_name="pkg-config-${PKGCONFIG_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download pkgconfig "${archive_name}" \
+	download_extract pkgconfig "${archive_name}" \
 		"http://pkgconfig.freedesktop.org/releases/${archive_name}"
 
 	"${download_only}" && return
@@ -147,7 +160,7 @@ build_nasm() {
 		local dir_name="nasm-${NASM_VERSION}"
 		local archive_name="${dir_name}-macosx.zip"
 
-		download nasm "${archive_name}" \
+		download_extract nasm "${archive_name}" \
 			"https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/macosx/${archive_name}"
 
 		"${download_only}" && return
@@ -167,7 +180,7 @@ build_zlib() {
 	local dir_name="zlib-${ZLIB_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download zlib "${archive_name}" \
+	download_extract zlib "${archive_name}" \
 		"https://zlib.net/fossils/${archive_name}" \
 		"https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/${archive_name}"
 
@@ -193,7 +206,7 @@ build_gmp() {
 	local dir_name="gmp-${GMP_VERSION}"
 	local archive_name="${dir_name}.tar.bz2"
 
-	download gmp "${archive_name}" \
+	download_extract gmp "${archive_name}" \
 		"https://gmplib.org/download/gmp/${archive_name}" \
 		"https://ftpmirror.gnu.org/gnu/gmp/${archive_name}" \
 		"https://ftp.gnu.org/gnu/gmp/${archive_name}"
@@ -238,7 +251,7 @@ build_nettle() {
 	local dir_name="nettle-${NETTLE_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download nettle "${archive_name}" \
+	download_extract nettle "${archive_name}" \
 		"https://ftpmirror.gnu.org/gnu/nettle/${archive_name}" \
 		"https://ftp.gnu.org/gnu/nettle/${archive_name}"
 
@@ -256,7 +269,7 @@ build_curl() {
 	local dir_name="curl-${CURL_VERSION}"
 	local archive_name="${dir_name}.tar.xz"
 
-	download curl "${archive_name}" \
+	download_extract curl "${archive_name}" \
 		"https://curl.se/download/${archive_name}" \
 		"https://github.com/curl/curl/releases/download/curl-${CURL_VERSION//./_}/${archive_name}"
 
@@ -288,7 +301,7 @@ build_sdl2() {
 		;;
 	esac
 
-	download sdl2 "${archive_name}" \
+	download_extract sdl2 "${archive_name}" \
 		"https://www.libsdl.org/release/${archive_name}" \
 		"https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/${archive_name}"
 
@@ -346,7 +359,7 @@ build_glew() {
 	local dir_name="glew-${GLEW_VERSION}"
 	local archive_name="${dir_name}.tgz"
 
-	download glew "${archive_name}" \
+	download_extract glew "${archive_name}" \
 		"https://github.com/nigels-com/glew/releases/download/glew-${GLEW_VERSION}/${archive_name}" \
 		"https://downloads.sourceforge.net/project/glew/glew/${GLEW_VERSION}/${archive_name}"
 
@@ -381,7 +394,7 @@ build_png() {
 	local dir_name="libpng-${PNG_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download png "${archive_name}" \
+	download_extract png "${archive_name}" \
 		"https://download.sourceforge.net/libpng/${archive_name}"
 
 	"${download_only}" && return
@@ -398,7 +411,7 @@ build_jpeg() {
 	local dir_name="libjpeg-turbo-${JPEG_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download jpeg "${archive_name}" \
+	download_extract jpeg "${archive_name}" \
 		"https://downloads.sourceforge.net/project/libjpeg-turbo/${JPEG_VERSION}/${archive_name}"
 
 	"${download_only}" && return
@@ -469,7 +482,7 @@ build_webp() {
 	local dir_name="libwebp-${WEBP_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download webp "${archive_name}" \
+	download_extract webp "${archive_name}" \
 		"https://storage.googleapis.com/downloads.webmproject.org/releases/webp/${archive_name}"
 
 	"${download_only}" && return
@@ -486,7 +499,7 @@ build_freetype() {
 	local dir_name="freetype-${FREETYPE_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download freetype "${archive_name}" \
+	download_extract freetype "${archive_name}" \
 		"https://download.savannah.gnu.org/releases/freetype/${archive_name}"
 
 	"${download_only}" && return
@@ -519,7 +532,7 @@ build_openal() {
 		;;
 	esac
 
-	download openal "${archive_name}" \
+	download_extract openal "${archive_name}" \
 		"https://openal-soft.org/openal-releases/${archive_name}" \
 		"https://github.com/kcat/openal-soft/releases/download/${OPENAL_VERSION}/${archive_name}" \
 
@@ -561,7 +574,7 @@ build_ogg() {
 	local dir_name="libogg-${OGG_VERSION}"
 	local archive_name="libogg-${OGG_VERSION}.tar.gz"
 
-	download ogg "${archive_name}" \
+	download_extract ogg "${archive_name}" \
 		"https://downloads.xiph.org/releases/ogg/${archive_name}"
 
 	"${download_only}" && return
@@ -581,7 +594,7 @@ build_vorbis() {
 	local dir_name="libvorbis-${VORBIS_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download vorbis "${archive_name}" \
+	download_extract vorbis "${archive_name}" \
 		"https://downloads.xiph.org/releases/vorbis/${archive_name}"
 
 	"${download_only}" && return
@@ -598,7 +611,7 @@ build_opus() {
 	local dir_name="opus-${OPUS_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download opus "${archive_name}" \
+	download_extract opus "${archive_name}" \
 		"https://downloads.xiph.org/releases/opus/${archive_name}"
 
 	"${download_only}" && return
@@ -623,7 +636,7 @@ build_opusfile() {
 	local dir_name="opusfile-${OPUSFILE_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download opusfile "${archive_name}" \
+	download_extract opusfile "${archive_name}" \
 		"https://downloads.xiph.org/releases/opus/${archive_name}"
 
 	"${download_only}" && return
@@ -640,7 +653,7 @@ build_lua() {
 	local dir_name="lua-${LUA_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download lua "${archive_name}" \
+	download_extract lua "${archive_name}" \
 		"https://www.lua.org/ftp/${archive_name}"
 
 	"${download_only}" && return
@@ -680,7 +693,7 @@ build_ncurses() {
 	local dir_name="ncurses-${NCURSES_VERSION}"
 	local archive_name="${dir_name}.tar.gz"
 
-	download ncurses "${archive_name}" \
+	download_extract ncurses "${archive_name}" \
 		"https://ftpmirror.gnu.org/gnu/ncurses/${archive_name}" \
 		"https://ftp.gnu.org/pub/gnu/ncurses/${archive_name}"
 
@@ -719,7 +732,7 @@ build_wasisdk() {
 	local archive_name="${dir_name}-${WASISDK_PLATFORM}.tar.gz"
 	local WASISDK_VERSION_MAJOR="$(echo "${WASISDK_VERSION}" | cut -f1 -d'.')"
 
-	download wasisdk "${archive_name}" \
+	download_extract wasisdk "${archive_name}" \
 		"https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASISDK_VERSION_MAJOR}/${archive_name}"
 
 	"${download_only}" && return
@@ -758,7 +771,7 @@ build_wasmtime() {
 	local dir_name="wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-${WASMTIME_PLATFORM}-c-api"
 	local archive_name="${folder_name}.${ARCHIVE_EXT}"
 
-	download wasmtime "${archive_name}" \
+	download_extract wasmtime "${archive_name}" \
 		"https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/${archive_name}"
 
 	"${download_only}" && return
@@ -804,7 +817,7 @@ build_naclsdk() {
 
 	local archive_name="naclsdk_${NACLSDK_PLATFORM}-${NACLSDK_VERSION}.${TAR_EXT}.bz2"
 
-	download naclsdk "${archive_name}" \
+	download_extract naclsdk "${archive_name}" \
 		"https://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/${NACLSDK_VERSION}/naclsdk_${NACLSDK_PLATFORM}.tar.bz2"
 
 	"${download_only}" && return
@@ -865,7 +878,7 @@ build_naclsdk() {
 build_naclports() {
 	local archive_name="naclports-${NACLSDK_VERSION}.tar.bz2"
 
-	download naclports "${archive_name}" \
+	download_extract naclports "${archive_name}" \
 		"https://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/${NACLSDK_VERSION}/naclports.tar.bz2"
 
 	"${download_only}" && return
@@ -1174,6 +1187,7 @@ errorHelp() {
 
 	Options:
 	\t--download-only — only download source packages, do not build them
+	\t--prefer-ours — attempt to download from unvanquished.net first
 
 	Platforms:
 	\t${all_platforms}
@@ -1221,9 +1235,14 @@ errorHelp() {
 }
 
 download_only='false'
+prefer_ours='false'
 case "${1-}" in
 '--download-only')
 	download_only='true'
+	shift
+;;
+'--prefer-ours')
+	prefer_ours='true'
 	shift
 ;;
 esac

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -1236,16 +1236,24 @@ errorHelp() {
 
 download_only='false'
 prefer_ours='false'
-case "${1-}" in
-'--download-only')
-	download_only='true'
-	shift
-;;
-'--prefer-ours')
-	prefer_ours='true'
-	shift
-;;
-esac
+while [ -n "${1:-}" ]
+do
+	case "${1-}" in
+	'--download-only')
+		download_only='true'
+		shift
+	;;
+	'--prefer-ours')
+		prefer_ours='true'
+		shift
+	;;
+	'--'*)
+		helpError
+	;;
+	*)
+		break
+	esac
+done
 
 # Usage
 if [ "${#}" -lt "2" ]; then

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -1177,7 +1177,7 @@ all_linux_armhf_default_packages="${all_linux_arm64_default_packages}"
 
 linux_build_platforms='linux-amd64-default linux-arm64-default linux-armhf-default linux-i686-default windows-amd64-mingw windows-amd64-msvc windows-i686-mingw windows-i686-msvc'
 macos_build_platforms='macos-amd64-default'
-all_platforms="$(echo ${linux_build_platforms} ${macos_build_platforms} | tr ' ' '\n' | sort -u)"
+all_platforms="$(echo ${linux_build_platforms} ${macos_build_platforms} | tr ' ' '\n' | sort -u | xargs echo)"
 
 errorHelp() {
 	sed -e 's/\\t/'$'\t''/g' <<-EOF
@@ -1192,14 +1192,17 @@ errorHelp() {
 	Platforms:
 	\t${all_platforms}
 
+	Virtual platforms:
+	\tall: all platforms
+	\tbuild-linux — platforms buildable on linux: ${linux_build_platforms}
+	\tbuild-macos — platforms buildable on macos: ${macos_build_platforms}
+
 	Packages:
 	\tpkgconfig nasm zlib gmp nettle curl sdl2 glew png jpeg webp freetype openal ogg vorbis opus opusfile lua naclsdk naclports wasisdk wasmtime
 
 	Virtual packages:
 	\tbase — build packages for pre-built binaries to be downloaded when building the game
 	\tall — build all supported packages that can possibly be involved in building the game
-	\tbuild-linux — build all packages buildable on linux: ${linux_build_platforms}
-	\tbuild-macos — build all packages buildable on macos: ${macos_build_platforms}
 	\tinstall — create a stripped down version of the built packages that CMake can use
 	\tpackage — create a zip/tarball of the dependencies so they can be distributed
 	\twipe — remove products of build process, excepting download cache but INCLUDING installed files. Must be last

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -1180,7 +1180,7 @@ macos_build_platforms='macos-amd64-default'
 all_platforms="$(echo ${linux_build_platforms} ${macos_build_platforms} | tr ' ' '\n' | sort -u)"
 
 errorHelp() {
-	sed -e 's/\\t/\t/g' <<-EOF
+	sed -e 's/\\t/'$'\t''/g' <<-EOF
 	usage: $(basename "${BASH_SOURCE[0]}") [OPTION] <PLATFORM> <PACKAGE[S]...>
 
 	Script to build dependencies for platforms which do not provide them

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -1294,7 +1294,7 @@ case "${platform}" in
 esac
 
 for PLATFORM in ${platform_list}
-do
+do (
 	"setup_${PLATFORM}"
 
 	# Build packages
@@ -1302,4 +1302,4 @@ do
 		cd "${WORK_DIR}"
 		"build_${pkg}"
 	done
-done
+) done

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -1142,7 +1142,7 @@ base_windows_i686_msvc_packages="${base_windows_amd64_msvc_packages}"
 all_windows_i686_msvc_packages="${base_windows_amd64_msvc_packages}"
 
 base_windows_amd64_mingw_packages='zlib gmp nettle curl sdl2 glew png jpeg webp freetype openal ogg vorbis opus opusfile lua naclsdk naclports'
-all_mingw_packages="${base_windows_amd64_mingw_packages}"
+all_windows_amd64_mingw_packages="${base_windows_amd64_mingw_packages}"
 
 base_windows_i686_mingw_packages="${base_windows_amd64_mingw_packages}"
 all_windows_i686_mingw_packages="${base_windows_amd64_mingw_packages}"

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -111,7 +111,7 @@ download() {
 		fi
 		local download_url="${1}"; shift
 		log status "Downloading ${download_url}"
-		if ! "${CURL}" -L --fail -o "${tarball_file}" "${download_url}"
+		if ! "${CURL}" -R -L --fail -o "${tarball_file}" "${download_url}"
 		then
 			log warning "Failed to download ${download_url}"
 			rm -f "${tarball_file}"

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -392,7 +392,7 @@ build_glew() {
 # Build PNG
 build_png() {
 	local dir_name="libpng-${PNG_VERSION}"
-	local archive_name="${dir_name}.tar.gz"
+	local archive_name="${dir_name}.tar.xz"
 
 	download_extract png "${archive_name}" \
 		"https://download.sourceforge.net/libpng/${archive_name}"
@@ -497,7 +497,7 @@ build_webp() {
 # Build FreeType
 build_freetype() {
 	local dir_name="freetype-${FREETYPE_VERSION}"
-	local archive_name="${dir_name}.tar.gz"
+	local archive_name="${dir_name}.tar.xz"
 
 	download_extract freetype "${archive_name}" \
 		"https://download.savannah.gnu.org/releases/freetype/${archive_name}"
@@ -572,7 +572,7 @@ build_openal() {
 # Build Ogg
 build_ogg() {
 	local dir_name="libogg-${OGG_VERSION}"
-	local archive_name="libogg-${OGG_VERSION}.tar.gz"
+	local archive_name="libogg-${OGG_VERSION}.tar.xz"
 
 	download_extract ogg "${archive_name}" \
 		"https://downloads.xiph.org/releases/ogg/${archive_name}"
@@ -592,7 +592,7 @@ build_ogg() {
 # Build Vorbis
 build_vorbis() {
 	local dir_name="libvorbis-${VORBIS_VERSION}"
-	local archive_name="${dir_name}.tar.gz"
+	local archive_name="${dir_name}.tar.xz"
 
 	download_extract vorbis "${archive_name}" \
 		"https://downloads.xiph.org/releases/vorbis/${archive_name}"

--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -117,6 +117,9 @@ download() {
 			rm -f "${tarball_file}"
 		fi
 	done
+
+	"${download_only}" && return
+
 	extract "${tarball_file}" "${extract_dir}"
 }
 
@@ -127,6 +130,8 @@ build_pkgconfig() {
 
 	download pkgconfig "${archive_name}" \
 		"http://pkgconfig.freedesktop.org/releases/${archive_name}"
+
+	"${download_only}" && return
 
 	cd "${dir_name}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
@@ -144,6 +149,8 @@ build_nasm() {
 
 		download nasm "${archive_name}" \
 			"https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/macosx/${archive_name}"
+
+		"${download_only}" && return
 
 		cp "${dir_name}/nasm" "${PREFIX}/bin"
 		;;
@@ -163,6 +170,8 @@ build_zlib() {
 	download zlib "${archive_name}" \
 		"https://zlib.net/fossils/${archive_name}" \
 		"https://github.com/madler/zlib/releases/download/v${ZLIB_VERSION}/${archive_name}"
+
+	"${download_only}" && return
 
 	cd "${dir_name}"
 	case "${PLATFORM}" in
@@ -188,6 +197,8 @@ build_gmp() {
 		"https://gmplib.org/download/gmp/${archive_name}" \
 		"https://ftpmirror.gnu.org/gnu/gmp/${archive_name}" \
 		"https://ftp.gnu.org/gnu/gmp/${archive_name}"
+
+	"${download_only}" && return
 
 	cd "${dir_name}"
 	case "${PLATFORM}" in
@@ -231,6 +242,8 @@ build_nettle() {
 		"https://ftpmirror.gnu.org/gnu/nettle/${archive_name}" \
 		"https://ftp.gnu.org/gnu/nettle/${archive_name}"
 
+	"${download_only}" && return
+
 	cd "${dir_name}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
 	CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --libdir="${PREFIX}/lib" "${CONFIGURE_SHARED[@]}"
@@ -246,6 +259,8 @@ build_curl() {
 	download curl "${archive_name}" \
 		"https://curl.se/download/${archive_name}" \
 		"https://github.com/curl/curl/releases/download/curl-${CURL_VERSION//./_}/${archive_name}"
+
+	"${download_only}" && return
 
 	cd "${dir_name}"
 	# The user-provided CFLAGS doesn't drop the default -O2
@@ -276,6 +291,8 @@ build_sdl2() {
 	download sdl2 "${archive_name}" \
 		"https://www.libsdl.org/release/${archive_name}" \
 		"https://github.com/libsdl-org/SDL/releases/download/release-${SDL2_VERSION}/${archive_name}"
+
+	"${download_only}" && return
 
 	case "${PLATFORM}" in
 	windows-*-mingw)
@@ -333,6 +350,8 @@ build_glew() {
 		"https://github.com/nigels-com/glew/releases/download/glew-${GLEW_VERSION}/${archive_name}" \
 		"https://downloads.sourceforge.net/project/glew/glew/${GLEW_VERSION}/${archive_name}"
 
+	"${download_only}" && return
+
 	cd "${dir_name}"
 	case "${PLATFORM}" in
 	windows-*-*)
@@ -365,6 +384,8 @@ build_png() {
 	download png "${archive_name}" \
 		"https://download.sourceforge.net/libpng/${archive_name}"
 
+	"${download_only}" && return
+
 	cd "${dir_name}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
 	CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --libdir="${PREFIX}/lib" "${CONFIGURE_SHARED[@]}"
@@ -379,6 +400,8 @@ build_jpeg() {
 
 	download jpeg "${archive_name}" \
 		"https://downloads.sourceforge.net/project/libjpeg-turbo/${JPEG_VERSION}/${archive_name}"
+
+	"${download_only}" && return
 
 	case "${PLATFORM}" in
 	windows-*-*)
@@ -449,6 +472,8 @@ build_webp() {
 	download webp "${archive_name}" \
 		"https://storage.googleapis.com/downloads.webmproject.org/releases/webp/${archive_name}"
 
+	"${download_only}" && return
+
 	cd "${dir_name}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
 	CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --libdir="${PREFIX}/lib" --disable-libwebpdemux "${CONFIGURE_SHARED[@]}"
@@ -463,6 +488,8 @@ build_freetype() {
 
 	download freetype "${archive_name}" \
 		"https://download.savannah.gnu.org/releases/freetype/${archive_name}"
+
+	"${download_only}" && return
 
 	cd "${dir_name}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
@@ -495,6 +522,8 @@ build_openal() {
 	download openal "${archive_name}" \
 		"https://openal-soft.org/openal-releases/${archive_name}" \
 		"https://github.com/kcat/openal-soft/releases/download/${OPENAL_VERSION}/${archive_name}" \
+
+	"${download_only}" && return
 
 	case "${PLATFORM}" in
 	windows-*-*)
@@ -535,6 +564,8 @@ build_ogg() {
 	download ogg "${archive_name}" \
 		"https://downloads.xiph.org/releases/ogg/${archive_name}"
 
+	"${download_only}" && return
+
 	cd "${dir_name}"
 	# This header breaks the vorbis and opusfile Mac builds
 	cat <(echo '#include <stdint.h>') include/ogg/os_types.h > os_types.tmp
@@ -553,6 +584,8 @@ build_vorbis() {
 	download vorbis "${archive_name}" \
 		"https://downloads.xiph.org/releases/vorbis/${archive_name}"
 
+	"${download_only}" && return
+
 	cd "${dir_name}"
 	# The user-provided CFLAGS doesn't drop the default -O3
 	./configure --host="${HOST}" --prefix="${PREFIX}" --libdir="${PREFIX}/lib" "${CONFIGURE_SHARED[@]}" --disable-examples
@@ -567,6 +600,8 @@ build_opus() {
 
 	download opus "${archive_name}" \
 		"https://downloads.xiph.org/releases/opus/${archive_name}"
+
+	"${download_only}" && return
 
 	cd "${dir_name}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
@@ -591,6 +626,8 @@ build_opusfile() {
 	download opusfile "${archive_name}" \
 		"https://downloads.xiph.org/releases/opus/${archive_name}"
 
+	"${download_only}" && return
+
 	cd "${dir_name}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
 	CFLAGS="${CFLAGS} -O2" ./configure --host="${HOST}" --prefix="${PREFIX}" --libdir="${PREFIX}/lib" "${CONFIGURE_SHARED[@]}" --disable-http
@@ -605,6 +642,8 @@ build_lua() {
 
 	download lua "${archive_name}" \
 		"https://www.lua.org/ftp/${archive_name}"
+
+	"${download_only}" && return
 
 	cd "${dir_name}"
 	case "${PLATFORM}" in
@@ -645,6 +684,8 @@ build_ncurses() {
 		"https://ftpmirror.gnu.org/gnu/ncurses/${archive_name}" \
 		"https://ftp.gnu.org/pub/gnu/ncurses/${archive_name}"
 
+	"${download_only}" && return
+
 	cd "${dir_name}"
 	# The default -O2 is dropped when there's user-provided CFLAGS.
 	# Configure terminfo search dirs based on the ones used in Debian. By default it will only look in (only) the install directory.
@@ -680,6 +721,8 @@ build_wasisdk() {
 
 	download wasisdk "${archive_name}" \
 		"https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASISDK_VERSION_MAJOR}/${archive_name}"
+
+	"${download_only}" && return
 
 	cp -r "${dir_name}" "${PREFIX}/wasi-sdk"
 }
@@ -717,6 +760,8 @@ build_wasmtime() {
 
 	download wasmtime "${archive_name}" \
 		"https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/${archive_name}"
+
+	"${download_only}" && return
 
 	cd "${dir_name}"
 	cp -r include/* "${PREFIX}/include"
@@ -761,6 +806,8 @@ build_naclsdk() {
 
 	download naclsdk "${archive_name}" \
 		"https://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/${NACLSDK_VERSION}/naclsdk_${NACLSDK_PLATFORM}.tar.bz2"
+
+	"${download_only}" && return
 
 	cp pepper_*"/tools/sel_ldr_${NACLSDK_ARCH}${EXE}" "${PREFIX}/nacl_loader${EXE}"
 	cp pepper_*"/tools/irt_core_${NACLSDK_ARCH}.nexe" "${PREFIX}/irt_core-${DAEMON_ARCH}.nexe"
@@ -821,6 +868,8 @@ build_naclports() {
 	download naclports "${archive_name}" \
 		"https://storage.googleapis.com/nativeclient-mirror/nacl/nacl_sdk/${NACLSDK_VERSION}/naclports.tar.bz2"
 
+	"${download_only}" && return
+
 	mkdir -p "${PREFIX}/pnacl_deps/"{include,lib}
 	cp pepper_*"/ports/include/"{lauxlib.h,lua.h,lua.hpp,luaconf.h,lualib.h} "${PREFIX}/pnacl_deps/include"
 	cp -a pepper_*"/ports/include/freetype2" "${PREFIX}/pnacl_deps/include"
@@ -830,6 +879,8 @@ build_naclports() {
 # The import libraries generated by MinGW seem to have issues, so we use LLVM's version instead.
 # So LLVM must be installed, e.g. 'sudo apt install llvm'
 build_genlib() {
+	"${download_only}" && return
+
 	case "${PLATFORM}" in
 	windows-*-msvc)
 		mkdir -p "${PREFIX}/def"
@@ -1111,12 +1162,23 @@ all_linux_arm64_default_packages='zlib gmp nettle curl sdl2 glew png jpeg webp f
 base_linux_armhf_default_packages="${base_linux_arm64_default_packages}"
 all_linux_armhf_default_packages="${all_linux_arm64_default_packages}"
 
+download_only='false'
+case "${1-}" in
+'--download-only')
+	download_only='true'
+	shift
+;;
+esac
+
 # Usage
 if [ "${#}" -lt "2" ]; then
 	sed -e 's/\\t/\t/g' <<-EOF
-	usage: $(basename "${BASH_SOURCE[0]}") <platform> <package[s]...>
+	usage: $(basename "${BASH_SOURCE[0]}") [OPTION] <PLATFORM> <PACKAGE[S]...>
 
 	Script to build dependencies for platforms which do not provide them
+
+	Options:
+	\t--download-only — only download source packages, do not build them
 
 	Platforms:
 	\twindows-i686-msvc windows-amd64-msvc windows-i686-mingw windows-amd64-mingw macos-amd64-default linux-amd64-default linux-i686-default linux-arm64-default linux-armhf-default


### PR DESCRIPTION
Fixes Unvanquished/unvanquished-infrastructure#37:

- https://github.com/Unvanquished/unvanquished-infrastructure/issues/37

Also brings other improvements and fixes.

This implements:

-   external_deps: tell curl to set the remote timestamp of the downloaded archive

-   external_deps: add --download-only option

-   external_deps: fix all windows-amd64-mingw package list

-   external_deps: add meta platforms like 'all'
    
    This make possible to do:
    
    ./build.sh --download-only all all
    
    or:
    
    ./build.sh build-linux base

-   external_deps: add our own mirror and add --prefer-ours option (disabled by default)

-   external_deps: make options cumulative

-   external_deps: fix help printing on macOS

-   external_deps: prefer xz archives when available