### PR TITLE
renderer: implement ivec_t and the ability to send integer vectors to GLSL

### DIFF
--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -227,7 +227,6 @@ void  Com_Free_Aligned( void *ptr );
 
 	using vec_t = float;
 	using vec2_t = vec_t[2];
-
 	using vec3_t = vec_t[3];
 	using vec4_t = vec_t[4];
 
@@ -235,6 +234,11 @@ void  Com_Free_Aligned( void *ptr );
 	using matrix3x3_t = vec_t[3 * 3];
 	using matrix_t = vec_t[4 * 4];
 	using quat_t = vec_t[4];
+
+	using ivec_t = int;
+	using ivec2_t = ivec_t[2];
+	using ivec3_t = ivec_t[3];
+	using ivec4_t = ivec_t[4];
 
 	// A transform_t represents a product of basic
 	// transformations, which are a rotation about an arbitrary

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -418,6 +418,127 @@ public:
 	}
 };
 
+class GLUniform2i : protected GLUniform
+{
+protected:
+	GLUniform2i( GLShader *shader, const char *name ) :
+	GLUniform( shader, name )
+	{
+	}
+
+	inline void SetValue( const ivec2_t v )
+	{
+		shaderProgram_t *p = _shader->GetProgram();
+
+		ASSERT_EQ(p, glState.currentProgram);
+
+#if defined( LOG_GLSL_UNIFORMS )
+		if ( r_logFile->integer )
+		{
+			GLimp_LogComment( va( "GLSL_SetUniform2i( %s, shader: %s, value: [ %d, %d ] ) ---\n",
+				this->GetName(), _shader->GetName().c_str(), v[ 0 ], v[ 1 ] ) );
+		}
+#endif
+#if defined( USE_UNIFORM_FIREWALL )
+		ivec2_t *firewall = ( ivec2_t * ) &p->uniformFirewall[ _firewallIndex ];
+
+		if ( !memcmp( *firewall, v, sizeof( *firewall ) ) )
+		{
+			return;
+		}
+
+		( *firewall )[ 0 ] = v[ 0 ];
+		( *firewall )[ 1 ] = v[ 1 ];
+#endif
+		glUniform2i( p->uniformLocations[ _locationIndex ], v[ 0 ], v[ 1 ] );
+	}
+
+	size_t GetSize() override
+	{
+		return sizeof( ivec2_t );
+	}
+};
+
+class GLUniform3i : protected GLUniform
+{
+protected:
+	GLUniform3i( GLShader *shader, const char *name ) :
+	GLUniform( shader, name )
+	{
+	}
+
+	inline void SetValue( const ivec3_t v )
+	{
+		shaderProgram_t *p = _shader->GetProgram();
+
+		ASSERT_EQ(p, glState.currentProgram);
+
+#if defined( LOG_GLSL_UNIFORMS )
+		if ( r_logFile->integer )
+		{
+			GLimp_LogComment( va( "GLSL_SetUniform3i( %s, shader: %s, value: [ %d, %d, %d ] ) ---\n",
+				this->GetName(), _shader->GetName().c_str(), v[ 0 ], v[ 1 ], v[ 2 ] ) );
+		}
+#endif
+#if defined( USE_UNIFORM_FIREWALL )
+		ivec3_t *firewall = ( ivec3_t * ) &p->uniformFirewall[ _firewallIndex ];
+
+		if ( !memcmp( *firewall, v, sizeof( *firewall ) ) )
+		{
+			return;
+		}
+
+		VectorCopy( v, *firewall );
+#endif
+		glUniform3i( p->uniformLocations[ _locationIndex ], v[ 0 ], v[ 1 ], v[ 2 ] );
+	}
+public:
+	size_t GetSize() override
+	{
+		return sizeof( ivec3_t );
+	}
+};
+
+class GLUniform4i : protected GLUniform
+{
+protected:
+	GLUniform4i( GLShader *shader, const char *name ) :
+	GLUniform( shader, name )
+	{
+	}
+
+	inline void SetValue( const ivec4_t v )
+	{
+		shaderProgram_t *p = _shader->GetProgram();
+
+		ASSERT_EQ(p, glState.currentProgram);
+
+#if defined( LOG_GLSL_UNIFORMS )
+		if ( r_logFile->integer )
+		{
+			GLimp_LogComment( va( "GLSL_SetUniform4i( %s, shader: %s, value: [ %d, %d, %d, %d ] ) ---\n",
+				this->GetName(), _shader->GetName().c_str(), v[ 0 ], v[ 1 ], v[ 2 ], v[ 3 ] ) );
+		}
+#endif
+#if defined( USE_UNIFORM_FIREWALL )
+		ivec4_t *firewall = ( ivec4_t * ) &p->uniformFirewall[ _firewallIndex ];
+
+		if ( !memcmp( *firewall, v, sizeof( *firewall ) ) )
+		{
+			return;
+		}
+
+		Vector4Copy( v, *firewall );
+#endif
+		glUniform4i( p->uniformLocations[ _locationIndex ], v[ 0 ], v[ 1 ], v[ 2 ], v[ 3 ] );
+	}
+public:
+	size_t GetSize() override
+	{
+		return sizeof( ivec4_t );
+	}
+};
+
 class GLUniform1f : protected GLUniform
 {
 protected:


### PR DESCRIPTION
Right now we can only send a single integer to GLSL, or float vectors. Meaning that if we need to sends more than one integer, we either have to send multiple variables, or to send integers in floats vectors.

This implements the `ivec_t` type in engine and implements the related classes to send `ivec2`, `ivec3` and `ivec4` to GLSL in a similar way to what we already do for `vec2`, `vec3` and `vec4`.