### PR TITLE
WIP: renderer: implement GLSL sRGB support

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -158,6 +158,7 @@ set(GLSLSOURCELIST
     ${ENGINE_DIR}/renderer/glsl_source/blur_vp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/cameraEffects_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/cameraEffects_vp.glsl
+    ${ENGINE_DIR}/renderer/glsl_source/colorSpace.glsl
     ${ENGINE_DIR}/renderer/glsl_source/computeLight_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/contrast_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/contrast_vp.glsl

--- a/src/common/Color.h
+++ b/src/common/Color.h
@@ -38,6 +38,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Compiler.h"
 #include "Math.h"
 
+#define convertFromSRGB( v ) v <= 0.04045f ? v * (1.0f / 12.92f) : pow((v + 0.055f) * (1.0f / 1.055f), 2.4f)
+
 namespace Color {
 
 /*
@@ -254,6 +256,20 @@ public:
 	CONSTEXPR_FUNCTION_RELAXED void SetAlpha( component_type v ) NOEXCEPT
 	{
 		data_[ 3 ] = v;
+	}
+
+	CONSTEXPR_FUNCTION_RELAXED component_type ConvertFromSRGB( component_type v ) NOEXCEPT
+	{
+		float f = float( v ) / 255.0f;
+		f = convertFromSRGB( f );
+		return component_type( f * 255 );
+	}
+
+	CONSTEXPR_FUNCTION_RELAXED void ConvertFromSRGB() NOEXCEPT
+	{
+		SetRed( ConvertFromSRGB( Red() ) );
+		SetGreen( ConvertFromSRGB( Green() ) );
+		SetBlue( ConvertFromSRGB( Blue() ) );
 	}
 
 	CONSTEXPR_FUNCTION_RELAXED BasicColor& operator*=( float factor ) NOEXCEPT

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -157,6 +157,9 @@ void UpdateSurfaceDataGeneric3D( uint32_t* materials, shaderStage_t* pStage, boo
 	Tess_ComputeColor( pStage );
 	gl_genericShaderMaterial->SetUniform_Color( tess.svars.color );
 
+	// u_LinearizeTexture
+	gl_genericShaderMaterial->SetUniform_LinearizeTexture( pStage->linearizeTexture );
+
 	bool hasDepthFade = pStage->hasDepthFade;
 	if ( hasDepthFade ) {
 		gl_genericShaderMaterial->SetUniform_DepthScale( pStage->depthFadeValue );
@@ -189,6 +192,9 @@ void UpdateSurfaceDataLightMapping( uint32_t* materials, shaderStage_t* pStage, 
 
 	// u_AlphaThreshold
 	gl_lightMappingShaderMaterial->SetUniform_AlphaTest( pStage->stateBits );
+
+	// u_LinearizeTexture
+	gl_lightMappingShaderMaterial->SetUniform_LinearizeTexture( pStage->linearizeTexture );
 
 	// HeightMap
 	if ( pStage->enableReliefMapping ) {
@@ -267,6 +273,9 @@ void UpdateSurfaceDataSkybox( uint32_t* materials, shaderStage_t* pStage, bool, 
 	gl_skyboxShaderMaterial->SetUniform_AlphaTest( GLS_ATEST_NONE );
 
 	gl_skyboxShaderMaterial->WriteUniformsToBuffer( materials );
+
+	// u_LinearizeTexture
+	gl_skyboxShaderMaterial->SetUniform_LinearizeTexture( pStage->linearizeTexture );
 }
 
 void UpdateSurfaceDataScreen( uint32_t* materials, shaderStage_t* pStage, bool, bool, bool ) {
@@ -359,6 +368,8 @@ void UpdateSurfaceDataFog( uint32_t* materials, shaderStage_t* pStage, bool, boo
 	materials += pStage->bufferOffset;
 
 	gl_fogQuake3ShaderMaterial->WriteUniformsToBuffer( materials );
+
+	gl_fogQuake3ShaderMaterial->SetUniform_LinearizeTexture( tr.worldLinearizeTexture );
 }
 
 /*

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -802,6 +802,11 @@ static std::string GenEngineConstants() {
 		AddConst( str, "r_RimExponent", r_rimExponent->value );
 	}
 
+	if ( r_cheapSRGB.Get() )
+	{
+		AddDefine( str, "r_cheapSRGB", 1 );
+	}
+
 	if ( r_showLightTiles->integer )
 	{
 		AddDefine( str, "r_showLightTiles", 1 );
@@ -2261,6 +2266,7 @@ GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_ColorModulateColorGen( this ),
 	u_Color( this ),
 	u_Bones( this ),
@@ -2293,6 +2299,7 @@ GLShader_genericMaterial::GLShader_genericMaterial( GLShaderManager* manager ) :
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_ColorModulateColorGen( this ),
 	u_Color( this ),
 	u_DepthScale( this ),
@@ -2334,6 +2341,7 @@ GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 	u_ViewOrigin( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_Bones( this ),
 	u_VertexInterpolation( this ),
 	u_ReliefDepthScale( this ),
@@ -2402,6 +2410,7 @@ GLShader_lightMappingMaterial::GLShader_lightMappingMaterial( GLShaderManager* m
 	u_ViewOrigin( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_ReliefDepthScale( this ),
 	u_ReliefOffsetBias( this ),
 	u_NormalScale( this ),
@@ -2712,6 +2721,7 @@ GLShader_skybox::GLShader_skybox( GLShaderManager *manager ) :
 	u_CloudHeight( this ),
 	u_UseCloudMap( this ),
 	u_AlphaThreshold( this ),
+	u_LinearizeTexture( this ),
 	u_ModelViewProjectionMatrix( this )
 {
 }
@@ -2730,6 +2740,7 @@ GLShader_skyboxMaterial::GLShader_skyboxMaterial( GLShaderManager* manager ) :
 	u_CloudHeight( this ),
 	u_UseCloudMap( this ),
 	u_AlphaThreshold( this ),
+	u_LinearizeTexture( this ),
 	u_ModelViewProjectionMatrix( this )
 {}
 
@@ -2743,6 +2754,7 @@ GLShader_fogQuake3::GLShader_fogQuake3( GLShaderManager *manager ) :
 	u_FogMap( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_ColorGlobal( this ),
 	u_Bones( this ),
 	u_VertexInterpolation( this ),
@@ -2765,6 +2777,7 @@ GLShader_fogQuake3Material::GLShader_fogQuake3Material( GLShaderManager* manager
 	u_FogMap( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_ColorGlobal( this ),
 	u_FogDistanceVector( this ),
 	u_FogDepthVector( this ),
@@ -2782,6 +2795,7 @@ GLShader_fogGlobal::GLShader_fogGlobal( GLShaderManager *manager ) :
 	u_DepthMap( this ),
 	u_ModelViewProjectionMatrix( this ),
 	u_UnprojectMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_Color( this ),
 	u_FogDistanceVector( this )
 {
@@ -2896,7 +2910,8 @@ GLShader_cameraEffects::GLShader_cameraEffects( GLShaderManager *manager ) :
 	u_ColorModulate( this ),
 	u_TextureMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_InverseGamma( this )
+	u_InverseGamma( this ),
+	u_DelinearizeScreen( this )
 {
 }
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2806,6 +2806,36 @@ public:
 	}
 };
 
+class u_LinearizeTexture :
+	GLUniform1i
+{
+public:
+	u_LinearizeTexture( GLShader *shader ) :
+		GLUniform1i( shader, "u_LinearizeTexture" )
+	{
+	}
+
+	void SetUniform_LinearizeTexture( const int value )
+	{
+		this->SetValue( value );
+	}
+};
+
+class u_DelinearizeScreen :
+	GLUniform1i
+{
+public:
+	u_DelinearizeScreen( GLShader *shader ) :
+		GLUniform1i( shader, "u_DelinearizeScreen" )
+	{
+	}
+
+	void SetUniform_DelinearizeScreen( const int value )
+	{
+		this->SetValue( value );
+	}
+};
+
 class u_ShadowBlur :
 	GLUniform1f
 {
@@ -3834,6 +3864,7 @@ class GLShader_generic :
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_ColorModulateColorGen,
 	public u_Color,
 	public u_Bones,
@@ -3863,6 +3894,7 @@ class GLShader_genericMaterial :
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_ColorModulateColorGen,
 	public u_Color,
 	public u_DepthScale,
@@ -3901,6 +3933,7 @@ class GLShader_lightMapping :
 	public u_ViewOrigin,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_Bones,
 	public u_VertexInterpolation,
 	public u_ReliefDepthScale,
@@ -3952,6 +3985,7 @@ class GLShader_lightMappingMaterial :
 	public u_ViewOrigin,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_ReliefDepthScale,
 	public u_ReliefOffsetBias,
 	public u_NormalScale,
@@ -4195,6 +4229,7 @@ class GLShader_skybox :
 	public u_CloudHeight,
 	public u_UseCloudMap,
 	public u_AlphaThreshold,
+	public u_LinearizeTexture,
 	public u_ModelViewProjectionMatrix
 {
 public:
@@ -4210,6 +4245,7 @@ class GLShader_skyboxMaterial :
 	public u_CloudHeight,
 	public u_UseCloudMap,
 	public u_AlphaThreshold,
+	public u_LinearizeTexture,
 	public u_ModelViewProjectionMatrix {
 	public:
 	GLShader_skyboxMaterial( GLShaderManager* manager );
@@ -4221,6 +4257,7 @@ class GLShader_fogQuake3 :
 	public u_FogMap,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_ColorGlobal,
 	public u_Bones,
 	public u_VertexInterpolation,
@@ -4241,6 +4278,7 @@ class GLShader_fogQuake3Material :
 	public u_FogMap,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_ColorGlobal,
 	public u_FogDistanceVector,
 	public u_FogDepthVector,
@@ -4257,6 +4295,7 @@ class GLShader_fogGlobal :
 	public u_DepthMap,
 	public u_ModelViewProjectionMatrix,
 	public u_UnprojectMatrix,
+	public u_LinearizeTexture,
 	public u_Color,
 	public u_FogDistanceVector
 {
@@ -4354,7 +4393,8 @@ class GLShader_cameraEffects :
 	public u_ColorModulate,
 	public u_TextureMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_InverseGamma
+	public u_InverseGamma,
+	public u_DelinearizeScreen
 {
 public:
 	GLShader_cameraEffects( GLShaderManager *manager );

--- a/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
+++ b/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
@@ -22,8 +22,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* cameraEffects_fp.glsl */
 
+#insert colorSpace
+
 uniform sampler2D u_CurrentMap;
 
+uniform bool u_DelinearizeScreen;
 #if defined(r_colorGrading)
 uniform sampler3D u_ColorMap3D;
 #endif
@@ -41,6 +44,8 @@ void	main()
 	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	vec4 color = texture2D(u_CurrentMap, st);
+
+	convertToSRGB(color.rgb, u_DelinearizeScreen);
 
 	color = clamp(color, 0.0, 1.0);
 

--- a/src/engine/renderer/glsl_source/colorSpace.glsl
+++ b/src/engine/renderer/glsl_source/colorSpace.glsl
@@ -1,0 +1,107 @@
+#define SRGB_MIX
+
+uniform int u_LinearizeTexture;
+
+void convertFromSRGB(inout vec3 color, in bool condition) {
+	if (condition)
+	{
+	#if defined(r_cheapSRGB)
+		float gamma = 2.2;
+		color = pow(color, vec3(gamma));
+
+	#elif defined(SRGB_NAIVE)
+		// (((c) <= 0.04045f) ? (c) * (1.0f / 12.92f) : (float)pow(((c) + 0.055f)*(1.0f/1.055f), 2.4f))
+
+		float threshold = 0.0031308f;
+
+		color.r = color.r <= threshold ? color.r * (1.0f / 12.92f) : pow((color.r + 0.055f) * (1.0f / 1.055f), 2.4f);
+		color.g = color.g <= threshold ? color.g * (1.0f / 12.92f) : pow((color.g + 0.055f) * (1.0f / 1.055f), 2.4f);
+		color.b = color.b <= threshold ? color.b * (1.0f / 12.92f) : pow((color.b + 0.055f) * (1.0f / 1.055f), 2.4f);
+	#elif defined(SRGB_FBOOL)
+		float threshold = 0.0031308f;
+
+		vec3 yes = vec3(float(color.r <= threshold), float(color.g <= threshold), float(color.b <= threshold));
+		vec3 no = yes * -1.0f + 1.0f;
+
+		vec3 low = color * (1.0f / 12.92f);
+		vec3 high = pow((color + 0.055f) * (1.0f / 1.055f), vec3(2.4f));
+
+		color = (yes * low) + (no * high);
+	#elif defined(SRGB_BOOL)
+		float threshold = 0.0031308f;
+
+		bvec3 yes = bvec3(color.r <= threshold, color.g <= threshold, color.b <= threshold);
+		bvec3 no = bvec3(!yes.x, !yes.y, !yes.z);
+
+		vec3 low = color * (1.0f / 12.92f);
+		vec3 high = pow((color + 0.055f) * (1.0f / 1.055f), vec3(2.4f));
+
+		color = (float(yes) * low) + (float(no) * high);
+	#elif defined(SRGB_MIX)
+		float threshold = 0.0031308f;
+
+		bvec3 cutoff = lessThan(color, vec3(threshold));
+		vec3 low = color / vec3(12.92f);
+		vec3 high = pow((color + vec3(0.055f)) / vec3(1.055f), vec3(2.4f));
+
+		color = mix(high, low, cutoff);
+	#else
+		#error undefined SRGB computation
+	#endif
+	}
+}
+
+void convertFromSRGB(inout vec3 color, in int condition) {
+	convertFromSRGB(color, condition != 0);
+}
+
+void convertToSRGB(inout vec3 color, in bool condition) {
+	if (condition)
+	{
+	#if defined(r_cheapSRGB)
+		float gamma = 2.2;
+		color = pow(color, vec3(1/gamma));
+	#elif defined(SRGB_NAIVE)
+		// (((c) < 0.0031308f) ? (c) * 12.92f : 1.055f * (float)pow((c), 1.0f/2.4f) - 0.055f)
+		float threshold = 0.0031308f;
+
+		color.r = color.r < threshold ? color.r * 12.92f : 1.055f * pow(color.r, 1.0f / 2.4f) - 0.055f;
+		color.g = color.g < threshold ? color.g * 12.92f : 1.055f * pow(color.g, 1.0f / 2.4f) - 0.055f;
+		color.b = color.b < threshold ? color.b * 12.92f : 1.055f * pow(color.b, 1.0f / 2.4f) - 0.055f;
+	#elif defined(SRGB_FBOOL)
+		float threshold = 0.0031308f;
+
+		vec3 yes = vec3(float(color.r < threshold), float(color.g < threshold), float(color.b < threshold));
+		vec3 no = yes * -1.0f + 1.0f;
+
+		vec3 low = color * 12.92f;
+		vec3 high = pow(color, vec3(1.0f / 2.4f)) - 0.055f;
+
+		color = (yes * low) + (no * high);
+	#elif defined(SRGB_BOOL)
+		float threshold = 0.0031308f;
+
+		bvec3 yes = bvec3(color.r < threshold, color.g < threshold, color.b < threshold);
+		bvec3 no = bvec3(!yes.x, !yes.y, !yes.z);
+
+		vec3 low = color * 12.92f;
+		vec3 high = pow(color, vec3(1.0f / 2.4f)) - 0.055f;
+
+		color = (float(yes) * low) + (float(no) * high);
+	#elif defined(SRGB_MIX)
+		float threshold = 0.0031308f;
+
+		bvec3 cutoff = lessThan(color, vec3(threshold));
+		vec3 low = vec3(12.92f) * color;
+		vec3 high = vec3(1.055f) * pow(color, vec3(1.0f / 2.4f)) - vec3(0.055f);
+
+		color = mix(high, low, cutoff);
+	#else
+		#error undefined SRGB computation
+	#endif
+	}
+}
+
+void convertToSRGB(inout vec3 color, in int condition) {
+	convertToSRGB(color, condition != 0);
+}

--- a/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* fogGlobal_fp.glsl */
 
+#insert colorSpace
+
 uniform sampler2D	u_ColorMap; // fog texture
 uniform sampler2D	u_DepthMap;
 
@@ -51,6 +53,8 @@ void	main()
 	st.t = 1.0;
 
 	vec4 color = texture2D(u_ColorMap, st);
+
+	convertFromSRGB(color.rgb, u_LinearizeTexture);
 
 	outputColor = unpackUnorm4x8( u_Color ) * color;
 }

--- a/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* fogQuake3_fp.glsl */
 
+#insert colorSpace
+
 #define FOGQUAKE3_GLSL
 
 uniform sampler2D u_FogMap;
@@ -39,6 +41,8 @@ void	main()
 	vec4 color = texture2D(u_FogMap, var_TexCoords);
 
 	color *= var_Color;
+
+	convertFromSRGB(color.rgb, u_LinearizeTexture);
 
 	outputColor = color;
 

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* generic_fp.glsl */
 
+#insert colorSpace
+
 #define GENERIC_GLSL
 
 uniform sampler2D	u_ColorMap;
@@ -62,6 +64,10 @@ void	main()
 		discard;
 		return;
 	}
+
+#if !defined(GENERIC_2D)
+	convertFromSRGB(color.rgb, u_LinearizeTexture);
+#endif
 
 #if defined(USE_DEPTH_FADE)
 	float depth = texture2D(u_DepthMap, gl_FragCoord.xy / r_FBufSize).x;

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 /* lightMapping_fp.glsl */
 
 #insert common
+#insert colorSpace
 #insert computeLight_fp
 #insert reliefMapping_fp
 
@@ -101,13 +102,25 @@ void main()
 	vec4 diffuse = texture2D(u_DiffuseMap, texCoords);
 
 	// Apply vertex blend operation like: alphaGen vertex.
-	diffuse *= var_Color;
+	diffuse.a *= var_Color.a;
 
 	if(abs(diffuse.a + u_AlphaThreshold) <= 1.0)
 	{
 		discard;
 		return;
 	}
+
+	/* HACK: emulate three-bits bitfield
+	even: no color map linearization (first bit)
+	less than 2: no light map linearization (second bit)
+	positive: no material map linearization (extra bit) */
+	bool linearizeColorMap = bool(u_LinearizeTexture % 2);
+	bool linearizeLightMap = abs(u_LinearizeTexture) > 1;
+	bool linearizeMaterialMap = u_LinearizeTexture < 0;
+
+	convertFromSRGB(diffuse.rgb, linearizeColorMap);
+
+	diffuse.rgb *= var_Color.rgb;
 
 	// Compute normal in world space from normalmap.
 	#if defined(r_normalMapping)
@@ -119,6 +132,8 @@ void main()
 	#if defined(r_specularMapping) || defined(r_physicalMapping)
 		// Compute the material term.
 		vec4 material = texture2D(u_MaterialMap, texCoords);
+
+		convertFromSRGB(material.rgb, linearizeMaterialMap);
 	#elif ( defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1 )\
 		|| defined( USE_DELUXE_MAPPING ) || defined(USE_GRID_DELUXE_MAPPING )
 		// The computeDynamicLights function requires this variable to exist.
@@ -152,11 +167,21 @@ void main()
 		vec3 lightColor = texture2D(u_LightMap, var_TexLight).rgb;
 		lightColor *= lightFactor;
 
+		convertFromSRGB(lightColor, linearizeLightMap);
+
 		color.rgb = vec3(0.0);
 	#else
 		// Compute light color from lightgrid.
 		vec3 ambientColor, lightColor;
 		ReadLightGrid(texture3D(u_LightGrid1, lightGridPos), lightFactor, ambientColor, lightColor);
+
+		#if defined(r_cheapSRGB)
+			/* The light grid conversion from sRGB is done in C++ code
+			when loading it, meaning it's done before interpolation. */
+		#else
+			convertFromSRGB(lightColor, linearizeLightMap);
+			convertFromSRGB(ambientColor, linearizeLightMap);
+		#endif
 
 		color.rgb = ambientColor * r_AmbientScale * diffuse.rgb;
 	#endif
@@ -214,6 +239,8 @@ void main()
 	#if defined(r_glowMapping)
 		// Blend glow map.
 		vec3 glow = texture2D(u_GlowMap, texCoords).rgb;
+
+		convertFromSRGB(glow, linearizeColorMap);
 
 		color.rgb += glow;
 	#endif

--- a/src/engine/renderer/glsl_source/skybox_fp.glsl
+++ b/src/engine/renderer/glsl_source/skybox_fp.glsl
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* skybox_fp.glsl */
 
+#insert colorSpace
+
 #define SKYBOX_GLSL
 
 const float radiusWorld = 4096.0; // Value used by quake 3 skybox code
@@ -77,6 +79,8 @@ void	main()
 		discard;
 		return;
 	}
+
+	convertFromSRGB(color.rgb, u_LinearizeTexture);
 
 	outputColor = color;
 }

--- a/src/engine/renderer/shaders.cpp
+++ b/src/engine/renderer/shaders.cpp
@@ -10,6 +10,7 @@
 #include "blur_vp.glsl.h"
 #include "cameraEffects_fp.glsl.h"
 #include "cameraEffects_vp.glsl.h"
+#include "colorSpace.glsl.h"
 #include "computeLight_fp.glsl.h"
 #include "contrast_fp.glsl.h"
 #include "contrast_vp.glsl.h"
@@ -72,6 +73,7 @@ std::unordered_map<std::string, std::string> shadermap({
 	{ "cameraEffects_fp.glsl", std::string(reinterpret_cast<const char*>(cameraEffects_fp_glsl), sizeof(cameraEffects_fp_glsl)) },
 	{ "cameraEffects_vp.glsl", std::string(reinterpret_cast<const char*>(cameraEffects_vp_glsl), sizeof(cameraEffects_vp_glsl)) },
 	{ "computeLight_fp.glsl", std::string(reinterpret_cast<const char*>(computeLight_fp_glsl), sizeof(computeLight_fp_glsl)) },
+	{ "colorSpace.glsl", std::string(reinterpret_cast<const char*>(colorSpace_glsl), sizeof(colorSpace_glsl)) },
 	{ "contrast_fp.glsl", std::string(reinterpret_cast<const char*>(contrast_fp_glsl), sizeof(contrast_fp_glsl)) },
 	{ "contrast_vp.glsl", std::string(reinterpret_cast<const char*>(contrast_vp_glsl), sizeof(contrast_vp_glsl)) },
 	{ "common.glsl", std::string( reinterpret_cast< const char* >( common_glsl ), sizeof( common_glsl ) ) },

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -2980,6 +2980,9 @@ void RB_RenderGlobalFog()
 	// go back to the world modelview matrix
 	backEnd.orientation = backEnd.viewParms.world;
 
+	// u_LinearizeTexture
+	gl_fogGlobalShader->SetUniform_LinearizeTexture( tr.worldLinearizeTexture );
+
 	{
 		fog_t *fog;
 
@@ -3327,6 +3330,9 @@ void RB_CameraPostFX()
 
 	// enable shader, set arrays
 	gl_cameraEffectsShader->BindProgram( 0 );
+
+	// u_DelinearizeScreen
+	gl_cameraEffectsShader->SetUniform_DelinearizeScreen( tr.worldLinearizeTexture );
 
 	gl_cameraEffectsShader->SetUniform_ColorModulate( backEnd.viewParms.gradingWeights );
 

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -1027,6 +1027,10 @@ static void ParseFace( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf, in
 
 		cv->verts[ i ].lightColor = Color::Adapt( verts[ i ].color );
 
+		if ( tr.worldLinearizeLightMap )
+		{
+			cv->verts[ i ].lightColor.ConvertFromSRGB();
+		}
 
 		if ( tr.legacyOverBrightClamping )
 		{
@@ -4150,6 +4154,20 @@ void R_LoadLightGrid( lump_t *l )
 		{
 			ambientColor[ j ] = tmpAmbient[ j ] * ( 1.0f / 255.0f );
 			directedColor[ j ] = tmpDirected[ j ] * ( 1.0f / 255.0f );
+
+			if ( tr.worldLinearizeLightMap )
+			{
+				if ( r_cheapSRGB.Get() )
+				{
+					ambientColor[ j ] = convertFromSRGB( ambientColor[ j ] );
+					directedColor[ j ] = convertFromSRGB( directedColor[ j ] );
+				}
+				else
+				{
+					/* When not cheap, the light grid conversion from sRGB is done
+					in GLSL code after interpolation. */
+				}
+			}
 		}
 
 		// standard spherical coordinates to cartesian coordinates conversion
@@ -4418,6 +4436,73 @@ void R_LoadEntities( lump_t *l, std::string &externalEntities )
 				Log::Debug("map features directional light mapping" );
 				// This will be disabled if the engine fails to load the lightmaps.
 				tr.worldDeluxeMapping = glConfig2.deluxeMapping;
+			}
+
+			bool sRGBtex = false;
+			bool sRGBcolor = false;
+			bool sRGBlight = false;
+
+			s = strstr( value, "-sRGB" );
+
+			if ( s && ( s[5] == ' ' || s[5] == '\0' ) )
+			{
+				sRGBtex = true;
+				sRGBcolor = true;
+				sRGBlight = true;
+			}
+
+			s = strstr( value, "-nosRGB" );
+
+			if ( s && ( s[5] == ' ' || s[5] == '\0' ) )
+			{
+				sRGBtex = false;
+				sRGBcolor = false;
+				sRGBlight = true;
+			}
+
+			if ( strstr( value, "-sRGBlight" ) )
+			{
+				sRGBlight = true;
+			}
+
+			if ( strstr( value, "-nosRGBlight" ) )
+			{
+				sRGBlight = false;
+			}
+
+			if ( strstr( value, "-sRGBcolor" ) )
+			{
+				sRGBcolor = true;
+			}
+
+			if ( strstr( value, "-nosRGBcolor" ) )
+			{
+				sRGBcolor = false;
+			}
+
+			if ( strstr( value, "-sRGBtex" ) )
+			{
+				sRGBtex = true;
+			}
+
+			if ( strstr( value, "-nosRGBtex" ) )
+			{
+				sRGBtex = false;
+			}
+
+			if ( sRGBlight )
+			{
+				Log::Debug("map features lights in sRGB colorspace" );
+				tr.worldLinearizeLightMap = true;
+			}
+
+			if ( sRGBcolor && sRGBtex )
+			{
+				Log::Debug("map features lights computed with linear colors and textures" );
+				tr.worldLinearizeTexture = true;
+				/* The forceLegacyMapOverBrightClamping is only compatible and purposed
+				with legacy maps without color linearization. */
+				tr. legacyOverBrightClamping= false;
 			}
 
 			continue;
@@ -5091,6 +5176,8 @@ void RE_LoadWorldMap( const char *name )
 	// tr.worldDeluxeMapping will be set by R_LoadEntities()
 	tr.worldDeluxeMapping = false;
 	tr.worldHDR_RGBE = false;
+	tr.worldLinearizeTexture = false;
+	tr.worldLinearizeLightMap = false;
 
 	s_worldData = {};
 	Q_strncpyz( s_worldData.name, name, sizeof( s_worldData.name ) );

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -3095,15 +3095,6 @@ void R_InitImages()
 	Mappers may port and fix maps by multiplying the lights by 2.5
 	and set the mapOverBrightBits key to 0 in map entities lump.
 
-	It will be possible to assume tr.mapOverBrightBits is 0 when
-	loading maps compiled with sRGB lightmaps as there is no
-	legacy map using sRGB lightmap yet, and then we will be
-	able to avoid the need to explicitly set mapOverBrightBits
-	to 0 in map entities. It will be required to assume that
-	tr.mapOverBrightBits is 0 when loading maps compiled with
-	sRGB lightmaps because otherwise the color shift computation
-	will break the light computation, not only the deluxe one.
-
 	In legacy engines, tr.overbrightBits was non-zero when
 	hardware overbright bits were enabled, zero when disabled.
 	This engine do not implement hardware overbright bit, so

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -3054,59 +3054,6 @@ void R_InitImages()
 	tr.lightmaps.reserve( 128 );
 	tr.deluxemaps.reserve( 128 );
 
-	/* These are the values expected by the rest of the renderer
-	(esp. tr_bsp), used for "gamma correction of the map".
-	Both were set to 0 if we had neither COMPAT_ET nor COMPAT_Q3,
-	it may be interesting to remember.
-
-	Quake 3 and Tremulous values:
-
-	  tr.overbrightBits = 0; // Software implementation.
-	  tr.mapOverBrightBits = 2; // Quake 3 default.
-	  tr.identityLight = 1.0f / ( 1 << tr.overbrightBits );
-
-	Games like Quake 3 and Tremulous require tr.mapOverBrightBits
-	to be set to 2. Because this engine is primarily maintained for
-	Unvanquished and needs to keep compatibility with legacy Tremulous
-	maps, this value is set to 2.
-
-	Games like True Combat: Elite (Wolf:ET mod) or Urban Terror 4
-	(Quake 3 mod) require tr.mapOverBrightBits to be set to 0.
-
-	For some reasons the Wolf:ET engine sets this to 0 by default
-	but the game sets it to 2 (and requires it to be 2 for maps
-	looking as expected).
-
-	The mapOverBrightBits value will be read as map entity key
-	by R_LoadEntities() in tr_bsp, making possible to override
-	the default value and properly render a map with another
-	value than the default one.
-
-	If this key is missing in map entity lump, there is no way
-	to know the required value for mapOverBrightBits when loading
-	a BSP, one may rely on arena files to do some guessing when
-	loading foreign maps and games ported to the Dæmon engine may
-	require to set a different default than what Unvanquished
-	requires.
-
-	Using a non-zero value for tr.mapOverBrightBits turns light
-	non-linear and makes deluxe mapping buggy though.
-
-	Mappers may port and fix maps by multiplying the lights by 2.5
-	and set the mapOverBrightBits key to 0 in map entities lump.
-
-	In legacy engines, tr.overbrightBits was non-zero when
-	hardware overbright bits were enabled, zero when disabled.
-	This engine do not implement hardware overbright bit, so
-	this is always zero, and we can remove it and simplify all
-	the computations making use of it.
-
-	Because tr.overbrightBits is always 0, tr.identityLight is
-	always 1.0f. We can entirely remove it. */
-
-	tr.mapOverBrightBits = r_overbrightDefaultExponent.Get();
-	tr.legacyOverBrightClamping = r_overbrightDefaultClamp.Get();
-
 	// create default texture and white texture
 	R_CreateBuiltinImages();
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -92,9 +92,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 		Cvar::NONE, 4, 1, MAX_REF_LIGHTS / 16 );
 	cvar_t      *r_realtimeLightingCastShadows;
 	cvar_t      *r_precomputedLighting;
-	Cvar::Cvar<int> r_overbrightDefaultExponent("r_overbrightDefaultExponent", "default map light color shift (multiply by 2^x)", Cvar::NONE, 2);
-	Cvar::Cvar<bool> r_overbrightDefaultClamp("r_overbrightDefaultClamp", "clamp lightmap colors to 1 (in absence of map worldspawn value)", Cvar::NONE, false);
-	Cvar::Cvar<bool> r_overbrightIgnoreMapSettings("r_overbrightIgnoreMapSettings", "force usage of r_overbrightDefaultClamp / r_overbrightDefaultExponent, ignoring worldspawn", Cvar::NONE, false);
+	Cvar::Cvar<int> r_overbrightDefaultLegacyExponent("r_overbrightDefaultLegacyExponent", "default map light color shift for legacy maps (multiply by 2^x)", Cvar::NONE, 2);
+	Cvar::Cvar<int> r_overbrightDefaultLinearExponent("r_overbrightDefaultLinearExponent", "default map light color shift for maps with linear colorspace (multiply by 2^x)", Cvar::NONE, 1);
+	Cvar::Cvar<bool> r_overbrightDefaultLegacyClamp("r_overbrightDefaultLegacyClamp", "clamp legacy lightmap colors to 1 (in absence of map worldspawn value)", Cvar::NONE, false);
+	Cvar::Cvar<bool> r_overbrightIgnoreMapSettings("r_overbrightIgnoreMapSettings", "force usage of r_overbrightDefaultLegacyClamp / r_overbrightDefaultLegacyExponent / r_overbrightDefaultLinearExponent, ignoring worldspawn", Cvar::NONE, false);
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	Cvar::Cvar<bool> r_colorGrading( "r_colorGrading", "Use color grading", Cvar::NONE, true );
 	Cvar::Cvar<bool> r_preferBindlessTextures( "r_preferBindlessTextures", "use bindless textures even when material system is off", Cvar::NONE, false );
@@ -1169,8 +1170,9 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_subdivisions = Cvar_Get( "r_subdivisions", "4", CVAR_LATCH );
 		r_realtimeLightingCastShadows = Cvar_Get( "r_realtimeLightingCastShadows", "1", 0 );
 		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_CHEAT | CVAR_LATCH );
-		Cvar::Latch( r_overbrightDefaultExponent );
-		Cvar::Latch( r_overbrightDefaultClamp );
+		Cvar::Latch( r_overbrightDefaultLegacyExponent );
+		Cvar::Latch( r_overbrightDefaultLinearExponent );
+		Cvar::Latch( r_overbrightDefaultLegacyClamp );
 		Cvar::Latch( r_overbrightIgnoreMapSettings );
 		Cvar::Latch( r_lightMode );
 		Cvar::Latch( r_colorGrading );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -203,6 +203,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_rimExponent;
 
 	Cvar::Cvar<bool> r_highPrecisionRendering("r_highPrecisionRendering", "use high precision frame buffers for rendering and blending", Cvar::NONE, true);
+	Cvar::Cvar<bool> r_cheapSRGB("r_cheapSRGB", "use cheap sRGB computation when converting images", Cvar::NONE, false);
 
 	cvar_t      *r_gamma;
 	cvar_t      *r_lockpvs;
@@ -1290,6 +1291,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		AssertCvarRange( r_rimExponent, 0.5, 8.0, false );
 
 		Cvar::Latch( r_highPrecisionRendering );
+		Cvar::Latch( r_cheapSRGB );
 
 		r_drawBuffer = Cvar_Get( "r_drawBuffer", "GL_BACK", CVAR_CHEAT );
 		r_lockpvs = Cvar_Get( "r_lockpvs", "0", CVAR_CHEAT );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2829,7 +2829,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		viewParms_t    viewParms;
 
-		// r_overbrightDefaultExponent, but can be overridden by mapper using the worldspawn
+		// r_overbrightDefault[Linear/Legacy]Exponent, but can be overridden by mapper using the worldspawn
 		int mapOverBrightBits;
 		// pow(2, mapOverbrightBits)
 		float mapLightFactor;
@@ -2959,8 +2959,9 @@ enum class shaderProfilerRenderSubGroupsMode {
 	extern Cvar::Range<Cvar::Cvar<int>> r_realtimeLightLayers;
 	extern cvar_t *r_realtimeLightingCastShadows;
 	extern cvar_t *r_precomputedLighting;
-	extern Cvar::Cvar<int> r_overbrightDefaultExponent;
-	extern Cvar::Cvar<bool> r_overbrightDefaultClamp;
+	extern Cvar::Cvar<int> r_overbrightDefaultLinearExponent;
+	extern Cvar::Cvar<int> r_overbrightDefaultLegacyExponent;
+	extern Cvar::Cvar<bool> r_overbrightDefaultLegacyClamp;
 	extern Cvar::Cvar<bool> r_overbrightIgnoreMapSettings;
 	extern Cvar::Range<Cvar::Cvar<int>> r_lightMode;
 	extern Cvar::Cvar<bool> r_colorGrading;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1123,6 +1123,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		bool            dpMaterial;
 
+		int linearizeTexture;
 		// Core renderer (code path for when only OpenGL Core is available, or compatible OpenGL 2).
 		stageRenderer_t colorRenderer;
 
@@ -2731,6 +2732,8 @@ enum class shaderProfilerRenderSubGroupsMode {
 		bool   worldLightMapping;
 		bool   worldDeluxeMapping;
 		bool   worldHDR_RGBE;
+		bool worldLinearizeTexture;
+		bool worldLinearizeLightMap;
 
 		lightMode_t lightMode;
 		lightMode_t worldLight;
@@ -3025,6 +3028,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 	extern cvar_t *r_rimExponent;
 
 	extern Cvar::Cvar<bool> r_highPrecisionRendering;
+	extern Cvar::Cvar<bool> r_cheapSRGB;
 
 	extern cvar_t *r_logFile; // number of frames to emit GL logs
 

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -334,6 +334,14 @@ void RE_AddDynamicLightToSceneET( const vec3_t org, float radius, float intensit
 	light->l.color[ 1 ] = g;
 	light->l.color[ 2 ] = b;
 
+	// Linearize dynamic lights.
+	if ( tr.worldLinearizeTexture )
+	{
+		light->l.color[ 0 ] = convertFromSRGB( light->l.color[ 0 ] );
+		light->l.color[ 1 ] = convertFromSRGB( light->l.color[ 1 ] );
+		light->l.color[ 2 ] = convertFromSRGB( light->l.color[ 2 ] );
+	}
+
 	light->l.inverseShadows = (flags & REF_INVERSE_DLIGHT) != 0;
 	light->l.noShadows = !r_realtimeLightingCastShadows->integer && !light->l.inverseShadows;
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2434,6 +2434,11 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 			{
 				rgb = Math::Clamp( RB_EvalExpression( &pStage->rgbExp, 1.0 ), 0.0f, 1.0f );
 
+				if ( tr.worldLinearizeTexture )
+				{
+					rgb = convertFromSRGB ( rgb );
+				}
+
 				tess.svars.color = Color::White * rgb;
 				break;
 			}
@@ -2460,6 +2465,13 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 					red = Math::Clamp( RB_EvalExpression( &pStage->redExp, 1.0 ), 0.0f, 1.0f );
 					green = Math::Clamp( RB_EvalExpression( &pStage->greenExp, 1.0 ), 0.0f, 1.0f );
 					blue = Math::Clamp( RB_EvalExpression( &pStage->blueExp, 1.0 ), 0.0f, 1.0f );
+				}
+
+				if ( tr.worldLinearizeTexture )
+				{
+					red = convertFromSRGB ( red );
+					green = convertFromSRGB ( green );
+					blue = convertFromSRGB ( blue );
 				}
 
 				tess.svars.color.SetRed( red );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -860,6 +860,9 @@ void Render_generic3D( shaderStage_t *pStage )
 	gl_genericShader->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
 	gl_genericShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 
+	// u_LinearizeTexture
+	gl_genericShader->SetUniform_LinearizeTexture( pStage->linearizeTexture );
+
 	// u_Bones
 	if ( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning )
 	{
@@ -1032,6 +1035,9 @@ void Render_lightMapping( shaderStage_t *pStage )
 	gl_lightMappingShader->SetUniform_ViewOrigin( viewOrigin );
 
 	gl_lightMappingShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
+
+	// u_LinearizeTexture
+	gl_lightMappingShader->SetUniform_LinearizeTexture( pStage->linearizeTexture );
 
 	if ( glConfig2.realtimeLighting &&
 	     r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) )
@@ -1960,6 +1966,9 @@ void Render_skybox( shaderStage_t *pStage )
 		GL_BindToTMU( 0, pStage->bundle[TB_COLORMAP].image[0] )
 	);
 
+	// u_LinearizeTexture
+	gl_skyboxShader->SetUniform_LinearizeTexture( pStage->linearizeTexture );
+
 	// u_AlphaThreshold
 	gl_skyboxShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 
@@ -2267,6 +2276,9 @@ void Render_fog( shaderStage_t* pStage )
 	gl_fogQuake3Shader->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
 
 	gl_fogQuake3Shader->BindProgram( 0 );
+
+	// u_LinearizeTexture
+	gl_fogQuake3Shader->SetUniform_LinearizeTexture( tr.worldLinearizeTexture );
 
 	gl_fogQuake3Shader->SetUniform_FogDistanceVector( fogDistanceVector );
 	gl_fogQuake3Shader->SetUniform_FogDepthVector( fogDepthVector );

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -102,6 +102,9 @@ void Tess_StageIteratorSky()
 
 	gl_skyboxShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 
+	// u_LinearizeTexture
+	gl_skyboxShader->SetUniform_LinearizeTexture( tr.worldLinearizeTexture );
+
 	gl_skyboxShader->SetRequiredVertexPointers();
 
 	// draw the outer skybox
@@ -160,6 +163,9 @@ void Tess_StageIteratorSky()
 
 		// u_AlphaThreshold
 		gl_skyboxShader->SetUniform_AlphaTest( pStage->stateBits );
+
+		// u_LinearizeTexture
+		gl_skyboxShader->SetUniform_LinearizeTexture( tr.worldLinearizeTexture );
 
 		GL_State( pStage->stateBits );
 


### PR DESCRIPTION
This is a GLSL implementation and it produces awful color banding, I assume this is caused by precision loss when computed data is passed from framebuffers to framebuffers.

## Why a GLSL implementation?

We have to keep it the computed colors of a stage in linear space in order to have correct stage blending, but then we lose precision when converting to sRGB for display at the very end.

I know OpenGL provides native features for sRGB but I want a GLSL fallback to exist if:

- a device doesn't provide the sRGB extensions for all image formats we support.
- some unsolvable problem makes us unable to use builtin sRGB features.

About the second point, one problem we have is that when loading light styles, we may upload an image to the GPU before knowing it's a lightmap, meaning that when we know it's a lightmap, it's already too late to use OpenGL builtin features to declare the texture as sRGB. This may be fixed with a complex rewrite of our shader parsing code by not loading images on the fly but deferring all image loading once the stage is fully parsed.

I'm not against a native OpenGL sRGB implementation but I believe that should come later when we have the most generic implementation working.

## About precision loss

I'm also not sure that using the builtin OpenGL sRGB features would fix the color banding produced here, as I expect the sRGB framebuffer to have the same precision.

I expect builtin OpenGL sRGB feature is that if you have a sRGB framebuffer and a linear image and a sRGB image properly declared, things are automatically converted for you in input and output.

But we blend multiple stages.

An engine that implements the same features like DarkPlaces doesn't support stage blending, so it's easier for them to implement those sRGB features, and maybe they just avoid the problems we are facing because they don't have the handle use cases that produce such errors.

For example, if implement the exact same GLSL code but contained in a single stage, in the `lightMap_fp.glsl` code, and use a game level that only display single-stage materials, I get no color banding at all.

## What those features are about?

### About operating in linear space

To have a physically correct light computation, the linear light map should be blended over a linear diffuse map, the complete light mapping code (deluxe/normal/specular…) should compute in linear space with linear data.

Historically, all diffuse maps are in sRGB space because it is what you get when you edit a file in a painting tool. Any workflow based on tools like GIMP, Krita, MyPaint, PhotoShop, Paint, etc. produce a sRGB image because what is painted is observed by the artist using an human eye that has non-linear response to light.

This article by John Novak is very useful to read on such topic, if you feel you miss something when reading my text, please re-read it: https://blog.johnnovak.net/2016/09/21/what-every-coder-should-know-about-gamma/

Because of the same reason, the light values written in game level light entities are in sRGB space, as the NetRadiant color picker is observed by an human eye. By convention, all other lights values are expected to be in sRGB space as well like the values in light emitting materials, in a way they are the sames as the one you would select with the NetRadiant color picker for a light entity.

The sRGB curve is an approximation of that non-linear human eye response to light, so we can convert back to linear (for computation) and forth (for display).

So, to physically compute blend lights for a game, the light map computation at game level compilation time must convert diffuse maps and light values to linear space. Historically, `q3map2` was wrongly computing lights with diffuse maps and light values in sRGB space. This is still the default because of backward compatibility needs. However, q3map2 now provides the `-sRGBtex` and `-sRGBcolor` options to tell the light computation to convert the diffuse map and light color values to linear space before the actual computation. This fixes half of the problem. The produced light map is always assumed to be in linear space.

Then, to physically blend lights in a game, the light map blending at game render time should blend linear diffuse maps with linear light maps. While light maps are always considered to be in linear space, the diffuse maps are not. Historically, 
the Quake3 game engine mistakenly blended linear lightmaps with sRGB diffuse maps. This produced non-physical light rendering. Because that computation is wrong, games like Wolf:ET used an alternate broken computation in q3map2 that makes the problem less problemating when feeding the broken computation in engine with, as in this case, broken in a way plus broken in the other way is less broken. The `learnopengl.com` website explains that trick in the “Attenuation” section. But all of this is wrong, the Wolf:ET trick was just attempting to hide wrongness with wrongness. I'm not sure the article is totally right about the topic, but that part explains well what the Wolf:ET hack did: https://learnopengl.com/Advanced-Lighting/Gamma-Correction

#### What this implementation does?

If the `-sRGBtex` and `-sRGBcolor` q3map2 options were used at game level compilation time, the engine assumes the game level author knows what he is doing and actually wants a physically correct light computation, not only at game level compilation time, but also at game level render time. The engine then converts all diffuse maps in linear space before blending lights on them, but do not convert the result computation back to sRGB after that because the engine may blend other stages and we also want to do stage blending in linear space to have physically correct blends (like translucent textures acting like they would do in the real world). Then, at the very end, when everything is computed and blended and ready to be displayed on the screen, the whole screen is converted to sRGB so the human eye can see it.

The banding observed when running this code is assumed to come from the fact the last conversion step can't obviously reconstruct the missing colors when converting back to sRGB.

### About sRGB lightmaps

You may ask: why would people want to do that? I just said both diffuse maps and light maps should be in linear space when blending them to have a physically correct computation!

Yes, but the sRGB colorspace introduces a bias in the storage that gives more precision to color values the human eye is sensitive to. This means by storing a lightmap in a 8 bit image in sRGB color space, we can provide more precision in the dark areas, where the human eye is good at spotting differences, at the expense of bright areas, where differences are less noticeable by the human eye. If you discover this by reading these lines, please re-read the article by John Novak, especially the “Light emission vs perceptual brightness” and the “Physical vs perceptual linearity” sections: https://blog.johnnovak.net/2016/09/21/what-every-coder-should-know-about-gamma/#light-emission-vs-perceptual-brightness

Xonotic uses this trick: they ship light maps in sRGB space, and convert them back in linear space at game render time before blending them with diffuse maps, getting more precision in the low value while completely avoiding the usage of high-precision lightmaps, still using 8-bit per lightmap pixel and not 16-bit or other formats (they even ship light maps in jpeg format!). This also means such light maps with more precision in dark areas can still be stored in the light map lump of the BSP itself since the 8-bit per channel precision is kept. For Unvanquished we always recommend to do external lightmaps but one can truly recognize the cleverness of the trick, biasing the storage to get more precision in some range while keeping the compatibility with the storage format.

The ability to get better precision in darker areas while keeping the ability to store our lightmaps in 8-bit per channel formats would be good for us, as we usually use the 8-bit lossless WebP format to get a good light map compression.

The `q3map2` tool provide the `-sRGBlight` option to convert light maps from linear space to sRGB space when writing them in the BSP lump or in external TGA images (we can then convert to 8-bit PNG, WebP, etc.).

#### What this implementation does?

If the `-sRGBlight` q3map2 option was used at game level compilation time, the engine converts back the lightmap to linear space before blending it on the diffuse map and doing other operations like normal and specular mapping.

### About the `-sRGB` q3map2 option and others

The `q3map2` map compiler provides a `-sRGB` option that both sets `-sRGBtex`, `-sRGBcolor` and `-sRGBlight`. It is an all-in-one option used by Xonotic to compile their maps to sets all those options.

It is still good to have the ability to compute light maps in linear space but also store them in linear space. For example if one day our engine implements HDR lightmaps, we would not need to use the sRGB lightmap trick, and we would only want to tell q3map2 to do physically correct computations `-sRGBtex` and `-sRGBcolor`, but store linear HDR lightmaps, then with using `-sRGBlight` option.

That's why I implemented a separate detection of “what computation the game level author used in q3map2 and then expects from the renderer” and “what lightmap storage the game level author used.

It may also be possible to do a legacy quake3-like non-physical light computation in q3map2 but still storing the lightmap in sRGB space to bias the storage to get more precision in the darker areas.

## How to fix that ugly color banding?

Because we heavily rely on material stage blending (terrain blending, light styles, special effects, etc.), we cannot fix such color banding by converting computed stages to sRGB at the end of the stage rendering without having non-physical stage blends. Maybe we can fix that color banding by using a higher-precision framebuffer, if that's possible.

One may investigate a native sRGB OpenGL implementation but I doubt this will fix our issue because it looks like our problems comes from the fact we lose precision between computing stages.

It's OK to have less good looking game levels in low presets (especially the lowest one), so we may have:

- Such implementation writing in 8-bit per channel framebuffers, and with bad color banding. Such implementation would be used usable in low presets.
  If one day we implement this using native OpenGL features, this would also be the fallback if the required features are missing.
- An implementation writing in higher precision framebuffers for higher presets.

Also some people may accept a less physically correct rendering if that's faster, so I guess the engine may also do that:

- Converting back to sRGB at the end of each stage, having a physically correct lighting but non-physically correct blend, avoind color banding, writing in 8-bit per channel framebuffers. Such implementation would be used in low presets.
- An implementation writing in higher precision framebuffers for higher presets.

If we do that, we would add a cvar for enabling or not the higher-precision framebuffers.

## About the legacy `mapOverBrightBits` trick

Tweaking the lights with `mapOverBrightBits` is making the lights non-linear, so when detecting the game level was compiled with physically correct light computation, this implementation also assumes the gamel level author doesn't want to use any `mapOverBrightBits`, which would make everything easier as we would not require the game level author to add a specific worldspawn entity key to disable `mapOverBrightBits` when using a physically correct game level: he would just use the physically correct map compilation option in build menu, and the engine would guess he also wants to disable mapOverBrightBits. This will allow our engine to still enable `mapOverBrighBits` on legacy game levels and disable it on newer game levels without requiring to set any `mapOverBrightBits` worldspawn entity key, neither on legacy maps (this is better for out-of-the box legacy support), neither on newer game levels (this is better to make the task of the game level editor simpler; and would prevent mistakes).