### PR TITLE
Fix portal blending with portal surfaces

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -5532,6 +5532,9 @@ const RenderCommand *PreparePortalCommand::ExecuteSelf( ) const
 
 	GL_LoadModelViewMatrix( backEnd.orientation.modelViewMatrix );
 
+	glClearStencil( 0 ); // Clear stencil buffer to avoid overwritting the color buffer when multiple portals are on the screen
+	glClear( GL_STENCIL_BUFFER_BIT ); // Might need to check if backEnd.viewParms.portalLevel == 0
+
 	if ( backEnd.viewParms.portalLevel == 0 ) {
 		glEnable( GL_STENCIL_TEST );
 		glStencilMask( 0xff );
@@ -5605,10 +5608,10 @@ const RenderCommand *FinalisePortalCommand::ExecuteSelf( ) const
 	GL_LoadModelViewMatrix( backEnd.orientation.modelViewMatrix );
 
 	glStencilFunc( GL_EQUAL, backEnd.viewParms.portalLevel + 1, 0xff );
-	glStencilOp( GL_KEEP, GL_KEEP, GL_DECR );
+	glStencilOp( GL_KEEP, GL_KEEP, GL_KEEP );
 
-	GL_State( GLS_DEPTHMASK_TRUE | GLS_DEPTHFUNC_ALWAYS | GLS_COLORMASK_BITS );
-	glState.glStateBitsMask = GLS_DEPTHMASK_TRUE | GLS_DEPTHFUNC_ALWAYS | GLS_COLORMASK_BITS;
+	GL_State( GLS_DEPTHMASK_TRUE | GLS_DEPTHFUNC_ALWAYS);
+	glState.glStateBitsMask = GLS_DEPTHMASK_TRUE | GLS_DEPTHFUNC_ALWAYS;
 
 	Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader,
 		    nullptr, false, false, -1, -1 );


### PR DESCRIPTION
Enables writing to color buffer when rendering the portal surface in FinalisePortalCommand::ExecuteSelf(). Changes glStencilOp to avoid stencil test failing in light pass, and clears stencil buffer in case there were multiple portals on the screen. Fixes #1011.

`glStencilOp( GL_KEEP, GL_KEEP, GL_DECR )` was likely intended to prevent incorrect rendering with multiple portals on the screen, but it was preventing the portal surface from rendering.

Here's some screenshots:
![unvanquished_2024-01-07_020340_000](https://github.com/DaemonEngine/Daemon/assets/10687142/57651dae-fcda-4ca9-8f11-b354983c4f83)
![unvanquished_2024-01-07_020416_000](https://github.com/DaemonEngine/Daemon/assets/10687142/3a50f251-8f48-467e-9105-a71f59d4bf96)
![unvanquished_2024-01-07_020443_000](https://github.com/DaemonEngine/Daemon/assets/10687142/dccf1763-b7ce-49b7-bbc5-b4a0fb3095f6)

~~The colour is slightly off because for some reason the portal surfaces are rendered twice, so they blend with themselves.~~ The colour is off due to light pass, which may or may not be a bug with the lighting system. Using Nsight confirms that the first draw produces the expected result (this is not the final colour that will be in the frame, but it illustrates the issue):
![debug_portal_blend1](https://github.com/DaemonEngine/Daemon/assets/10687142/bec589f8-5eee-4163-a431-3195a26addab)
![debug_portal_blend2](https://github.com/DaemonEngine/Daemon/assets/10687142/ed8189ab-3bcd-423c-b1d9-4394fa2d1d54)