### PR TITLE
Unify list command and function naming

### DIFF
--- a/src/engine/client/key_binding.cpp
+++ b/src/engine/client/key_binding.cpp
@@ -456,11 +456,11 @@ std::string ExtraInfoKeyString(Key key)
 	return KeyToString(key);
 }
 
-class BindListCmd: public Cmd::StaticCmd
+class ListBindsCmd: public Cmd::StaticCmd
 {
 public:
-	BindListCmd():
-		StaticCmd("bindlist", Cmd::KEY_BINDING, "Lists all key bindings")
+	ListBindsCmd():
+		StaticCmd("listBinds", Cmd::KEY_BINDING, "Lists all key bindings")
 	{}
 
 	void Run(const Cmd::Args&) const override
@@ -811,7 +811,7 @@ public:
 	// TODO: completion
 };
 
-const BindListCmd BindListCmdRegistration;
+const ListBindsCmd ListBindsCmdRegistration;
 const BindCmd BindCmdRegistration{"bind", "Set or view command to be executed when a key is pressed", false};
 const BindCmd TeambindCmdRegistration{"teambind", "Set key binding for a specific team", true};
 const EditBindCmd EditBindCmdRegistration;

--- a/src/engine/renderer/tr_animation.cpp
+++ b/src/engine/renderer/tr_animation.cpp
@@ -583,10 +583,10 @@ skelAnimation_t *R_GetAnimationByHandle( qhandle_t index )
 
 /*
 ================
-R_AnimationList_f
+R_ListAnimations_f
 ================
 */
-void R_AnimationList_f()
+void R_ListAnimations_f()
 {
 	int             i;
 	skelAnimation_t *anim;

--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -605,10 +605,10 @@ void R_ShutdownFBOs()
 
 /*
 ============
-R_FBOList_f
+R_ListFBOs_f
 ============
 */
-void R_FBOList_f()
+void R_ListFBOs_f()
 {
 	int   i;
 	FBO_t *fbo;

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -146,10 +146,10 @@ void GL_TextureMode( const char *string )
 
 /*
 ===============
-R_ImageList_f
+R_ListImages_f
 ===============
 */
-void R_ImageList_f()
+void R_ListImages_f()
 {
 	int        i;
 	image_t    *image;

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -499,9 +499,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	}
 
 	/*
-	** R_ModeList_f
+	** R_ListModes_f
 	*/
-	static void R_ModeList_f()
+	static void R_ListModes_f()
 	{
 		int i;
 
@@ -1343,15 +1343,15 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_showDecalProjectors = Cvar_Get( "r_showDecalProjectors", "0", CVAR_CHEAT );
 
 		// make sure all the commands added here are also removed in R_Shutdown
-		ri.Cmd_AddCommand( "imagelist", R_ImageList_f );
-		ri.Cmd_AddCommand( "shaderlist", R_ShaderList_f );
+		ri.Cmd_AddCommand( "listImages", R_ListImages_f );
+		ri.Cmd_AddCommand( "listShaders", R_ListShaders_f );
 		ri.Cmd_AddCommand( "shaderexp", R_ShaderExp_f );
-		ri.Cmd_AddCommand( "skinlist", R_SkinList_f );
-		ri.Cmd_AddCommand( "modellist", R_Modellist_f );
-		ri.Cmd_AddCommand( "modelist", R_ModeList_f );
-		ri.Cmd_AddCommand( "animationlist", R_AnimationList_f );
-		ri.Cmd_AddCommand( "fbolist", R_FBOList_f );
-		ri.Cmd_AddCommand( "vbolist", R_VBOList_f );
+		ri.Cmd_AddCommand( "listSkins", R_ListSkins_f );
+		ri.Cmd_AddCommand( "listModels", R_ListModels_f );
+		ri.Cmd_AddCommand( "listModes", R_ListModes_f );
+		ri.Cmd_AddCommand( "listAnimations", R_ListAnimations_f );
+		ri.Cmd_AddCommand( "listFBOs", R_ListFBOs_f );
+		ri.Cmd_AddCommand( "listVBOs", R_ListVBOs_f );
 		ri.Cmd_AddCommand( "gfxinfo", GfxInfo_f );
 		ri.Cmd_AddCommand( "buildcubemaps", R_BuildCubeMaps );
 
@@ -1509,17 +1509,17 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 	{
 		Log::Debug("RE_Shutdown( destroyWindow = %i )", destroyWindow );
 
-		ri.Cmd_RemoveCommand( "modellist" );
-		ri.Cmd_RemoveCommand( "imagelist" );
-		ri.Cmd_RemoveCommand( "shaderlist" );
+		ri.Cmd_RemoveCommand( "listModels" );
+		ri.Cmd_RemoveCommand( "listImages" );
+		ri.Cmd_RemoveCommand( "listShaders" );
 		ri.Cmd_RemoveCommand( "shaderexp" );
-		ri.Cmd_RemoveCommand( "skinlist" );
+		ri.Cmd_RemoveCommand( "listSkins" );
 		ri.Cmd_RemoveCommand( "gfxinfo" );
-		ri.Cmd_RemoveCommand( "modelist" );
+		ri.Cmd_RemoveCommand( "listModes" );
 		ri.Cmd_RemoveCommand( "shaderstate" );
-		ri.Cmd_RemoveCommand( "animationlist" );
-		ri.Cmd_RemoveCommand( "fbolist" );
-		ri.Cmd_RemoveCommand( "vbolist" );
+		ri.Cmd_RemoveCommand( "listAnimations" );
+		ri.Cmd_RemoveCommand( "listFBOs" );
+		ri.Cmd_RemoveCommand( "listVBOs" );
 		ri.Cmd_RemoveCommand( "generatemtr" );
 		ri.Cmd_RemoveCommand( "buildcubemaps" );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3566,7 +3566,6 @@ inline bool checkGLErrors()
 
 	void     R_AddWorldInteractions( trRefLight_t *light );
 	void     R_AddPrecachedWorldInteractions( trRefLight_t *light );
-	void     R_ShutdownVBOs();
 
 	/*
 	============================================================

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2510,7 +2510,7 @@ enum class deluxeMode_t { NONE, GRID, MAP };
 
 	void               R_ModelBounds( qhandle_t handle, vec3_t mins, vec3_t maxs );
 
-	void               R_Modellist_f();
+	void               R_ListModels_f();
 
 //====================================================
 	extern refimport_t ri;
@@ -3315,8 +3315,8 @@ inline bool checkGLErrors()
 
 	bool   R_GetModeInfo( int *width, int *height, int mode );
 
-	void       R_ImageList_f();
-	void       R_SkinList_f();
+	void       R_ListImages_f();
+	void       R_ListSkins_f();
 
 // https://zerowing.idsoftware.com/bugzilla/show_bug.cgi?id=516
 	const void *RB_TakeScreenshotCmd( const void *data );
@@ -3372,7 +3372,7 @@ inline bool checkGLErrors()
 	shader_t  *R_FindShaderByName( const char *name );
 	const char *RE_GetShaderNameFromHandle( qhandle_t shader );
 	void      R_InitShaders();
-	void      R_ShaderList_f();
+	void      R_ListShaders_f();
 	void      R_ShaderExp_f();
 	void      R_RemapShader( const char *oldShader, const char *newShader, const char *timeOffset );
 
@@ -3682,7 +3682,7 @@ inline bool checkGLErrors()
 
 	void     R_InitFBOs();
 	void     R_ShutdownFBOs();
-	void     R_FBOList_f();
+	void     R_ListFBOs_f();
 
 	/*
 	============================================================
@@ -3705,7 +3705,7 @@ inline bool checkGLErrors()
 
 	void  R_InitVBOs();
 	void  R_ShutdownVBOs();
-	void  R_VBOList_f();
+	void  R_ListVBOs_f();
 
 	/*
 	============================================================
@@ -3773,7 +3773,7 @@ inline bool checkGLErrors()
 	qhandle_t RE_RegisterAnimationIQM( const char *name, IQAnim_t *data );
 
 	skelAnimation_t *R_GetAnimationByHandle( qhandle_t hAnim );
-	void            R_AnimationList_f();
+	void            R_ListAnimations_f();
 
 	void            R_AddMD5Surfaces( trRefEntity_t *ent );
 	void            R_AddMD5Interactions( trRefEntity_t *ent, trRefLight_t *light, interactionType_t iaType );

--- a/src/engine/renderer/tr_model.cpp
+++ b/src/engine/renderer/tr_model.cpp
@@ -307,10 +307,10 @@ void R_ModelInit()
 
 /*
 ================
-R_Modellist_f
+R_ListModels_f
 ================
 */
-void R_Modellist_f()
+void R_ListModels_f()
 {
 	int      i, j, k;
 	model_t  *mod;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6215,13 +6215,13 @@ shader_t       *R_GetShaderByHandle( qhandle_t hShader )
 
 /*
 ===============
-R_ShaderList_f
+R_ListShaders_f
 
 Dump information on all valid shaders to the console
 A second parameter will cause it to print in sorted order
 ===============
 */
-void R_ShaderList_f()
+void R_ListShaders_f()
 {
 	const char *prefix = ri.Cmd_Argc() > 1 ? ri.Cmd_Argv( 1 ) : nullptr;
 

--- a/src/engine/renderer/tr_skin.cpp
+++ b/src/engine/renderer/tr_skin.cpp
@@ -329,10 +329,10 @@ skin_t         *R_GetSkinByHandle( qhandle_t hSkin )
 
 /*
 ===============
-R_SkinList_f
+R_ListSkins_f
 ===============
 */
-void R_SkinList_f()
+void R_ListSkins_f()
 {
 	int    i, j;
 	skin_t *skin;

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -1277,10 +1277,10 @@ void Tess_UpdateVBOs()
 
 /*
 ============
-R_VBOList_f
+R_ListVBOs_f
 ============
 */
-void R_VBOList_f()
+void R_ListVBOs_f()
 {
 	int   i;
 	VBO_t *vbo;


### PR DESCRIPTION
This is some lazy task I did to change my mind and this put an end to something that annoyed me for a long time. This unifies our engine `list` commands and functions.

I was worrided we had `listCvars` and `listCmd` but `imagelist` and `shaderlist`, so we no also have `listImages` and `listShaders`, which also greatly improves command completion when looking for “_what do we can list_”? This also totally removes the extra useless mental load of thinking about “_is the name of the command I need starting or ending with `list`_”?

I also unified the related functions.

For example we had `R_InitVBOs()`, `R_ShutdownVBOs()`, `R_InitFBOs()`, and `R_ShutdownFBOs()` but `R_VBOList_f()` and `R_FBOList_f()`, we now have `R_ListVBOs_f()` and `R_ListFBOs_f()` which is more consistent with other function names.

Same for `BindListCmd()` which is now named `ListBindsCmd()` which is more consistent with existing `BindCmd()` and `EditBindCmd`, basically following the same `verbObject` naming scheme.

An extra commit deletes a duplicate `R_ShutdownVBOs()` declaration.