### PR TITLE
compiler: avoid breakpoint warning when building nacl gamecode (fix CI)

### DIFF
--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -85,8 +85,8 @@ int CountTrailingZeroes(unsigned long long x);
 // Raise an exception and break in the debugger
 #if defined(DAEMON_ARCH_i686) || defined(DAEMON_ARCH_amd64)
 	#define BREAKPOINT() __asm__ __volatile__("int $3\n\t")
-#elif defined(DAEMON_ARCH_pnacl)
-	// TODO: find how to implement breakpoint on PNaCl
+#elif defined(DAEMON_ARCH_nacl)
+	// TODO: find how to implement breakpoint on NaCl
 	// Accept our fate, do not raise a warning.
 	#define BREAKPOINT()
 #else


### PR DESCRIPTION
The `DAEMON_ARCH_pnacl` define is now `DAEMON_ARCH_nacl` (PNaCl is a toolchain, NaCl is an architecture), without this change, the Game CI raises this warning and aborts.