### PR TITLE
Add FPS counter to curses window and /showfps command

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -61,6 +61,7 @@ set(COMMONLIST
     ${COMMON_DIR}/String.h
     ${COMMON_DIR}/System.cpp
     ${COMMON_DIR}/System.h
+    ${COMMON_DIR}/Util.cpp
     ${COMMON_DIR}/Util.h
     ${COMMON_DIR}/cm/cm_load.cpp
     ${COMMON_DIR}/cm/cm_local.h
@@ -272,6 +273,7 @@ set(ENGINETESTLIST
     ${COMMON_DIR}/ColorTest.cpp
     ${COMMON_DIR}/StringTest.cpp
     ${COMMON_DIR}/cm/unittest.cpp
+    ${COMMON_DIR}/UtilTest.cpp
     ${ENGINE_DIR}/framework/CommandSystemTest.cpp
 )
 

--- a/src/common/Util.h
+++ b/src/common/Util.h
@@ -172,6 +172,14 @@ std::unique_ptr<T> make_unique(U&&... args)
 	return std::unique_ptr<T>(new T(std::forward<U>(args)...));
 }
 
+// Maintains an FPS counter using an exponential moving average algorithm.
+// More recently completed frames are given more weight in the counter. 50% of the weight is given
+// to the framerate during the last `halfLife` seconds. halfLife should be the same for every call
+// for a given counter.
+// frameMs is the duration in milliseconds of the latest completed frame. It is assumed that the
+// latest frame began at the same time the previous one ended.
+void UpdateFPSCounter(float halfLife, int frameMs, float& fps);
+
 } // namespace Util
 
 #endif // COMMON_UTIL_H_

--- a/src/common/UtilTest.cpp
+++ b/src/common/UtilTest.cpp
@@ -1,0 +1,40 @@
+#include <gtest/gtest.h>
+
+#include "Util.h"
+
+namespace Util {
+	namespace {
+		TEST(FPSCounterTest, FPS5000)
+		{
+			float counter = 0;
+			for (int i = 9999; i--; ) {
+				UpdateFPSCounter(1.0f, 0, counter);
+				UpdateFPSCounter(1.0f, 0, counter);
+				UpdateFPSCounter(1.0f, 0, counter);
+				UpdateFPSCounter(1.0f, 0, counter);
+				UpdateFPSCounter(1.0f, 1, counter);
+			}
+			EXPECT_NEAR(5000, counter, /*tolerance=*/10);
+		}
+
+		TEST(FPSCounterTest, FPS40)
+		{
+			float counter = 23;
+			for (int i = 99; i--; )
+			{
+				// 2 frames every 50 ms
+				UpdateFPSCounter(1.0f, 20, counter);
+				UpdateFPSCounter(1.0f, 30, counter);
+			}
+			EXPECT_NEAR(40, counter, /*tolerance=*/1);
+		}
+
+		TEST(FPSCounterTest, LongFrame)
+		{
+			float counter = 60;
+			UpdateFPSCounter(0.5f, 500, counter);
+			// 0.5 * 60 + 0.5 * 2
+			EXPECT_FLOAT_EQ(31, counter);
+		}
+	} // namespace
+} // namespace Util

--- a/src/engine/client/ClientApplication.cpp
+++ b/src/engine/client/ClientApplication.cpp
@@ -94,6 +94,7 @@ class ClientApplication : public Application {
 
         void Frame() override {
             Com_Frame();
+            ::Application::Application::Frame(); // call base class
         }
 
         void OnDrop(bool error, Str::StringRef reason) override {

--- a/src/engine/framework/Application.cpp
+++ b/src/engine/framework/Application.cpp
@@ -60,6 +60,17 @@ namespace Application {
         Log::Notice("Unknown command '%s'", args[0]);
     }
 
+    // Update FPS
+    void Application::Frame() {
+        int time = Sys::Milliseconds();
+        Util::UpdateFPSCounter(1.0f, time - lastFrame_, fps_);
+        lastFrame_ = time;
+    }
+
+    float Application::GetFPS() const {
+        return fps_;
+    }
+
     const Traits& Application::GetTraits() const {
         return traits;
     }
@@ -74,6 +85,10 @@ namespace Application {
 
     void Frame() {
         GetApp().Frame();
+    }
+
+    float GetFPS() {
+        return GetApp().GetFPS();
     }
 
     void OnDrop(bool error, Str::StringRef reason) {

--- a/src/engine/framework/Application.h
+++ b/src/engine/framework/Application.h
@@ -58,22 +58,29 @@ class Application {
 
         virtual void LoadInitialConfig(bool resetConfig);
         virtual void Initialize();
-        virtual void Frame() {}
+        virtual void Frame();
 
         virtual void OnDrop(bool error, Str::StringRef reason);
         virtual void Shutdown(bool error, Str::StringRef message);
 
         virtual void OnUnhandledCommand(const Cmd::Args& args);
 
+        float GetFPS() const;
+
         const Traits& GetTraits() const;
 
     protected:
         Traits traits;
+
+    private:
+        int lastFrame_;
+        float fps_;
 };
 
 void LoadInitialConfig(bool resetConfig);
 void Initialize();
 void Frame();
+float GetFPS();
 
 void OnDrop(bool error, Str::StringRef reason);
 void Shutdown(bool error, Str::StringRef message);

--- a/src/engine/framework/BaseCommands.cpp
+++ b/src/engine/framework/BaseCommands.cpp
@@ -33,6 +33,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <common/FileSystem.h>
 
+#include "Application.h"
 #include "CommandSystem.h"
 #include "CvarSystem.h"
 
@@ -1006,5 +1007,15 @@ namespace Cmd {
             }
     };
     static ListAliasesCmd ListAliasesCmdRegistration;
+
+    class ShowFPSCommand : public Cmd::StaticCmd {
+    public:
+        ShowFPSCommand() : StaticCmd("showfps", "print engine frame rate") {}
+
+        void Run(const Cmd::Args&) const override {
+            Print("FPS: %.1f", Application::GetFPS());
+        }
+    };
+    static ShowFPSCommand showFPSRegistration;
 
 }

--- a/src/engine/server/ServerApplication.cpp
+++ b/src/engine/server/ServerApplication.cpp
@@ -58,6 +58,7 @@ class ServerApplication : public Application {
 
         void Frame() override {
             Com_Frame();
+            ::Application::Application::Frame(); // call base class
         }
 
         void OnDrop(bool error, Str::StringRef reason) override {


### PR DESCRIPTION
Implement an exponential moving average algorithm for counting FPS and make it available for the engine in two ways: a `showfps` printing command, and a counter in the curses console. This can be useful to monitor for server performance issues.

I also have a branch to replace the cgame FPS counter with this algorithm (haven't uploaded it yet). It's better than the current algorithm because if you have a perfectly stable FPS, the FPS counter will also be stable (unless it's right at a half-integer I guess). With the current algorithm the FPS tends to flicker between various numbers even if the frame times are very consistent.