### PR TITLE
renderer: implement mapOverBrightBits in GLSL

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1573,6 +1573,7 @@ void GLShader_generic2D::SetShaderProgramUniforms( shaderProgram_t *shaderProgra
 
 GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	GLShader( "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
+	u_MapOverBrightBitsShift( this ),
 	u_TextureMatrix( this ),
 	u_ViewOrigin( this ),
 	u_ViewUp( this ),
@@ -1610,6 +1611,7 @@ void GLShader_generic::SetShaderProgramUniforms( shaderProgram_t *shaderProgram 
 GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 	GLShader( "lightMapping",
 	ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT | ATTR_COLOR, manager ),
+	u_MapOverBrightBitsShift( this ),
 	u_TextureMatrix( this ),
 	u_SpecularExponent( this ),
 	u_ColorModulate( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1304,6 +1304,21 @@ public:
 	}
 };
 
+class u_MapOverBrightBitsShift :
+	GLUniform1i
+{
+public:
+	u_MapOverBrightBitsShift( GLShader *shader ) :
+		GLUniform1i( shader, "u_MapOverBrightBitsShift" )
+	{
+	}
+
+	void SetUniform_MapOverBrightBitsShift( int mapOverBrightBitsShift )
+	{
+		this->SetValue( mapOverBrightBitsShift );
+	}
+};
+
 class u_TextureMatrix :
 	GLUniformMatrix4f
 {
@@ -2238,6 +2253,7 @@ public:
 
 class GLShader_generic :
 	public GLShader,
+	public u_MapOverBrightBitsShift,
 	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_ViewUp,
@@ -2267,6 +2283,7 @@ public:
 
 class GLShader_lightMapping :
 	public GLShader,
+	public u_MapOverBrightBitsShift,
 	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_ColorModulate,

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -33,7 +33,25 @@ IN(smooth) vec2         var_FadeDepth;
 uniform sampler2D       u_DepthMap;
 #endif
 
+#if !defined(GENERIC_2D) && defined(USE_TCGEN_LIGHTMAP)
+uniform int u_MapOverBrightBitsShift;
+#endif
+
 DECLARE_OUTPUT(vec4)
+
+void mapOverBrightBits(inout vec3 color, in float shift)
+{
+	if (shift > 1)
+	{
+		color *= shift;
+		float maxComponent = 1.0;
+		maxComponent = max(maxComponent, color.r);
+		maxComponent = max(maxComponent, color.g);
+		maxComponent = max(maxComponent, color.b);
+		maxComponent = 1.0 / maxComponent;
+		color *= maxComponent;
+	}
+}
 
 void	main()
 {
@@ -53,7 +71,12 @@ void	main()
 	color.a *= smoothstep(gl_FragCoord.z, fadeDepth, depth);
 #endif
 
+#if !defined(GENERIC_2D) && defined(USE_TCGEN_LIGHTMAP)
+	mapOverBrightBits(color.rgb, u_MapOverBrightBitsShift);
+#endif
+
 	color *= var_Color;
+
 	outputColor = color;
 
 #if defined(GENERIC_2D)

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -59,7 +59,23 @@ IN(smooth) vec3		var_Normal;
 	uniform vec3 u_LightGridScale;
 #endif
 
+uniform int u_MapOverBrightBitsShift;
+
 DECLARE_OUTPUT(vec4)
+
+void mapOverBrightBits(inout vec3 color, in float shift)
+{
+	if (shift > 1)
+	{
+		color *= shift;
+		float maxComponent = 1.0;
+		maxComponent = max(maxComponent, color.r);
+		maxComponent = max(maxComponent, color.g);
+		maxComponent = max(maxComponent, color.b);
+		maxComponent = 1.0 / maxComponent;
+		color *= maxComponent;
+	}
+}
 
 void main()
 {
@@ -124,6 +140,8 @@ void main()
 		vec3 ambientColor, lightColor;
 		ReadLightGrid(texture3D(u_LightGrid1, lightGridPos), ambientColor, lightColor);
 
+		mapOverBrightBits(ambientColor.rgb, u_MapOverBrightBitsShift);
+
 		color.rgb = ambientColor * r_AmbientScale * diffuse.rgb;
 	#endif
 
@@ -152,6 +170,8 @@ void main()
 		// Divide by cosine term to restore original light color.
 		lightColor /= clamp(dot(normalize(var_Normal), lightDir), 0.3, 1.0);
 	#endif
+
+	mapOverBrightBits(lightColor.rgb, u_MapOverBrightBitsShift);
 
 	// Blend static light.
 	#if defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING)

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1798,10 +1798,7 @@ image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 		return nullptr;
 	}
 
-	if ( imageParams.bits & IF_LIGHTMAP )
-	{
-		R_ProcessLightmap( pic[ 0 ], 4, width, height, imageParams.bits, pic[ 0 ] );
-	}
+	// Color shift for overbright bits is now done in GLSL.
 
 	image = R_CreateImage( ( char * ) buffer, (const byte **)pic, width, height, numMips, imageParams );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2822,7 +2822,8 @@ enum class deluxeMode_t { NONE, GRID, MAP };
 
 		viewParms_t    viewParms;
 
-		int            mapOverBrightBits; // r_mapOverbrightBits->integer, but can be overridden by mapper using the worldspawn
+		int mapOverBrightBits; // r_mapOverbrightBits->integer, but can be overridden by mapper using the worldspawn
+		int mapOverBrightBitsShift; // pow(2, mapOverbrightBits)
 
 		orientationr_t orientation; // for current entity
 
@@ -3305,7 +3306,6 @@ inline bool checkGLErrors()
 	void      RE_Shutdown( bool destroyWindow );
 
 	bool   R_GetEntityToken( char *buffer, int size );
-	float      R_ProcessLightmap( byte *pic, int in_padding, int width, int height, int bits, byte *pic_out );  // Arnout
 
 	model_t    *R_AllocModel();
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -732,6 +732,12 @@ static void Render_generic( shaderStage_t *pStage )
 		gl_genericShader->SetUniform_AlphaTest(pStage->stateBits);
 	}
 
+	// u_MapOverBrightBitsShift
+	if ( pStage->tcGen_Lightmap )
+	{
+		gl_genericShader->SetUniform_MapOverBrightBitsShift( tr.mapOverBrightBitsShift );
+	}
+
 	// u_ColorGen
 	switch ( pStage->rgbGen )
 	{
@@ -895,6 +901,7 @@ static void Render_lightMapping( shaderStage_t *pStage )
 
 	lightMode_t lightMode = lightMode_t::FULLBRIGHT;
 	deluxeMode_t deluxeMode = deluxeMode_t::NONE;
+	int mapOverBrightBitsShift = 1;
 
 	/* TODO: investigate what this is. It's probably a hack to detect some
 	specific use case. Without knowing which use case this takes care about,
@@ -949,6 +956,7 @@ static void Render_lightMapping( shaderStage_t *pStage )
 	switch ( lightMode )
 	{
 		case lightMode_t::VERTEX:
+			mapOverBrightBitsShift = tr.mapOverBrightBitsShift;
 			// Do not rewrite pStage->rgbGen.
 			colorGen = colorGen_t::CGEN_VERTEX;
 			tess.svars.color.SetRed( 0.0f );
@@ -957,12 +965,14 @@ static void Render_lightMapping( shaderStage_t *pStage )
 			break;
 
 		case lightMode_t::GRID:
+			mapOverBrightBitsShift = tr.mapOverBrightBitsShift;
 			// Store lightGrid1 as lightmap,
 			// the GLSL code will know how to deal with it.
 			lightmap = tr.lightGrid1Image;
 			break;
 
 		case lightMode_t::MAP:
+			mapOverBrightBitsShift = tr.mapOverBrightBitsShift;
 			lightmap = GetLightMap();
 
 			if ( r_showLightMaps->integer )
@@ -1084,6 +1094,9 @@ static void Render_lightMapping( shaderStage_t *pStage )
 
 	// u_AlphaTest
 	gl_lightMappingShader->SetUniform_AlphaTest( pStage->stateBits );
+
+	// u_MapOverBrightBitsShift
+	gl_lightMappingShader->SetUniform_MapOverBrightBitsShift( mapOverBrightBitsShift );
 
 	// bind u_HeightMap
 	if ( pStage->enableReliefMapping )

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1450,6 +1450,9 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, const int bundleI
 	else if ( !Q_stricmp( token, "$lightmap" ) )
 	{
 		stage->type = stageType_t::ST_LIGHTMAP;
+		/*  This is not needed to compute coordinates, but we use this to select
+		specific lightmap code in generic_fp.glsl. */
+		stage->tcGen_Lightmap = true;
 		return true;
 	}
 


### PR DESCRIPTION
Implement mapOverBrightBits in GLSL.

This is required for deluxe mapping since we need to do the computation on lights without blended attenuation.

This will also be required when using lightmaps in non-linear colorspace as the computation would have to be done on lights after they are linearized.