### PR TITLE
Fix lightmaps for portal surfaces

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -5611,7 +5611,7 @@ const RenderCommand *FinalisePortalCommand::ExecuteSelf( ) const
 	glStencilOp( GL_KEEP, GL_KEEP, GL_KEEP );
 
 	Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader,
-		nullptr, false, false, -1, -1 );
+		nullptr, false, false, surface->lightmapNum(), surface->fogNum(), true );
 	rb_surfaceTable[Util::ordinal( *( surface->surface ) )]( surface->surface );
 	Tess_End();
 


### PR DESCRIPTION
Changes the portal surfaces to render as a BSP surface in Tess_Begin() in FinalisePortalCommand. Sets the lightmapNum and fogNum, although this isn't necessary since &lightmap always uses worlds lightmap (-1).

Note: this does not fix dynamic lights for portals.

Screenshots:
Without lightmap:
![unvanquished_2024-01-27_173416_000](https://github.com/DaemonEngine/Daemon/assets/10687142/356438b4-6b83-46ab-a3ec-68c0e8326da1)
With lightmap:
![unvanquished_2024-01-27_173206_000](https://github.com/DaemonEngine/Daemon/assets/10687142/aa5b9c4e-ea8f-4978-8b65-1be735d51685)
Without lightmap:
![unvanquished_2024-01-27_173438_000](https://github.com/DaemonEngine/Daemon/assets/10687142/5cd5721a-3664-4398-a5a5-884499c42d90)
With lightmap:
![unvanquished_2024-01-27_173241_000](https://github.com/DaemonEngine/Daemon/assets/10687142/05218fca-c482-4c40-8b54-006384a3ad19)