### PR TITLE
Fix portal surface blending, entity selection and recursive mirrors

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1618,6 +1618,7 @@ enum class deluxeMode_t { NONE, GRID, MAP };
 		vec3_t         pvsOrigin; // may be different than or.origin for portals
 
 		int            portalLevel; // number of portals this view is through
+		int            mirrorLevel;
 		bool           isMirror; // the portal is a mirror, invert the face culling
 
 		int            frameSceneNum; // copied from tr.frameSceneNum
@@ -3519,6 +3520,7 @@ inline bool checkGLErrors()
 
 	void Tess_StageIteratorDebug();
 	void Tess_StageIteratorGeneric();
+	void Tess_StageIteratorPortal();
 	void Tess_StageIteratorDepthFill();
 	void Tess_StageIteratorShadowFill();
 	void Tess_StageIteratorLighting();

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2882,6 +2882,67 @@ void Tess_StageIteratorGeneric()
 	}
 }
 
+
+void Tess_StageIteratorPortal() {
+	int stage;
+
+	// log this call
+	if ( r_logFile->integer ) {
+		// don't just call LogComment, or we will get
+		// a call to va() every frame!
+		GLimp_LogComment( va
+		( "--- Tess_StageIteratorPortal( %s, %i vertices, %i triangles ) ---\n", tess.surfaceShader->name,
+			tess.numVertexes, tess.numIndexes / 3 ) );
+	}
+
+	GL_CheckErrors();
+
+	if ( !glState.currentVBO || !glState.currentIBO || glState.currentVBO == tess.vbo || glState.currentIBO == tess.ibo ) {
+		Tess_UpdateVBOs();
+	}
+
+	// set face culling appropriately
+	if ( backEnd.currentEntity->e.renderfx & RF_SWAPCULL )
+		GL_Cull( ReverseCull( tess.surfaceShader->cullType ) );
+	else
+		GL_Cull( tess.surfaceShader->cullType );
+
+	// call shader function
+	for ( stage = 0; stage < MAX_SHADER_STAGES; stage++ ) {
+		shaderStage_t* pStage = tess.surfaceStages[stage];
+
+		if ( !pStage ) {
+			break;
+		}
+
+		if ( !RB_EvalExpression( &pStage->ifExp, 1.0 ) ) {
+			continue;
+		}
+
+		switch ( pStage->type ) {
+			case stageType_t::ST_COLORMAP:
+			case stageType_t::ST_LIGHTMAP:
+			case stageType_t::ST_DIFFUSEMAP:
+			case stageType_t::ST_COLLAPSE_lighting_PHONG:
+			case stageType_t::ST_COLLAPSE_lighting_PBR:
+			case stageType_t::ST_COLLAPSE_reflection_CB:
+			case stageType_t::ST_REFLECTIONMAP:
+			case stageType_t::ST_REFRACTIONMAP:
+			case stageType_t::ST_DISPERSIONMAP:
+			case stageType_t::ST_SKYBOXMAP:
+			case stageType_t::ST_SCREENMAP:
+			case stageType_t::ST_PORTALMAP:
+			case stageType_t::ST_HEATHAZEMAP:
+			case stageType_t::ST_LIQUIDMAP:
+				Render_generic( pStage );
+				return;
+
+			default:
+				break;
+		}
+	}
+}
+
 void Tess_StageIteratorDepthFill()
 {
 	int stage;


### PR DESCRIPTION
Fixes portal blending with portal surfaces, misc_portal_surface entity selection and GL_FrontFace for mirrors in chains of recursive portals/mirrors. Fixes #1011. Disables the 64qu distance limit for portal entities which wasn't working properly anyway.

Portal entities are now chosen based on their distance to the center of the portals surface (calculated as the average of all vertices). Old code was checking if they are within 64qu of the plane, which was resulting in portals entities that are actually much further away being chosen.

Introduces Tess_StageIteratorPortal(), intended for portals to properly write to stencil buffer.

Screenshots (some blended surfaces look slightly off, this might be an issue with lighting in general, portals themselves blend correctly):
![unvanquished_2024-01-09_210516_000](https://github.com/DaemonEngine/Daemon/assets/10687142/d1bf167c-d000-4ff4-a4b3-eecf6d9a88b2)
![unvanquished_2024-01-09_203209_000](https://github.com/DaemonEngine/Daemon/assets/10687142/06343710-39dd-41e7-96d1-b2e6da3c89ce)
![unvanquished_2024-01-09_195110_000](https://github.com/DaemonEngine/Daemon/assets/10687142/c6581233-9a38-48c2-9731-b81487eec1cd)
![unvanquished_2024-01-09_195048_000](https://github.com/DaemonEngine/Daemon/assets/10687142/1e33c1ab-f14b-420e-a7b2-2f8c8bd20705)
![unvanquished_2024-01-07_020443_000](https://github.com/DaemonEngine/Daemon/assets/10687142/9f51bb5e-c244-4bb2-8319-76d5560e04b7)
![unvanquished_2024-01-07_020416_000](https://github.com/DaemonEngine/Daemon/assets/10687142/003a1153-656d-4f61-941b-96410cf13a5c)
![unvanquished_2024-01-07_020340_000](https://github.com/DaemonEngine/Daemon/assets/10687142/ba2e0d0a-749e-4451-91c5-71c976eb3e45)