### PR TITLE
introduce `plane_t` struct with `normal` and `dist` members

### DIFF
--- a/src/common/cm/cm_local.h
+++ b/src/common/cm/cm_local.h
@@ -84,7 +84,7 @@ struct cbrush_t
 
 struct cPlane_t
 {
-	float           plane[ 4 ];
+	plane_t plane;
 	// signx + (signy<<1) + (signz<<2), used as lookup during collision
 	// used to determine which corner of a box would pass through a plane first/last
 	int             signbits;
@@ -287,7 +287,7 @@ extern int numFacets;
 extern cFacet_t facets[];
 
 void     CM_ResetPlaneCounts();
-int      CM_FindPlane2( float plane[ 4 ], bool *flipped );
+int CM_FindPlane2( const plane_t &plane, bool *flipped );
 int      CM_FindPlane( const float *p1, const float *p2, const float *p3 );
 planeSide_t CM_PointOnPlaneSide( float *p, int planeNum );
 bool CM_ValidateFacet( cFacet_t *facet );

--- a/src/common/cm/cm_patch.cpp
+++ b/src/common/cm/cm_patch.cpp
@@ -418,42 +418,42 @@ static int CM_EdgePlaneNum( cGrid_t *grid, int gridPlanes[ MAX_GRID_SIZE ][ MAX_
 			p1 = grid->points[ i ][ j ];
 			p2 = grid->points[ i + 1 ][ j ];
 			p = CM_GridPlane( gridPlanes, i, j, 0 );
-			VectorMA( p1, 4, planes[ p ].plane, up );
+			VectorMA( p1, 4, planes[ p ].plane.normal, up );
 			return CM_FindPlane( p1, p2, up );
 
 		case 2: // bottom border
 			p1 = grid->points[ i ][ j + 1 ];
 			p2 = grid->points[ i + 1 ][ j + 1 ];
 			p = CM_GridPlane( gridPlanes, i, j, 1 );
-			VectorMA( p1, 4, planes[ p ].plane, up );
+			VectorMA( p1, 4, planes[ p ].plane.normal, up );
 			return CM_FindPlane( p2, p1, up );
 
 		case 3: // left border
 			p1 = grid->points[ i ][ j ];
 			p2 = grid->points[ i ][ j + 1 ];
 			p = CM_GridPlane( gridPlanes, i, j, 1 );
-			VectorMA( p1, 4, planes[ p ].plane, up );
+			VectorMA( p1, 4, planes[ p ].plane.normal, up );
 			return CM_FindPlane( p2, p1, up );
 
 		case 1: // right border
 			p1 = grid->points[ i + 1 ][ j ];
 			p2 = grid->points[ i + 1 ][ j + 1 ];
 			p = CM_GridPlane( gridPlanes, i, j, 0 );
-			VectorMA( p1, 4, planes[ p ].plane, up );
+			VectorMA( p1, 4, planes[ p ].plane.normal, up );
 			return CM_FindPlane( p1, p2, up );
 
 		case 4: // diagonal out of triangle 0
 			p1 = grid->points[ i + 1 ][ j + 1 ];
 			p2 = grid->points[ i ][ j ];
 			p = CM_GridPlane( gridPlanes, i, j, 0 );
-			VectorMA( p1, 4, planes[ p ].plane, up );
+			VectorMA( p1, 4, planes[ p ].plane.normal, up );
 			return CM_FindPlane( p1, p2, up );
 
 		case 5: // diagonal out of triangle 1
 			p1 = grid->points[ i ][ j ];
 			p2 = grid->points[ i + 1 ][ j + 1 ];
 			p = CM_GridPlane( gridPlanes, i, j, 1 );
-			VectorMA( p1, 4, planes[ p ].plane, up );
+			VectorMA( p1, 4, planes[ p ].plane.normal, up );
 			return CM_FindPlane( p1, p2, up );
 	}
 

--- a/src/common/cm/cm_polylib.cpp
+++ b/src/common/cm/cm_polylib.cpp
@@ -112,7 +112,13 @@ void WindingBounds( winding_t *w, vec3_t mins, vec3_t maxs )
 BaseWindingForPlane
 =================
 */
-winding_t      *BaseWindingForPlane( const vec3_t normal, const vec_t dist )
+winding_t *BaseWindingForPlane( const plane_t &plane )
+{
+	return BaseWindingForPlane( plane.normal, plane.dist  );
+}
+
+// Backward compatibility with game.
+winding_t *BaseWindingForPlane( const vec3_t normal, const vec_t dist )
 {
 	int       i, x;
 	vec_t     max, v;
@@ -206,6 +212,12 @@ winding_t      *CopyWinding( winding_t *w )
 ChopWindingInPlace
 =============
 */
+void ChopWindingInPlace( winding_t **inout, const plane_t &plane, const vec_t epsilon )
+{
+	ChopWindingInPlace( inout, plane.normal, plane.dist, epsilon );
+}
+
+// Backward compatibility with game.
 void ChopWindingInPlace( winding_t **inout, const vec3_t normal, const vec_t dist, const vec_t epsilon )
 {
 // FIXME: https://github.com/DaemonEngine/Daemon/issues/169

--- a/src/common/cm/cm_polylib.h
+++ b/src/common/cm/cm_polylib.h
@@ -53,11 +53,15 @@ struct winding_t
 
 winding_t *AllocWinding( int points );
 winding_t *CopyWinding( winding_t *w );
+winding_t *BaseWindingForPlane( const plane_t &plane );
+// Backward compatibility with game.
 winding_t *BaseWindingForPlane( const vec3_t normal, const vec_t dist );
 void      FreeWinding( winding_t *w );
 void      WindingBounds( winding_t *w, vec3_t mins, vec3_t maxs );
 
-void      ChopWindingInPlace( winding_t **w, const vec3_t normal, const vec_t dist, const vec_t epsilon );
+void ChopWindingInPlace( winding_t **w, const plane_t &plane, const vec_t epsilon );
+// Backward compatibility with game.
+void ChopWindingInPlace( winding_t **w, const vec3_t normal, const vec_t dist, const vec_t epsilon );
 
 // frees the original if clipped
 

--- a/src/engine/qcommon/q_math.cpp
+++ b/src/engine/qcommon/q_math.cpp
@@ -225,23 +225,32 @@ void ByteToDir( int b, vec3_t dir )
 	VectorCopy( bytedirs[ b ], dir );
 }
 
-vec_t PlaneNormalize( vec4_t plane )
+void PlaneSet( plane_t &out, const vec_t x, const vec_t y, const vec_t z, const vec_t dist )
 {
-	vec_t length2, ilength;
+	VectorSet( out.normal, x, y, z );
+	out.dist = dist;
+}
 
-	length2 = DotProduct( plane, plane );
+void PlaneSet( plane_t &out, const vec4_t v )
+{
+	PlaneSet( out, v[ 0 ], v[ 1 ], v[ 2 ], v[ 3 ] );
+}
+
+vec_t PlaneNormalize( plane_t &plane )
+{
+	vec_t length2 = DotProduct( plane.normal, plane.normal );
 
 	if ( length2 == 0.0f )
 	{
-		VectorClear( plane );
+		VectorClear( plane.normal );
 		return 0.0f;
 	}
 
-	ilength = Q_rsqrt( length2 );
-	plane[ 0 ] = plane[ 0 ] * ilength;
-	plane[ 1 ] = plane[ 1 ] * ilength;
-	plane[ 2 ] = plane[ 2 ] * ilength;
-	plane[ 3 ] = plane[ 3 ] * ilength;
+	vec_t ilength = Q_rsqrt( length2 );
+	plane.normal[ 0 ] *= ilength;
+	plane.normal[ 1 ] *= ilength;
+	plane.normal[ 2 ] *= ilength;
+	plane.dist *= ilength;
 
 	return length2 * ilength;
 }
@@ -270,20 +279,20 @@ vec_t PlaneNormalize( vec4_t plane )
  * See the function below if you want the normal to be on the other side
  * =====================
  */
-bool PlaneFromPoints( vec4_t plane, const vec3_t a, const vec3_t b, const vec3_t c )
+bool PlaneFromPoints( plane_t &plane, const vec3_t a, const vec3_t b, const vec3_t c )
 {
 	vec3_t d1, d2;
 
 	VectorSubtract( b, a, d1 );
 	VectorSubtract( c, a, d2 );
-	CrossProduct( d2, d1, plane );
+	CrossProduct( d2, d1, plane.normal );
 
-	if ( VectorNormalize( plane ) == 0 )
+	if ( VectorNormalize( plane.normal ) == 0 )
 	{
 		return false;
 	}
 
-	plane[ 3 ] = DotProduct( a, plane );
+	plane.dist = DotProduct( a, plane.normal );
 	return true;
 }
 /*
@@ -293,7 +302,7 @@ bool PlaneFromPoints( vec4_t plane, const vec3_t a, const vec3_t b, const vec3_t
  * Returns false if the triangle is degenerate.
  * =====================
  */
-bool PlaneFromPointsOrder( vec4_t plane, const vec3_t a, const vec3_t b, const vec3_t c, bool cw )
+bool PlaneFromPointsOrder( plane_t &plane, const vec3_t a, const vec3_t b, const vec3_t c, bool cw )
 {
 	vec3_t d1, d2;
 
@@ -302,24 +311,24 @@ bool PlaneFromPointsOrder( vec4_t plane, const vec3_t a, const vec3_t b, const v
 
 	if ( cw )
 	{
-		CrossProduct( d2, d1, plane );
+		CrossProduct( d2, d1, plane.normal );
 	}
 
 	else
 	{
-		CrossProduct( d1, d2, plane );
+		CrossProduct( d1, d2, plane.normal );
 	}
 
-	if ( VectorNormalize( plane ) == 0 )
+	if ( VectorNormalize( plane.normal ) == 0 )
 	{
 		return false;
 	}
 
-	plane[ 3 ] = DotProduct( a, plane );
+	plane.dist = DotProduct( a, plane.normal );
 	return true;
 }
 
-bool PlanesGetIntersectionPoint( const vec4_t plane1, const vec4_t plane2, const vec4_t plane3, vec3_t out )
+bool PlanesGetIntersectionPoint( const plane_t &plane1, const plane_t &plane2, const plane_t &plane3, vec3_t out )
 {
 	// http://www.cgafaq.info/wiki/Intersection_of_three_planes
 
@@ -327,9 +336,9 @@ bool PlanesGetIntersectionPoint( const vec4_t plane1, const vec4_t plane2, const
 	vec3_t n1n2, n2n3, n3n1;
 	vec_t  denom;
 
-	VectorNormalize2( plane1, n1 );
-	VectorNormalize2( plane2, n2 );
-	VectorNormalize2( plane3, n3 );
+	VectorNormalize2( plane1.normal, n1 );
+	VectorNormalize2( plane2.normal, n2 );
+	VectorNormalize2( plane3.normal, n3 );
 
 	CrossProduct( n1, n2, n1n2 );
 	CrossProduct( n2, n3, n2n3 );
@@ -347,23 +356,21 @@ bool PlanesGetIntersectionPoint( const vec4_t plane1, const vec4_t plane2, const
 
 	VectorClear( out );
 
-	VectorMA( out, plane1[ 3 ], n2n3, out );
-	VectorMA( out, plane2[ 3 ], n3n1, out );
-	VectorMA( out, plane3[ 3 ], n1n2, out );
+	VectorMA( out, plane1.dist, n2n3, out );
+	VectorMA( out, plane2.dist, n3n1, out );
+	VectorMA( out, plane3.dist, n1n2, out );
 
 	VectorScale( out, 1.0f / denom, out );
 
 	return true;
 }
 
-void PlaneIntersectRay( const vec3_t rayPos, const vec3_t rayDir, const vec4_t plane, vec3_t res )
+void PlaneIntersectRay( const vec3_t rayPos, const vec3_t rayDir, const plane_t &plane, vec3_t res )
 {
 	vec3_t dir;
-	float  sect;
-
 	VectorNormalize2( rayDir, dir );
 
-	sect = - ( DotProduct( plane, rayPos ) - plane[ 3 ] ) / DotProduct( plane, rayDir );
+	vec_t sect = - ( DotProduct( plane.normal, rayPos ) - plane.dist ) / DotProduct( plane.normal, rayDir );
 	VectorScale( dir, sect, dir );
 	VectorAdd( rayPos, dir, res );
 }
@@ -2135,33 +2142,36 @@ void MatrixFromQuat( matrix_t m, const quat_t q )
 #endif
 }
 
-void MatrixFromPlanes( matrix_t m, const vec4_t left, const vec4_t right, const vec4_t bottom, const vec4_t top, const vec4_t near, const vec4_t far )
+void MatrixFromPlanes( matrix_t m,
+		const plane_t left, const plane_t right,
+		const plane_t bottom, const plane_t top,
+		const plane_t near, const plane_t far )
 {
-	m[ 0 ] = ( right[ 0 ] - left[ 0 ] ) / 2;
-	m[ 1 ] = ( top[ 0 ] - bottom[ 0 ] ) / 2;
-	m[ 2 ] = ( far[ 0 ] - near[ 0 ] ) / 2;
-	m[ 3 ] = right[ 0 ] - ( right[ 0 ] - left[ 0 ] ) / 2;
+	m[ 0 ] = ( right.normal[ 0 ] - left.normal[ 0 ] ) / 2;
+	m[ 1 ] = ( top.normal[ 0 ] - bottom.normal[ 0 ] ) / 2;
+	m[ 2 ] = ( far.normal[ 0 ] - near.normal[ 0 ] ) / 2;
+	m[ 3 ] = right.normal[ 0 ] - ( right.normal[ 0 ] - left.normal[ 0 ] ) / 2;
 
-	m[ 4 ] = ( right[ 1 ] - left[ 1 ] ) / 2;
-	m[ 5 ] = ( top[ 1 ] - bottom[ 1 ] ) / 2;
-	m[ 6 ] = ( far[ 1 ] - near[ 1 ] ) / 2;
-	m[ 7 ] = right[ 1 ] - ( right[ 1 ] - left[ 1 ] ) / 2;
+	m[ 4 ] = ( right.normal[ 1 ] - left.normal[ 1 ] ) / 2;
+	m[ 5 ] = ( top.normal[ 1 ] - bottom.normal[ 1 ] ) / 2;
+	m[ 6 ] = ( far.normal[ 1 ] - near.normal[ 1 ] ) / 2;
+	m[ 7 ] = right.normal[ 1 ] - ( right.normal[ 1 ] - left.normal[ 1 ] ) / 2;
 
-	m[ 8 ] = ( right[ 2 ] - left[ 2 ] ) / 2;
-	m[ 9 ] = ( top[ 2 ] - bottom[ 2 ] ) / 2;
-	m[ 10 ] = ( far[ 2 ] - near[ 2 ] ) / 2;
-	m[ 11 ] = right[ 2 ] - ( right[ 2 ] - left[ 2 ] ) / 2;
+	m[ 8 ] = ( right.normal[ 2 ] - left.normal[ 2 ] ) / 2;
+	m[ 9 ] = ( top.normal[ 2 ] - bottom.normal[ 2 ] ) / 2;
+	m[ 10 ] = ( far.normal[ 2 ] - near.normal[ 2 ] ) / 2;
+	m[ 11 ] = right.normal[ 2 ] - ( right.normal[ 2 ] - left.normal[ 2 ] ) / 2;
 
 #if 0
-	m[ 12 ] = ( right[ 3 ] - left[ 3 ] ) / 2;
-	m[ 13 ] = ( top[ 3 ] - bottom[ 3 ] ) / 2;
-	m[ 14 ] = ( far[ 3 ] - near[ 3 ] ) / 2;
-	m[ 15 ] = right[ 3 ] - ( right[ 3 ] - left[ 3 ] ) / 2;
+	m[ 12 ] = ( right.dist - left.dist ) / 2;
+	m[ 13 ] = ( top.dist - bottom.dist ) / 2;
+	m[ 14 ] = ( far.dist - near.dist ) / 2;
+	m[ 15 ] = right.dist - ( right.dist - left.dist ) / 2;
 #else
-	m[ 12 ] = ( -right[ 3 ] - -left[ 3 ] ) / 2;
-	m[ 13 ] = ( -top[ 3 ] - -bottom[ 3 ] ) / 2;
-	m[ 14 ] = ( -far[ 3 ] - -near[ 3 ] ) / 2;
-	m[ 15 ] = -right[ 3 ] - ( -right[ 3 ] - -left[ 3 ] ) / 2;
+	m[ 12 ] = ( -right.dist - -left.dist ) / 2;
+	m[ 13 ] = ( -top.dist - -bottom.dist ) / 2;
+	m[ 14 ] = ( -far.dist - -near.dist ) / 2;
+	m[ 15 ] = -right.dist - ( -right.dist - -left.dist ) / 2;
 #endif
 }
 
@@ -2366,27 +2376,26 @@ void MatrixTransform4( const matrix_t m, const vec4_t in, vec4_t out )
 	out[ 3 ] = m[ 3 ] * in[ 0 ] + m[ 7 ] * in[ 1 ] + m[ 11 ] * in[ 2 ] + m[ 15 ] * in[ 3 ];
 }
 
-void MatrixTransformPlane( const matrix_t m, const vec4_t in, vec4_t out )
+void MatrixTransformPlane( const matrix_t m, const plane_t &in, plane_t &out )
 {
-	vec3_t translation;
-	vec3_t planePos;
-
 	// rotate the plane normal
-	MatrixTransformNormal( m, in, out );
+	MatrixTransformNormal( m, in.normal, out.normal );
 
 	// add new position to current plane position
+	vec3_t translation;
 	VectorSet( translation,  m[ 12 ], m[ 13 ], m[ 14 ] );
-	VectorMA( translation, in[ 3 ], out, planePos );
 
-	out[ 3 ] = DotProduct( out, planePos );
+	vec3_t planePos;
+	VectorMA( translation, in.dist, out.normal, planePos );
+
+	out.dist = DotProduct( out.normal, planePos );
 }
 
-void MatrixTransformPlane2( const matrix_t m, vec4_t inout )
+void MatrixTransformPlane2( const matrix_t m, plane_t &inout )
 {
-	vec4_t tmp;
-
+	plane_t tmp;
 	MatrixTransformPlane( m, inout, tmp );
-	Vector4Copy( tmp, inout );
+	inout = tmp;
 }
 
 /*
@@ -2704,11 +2713,9 @@ void MatrixOrthogonalProjectionRH( matrix_t m, vec_t left, vec_t right, vec_t bo
  *
  * http://msdn.microsoft.com/en-us/library/bb205356%28v=VS.85%29.aspx
  */
-void MatrixPlaneReflection( matrix_t m, const vec4_t plane )
+void MatrixPlaneReflection( matrix_t m, const plane_t plane )
 {
-	vec4_t P;
-	Vector4Copy( plane, P );
-
+	plane_t P = plane;
 	PlaneNormalize( P );
 
 	/*
@@ -2719,18 +2726,18 @@ void MatrixPlaneReflection( matrix_t m, const vec4_t plane )
 	 */
 
 	// Quake uses a different plane equation
-	m[ 0 ] = -2 * P[ 0 ] * P[ 0 ] + 1;
-	m[ 4 ] = -2 * P[ 0 ] * P[ 1 ];
-	m[ 8 ] = -2 * P[ 0 ] * P[ 2 ];
-	m[ 12 ] = 2 * P[ 0 ] * P[ 3 ];
-	m[ 1 ] = -2 * P[ 1 ] * P[ 0 ];
-	m[ 5 ] = -2 * P[ 1 ] * P[ 1 ] + 1;
-	m[ 9 ] = -2 * P[ 1 ] * P[ 2 ];
-	m[ 13 ] = 2 * P[ 1 ] * P[ 3 ];
-	m[ 2 ] = -2 * P[ 2 ] * P[ 0 ];
-	m[ 6 ] = -2 * P[ 2 ] * P[ 1 ];
-	m[ 10 ] = -2 * P[ 2 ] * P[ 2 ] + 1;
-	m[ 14 ] = 2 * P[ 2 ] * P[ 3 ];
+	m[ 0 ] = -2 * P.normal[ 0 ] * P.normal[ 0 ] + 1;
+	m[ 4 ] = -2 * P.normal[ 0 ] * P.normal[ 1 ];
+	m[ 8 ] = -2 * P.normal[ 0 ] * P.normal[ 2 ];
+	m[ 12 ] = 2 * P.normal[ 0 ] * P.dist;
+	m[ 1 ] = -2 * P.normal[ 1 ] * P.normal[ 0 ];
+	m[ 5 ] = -2 * P.normal[ 1 ] * P.normal[ 1 ] + 1;
+	m[ 9 ] = -2 * P.normal[ 1 ] * P.normal[ 2 ];
+	m[ 13 ] = 2 * P.normal[ 1 ] * P.dist;
+	m[ 2 ] = -2 * P.normal[ 2 ] * P.normal[ 0 ];
+	m[ 6 ] = -2 * P.normal[ 2 ] * P.normal[ 1 ];
+	m[ 10 ] = -2 * P.normal[ 2 ] * P.normal[ 2 ] + 1;
+	m[ 14 ] = 2 * P.normal[ 2 ] * P.dist;
 	m[ 3 ] = 0;
 	m[ 7 ] = 0;
 	m[ 11 ] = 0;

--- a/src/engine/qcommon/q_math.cpp
+++ b/src/engine/qcommon/q_math.cpp
@@ -231,6 +231,12 @@ void PlaneSet( plane_t &out, const vec_t x, const vec_t y, const vec_t z, const 
 	out.dist = dist;
 }
 
+void PlaneSet( plane_t &out, const vec3_t normal, const vec_t dist )
+{
+	VectorCopy( normal, out.normal );
+	out.dist = dist;
+}
+
 void PlaneSet( plane_t &out, const vec4_t v )
 {
 	PlaneSet( out, v[ 0 ], v[ 1 ], v[ 2 ], v[ 3 ] );

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -431,13 +431,7 @@ inline float DotProduct( const vec3_t x, const vec3_t y )
 #define Vector2Subtract( a,b,c )     ( ( c )[ 0 ] = ( a )[ 0 ] - ( b )[ 0 ],( c )[ 1 ] = ( a )[ 1 ] - ( b )[ 1 ] )
 
 #define Vector4Set( v, x, y, z, n )  ( ( v )[ 0 ] = ( x ),( v )[ 1 ] = ( y ),( v )[ 2 ] = ( z ),( v )[ 3 ] = ( n ) )
-#define Vector4Subtract( a,b,c )     ( ( c )[ 0 ] = ( a )[ 0 ] - ( b )[ 0 ],( c )[ 1 ] = ( a )[ 1 ] - ( b )[ 1 ],( c )[ 2 ] = ( a )[ 2 ] - ( b )[ 3 ],( c )[ 3 ] = ( a )[ 3 ] - ( b )[ 3 ] )
-#define Vector4Negate( a,b )         ( ( b )[ 0 ] = -( a )[ 0 ],( b )[ 1 ] = -( a )[ 1 ],( b )[ 2 ] = -( a )[ 2 ],( b )[ 3 ] = -( a )[ 3 ] )
 #define Vector4Copy( a,b )           ( ( b )[ 0 ] = ( a )[ 0 ],( b )[ 1 ] = ( a )[ 1 ],( b )[ 2 ] = ( a )[ 2 ],( b )[ 3 ] = ( a )[ 3 ] )
-/** Stands for MultiplyAdd: adding a vector "b" scaled by "s" to "v" and writing it to "o" */
-#define Vector4MA( v, s, b, o )      ( ( o )[ 0 ] = ( v )[ 0 ] + ( b )[ 0 ] * ( s ),( o )[ 1 ] = ( v )[ 1 ] + ( b )[ 1 ] * ( s ),( o )[ 2 ] = ( v )[ 2 ] + ( b )[ 2 ] * ( s ),( o )[ 3 ] = ( v )[ 3 ] + ( b )[ 3 ] * ( s ) )
-#define Vector4Average( v, b, s, o ) ( ( o )[ 0 ] = ( ( v )[ 0 ] * ( 1 - ( s ) ) ) + ( ( b )[ 0 ] * ( s ) ),( o )[ 1 ] = ( ( v )[ 1 ] * ( 1 - ( s ) ) ) + ( ( b )[ 1 ] * ( s ) ),( o )[ 2 ] = ( ( v )[ 2 ] * ( 1 - ( s ) ) ) + ( ( b )[ 2 ] * ( s ) ),( o )[ 3 ] = ( ( v )[ 3 ] * ( 1 - ( s ) ) ) + ( ( b )[ 3 ] * ( s ) ) )
-
 #define DotProduct4(x, y)            (( x )[ 0 ] * ( y )[ 0 ] + ( x )[ 1 ] * ( y )[ 1 ] + ( x )[ 2 ] * ( y )[ 2 ] + ( x )[ 3 ] * ( y )[ 3 ] )
 
 #define SnapVector( v )              do { ( v )[ 0 ] = ( floor( ( v )[ 0 ] + 0.5f ) ); ( v )[ 1 ] = ( floor( ( v )[ 1 ] + 0.5f ) ); ( v )[ 2 ] = ( floor( ( v )[ 2 ] + 0.5f ) ); } while ( 0 )
@@ -551,7 +545,7 @@ inline float DotProduct( const vec3_t x, const vec3_t y )
 	void  AngleVectors( const vec3_t angles, vec3_t forward, vec3_t right, vec3_t up );
 
 	void PlaneSet( plane_t &out, const vec_t x, const vec_t y, const vec_t z, const vec_t dist );
-	void PlaneSet( plane_t &out, const vec4_t v );
+	void PlaneSet( plane_t &out, const vec3_t v, const vec_t dist );
 	vec_t PlaneNormalize( plane_t &plane );  // returns normal length
 
 	/* greebo: This calculates the intersection point of three planes.

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1532,7 +1532,6 @@ static void RB_SetupLightForShadowing( trRefLight_t *light, int index,
 				vec3_t   viewOrigin, viewDirection;
 				matrix_t rotationMatrix, transformMatrix, viewMatrix, projectionMatrix, viewProjectionMatrix;
 				matrix_t cropMatrix;
-				vec4_t   splitFrustum[ 6 ];
 				vec3_t   splitFrustumNearCorners[ 4 ];
 				vec3_t   splitFrustumFarCorners[ 4 ];
 				vec3_t   splitFrustumBounds[ 2 ];
@@ -1597,10 +1596,11 @@ static void RB_SetupLightForShadowing( trRefLight_t *light, int index,
 
 					MatrixLookAtRH( light->viewMatrix, viewOrigin, lightDirection, up );
 
+					plane_t splitFrustum[ 6 ];
 					for ( j = 0; j < 6; j++ )
 					{
-						VectorCopy( backEnd.viewParms.frustums[ 1 + splitFrustumIndex ][ j ].normal, splitFrustum[ j ] );
-						splitFrustum[ j ][ 3 ] = backEnd.viewParms.frustums[ 1 + splitFrustumIndex ][ j ].dist;
+						VectorCopy( backEnd.viewParms.frustums[ 1 + splitFrustumIndex ][ j ].normal, splitFrustum[ j ].normal );
+						splitFrustum[ j ].dist = backEnd.viewParms.frustums[ 1 + splitFrustumIndex ][ j ].dist;
 					}
 
 					R_CalcFrustumNearCorners( splitFrustum, splitFrustumNearCorners );
@@ -1877,7 +1877,6 @@ static void RB_SetupLightForLighting( trRefLight_t *light )
 
 						{
 							int    j;
-							vec4_t splitFrustum[ 6 ];
 							vec3_t farCorners[ 4 ];
 							vec3_t nearCorners[ 4 ];
 
@@ -1913,10 +1912,11 @@ static void RB_SetupLightForLighting( trRefLight_t *light )
 							tess.numIndexes = 0;
 							tess.numVertexes = 0;
 
+							plane_t splitFrustum[ 6 ];
 							for ( j = 0; j < 6; j++ )
 							{
-								VectorCopy( backEnd.viewParms.frustums[ 1 + frustumIndex ][ j ].normal, splitFrustum[ j ] );
-								splitFrustum[ j ][ 3 ] = backEnd.viewParms.frustums[ 1 + frustumIndex ][ j ].dist;
+								VectorCopy( backEnd.viewParms.frustums[ 1 + frustumIndex ][ j ].normal, splitFrustum[ j ].normal );
+								splitFrustum[ j ].dist = backEnd.viewParms.frustums[ 1 + frustumIndex ][ j ].dist;
 							}
 
 							R_CalcFrustumNearCorners( splitFrustum, nearCorners );
@@ -4319,7 +4319,6 @@ static void RB_RenderDebugUtils()
 
 				{
 					int    j;
-					vec4_t splitFrustum[ 6 ];
 					vec3_t farCorners[ 4 ];
 					vec3_t nearCorners[ 4 ];
 					vec3_t cropBounds[ 2 ];
@@ -4382,10 +4381,11 @@ static void RB_RenderDebugUtils()
 
 					Tess_MapVBOs( false );
 
+					plane_t splitFrustum[ 6 ];
 					for ( j = 0; j < 6; j++ )
 					{
-						VectorCopy( backEnd.viewParms.frustums[ 0 ][ j ].normal, splitFrustum[ j ] );
-						splitFrustum[ j ][ 3 ] = backEnd.viewParms.frustums[ 0 ][ j ].dist;
+						VectorCopy( backEnd.viewParms.frustums[ 0 ][ j ].normal, splitFrustum[ j ].normal );
+						splitFrustum[ j ].dist = backEnd.viewParms.frustums[ 0 ][ j ].dist;
 					}
 
 					// calculate split frustum corner points

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -5052,13 +5052,13 @@ static int UpdateLightTriangles( const srfVert_t *verts, int numTriangles, srfTr
 	for ( i = 0, tri = triangles; i < numTriangles; i++, tri++ )
 	{
 		vec3_t pos[ 3 ];
-		vec4_t triPlane;
 		float  d;
 
 		VectorCopy( verts[ tri->indexes[ 0 ] ].xyz, pos[ 0 ] );
 		VectorCopy( verts[ tri->indexes[ 1 ] ].xyz, pos[ 1 ] );
 		VectorCopy( verts[ tri->indexes[ 2 ] ].xyz, pos[ 2 ] );
 
+		plane_t triPlane;
 		if ( PlaneFromPoints( triPlane, pos[ 0 ], pos[ 1 ], pos[ 2 ] ) )
 		{
 
@@ -5069,14 +5069,14 @@ static int UpdateLightTriangles( const srfVert_t *verts, int numTriangles, srfTr
 				// light direction is from surface to light
 				VectorCopy( tr.sunDirection, lightDirection );
 
-				d = DotProduct( triPlane, lightDirection );
+				d = DotProduct( triPlane.normal, lightDirection );
 
 				tri->facingLight = surfaceShader->cullType == CT_TWO_SIDED || ( d > 0 && surfaceShader->cullType != CT_BACK_SIDED );
 			}
 			else
 			{
 				// check if light origin is behind triangle
-				d = DotProduct( triPlane, light->origin ) - triPlane[ 3 ];
+				d = DotProduct( triPlane.normal, light->origin ) - triPlane.dist;
 
 				tri->facingLight = surfaceShader->cullType == CT_TWO_SIDED || ( d > 0 && surfaceShader->cullType != CT_BACK_SIDED );
 			}

--- a/src/engine/renderer/tr_light.cpp
+++ b/src/engine/renderer/tr_light.cpp
@@ -743,10 +743,6 @@ void R_SetupLightProjection( trRefLight_t *light )
 
 		case refLightType_t::RL_PROJ:
 			{
-				/* This was previously set as a vec4_t with lightProject[ x ] being 0,
-				but then the fourth component never contributed to any computation
-				and was always zeroed again after computation as a multiple of 0,
-				only the normal vec3 is used for computation. */
 				plane_t lightProject[ 4 ];
 
 				{
@@ -776,51 +772,24 @@ void R_SetupLightProjection( trRefLight_t *light )
 
 				// now offset to center
 				{
-					/* This was previously set as a vec4_t with targetGlobal[ 3 ] being 1
-					but then the fourth component never contributed to any computation
-					and was always zeroed after computation as a multiple of 0. */
 					vec3_t targetGlobal;
 					VectorSet( targetGlobal,
 						light->l.projTarget[ 0 ], light->l.projTarget[ 1 ],
 						light->l.projTarget[ 2 ] );
 
 					{
-						/* This was previously doing a DotProduct4 on a vec4_t
-						but targetGlobal[ 3 ] was 1 and lightProject[ 0 ][ 3 ] was 0
-						so this was converted to DotProduct( vec3, vec3 ) + ( 1 * 0 )
-						and then the useless added zero removed. */
 						vec_t a = DotProduct( targetGlobal, lightProject[ 0 ].normal );
-						/* This was previously doing a DotProduct4 on a vec4_t
-						but targetGlobal[ 3 ] was 1 and lightProject[ 2 ][ 3 ] was 0
-						so this was converted to DotProduct( vec3, vec3 ) + ( 1 * 0 )
-						and then the useless added zero removed. */
 						vec_t b = DotProduct( targetGlobal, lightProject[ 2 ].normal );
 						vec_t ofs = 0.5 - a / b;
 
-						/* This was previously doing a Vector4MA on a vec4_t
-						but lightProject[ 0 ][ 3 ] and lightProject[ 2 ][ 0 ] were 0
-						so lightProject[ 0 ][ 3 ] was rewritten as 0 + s * 0
-						and then that useless zero was removed. */
 						VectorMA( lightProject[ 0 ].normal, ofs, lightProject[ 2 ].normal, lightProject[ 0 ].normal );
 					}
 
 					{
-						/* This was previously doing a DotProduct4 on a vec4_t
-						but targetGlobal[ 3 ] was 1 and lightProject[ 1 ][ 3 ] was 0
-						so this was converted to DotProduct( vec3, vec3 ) + ( 1 * 0 )
-						and then the useless added zero removed. */
 						vec_t a = DotProduct( targetGlobal, lightProject[ 1 ].normal );
-						/* This was previously doing a DotProduct4 on a vec4_t
-						but targetGlobal[ 3 ] was 1 and lightProject[ 2 ][ 3 ] was 0
-						so this was converted to DotProduct( vec3, vec3 ) + ( 1 * 0 )
-						and then the useless added zero removed. */
 						vec_t b = DotProduct( targetGlobal, lightProject[ 2 ].normal );
 						vec_t ofs = 0.5 - a / b;
 
-						/* This was previously doing a Vector4MA on a vec4_t
-						but lightProject[ 0 ][ 3 ] and lightProject[ 2 ][ 0 ] were 0
-						so lightProject[ 0 ][ 3 ] was rewritten as 0 + s * 0
-						and then that useless zero was removed. */
 						VectorMA( lightProject[ 0 ].normal, ofs, lightProject[ 2 ].normal, lightProject[ 0 ].normal );
 					}
 				}
@@ -877,8 +846,6 @@ void R_SetupLightProjection( trRefLight_t *light )
 				frustum[ FRUSTUM_BOTTOM ] = lightProject[ 1 ];
 
 				{
-					/* This was previously done on a vec4_t and subtracting the fourth
-					component, but 0 - 0 is 0 so we skipped that computation. */
 					vec3_t normal;
 					VectorSubtract( lightProject[ 2 ].normal, lightProject[ 0 ].normal, normal );
 
@@ -886,8 +853,6 @@ void R_SetupLightProjection( trRefLight_t *light )
 				}
 
 				{
-					/* This was previously done on a vec4_t and subtracting the fourth
-					component, but 0 - 0 is 0 so we skipped that computation. */
 					vec3_t normal;
 					VectorSubtract( lightProject[ 2 ].normal, lightProject[ 1 ].normal, normal );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -437,7 +437,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		int                       restrictInteractionLast;
 
 		frustum_t                 frustum;
-		vec4_t                    localFrustum[ 6 ];
+		plane_t localFrustum[ 6 ];
 		struct VBO_t              *frustumVBO;
 
 		struct IBO_t              *frustumIBO;
@@ -1466,7 +1466,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		float    radius, radius2;
 		bool omnidirectional;
 		int      numPlanes; // either 5 or 6, for quad or triangle projectors
-		vec4_t   planes[ 6 ];
+		plane_t planes[ 6 ];
 		vec4_t   texMat[ 3 ][ 2 ];
 	};
 
@@ -3085,15 +3085,15 @@ inline bool checkGLErrors()
 	template<size_t frustumSize>
 	inline
 	typename std::enable_if<(frustumSize >= frustumBits_t::FRUSTUM_NEAR + 1)>::type
-	R_CalcFrustumNearCorners( const vec4_t(&frustum)[frustumSize], vec3_t (&corners)[ 4 ] ) {
-		extern void R_CalcFrustumNearCornersUnsafe( const vec4_t frustum[frustumBits_t::FRUSTUM_NEAR + 1], vec3_t (&corners)[ 4 ] );
+	R_CalcFrustumNearCorners( const plane_t(&frustum)[frustumSize], vec3_t (&corners)[ 4 ] ) {
+		extern void R_CalcFrustumNearCornersUnsafe( const plane_t frustum[frustumBits_t::FRUSTUM_NEAR + 1], vec3_t (&corners)[ 4 ] );
 		R_CalcFrustumNearCornersUnsafe( frustum, corners );
 	}
 	template<size_t frustumSize>
 	inline
 	typename std::enable_if<(frustumSize >= frustumBits_t::FRUSTUM_FAR + 1)>::type
-	R_CalcFrustumFarCorners( const vec4_t(&frustum)[frustumSize], vec3_t (&corners)[ 4 ] ) {
-		extern void R_CalcFrustumFarCornersUnsafe( const vec4_t frustum[frustumBits_t::FRUSTUM_FAR + 1], vec3_t (&corners)[ 4 ] );
+	R_CalcFrustumFarCorners( const plane_t(&frustum)[frustumSize], vec3_t (&corners)[ 4 ] ) {
+		extern void R_CalcFrustumFarCornersUnsafe( const plane_t frustum[frustumBits_t::FRUSTUM_FAR + 1], vec3_t (&corners)[ 4 ] );
 		R_CalcFrustumFarCornersUnsafe( frustum, corners );
 	}
 

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -964,14 +964,14 @@ static void R_SetupFrustum()
 		//transform planes back to world space for culling
 		for (int i = 0; i <= FRUSTUM_NEAR; i++)
 		{
-			vec4_t plane;
-			VectorCopy(tr.viewParms.portalFrustum[i].normal, plane);
-			plane[3] = tr.viewParms.portalFrustum[i].dist;
+			plane_t plane;
+			VectorCopy(tr.viewParms.portalFrustum[i].normal, plane.normal);
+			plane.dist = tr.viewParms.portalFrustum[i].dist;
 
 			MatrixTransformPlane2(invTransform, plane);
 
-			VectorCopy(plane, tr.viewParms.frustums[0][i].normal);
-			tr.viewParms.frustums[0][i].dist = plane[3];
+			VectorCopy(plane.normal, tr.viewParms.frustums[0][i].normal);
+			tr.viewParms.frustums[0][i].dist = plane.dist;
 
 			SetPlaneSignbits(&tr.viewParms.frustums[0][i]);
 			tr.viewParms.frustums[0][i].type = PLANE_NON_AXIAL;
@@ -1089,7 +1089,7 @@ void R_SetupFrustum2( frustum_t frustum, const matrix_t mvp )
 
 // *INDENT-ON*
 
-void R_CalcFrustumNearCornersUnsafe( const vec4_t frustum[ FRUSTUM_NEAR + 1 ], vec3_t (&corners)[ 4 ] )
+void R_CalcFrustumNearCornersUnsafe( const plane_t frustum[ FRUSTUM_NEAR + 1 ], vec3_t (&corners)[ 4 ] )
 {
 	PlanesGetIntersectionPoint( frustum[ FRUSTUM_LEFT ], frustum[ FRUSTUM_TOP ], frustum[ FRUSTUM_NEAR ], corners[ 0 ] );
 	PlanesGetIntersectionPoint( frustum[ FRUSTUM_RIGHT ], frustum[ FRUSTUM_TOP ], frustum[ FRUSTUM_NEAR ], corners[ 1 ] );
@@ -1097,7 +1097,7 @@ void R_CalcFrustumNearCornersUnsafe( const vec4_t frustum[ FRUSTUM_NEAR + 1 ], v
 	PlanesGetIntersectionPoint( frustum[ FRUSTUM_LEFT ], frustum[ FRUSTUM_BOTTOM ], frustum[ FRUSTUM_NEAR ], corners[ 3 ] );
 }
 
-void R_CalcFrustumFarCornersUnsafe( const vec4_t frustum[ FRUSTUM_FAR + 1 ], vec3_t (&corners)[ 4 ] )
+void R_CalcFrustumFarCornersUnsafe( const plane_t frustum[ FRUSTUM_FAR + 1 ], vec3_t (&corners)[ 4 ] )
 {
 	PlanesGetIntersectionPoint( frustum[ FRUSTUM_LEFT ], frustum[ FRUSTUM_TOP ], frustum[ FRUSTUM_FAR ], corners[ 0 ] );
 	PlanesGetIntersectionPoint( frustum[ FRUSTUM_RIGHT ], frustum[ FRUSTUM_TOP ], frustum[ FRUSTUM_FAR ], corners[ 1 ] );
@@ -1216,7 +1216,6 @@ void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane )
 	srfTriangles_t *tri;
 	srfPoly_t      *poly;
 	srfVert_t      *v1, *v2, *v3;
-	vec4_t         plane4;
 
 	if ( !surfType )
 	{
@@ -1225,6 +1224,7 @@ void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane )
 		return;
 	}
 
+	plane_t plane4;
 	switch ( *surfType )
 	{
 		case surfaceType_t::SF_FACE:
@@ -1237,15 +1237,15 @@ void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane )
 			v2 = tri->verts + tri->triangles[ 0 ].indexes[ 1 ];
 			v3 = tri->verts + tri->triangles[ 0 ].indexes[ 2 ];
 			PlaneFromPoints( plane4, v1->xyz, v2->xyz, v3->xyz );
-			VectorCopy( plane4, plane->normal );
-			plane->dist = plane4[ 3 ];
+			VectorCopy( plane4.normal, plane->normal );
+			plane->dist = plane4.dist;
 			return;
 
 		case surfaceType_t::SF_POLY:
 			poly = ( srfPoly_t * ) surfType;
 			PlaneFromPoints( plane4, poly->verts[ 0 ].xyz, poly->verts[ 1 ].xyz, poly->verts[ 2 ].xyz );
-			VectorCopy( plane4, plane->normal );
-			plane->dist = plane4[ 3 ];
+			VectorCopy( plane4.normal, plane->normal );
+			plane->dist = plane4.dist;
 			return;
 
 		default:
@@ -1812,12 +1812,11 @@ static void R_SetupPortalFrustum( const viewParms_t& oldParms, const orientation
 	frustum[FRUSTUM_NEAR].dist = DotProduct(worldNearPlane, newParms.orientation.origin) - worldNearPlane[3];
 
 	// calculate new znear for parallel split frustums in this view
-	vec4_t frustumPlanes[FRUSTUM_PLANES];
-
+	plane_t frustumPlanes[FRUSTUM_PLANES];
 	for (int i = 0; i < FRUSTUM_PLANES; i++)
 	{
-		VectorCopy(frustum[i].normal, frustumPlanes[i]);
-		frustumPlanes[i][3] = frustum[i].dist;
+		VectorCopy(frustum[i].normal, frustumPlanes[i].normal);
+		frustumPlanes[i].dist = frustum[i].dist;
 	}
 
 	vec3_t nearCorners[4];


### PR DESCRIPTION
Previously the plane was stored in a `vec4_t`,
with the three first components being the normal,
and the last one being the distance.

A lot of code was running the `vec3_t` specific
macros on the `vec4_t`, it only worked because
we use unsafe types.

This change is a step on the road of making safe
types like `vec2_t`, `vec3_t`, `vec4_t` and turne
macros like `VectorCopy` into type-safe functions.

This also makes the code more explicit.

Instead of doing:

```c++
    vec3_t normal = { 0, 0, 0 };
    vec4_t plane;
    VectorCopy( normal, plane );
```

We can now do:

```c++
    vec3_t in = { 0, 0, 0 };
    plane_t plane;
    VectorCopy( normal, plane.normal );
```

The day `VectorCopy` is a type-safe function
instead of a macro, it will work.

There already exist a `cplane_t` struct
that carries `normal` and `dist` but also
more information, we may modify it to
use `plane_t` for `normal` and `dist`, this
would allow us to do:

```c++
    PlaneCopy( cplane.plane, plane )
```

instead of:

```c++
    VectorCopy( cplane.normal, plane.normal );
    plane.dist = cplane.dist;
```

But for now this is out of topic.