### PR TITLE
Implement alphaGen portal

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2833,7 +2833,7 @@ GLShader_portal::GLShader_portal( GLShaderManager *manager ) :
 	u_CurrentMap( this ),
 	u_ModelViewMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_PortalRange( this )
+	u_InversePortalRange( this )
 {
 }
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3373,16 +3373,16 @@ public:
 	}
 };
 
-class u_PortalRange :
+class u_InversePortalRange :
 	GLUniform1f
 {
 public:
-	u_PortalRange( GLShader *shader ) :
-		GLUniform1f( shader, "u_PortalRange" )
+	u_InversePortalRange( GLShader *shader ) :
+		GLUniform1f( shader, "u_InversePortalRange" )
 	{
 	}
 
-	void SetUniform_PortalRange( float value )
+	void SetUniform_InversePortalRange( float value )
 	{
 		this->SetValue( value );
 	}
@@ -4370,7 +4370,7 @@ class GLShader_portal :
 	public u_CurrentMap,
 	public u_ModelViewMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_PortalRange
+	public u_InversePortalRange
 {
 public:
 	GLShader_portal( GLShaderManager *manager );

--- a/src/engine/renderer/glsl_source/portal_fp.glsl
+++ b/src/engine/renderer/glsl_source/portal_fp.glsl
@@ -39,7 +39,7 @@ void	main()
 	float len = length(var_Position);
 
 	len /= u_PortalRange;
-	color.rgb *= 1.0 - clamp(len, 0.0, 1.0);
+	color.a = clamp(len, 0.0, 1.0);
 
 	outputColor = color;
 }

--- a/src/engine/renderer/glsl_source/portal_fp.glsl
+++ b/src/engine/renderer/glsl_source/portal_fp.glsl
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 /* portal_fp.glsl */
 
 uniform sampler2D	u_CurrentMap;
-uniform float		u_PortalRange;
+uniform float		u_InversePortalRange;
 
 IN(smooth) vec3		var_Position;
 IN(smooth) vec4		var_Color;
@@ -38,7 +38,7 @@ void	main()
 
 	float len = length(var_Position);
 
-	len /= u_PortalRange;
+	len *= u_InversePortalRange;
 	color.a = clamp(len, 0.0, 1.0);
 
 	outputColor = color;

--- a/src/engine/renderer/glsl_source/portal_fp.glsl
+++ b/src/engine/renderer/glsl_source/portal_fp.glsl
@@ -27,15 +27,13 @@ uniform float		u_PortalRange;
 
 IN(smooth) vec3		var_Position;
 IN(smooth) vec4		var_Color;
+IN(smooth) vec2	var_TexCoords;
 
 DECLARE_OUTPUT(vec4)
 
 void	main()
 {
-	// calculate the screen texcoord in the 0.0 to 1.0 range
-	vec2 st = gl_FragCoord.st / r_FBufSize;
-
-	vec4 color = texture2D(u_CurrentMap, st);
+	vec4 color = texture2D(u_CurrentMap, var_TexCoords);
 	color *= var_Color;
 
 	float len = length(var_Position);

--- a/src/engine/renderer/glsl_source/portal_vp.glsl
+++ b/src/engine/renderer/glsl_source/portal_vp.glsl
@@ -24,15 +24,19 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 IN vec3 		attr_Position;
 IN vec4			attr_Color;
+IN vec4 attr_TexCoord0;
 
 uniform mat4		u_ModelViewMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
 OUT(smooth) vec3	var_Position;
 OUT(smooth) vec4	var_Color;
+OUT(smooth) vec2	var_TexCoords;
 
 void	main()
 {
+	vec2 texCoord = attr_TexCoord0.xy;
+
 	// transform vertex position into homogenous clip-space
 	gl_Position = u_ModelViewProjectionMatrix * vec4(attr_Position, 1.0);
 
@@ -41,4 +45,6 @@ void	main()
 
 	// assign color
 	var_Color = attr_Color;
+
+	var_TexCoords = texCoord;
 }

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -850,6 +850,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	  AGEN_VERTEX,
 	  AGEN_ONE_MINUS_VERTEX,
 	  AGEN_WAVEFORM,
+	  AGEN_PORTAL,
 	  AGEN_CONST,
 	  AGEN_CUSTOM
 	};

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1277,6 +1277,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 
 		float          portalRange; // distance to fog out at
 		bool       isPortal;
+		bool portalOutOfRange;
 
 		cullType_t     cullType; // CT_FRONT_SIDED, CT_BACK_SIDED, or CT_TWO_SIDED
 		bool       polygonOffset; // set for decals and other items that must be offset

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1600,12 +1600,12 @@ static bool SurfBoxIsOffscreen(const drawSurf_t *drawSurf, screenRect_t& surfRec
 }
 
 /*
-** SurfIsOffscreen
+** PortalOffScreenOrOutOfRange
 **
-** Determines if a surface is completely offscreen.
+** Determines if a surface is completely offscreen or out of the portal range.
 ** also computes a conservative screen rectangle bounds for the surface
 */
-static bool SurfIsOffscreen( const drawSurf_t *drawSurf, screenRect_t& surfRect )
+static bool PortalOffScreenOrOutOfRange( const drawSurf_t *drawSurf, screenRect_t& surfRect )
 {
 	float        shortest = 100000000;
 	shader_t     *shader;
@@ -1872,8 +1872,9 @@ bool R_MirrorViewBySurface(drawSurf_t *drawSurf)
 	}
 
 	// trivially reject portal/mirror
-	if (SurfIsOffscreen(drawSurf, surfRect))
+	if (PortalOffScreenOrOutOfRange(drawSurf, surfRect))
 	{
+		// We still need to draw the surface itself when it's out of range, just not the portal view
 		if ( drawSurf->shader->portalOutOfRange ) {
 			R_AddPreparePortalCmd( drawSurf );
 			R_AddFinalisePortalCmd( drawSurf );

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1696,6 +1696,8 @@ static bool SurfIsOffscreen( const drawSurf_t *drawSurf, screenRect_t& surfRect 
 	surfRect.coords[2] = std::min(newRect.coords[2], surfRect.coords[2]);
 	surfRect.coords[3] = std::min(newRect.coords[3], surfRect.coords[3]);
 
+	shader->portalOutOfRange = false;
+
 	// trivially reject
 	if ( pointAnd )
 	{
@@ -1747,6 +1749,7 @@ static bool SurfIsOffscreen( const drawSurf_t *drawSurf, screenRect_t& surfRect 
 
 	if ( shortest > ( tess.surfaceShader->portalRange * tess.surfaceShader->portalRange ) )
 	{
+		shader->portalOutOfRange = true;
 		return true;
 	}
 
@@ -1871,6 +1874,10 @@ bool R_MirrorViewBySurface(drawSurf_t *drawSurf)
 	// trivially reject portal/mirror
 	if (SurfIsOffscreen(drawSurf, surfRect))
 	{
+		if ( drawSurf->shader->portalOutOfRange ) {
+			R_AddPreparePortalCmd( drawSurf );
+			R_AddFinalisePortalCmd( drawSurf );
+		}
 		return false;
 	}
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2140,7 +2140,7 @@ void Render_portal( shaderStage_t *pStage )
 	gl_portalShader->BindProgram( pStage->deformIndex );
 
 	{
-		GL_VertexAttribsState( ATTR_POSITION );
+		GL_VertexAttribsState( ATTR_POSITION | ATTR_TEXCOORD );
 		glVertexAttrib4fv( ATTR_INDEX_COLOR, tess.svars.color.ToArray() );
 	}
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2852,7 +2852,7 @@ void Tess_StageIteratorPortal() {
 			continue;
 		}
 
-		Render_portal( pStage );
+		Render_generic3D( pStage );
 	}
 }
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2144,7 +2144,7 @@ void Render_portal( shaderStage_t *pStage )
 		glVertexAttrib4fv( ATTR_INDEX_COLOR, tess.svars.color.ToArray() );
 	}
 
-	gl_portalShader->SetUniform_PortalRange( tess.surfaceShader->portalRange );
+	gl_portalShader->SetUniform_InversePortalRange( 1 / tess.surfaceShader->portalRange );
 
 	gl_portalShader->SetUniform_ModelViewMatrix( glState.modelViewMatrix[ glState.stackIndex ] );
 	gl_portalShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2128,6 +2128,8 @@ void Render_screen( shaderStage_t *pStage )
 	GL_CheckErrors();
 }
 
+/* This doesn't render the portal itself but the texture
+blended to it to fade it with distance. */
 void Render_portal( shaderStage_t *pStage )
 {
 	GLimp_LogComment( "--- Render_portal ---\n" );
@@ -2632,6 +2634,7 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 	switch ( pStage->alphaGen )
 	{
 		default:
+		case alphaGen_t::AGEN_PORTAL:
 		case alphaGen_t::AGEN_IDENTITY:
 		case alphaGen_t::AGEN_ONE_MINUS_VERTEX:
 			{

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -2817,10 +2817,8 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			}
 			else if ( !Q_stricmp( token, "portal" ) )
 			{
-				Log::Warn("alphaGen portal keyword not supported in shader '%s'", shader.name );
-				//stage->type = ST_PORTALMAP;
-				stage->alphaGen = alphaGen_t::AGEN_CONST;
-				stage->constantColor.SetAlpha( 0 );
+				stage->type = stageType_t::ST_PORTALMAP;
+				stage->alphaGen = alphaGen_t::AGEN_PORTAL;
 
 				token = COM_ParseExt2( text, false );
 


### PR DESCRIPTION
I don't claim it is working, but we need this to make it work.

We can notice the current code computes the distance to portal in fragment shader, but ioq3 does it in vertex shader, and it's probably faster to do it once per vertex than once per pixel, but this is a good start.

I'm not sure the existing GLSL code is correct, but the GLSL code will not run without those patches anyway.

The ioq3 code also does the range compute in the `generic` shader and at some point we may want to do the same as there may be other needs for doing blend operations according to distance, but yet again, we can look small and do small steps after small steps.