### PR TITLE
renderer: make GLSL code easier to read with computeLight, computeDeluxeLight and computeDynamicLights

### DIFF
--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -71,7 +71,11 @@ void ReadLightGrid(in vec4 texel, out vec3 ambientColor, out vec3 lightColor) {
 	lightColor = directedScale * texel.rgb;
 }
 
-void computeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightColor,
+void computeLight(in vec3 lightColor, vec4 diffuseColor, inout vec4 color) {
+	color.rgb += lightColor.rgb * diffuseColor.rgb;
+}
+
+void computeDeluxeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightColor,
 		   vec4 diffuseColor, vec4 materialColor,
 		   inout vec4 color ) {
   vec3 H = normalize( lightDir + viewDir );
@@ -172,7 +176,7 @@ int nextIdx( inout idxs_t idxs ) {
 const int numLayers = MAX_REF_LIGHTS / 256;
 
 #if defined(r_dynamicLight)
-void computeDLight( int idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse,
+void computeDynamicLight( int idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse,
 		    vec4 material, inout vec4 color ) {
   vec4 center_radius = GetLight( idx, center_radius );
   vec4 color_type = GetLight( idx, color_type );
@@ -199,12 +203,12 @@ void computeDLight( int idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse,
     L = GetLight( idx, direction_angle ).xyz;
     attenuation = 1.0;
   }
-  computeLight( L, normal, viewDir,
+  computeDeluxeLight( L, normal, viewDir,
 		attenuation * attenuation * color_type.xyz,
 		diffuse, material, color );
 }
 
-void computeDLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4 material,
+void computeDynamicLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4 material,
 		     inout vec4 color ) {
   vec2 tile = floor( gl_FragCoord.xy * (1.0 / float( TILE_SIZE ) ) ) + 0.5;
   vec3 tileScale = vec3( r_tileStep, 1.0/numLayers );
@@ -223,7 +227,7 @@ void computeDLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4 mater
         break;
       }
 
-      computeDLight( idx, P, normal, viewDir, diffuse, material, color );
+      computeDynamicLight( idx, P, normal, viewDir, diffuse, material, color );
 
 #if defined(r_showLightTiles)
       numLights++;

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -118,21 +118,13 @@ void main()
 		// Compute light color from world space lightmap.
 		vec3 lightColor = texture2D(u_LightMap, var_TexLight).rgb;
 
-		#if defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING)
-			color.rgb = vec3(0.0);
-		#else
-			color.rgb = lightColor.rgb * diffuse.rgb;
-		#endif
+		color.rgb = vec3(0.0);
 	#else
 		// Compute light color from lightgrid.
 		vec3 ambientColor, lightColor;
 		ReadLightGrid(texture3D(u_LightGrid1, lightGridPos), ambientColor, lightColor);
 
 		color.rgb = ambientColor * r_AmbientScale * diffuse.rgb;
-
-		#if !defined(USE_DELUXE_MAPPING) && !defined(USE_GRID_DELUXE_MAPPING)
-			color.rgb += lightColor.rgb * diffuse.rgb;
-		#endif
 	#endif
 
 	#if defined(USE_LIGHT_MAPPING) && defined(USE_DELUXE_MAPPING)
@@ -161,14 +153,16 @@ void main()
 		lightColor /= clamp(dot(normalize(var_Normal), lightDir), 0.3, 1.0);
 	#endif
 
+	// Blend static light.
 	#if defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING)
-		// Blend static light.
-		computeLight(lightDir, normal, viewDir, lightColor, diffuse, material, color);
+		computeDeluxeLight(lightDir, normal, viewDir, lightColor, diffuse, material, color);
+	#else
+		computeLight(lightColor, diffuse, color);
 	#endif
 
+	// Blend dynamic lights.
 	#if defined(r_dynamicLight)
-		// Blend dynamic lights.
-		computeDLights(var_Position, normal, viewDir, diffuse, material, color);
+		computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color);
 	#endif
 
 	// Add Rim Lighting to highlight the edges on model entities.

--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -129,7 +129,7 @@ void	main()
 	vec4 diffuse = vec4(0.0, 0.0, 0.0, 1.0);
 
 	// compute the specular term
-	computeLight(lightDir, normal, viewDir, lightColor, diffuse, reflectColor, color);
+	computeDeluxeLight(lightDir, normal, viewDir, lightColor, diffuse, reflectColor, color);
 
 	outputColor = color;
 


### PR DESCRIPTION
Make GLSL code easier to read with computeLight, computeDirectionalLight and computeDynamicLights.

The real magic is in `lightMapping_fp.glsl`, it makes easier to spot the actual alternative code to directional light computation that was previously disseminated everywhere, we now have a simple if/else condition calling one or the other function.