### PR TITLE
Fix portal blending with foreground translucent surfaces

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -446,6 +446,10 @@ void GL_State( uint32_t stateBits )
 				GL_DepthFunc( GL_LEQUAL );
 				break;
 
+			case GLS_DEPTHFUNC_ALWAYS:
+				GL_DepthFunc( GL_ALWAYS );
+				break;
+
 			case GLS_DEPTHFUNC_LESS:
 				GL_DepthFunc( GL_LESS );
 				break;
@@ -5600,14 +5604,11 @@ const RenderCommand *FinalisePortalCommand::ExecuteSelf( ) const
 
 	GL_LoadModelViewMatrix( backEnd.orientation.modelViewMatrix );
 
-	// set depth to max on portal area
-	glDepthRange( 1.0f, 1.0f );
-
 	glStencilFunc( GL_EQUAL, backEnd.viewParms.portalLevel + 1, 0xff );
 	glStencilOp( GL_KEEP, GL_KEEP, GL_DECR );
 
-	GL_State( GLS_DEPTHMASK_TRUE | GLS_DEPTHTEST_DISABLE | GLS_COLORMASK_BITS );
-	glState.glStateBitsMask = GLS_DEPTHMASK_TRUE | GLS_DEPTHTEST_DISABLE | GLS_COLORMASK_BITS;
+	GL_State( GLS_DEPTHMASK_TRUE | GLS_DEPTHFUNC_ALWAYS | GLS_COLORMASK_BITS );
+	glState.glStateBitsMask = GLS_DEPTHMASK_TRUE | GLS_DEPTHFUNC_ALWAYS | GLS_COLORMASK_BITS;
 
 	Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader,
 		    nullptr, false, false, -1, -1 );
@@ -5615,8 +5616,6 @@ const RenderCommand *FinalisePortalCommand::ExecuteSelf( ) const
 	Tess_End();
 
 	glState.glStateBitsMask = 0;
-
-	glDepthRange( 0.0f, 1.0f );
 
 	if( backEnd.viewParms.portalLevel == 0 ) {
 		glDisable( GL_STENCIL_TEST );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1453,18 +1453,20 @@ static inline void glFboSetExt()
 
 	  GLS_DEPTHFUNC_LESS = ( 1 << 20 ),
 	  GLS_DEPTHFUNC_EQUAL = ( 1 << 21 ),
+	  GLS_DEPTHFUNC_ALWAYS = ( 1 << 22 ),
 
 	  GLS_DEPTHFUNC_BITS = GLS_DEPTHFUNC_LESS
-	                       | GLS_DEPTHFUNC_EQUAL,
+	                       | GLS_DEPTHFUNC_EQUAL
+	                       | GLS_DEPTHFUNC_ALWAYS,
 
-	  GLS_ATEST_NONE   = ( 0 << 22 ),
-	  GLS_ATEST_GT_0   = ( 1 << 22 ),
-	  GLS_ATEST_LT_128 = ( 2 << 22 ),
-	  GLS_ATEST_GE_128 = ( 3 << 22 ),
-	  GLS_ATEST_LT_ENT = ( 4 << 22 ),
-	  GLS_ATEST_GT_ENT = ( 5 << 22 ),
+	  GLS_ATEST_NONE   = ( 0 << 23 ),
+	  GLS_ATEST_GT_0   = ( 1 << 23 ),
+	  GLS_ATEST_LT_128 = ( 2 << 23 ),
+	  GLS_ATEST_GE_128 = ( 3 << 23 ),
+	  GLS_ATEST_LT_ENT = ( 4 << 23 ),
+	  GLS_ATEST_GT_ENT = ( 5 << 23 ),
 
-	  GLS_ATEST_BITS   = ( 7 << 22 ),
+	  GLS_ATEST_BITS   = ( 7 << 23 ),
 
 	  GLS_REDMASK_FALSE = ( 1 << 26 ),
 	  GLS_GREENMASK_FALSE = ( 1 << 27 ),


### PR DESCRIPTION
Sets glDepthFunc to GL_ALWAYS when rendering the portal surface and enables depth test. Fixes #1012, https://github.com/Unvanquished/Unvanquished/issues/2476, and partially fixes #1010.

Introduces GLS_DEPTHFUNC_ALWAYS which sets glDepthFunc to GL_ALWAYS. Shifted some enums to avoid conflicts in GL_State().

Here are some comparison screenshots (before / after):
![unvanquished_2024-01-06_000553_000](https://github.com/DaemonEngine/Daemon/assets/10687142/d61a6f38-ad96-43aa-966b-938030b583d0)
![unvanquished_2024-01-06_001617_000](https://github.com/DaemonEngine/Daemon/assets/10687142/c07b6db4-3c69-4f64-985b-3a5cf2fb992f)
![unvanquished_2024-01-06_000717_000](https://github.com/DaemonEngine/Daemon/assets/10687142/e5453764-1166-443b-82b3-d00dcfbf32d0)
![unvanquished_2024-01-06_001713_000](https://github.com/DaemonEngine/Daemon/assets/10687142/d4a08e2c-cb6d-4460-b117-03af6e8c23e9)
![unvanquished_2024-01-06_000748_000](https://github.com/DaemonEngine/Daemon/assets/10687142/35868bc2-24cc-4ade-9bfe-45e581de812f)
![unvanquished_2024-01-06_001730_000](https://github.com/DaemonEngine/Daemon/assets/10687142/b3219836-da0e-4f66-9125-9e543fdf78ee)
![unvanquished_2024-01-06_001505_000](https://github.com/DaemonEngine/Daemon/assets/10687142/f554849f-ac9d-48bb-a22d-67214b41d170)
![unvanquished_2024-01-06_001818_000](https://github.com/DaemonEngine/Daemon/assets/10687142/adc5a63f-b7e4-488b-b412-dc03d948bb60)
