### PR TITLE
NUKE wrapAroundLighting

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -579,9 +579,6 @@ static std::string GenEngineConstants() {
 		AddConst( str, "MAX_GLSL_BONES", 4 );
 	}
 
-	if ( r_wrapAroundLighting->value )
-		AddConst( str, "r_wrapAroundLighting", r_wrapAroundLighting->value );
-
 	if ( r_halfLambertLighting->integer )
 		AddDefine( str, "r_halfLambertLighting", 1 );
 
@@ -1570,7 +1567,6 @@ GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 	u_ReliefOffsetBias( this ),
 	u_NormalScale( this ),
 	u_EnvironmentInterpolation( this ),
-	u_LightWrapAround( this ),
 	u_LightGridOrigin( this ),
 	u_LightGridScale( this ),
 	u_numLights( this ),
@@ -1631,7 +1627,6 @@ GLShader_forwardLighting_omniXYZ::GLShader_forwardLighting_omniXYZ( GLShaderMana
 	u_LightColor( this ),
 	u_LightRadius( this ),
 	u_LightScale( this ),
-	u_LightWrapAround( this ),
 	u_LightAttenuationMatrix( this ),
 	u_ShadowTexelSize( this ),
 	u_ShadowBlur( this ),
@@ -1690,7 +1685,6 @@ GLShader_forwardLighting_projXYZ::GLShader_forwardLighting_projXYZ( GLShaderMana
 	u_LightColor( this ),
 	u_LightRadius( this ),
 	u_LightScale( this ),
-	u_LightWrapAround( this ),
 	u_LightAttenuationMatrix( this ),
 	u_ShadowTexelSize( this ),
 	u_ShadowBlur( this ),
@@ -1751,7 +1745,6 @@ GLShader_forwardLighting_directionalSun::GLShader_forwardLighting_directionalSun
 	u_LightColor( this ),
 	u_LightRadius( this ),
 	u_LightScale( this ),
-	u_LightWrapAround( this ),
 	u_LightAttenuationMatrix( this ),
 	u_ShadowTexelSize( this ),
 	u_ShadowBlur( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1448,21 +1448,6 @@ public:
 	}
 };
 
-class u_LightWrapAround :
-	GLUniform1f
-{
-public:
-	u_LightWrapAround( GLShader *shader ) :
-		GLUniform1f( shader, "u_LightWrapAround" )
-	{
-	}
-
-	void SetUniform_LightWrapAround( float value )
-	{
-		this->SetValue( value );
-	}
-};
-
 class u_LightAttenuationMatrix :
 	GLUniformMatrix4f
 {
@@ -2262,7 +2247,6 @@ class GLShader_lightMapping :
 	public u_ReliefOffsetBias,
 	public u_NormalScale,
 	public u_EnvironmentInterpolation,
-	public u_LightWrapAround,
 	public u_LightGridOrigin,
 	public u_LightGridScale,
 	public u_numLights,
@@ -2298,7 +2282,6 @@ class GLShader_forwardLighting_omniXYZ :
 	public u_LightColor,
 	public u_LightRadius,
 	public u_LightScale,
-	public u_LightWrapAround,
 	public u_LightAttenuationMatrix,
 	public u_ShadowTexelSize,
 	public u_ShadowBlur,
@@ -2336,7 +2319,6 @@ class GLShader_forwardLighting_projXYZ :
 	public u_LightColor,
 	public u_LightRadius,
 	public u_LightScale,
-	public u_LightWrapAround,
 	public u_LightAttenuationMatrix,
 	public u_ShadowTexelSize,
 	public u_ShadowBlur,
@@ -2375,7 +2357,6 @@ class GLShader_forwardLighting_directionalSun :
 	public u_LightColor,
 	public u_LightRadius,
 	public u_LightScale,
-	public u_LightWrapAround,
 	public u_LightAttenuationMatrix,
 	public u_ShadowTexelSize,
 	public u_ShadowBlur,

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -73,15 +73,13 @@ void computeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightColor,
 #endif // USE_PHYSICAL_MAPPING || r_specularMapping
 
   // clamp( NdotL, 0.0, 1.0 ) is done below
-  // if no r_halfLambertLighting and no r_wrapAroundLighting.
+  // if no r_halfLambertLighting
   float NdotL = dot( normal, lightDir );
 
 #if defined(r_halfLambertLighting)
   // http://developer.valvesoftware.com/wiki/Half_Lambert
   NdotL = NdotL * 0.5 + 0.5;
   NdotL *= NdotL;
-#elif defined(r_wrapAroundLighting)
-  NdotL = clamp( NdotL + r_wrapAroundLighting, 0.0, 1.0) / clamp(1.0 + r_wrapAroundLighting, 0.0, 1.0);
 #else
   NdotL = clamp( NdotL, 0.0, 1.0 );
 #endif

--- a/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
@@ -67,7 +67,6 @@ uniform vec3		u_LightOrigin;
 uniform vec3		u_LightColor;
 uniform float		u_LightRadius;
 uniform float       u_LightScale;
-uniform	float		u_LightWrapAround;
 uniform float		u_AlphaThreshold;
 
 uniform mat4		u_ShadowMatrix[MAX_SHADOWMAPS];
@@ -960,11 +959,7 @@ void	main()
 	vec3 normal = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
 
 	// compute the light term
-#if defined(r_wrapAroundLighting)
-	float NL = clamp(dot(normal, lightDir) + u_LightWrapAround, 0.0, 1.0) / clamp(1.0 + u_LightWrapAround, 0.0, 1.0);
-#else
 	float NL = clamp(dot(normal, lightDir), 0.0, 1.0);
-#endif
 
 	// compute the diffuse term
 	vec4 diffuse = texture2D(u_DiffuseMap, texCoords);

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -171,7 +171,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_glowMapping;
 	cvar_t      *r_reflectionMapping;
 
-	cvar_t      *r_wrapAroundLighting;
 	cvar_t      *r_halfLambertLighting;
 	cvar_t      *r_rimLighting;
 	cvar_t      *r_rimExponent;
@@ -1233,7 +1232,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_glowMapping = Cvar_Get( "r_glowMapping", "1", CVAR_LATCH );
 		r_reflectionMapping = Cvar_Get( "r_reflectionMapping", "0", CVAR_LATCH | CVAR_ARCHIVE );
 
-		r_wrapAroundLighting = Cvar_Get( "r_wrapAroundLighting", "0.7", CVAR_CHEAT | CVAR_LATCH );
 		r_halfLambertLighting = Cvar_Get( "r_halfLambertLighting", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_rimLighting = Cvar_Get( "r_rimLighting", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_rimExponent = Cvar_Get( "r_rimExponent", "3", CVAR_CHEAT | CVAR_LATCH );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1285,8 +1285,6 @@ static inline void glFboSetExt()
 
 		expression_t    deformMagnitudeExp;
 
-		expression_t    wrapAroundLightingExp;
-
 		bool        noFog; // used only for shaders that have fog disabled, so we can enable it for individual stages
 	};
 
@@ -3003,7 +3001,6 @@ static inline void glFboSetExt()
 	extern cvar_t *r_glowMapping;
 	extern cvar_t *r_reflectionMapping;
 
-	extern cvar_t *r_wrapAroundLighting;
 	extern cvar_t *r_halfLambertLighting;
 	extern cvar_t *r_rimLighting;
 	extern cvar_t *r_rimExponent;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1075,11 +1075,6 @@ static void Render_lightMapping( shaderStage_t *pStage )
 
 	gl_lightMappingShader->SetUniform_Color( color );
 
-	if ( tess.bspSurface && !enableLightMapping )
-	{
-		gl_lightMappingShader->SetUniform_LightWrapAround( RB_EvalExpression( &pStage->wrapAroundLightingExp, 0 ) );
-	}
-
 	// u_AlphaTest
 	gl_lightMappingShader->SetUniform_AlphaTest( pStage->stateBits );
 
@@ -1507,7 +1502,6 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *pStage,
 	gl_forwardLightingShader_omniXYZ->SetUniform_LightColor( lightColor.ToArray() );
 	gl_forwardLightingShader_omniXYZ->SetUniform_LightRadius( light->sphereRadius );
 	gl_forwardLightingShader_omniXYZ->SetUniform_LightScale( light->l.scale );
-	gl_forwardLightingShader_omniXYZ->SetUniform_LightWrapAround( RB_EvalExpression( &pStage->wrapAroundLightingExp, 0 ) );
 	gl_forwardLightingShader_omniXYZ->SetUniform_LightAttenuationMatrix( light->attenuationMatrix2 );
 
 	GL_CheckErrors();
@@ -1692,7 +1686,6 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *pStage,
 	gl_forwardLightingShader_projXYZ->SetUniform_LightColor( lightColor.ToArray() );
 	gl_forwardLightingShader_projXYZ->SetUniform_LightRadius( light->sphereRadius );
 	gl_forwardLightingShader_projXYZ->SetUniform_LightScale( light->l.scale );
-	gl_forwardLightingShader_projXYZ->SetUniform_LightWrapAround( RB_EvalExpression( &pStage->wrapAroundLightingExp, 0 ) );
 	gl_forwardLightingShader_projXYZ->SetUniform_LightAttenuationMatrix( light->attenuationMatrix2 );
 
 	GL_CheckErrors();
@@ -1878,7 +1871,6 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *pStage, trRef
 	gl_forwardLightingShader_directionalSun->SetUniform_LightColor( lightColor.ToArray() );
 	gl_forwardLightingShader_directionalSun->SetUniform_LightRadius( light->sphereRadius );
 	gl_forwardLightingShader_directionalSun->SetUniform_LightScale( light->l.scale );
-	gl_forwardLightingShader_directionalSun->SetUniform_LightWrapAround( RB_EvalExpression( &pStage->wrapAroundLightingExp, 0 ) );
 	gl_forwardLightingShader_directionalSun->SetUniform_LightAttenuationMatrix( light->attenuationMatrix2 );
 
 	GL_CheckErrors();

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -3205,11 +3205,6 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 		{
 			ParseExpression( text, &stage->deformMagnitudeExp );
 		}
-		// wrapAroundLighting <arithmetic expression>
-		else if ( !Q_stricmp( token, "wrapAroundLighting" ) )
-		{
-			ParseExpression( text, &stage->wrapAroundLightingExp );
-		}
 		else
 		{
 			Log::Warn("unknown shader stage parameter '%s' in shader '%s'", token, shader.name );


### PR DESCRIPTION
Robert Beckebans, original XreaL author, said:

> Hi Thomas,
> The wrap around lighting term was something that was discussed in a very old game presentation where the devs provided some cheap outdoor lighting.
> I just experimented with it a bit but you can remove it. I would never use it again in such a way and yeah the code is wrong :)