### PR TITLE
Optimisation: skybox rendering

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1931,18 +1931,23 @@ void GLShader_reflection::SetShaderProgramUniforms( shaderProgram_t *shaderProgr
 
 GLShader_skybox::GLShader_skybox( GLShaderManager *manager ) :
 	GLShader( "skybox", ATTR_POSITION, manager ),
+	u_TextureMatrix( this ),
 	u_ViewOrigin( this ),
+	u_CloudHeight( this ),
+	u_UseCloudMap( this ),
+	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_Bones( this ),
 	u_VertexInterpolation( this ),
-	GLDeformStage( this )
+	GLDeformStage( this ),
+	GLCompileMacro_USE_ALPHA_TESTING( this )
 {
 }
 
 void GLShader_skybox::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
+	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_CloudMap" ), 1 );
 }
 
 GLShader_fogQuake3::GLShader_fogQuake3( GLShaderManager *manager ) :

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1678,6 +1678,19 @@ public:
 	}
 };
 
+
+class u_CloudHeight :
+	GLUniform1f {
+	public:
+	u_CloudHeight( GLShader* shader ) :
+		GLUniform1f( shader, "u_CloudHeight" ) {
+	}
+
+	void SetUniform_CloudHeight( const float cloudHeight ) {
+		this->SetValue( cloudHeight );
+	}
+};
+
 class u_Color :
 	GLUniform4f
 {
@@ -1795,6 +1808,18 @@ public:
 	void SetUniform_UnprojectMatrix( const matrix_t m )
 	{
 		this->SetValue( GL_FALSE, m );
+	}
+};
+
+class u_UseCloudMap :
+	GLUniform1i {
+	public:
+	u_UseCloudMap( GLShader* shader ) :
+		GLUniform1i( shader, "u_UseCloudMap" ) {
+	}
+
+	void SetUniform_UseCloudMap( const bool useCloudMap ) {
+		this->SetValue( useCloudMap );
 	}
 };
 
@@ -2470,12 +2495,16 @@ public:
 
 class GLShader_skybox :
 	public GLShader,
+	public u_TextureMatrix,
 	public u_ViewOrigin,
+	public u_CloudHeight,
+	public u_UseCloudMap,
+	public u_AlphaThreshold,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_Bones,
 	public u_VertexInterpolation,
-	public GLDeformStage
+	public GLDeformStage,
+	public GLCompileMacro_USE_ALPHA_TESTING
 {
 public:
 	GLShader_skybox( GLShaderManager *manager );

--- a/src/engine/renderer/glsl_source/skybox_vp.glsl
+++ b/src/engine/renderer/glsl_source/skybox_vp.glsl
@@ -24,7 +24,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 IN vec3 		attr_Position;
 
-uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
 OUT(smooth) vec3	var_Position;
@@ -34,7 +33,6 @@ void	main()
 	// transform vertex position into homogenous clip-space
 	gl_Position = u_ModelViewProjectionMatrix * vec4(attr_Position, 1.0);
 
-	// transform position into world space
-	var_Position = (u_ModelMatrix * vec4(attr_Position, 1.0)).xyz;
+	var_Position = attr_Position;
 }
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1634,6 +1634,7 @@ enum class deluxeMode_t { NONE, GRID, MAP };
 
 		float          fovX, fovY;
 		matrix_t       projectionMatrix;
+		matrix_t       projectionMatrixNonPortal; // For skybox rendering in portals
 		matrix_t       unprojectionMatrix; // transform pixel window space -> world space
 
 		float          parallelSplitDistances[ MAX_SHADOWMAPS + 1 ]; // distances in camera space
@@ -2827,6 +2828,9 @@ enum class deluxeMode_t { NONE, GRID, MAP };
 		orientationr_t orientation; // for current entity
 
 		trRefdef_t     refdef;
+
+		bool           hasSkybox;
+		drawSurf_t     *skybox;
 
 		vec3_t         sunLight; // from the sky shader for this level
 		vec3_t         sunDirection;

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -915,6 +915,10 @@ static void R_SetupProjection( bool infiniteFarClip )
 	{
 		MatrixPerspectiveProjectionFovXYRH( proj, tr.refdef.fov_x, tr.refdef.fov_y, zNear, zFar );
 	}
+
+	if ( tr.viewParms.portalLevel == 0 ) {
+		MatrixCopy( tr.viewParms.projectionMatrix, tr.viewParms.projectionMatrixNonPortal );
+	}
 }
 
 // *INDENT-ON*

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -527,20 +527,9 @@ void Tess_Begin( void ( *stageIteratorFunc )(),
 		Sys::Error( "tess.stageIteratorFunc == NULL" );
 	}
 
-	bool isSky = ( state != nullptr && state->isSky != false );
-
-	if ( isSky )
+	if ( state != nullptr && state->isSky )
 	{
-		if ( tess.stageIteratorFunc == &Tess_StageIteratorGeneric )
-		{
-			tess.stageIteratorFunc = &Tess_StageIteratorSky;
-			tess.stageIteratorFunc2 = &Tess_StageIteratorGeneric;
-		}
-		else if ( tess.stageIteratorFunc == &Tess_StageIteratorDepthFill )
-		{
-			tess.stageIteratorFunc = &Tess_StageIteratorSky;
-			tess.stageIteratorFunc2 = &Tess_StageIteratorDepthFill;
-		}
+		tess.stageIteratorFunc = &Tess_StageIteratorSky;
 	}
 
 	tess.skipTangentSpaces = skipTangentSpaces;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -3525,8 +3525,6 @@ static void ParseSkyParms( const char **text )
 		shader.sky.cloudHeight = 512;
 	}
 
-	R_InitSkyTexCoords( shader.sky.cloudHeight );
-
 	// innerbox
 	token = COM_ParseExt2( text, false );
 
@@ -3556,6 +3554,7 @@ static void ParseSkyParms( const char **text )
 		}
 	}
 
+	tr.hasSkybox = true;
 	shader.isSky = true;
 }
 

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -24,736 +24,20 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "tr_local.h"
 #include "gl_shader.h"
 
-static const int SKY_SUBDIVISIONS      = 8;
-static const int HALF_SKY_SUBDIVISIONS = ( SKY_SUBDIVISIONS / 2 );
-
-static float s_cloudTexCoords[ 6 ][ SKY_SUBDIVISIONS + 1 ][ SKY_SUBDIVISIONS + 1 ][ 2 ];
-static float s_cloudTexP[ 6 ][ SKY_SUBDIVISIONS + 1 ][ SKY_SUBDIVISIONS + 1 ];
-
-/*
-===================================================================================
-
-POLYGON TO BOX SIDE PROJECTION
-
-===================================================================================
-*/
-
-static const vec3_t sky_clip[ 6 ] =
-{
-	{ 1,  1,  0 },
-	{ 1,  -1, 0 },
-	{ 0,  -1, 1 },
-	{ 0,  1,  1 },
-	{ 1,  0,  1 },
-	{ -1, 0,  1 }
-};
-
-static float  sky_mins[ 2 ][ 6 ], sky_maxs[ 2 ][ 6 ];
-static float  sky_min, sky_max;
-
-/*
-================
-AddSkyPolygon
-================
-*/
-static void AddSkyPolygon( int nump, vec3_t vecs )
-{
-	int        i, j;
-	vec3_t     v, av;
-	float      s, t, dv;
-	int        axis;
-	float      *vp;
-
-	static const int vec_to_st[ 6 ][ 3 ] =
-	{
-		{ -2, 3,  1  },
-		{ 2,  3,  -1 },
-
-		{ 1,  3,  2  },
-		{ -1, 3,  -2 },
-
-		{ -2, -1, 3  },
-		{ -2, 1,  -3 }
-
-		//  {-1,2,3},
-		//  {1,2,-3}
-	};
-
-	// decide which face it maps to
-	VectorCopy( vec3_origin, v );
-
-	for ( i = 0, vp = vecs; i < nump; i++, vp += 3 )
-	{
-		VectorAdd( vp, v, v );
-	}
-
-	av[ 0 ] = fabsf( v[ 0 ] );
-	av[ 1 ] = fabsf( v[ 1 ] );
-	av[ 2 ] = fabsf( v[ 2 ] );
-
-	if ( av[ 0 ] > av[ 1 ] && av[ 0 ] > av[ 2 ] )
-	{
-		if ( v[ 0 ] < 0 )
-		{
-			axis = 1;
-		}
-		else
-		{
-			axis = 0;
-		}
-	}
-	else if ( av[ 1 ] > av[ 2 ] && av[ 1 ] > av[ 0 ] )
-	{
-		if ( v[ 1 ] < 0 )
-		{
-			axis = 3;
-		}
-		else
-		{
-			axis = 2;
-		}
-	}
-	else
-	{
-		if ( v[ 2 ] < 0 )
-		{
-			axis = 5;
-		}
-		else
-		{
-			axis = 4;
-		}
-	}
-
-	// project new texture coords
-	for ( i = 0; i < nump; i++, vecs += 3 )
-	{
-		j = vec_to_st[ axis ][ 2 ];
-
-		if ( j > 0 )
-		{
-			dv = vecs[ j - 1 ];
-		}
-		else
-		{
-			dv = -vecs[ -j - 1 ];
-		}
-
-		if ( dv < 0.001f )
-		{
-			continue; // don't divide by zero
-		}
-
-		j = vec_to_st[ axis ][ 0 ];
-
-		if ( j < 0 )
-		{
-			s = -vecs[ -j - 1 ] / dv;
-		}
-		else
-		{
-			s = vecs[ j - 1 ] / dv;
-		}
-
-		j = vec_to_st[ axis ][ 1 ];
-
-		if ( j < 0 )
-		{
-			t = -vecs[ -j - 1 ] / dv;
-		}
-		else
-		{
-			t = vecs[ j - 1 ] / dv;
-		}
-
-		if ( s < sky_mins[ 0 ][ axis ] )
-		{
-			sky_mins[ 0 ][ axis ] = s;
-		}
-
-		if ( t < sky_mins[ 1 ][ axis ] )
-		{
-			sky_mins[ 1 ][ axis ] = t;
-		}
-
-		if ( s > sky_maxs[ 0 ][ axis ] )
-		{
-			sky_maxs[ 0 ][ axis ] = s;
-		}
-
-		if ( t > sky_maxs[ 1 ][ axis ] )
-		{
-			sky_maxs[ 1 ][ axis ] = t;
-		}
-	}
-}
-
-static const float ON_EPSILON     = 0.1f; // point on plane side epsilon
-static const int MAX_CLIP_VERTS = 64;
-
-/*
-================
-ClipSkyPolygon
-================
-*/
-static void ClipSkyPolygon( int nump, vec3_t vecs, int stage )
-{
-	const float *norm;
-	float    *v;
-	bool front, back;
-	float    d, e;
-	float    dists[ MAX_CLIP_VERTS ];
-	planeSide_t sides[ MAX_CLIP_VERTS ];
-	vec3_t   newv[ 2 ][ MAX_CLIP_VERTS ];
-	int      newc[ 2 ];
-	int      i, j;
-
-	if ( nump > MAX_CLIP_VERTS - 2 )
-	{
-		Sys::Drop( "ClipSkyPolygon: MAX_CLIP_VERTS" );
-	}
-
-	if ( stage == 6 )
-	{
-		// fully clipped, so draw it
-		AddSkyPolygon( nump, vecs );
-		return;
-	}
-
-	front = back = false;
-	norm = sky_clip[ stage ];
-
-	for ( i = 0, v = vecs; i < nump; i++, v += 3 )
-	{
-		d = DotProduct( v, norm );
-
-		if ( d > ON_EPSILON )
-		{
-			front = true;
-			sides[ i ] = planeSide_t::SIDE_FRONT;
-		}
-		else if ( d < -ON_EPSILON )
-		{
-			back = true;
-			sides[ i ] = planeSide_t::SIDE_BACK;
-		}
-		else
-		{
-			sides[ i ] = planeSide_t::SIDE_ON;
-		}
-
-		dists[ i ] = d;
-	}
-
-	if ( !front || !back )
-	{
-		// not clipped
-		ClipSkyPolygon( nump, vecs, stage + 1 );
-		return;
-	}
-
-	// clip it
-	sides[ i ] = sides[ 0 ];
-	dists[ i ] = dists[ 0 ];
-	VectorCopy( vecs, ( vecs + ( i * 3 ) ) );
-	newc[ 0 ] = newc[ 1 ] = 0;
-
-	for ( i = 0, v = vecs; i < nump; i++, v += 3 )
-	{
-		switch ( sides[ i ] )
-		{
-			case planeSide_t::SIDE_CROSS:
-				break;
-			case planeSide_t::SIDE_FRONT:
-				VectorCopy( v, newv[ 0 ][ newc[ 0 ] ] );
-				newc[ 0 ]++;
-				break;
-
-			case planeSide_t::SIDE_BACK:
-				VectorCopy( v, newv[ 1 ][ newc[ 1 ] ] );
-				newc[ 1 ]++;
-				break;
-
-			case planeSide_t::SIDE_ON:
-				VectorCopy( v, newv[ 0 ][ newc[ 0 ] ] );
-				newc[ 0 ]++;
-				VectorCopy( v, newv[ 1 ][ newc[ 1 ] ] );
-				newc[ 1 ]++;
-				break;
-		}
-
-		if ( sides[ i ] == planeSide_t::SIDE_ON || sides[ i + 1 ] == planeSide_t::SIDE_ON || sides[ i + 1 ] == sides[ i ] )
-		{
-			continue;
-		}
-
-		d = dists[ i ] / ( dists[ i ] - dists[ i + 1 ] );
-
-		for ( j = 0; j < 3; j++ )
-		{
-			e = v[ j ] + d * ( v[ j + 3 ] - v[ j ] );
-			newv[ 0 ][ newc[ 0 ] ][ j ] = e;
-			newv[ 1 ][ newc[ 1 ] ][ j ] = e;
-		}
-
-		newc[ 0 ]++;
-		newc[ 1 ]++;
-	}
-
-	// continue
-	ClipSkyPolygon( newc[ 0 ], newv[ 0 ][ 0 ], stage + 1 );
-	ClipSkyPolygon( newc[ 1 ], newv[ 1 ][ 0 ], stage + 1 );
-}
-
-/*
-==============
-ClearSkyBox
-==============
-*/
-static void ClearSkyBox()
-{
-	static const float mins[ 2 ][ 6 ] = {
-		{ 9999, 9999, 9999, 9999, 9999, 9999 },
-		{ 9999, 9999, 9999, 9999, 9999, 9999 }
-	};
-
-	static const float maxs[ 2 ][ 6 ] = {
-		{ -9999, -9999, -9999, -9999, -9999, -9999 },
-		{ -9999, -9999, -9999, -9999, -9999, -9999 }
-	};
-
-	memcpy( sky_mins, mins, sizeof( mins ) );
-	memcpy( sky_maxs, maxs, sizeof( maxs ) );
-}
-
-/*
-================
-Tess_ClipSkyPolygons
-================
-*/
-void Tess_ClipSkyPolygons()
-{
-	vec3_t p[ 5 ]; // need one extra point for clipping
-	unsigned int i, j;
-
-	ClearSkyBox();
-
-	for ( i = 0; i < tess.numIndexes; i += 3 )
-	{
-		for ( j = 0; j < 3; j++ )
-		{
-			VectorSubtract( tess.verts[ tess.indexes[ i + j ] ].xyz, backEnd.viewParms.orientation.origin, p[ j ] );
-		}
-
-		ClipSkyPolygon( 3, p[ 0 ], 0 );
-	}
-}
-
-/*
-===================================================================================
-
-CLOUD VERTEX GENERATION
-
-===================================================================================
-*/
-
-/*
-** MakeSkyVec
-**
-** Parms: s, t range from -1 to 1
-*/
-static void MakeSkyVec( float s, float t, int axis, vec2_t outSt, vec4_t outXYZ )
-{
-	// 1 = s, 2 = t, 3 = 2048
-	static const int st_to_vec[ 6 ][ 3 ] =
-	{
-		{ 3,  -1, 2 },
-		{ -3, 1,  2 },
-
-		{ 1,  3,  2 },
-		{ -1, -3, 2 },
-
-		{ -2, -1, 3 }, // 0 degrees yaw, look straight up
-		{ 2,  -1, -3} // look straight down
-	};
-
-	vec3_t     b;
-	int        j, k;
-	float      boxSize;
-
-	boxSize = backEnd.viewParms.zFar / M_ROOT3;
-	b[ 0 ] = s * boxSize;
-	b[ 1 ] = t * boxSize;
-	b[ 2 ] = boxSize;
-
-	for ( j = 0; j < 3; j++ )
-	{
-		k = st_to_vec[ axis ][ j ];
-
-		if ( k < 0 )
-		{
-			outXYZ[ j ] = -b[ -k - 1 ];
-		}
-		else
-		{
-			outXYZ[ j ] = b[ k - 1 ];
-		}
-	}
-
-	outXYZ[ 3 ] = 1;
-
-	// avoid bilerp seam
-	s = ( s + 1 ) * 0.5F;
-	t = ( t + 1 ) * 0.5F;
-
-	if ( s < sky_min )
-	{
-		s = sky_min;
-	}
-	else if ( s > sky_max )
-	{
-		s = sky_max;
-	}
-
-	if ( t < sky_min )
-	{
-		t = sky_min;
-	}
-	else if ( t > sky_max )
-	{
-		t = sky_max;
-	}
-
-	t = 1.0F - t;
-
-	if ( outSt )
-	{
-		outSt[ 0 ] = s;
-		outSt[ 1 ] = t;
-	}
-}
-
-static vec4_t s_skyPoints[ SKY_SUBDIVISIONS + 1 ][ SKY_SUBDIVISIONS + 1 ];
-static vec2_t s_skyTexCoords[ SKY_SUBDIVISIONS + 1 ][ SKY_SUBDIVISIONS + 1 ];
-
-static void FillCloudySkySide( const int mins[ 2 ], const int maxs[ 2 ], bool addIndexes )
-{
-	int s, t;
-	int vertexStart = tess.numVertexes;
-	int tHeight, sWidth;
-
-	tHeight = maxs[ 1 ] - mins[ 1 ] + 1;
-	sWidth = maxs[ 0 ] - mins[ 0 ] + 1;
-
-	for ( t = mins[ 1 ] + HALF_SKY_SUBDIVISIONS; t <= maxs[ 1 ] + HALF_SKY_SUBDIVISIONS; t++ )
-	{
-		for ( s = mins[ 0 ] + HALF_SKY_SUBDIVISIONS; s <= maxs[ 0 ] + HALF_SKY_SUBDIVISIONS; s++ )
-		{
-			VectorAdd( s_skyPoints[ t ][ s ], backEnd.viewParms.orientation.origin, tess.verts[ tess.numVertexes ].xyz );
-
-			tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( s_skyTexCoords[ t ][ s ][ 0 ] );
-			tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( s_skyTexCoords[ t ][ s ][ 1 ] );
-
-			tess.numVertexes++;
-
-			if ( tess.numVertexes >= SHADER_MAX_VERTEXES )
-			{
-				Sys::Drop( "SHADER_MAX_VERTEXES hit in FillCloudySkySide()" );
-			}
-		}
-	}
-
-	tess.attribsSet |= ATTR_POSITION | ATTR_TEXCOORD;
-
-	// only add indexes for one pass, otherwise it would draw multiple times for each pass
-	if ( addIndexes )
-	{
-		for ( t = 0; t < tHeight - 1; t++ )
-		{
-			for ( s = 0; s < sWidth - 1; s++ )
-			{
-				tess.indexes[ tess.numIndexes ] = vertexStart + s + t * ( sWidth );
-				tess.numIndexes++;
-				tess.indexes[ tess.numIndexes ] = vertexStart + s + ( t + 1 ) * ( sWidth );
-				tess.numIndexes++;
-				tess.indexes[ tess.numIndexes ] = vertexStart + s + 1 + t * ( sWidth );
-				tess.numIndexes++;
-
-				tess.indexes[ tess.numIndexes ] = vertexStart + s + ( t + 1 ) * ( sWidth );
-				tess.numIndexes++;
-				tess.indexes[ tess.numIndexes ] = vertexStart + s + 1 + ( t + 1 ) * ( sWidth );
-				tess.numIndexes++;
-				tess.indexes[ tess.numIndexes ] = vertexStart + s + 1 + t * ( sWidth );
-				tess.numIndexes++;
-			}
-		}
-	}
-}
-
-static void DrawSkyBox()
-{
-	int i;
-
-	sky_min = 0;
-	sky_max = 1;
-
-	memset( s_skyTexCoords, 0, sizeof( s_skyTexCoords ) );
-
-	// set up for drawing
-	tess.multiDrawPrimitives = 0;
-	tess.numIndexes = 0;
-	tess.numVertexes = 0;
-	tess.attribsSet = 0;
-
-	GL_State( GLS_DEFAULT );
-
-	Tess_MapVBOs( false );
-
-	for ( i = 0; i < 6; i++ )
-	{
-		int sky_mins_subd[ 2 ], sky_maxs_subd[ 2 ];
-		int s, t;
-
-		sky_mins[ 0 ][ i ] = floor( sky_mins[ 0 ][ i ] * HALF_SKY_SUBDIVISIONS ) / HALF_SKY_SUBDIVISIONS;
-		sky_mins[ 1 ][ i ] = floor( sky_mins[ 1 ][ i ] * HALF_SKY_SUBDIVISIONS ) / HALF_SKY_SUBDIVISIONS;
-		sky_maxs[ 0 ][ i ] = ceil( sky_maxs[ 0 ][ i ] * HALF_SKY_SUBDIVISIONS ) / HALF_SKY_SUBDIVISIONS;
-		sky_maxs[ 1 ][ i ] = ceil( sky_maxs[ 1 ][ i ] * HALF_SKY_SUBDIVISIONS ) / HALF_SKY_SUBDIVISIONS;
-
-		if ( ( sky_mins[ 0 ][ i ] >= sky_maxs[ 0 ][ i ] ) || ( sky_mins[ 1 ][ i ] >= sky_maxs[ 1 ][ i ] ) )
-		{
-			continue;
-		}
-
-		sky_mins_subd[ 0 ] = sky_mins[ 0 ][ i ] * HALF_SKY_SUBDIVISIONS;
-		sky_mins_subd[ 1 ] = sky_mins[ 1 ][ i ] * HALF_SKY_SUBDIVISIONS;
-		sky_maxs_subd[ 0 ] = sky_maxs[ 0 ][ i ] * HALF_SKY_SUBDIVISIONS;
-		sky_maxs_subd[ 1 ] = sky_maxs[ 1 ][ i ] * HALF_SKY_SUBDIVISIONS;
-
-		if ( sky_mins_subd[ 0 ] < -HALF_SKY_SUBDIVISIONS )
-		{
-			sky_mins_subd[ 0 ] = -HALF_SKY_SUBDIVISIONS;
-		}
-		else if ( sky_mins_subd[ 0 ] > HALF_SKY_SUBDIVISIONS )
-		{
-			sky_mins_subd[ 0 ] = HALF_SKY_SUBDIVISIONS;
-		}
-
-		if ( sky_mins_subd[ 1 ] < -HALF_SKY_SUBDIVISIONS )
-		{
-			sky_mins_subd[ 1 ] = -HALF_SKY_SUBDIVISIONS;
-		}
-		else if ( sky_mins_subd[ 1 ] > HALF_SKY_SUBDIVISIONS )
-		{
-			sky_mins_subd[ 1 ] = HALF_SKY_SUBDIVISIONS;
-		}
-
-		if ( sky_maxs_subd[ 0 ] < -HALF_SKY_SUBDIVISIONS )
-		{
-			sky_maxs_subd[ 0 ] = -HALF_SKY_SUBDIVISIONS;
-		}
-		else if ( sky_maxs_subd[ 0 ] > HALF_SKY_SUBDIVISIONS )
-		{
-			sky_maxs_subd[ 0 ] = HALF_SKY_SUBDIVISIONS;
-		}
-
-		if ( sky_maxs_subd[ 1 ] < -HALF_SKY_SUBDIVISIONS )
-		{
-			sky_maxs_subd[ 1 ] = -HALF_SKY_SUBDIVISIONS;
-		}
-		else if ( sky_maxs_subd[ 1 ] > HALF_SKY_SUBDIVISIONS )
-		{
-			sky_maxs_subd[ 1 ] = HALF_SKY_SUBDIVISIONS;
-		}
-
-		// iterate through the subdivisions
-		for ( t = sky_mins_subd[ 1 ] + HALF_SKY_SUBDIVISIONS; t <= sky_maxs_subd[ 1 ] + HALF_SKY_SUBDIVISIONS; t++ )
-		{
-			for ( s = sky_mins_subd[ 0 ] + HALF_SKY_SUBDIVISIONS; s <= sky_maxs_subd[ 0 ] + HALF_SKY_SUBDIVISIONS; s++ )
-			{
-				MakeSkyVec( ( s - HALF_SKY_SUBDIVISIONS ) / ( float ) HALF_SKY_SUBDIVISIONS,
-				            ( t - HALF_SKY_SUBDIVISIONS ) / ( float ) HALF_SKY_SUBDIVISIONS,
-				            i, s_skyTexCoords[ t ][ s ], s_skyPoints[ t ][ s ] );
-			}
-		}
-
-		// only add indexes for first stage
-		FillCloudySkySide( sky_mins_subd, sky_maxs_subd, true );
-	}
-	Tess_UpdateVBOs( );
-	GL_VertexAttribsState( tess.attribsSet );
-
-	Tess_DrawElements();
-}
-
-static void FillCloudBox( int stage )
-{
-	int i;
-
-	// Iterate from 0 to 4 (5 times) and not from 0 to 5 (6 times),
-	// because for now we don't want to draw the bottom, even if fullClouds.
-	for ( i = 0; i < 5; i++ )
-	{
-		int   sky_mins_subd[ 2 ], sky_maxs_subd[ 2 ];
-		int   s, t;
-		const int MIN_T{-HALF_SKY_SUBDIVISIONS};
-
-		sky_mins[ 0 ][ i ] = floor( sky_mins[ 0 ][ i ] * HALF_SKY_SUBDIVISIONS ) / HALF_SKY_SUBDIVISIONS;
-		sky_mins[ 1 ][ i ] = floor( sky_mins[ 1 ][ i ] * HALF_SKY_SUBDIVISIONS ) / HALF_SKY_SUBDIVISIONS;
-		sky_maxs[ 0 ][ i ] = ceil( sky_maxs[ 0 ][ i ] * HALF_SKY_SUBDIVISIONS ) / HALF_SKY_SUBDIVISIONS;
-		sky_maxs[ 1 ][ i ] = ceil( sky_maxs[ 1 ][ i ] * HALF_SKY_SUBDIVISIONS ) / HALF_SKY_SUBDIVISIONS;
-
-		if ( ( sky_mins[ 0 ][ i ] >= sky_maxs[ 0 ][ i ] ) || ( sky_mins[ 1 ][ i ] >= sky_maxs[ 1 ][ i ] ) )
-		{
-			continue;
-		}
-
-		sky_mins_subd[ 0 ] = Q_ftol( sky_mins[ 0 ][ i ] * HALF_SKY_SUBDIVISIONS );
-		sky_mins_subd[ 1 ] = Q_ftol( sky_mins[ 1 ][ i ] * HALF_SKY_SUBDIVISIONS );
-		sky_maxs_subd[ 0 ] = Q_ftol( sky_maxs[ 0 ][ i ] * HALF_SKY_SUBDIVISIONS );
-		sky_maxs_subd[ 1 ] = Q_ftol( sky_maxs[ 1 ][ i ] * HALF_SKY_SUBDIVISIONS );
-
-		if ( sky_mins_subd[ 0 ] < -HALF_SKY_SUBDIVISIONS )
-		{
-			sky_mins_subd[ 0 ] = -HALF_SKY_SUBDIVISIONS;
-		}
-		else if ( sky_mins_subd[ 0 ] > HALF_SKY_SUBDIVISIONS )
-		{
-			sky_mins_subd[ 0 ] = HALF_SKY_SUBDIVISIONS;
-		}
-
-		if ( sky_mins_subd[ 1 ] < MIN_T )
-		{
-			sky_mins_subd[ 1 ] = MIN_T;
-		}
-		else if ( sky_mins_subd[ 1 ] > HALF_SKY_SUBDIVISIONS )
-		{
-			sky_mins_subd[ 1 ] = HALF_SKY_SUBDIVISIONS;
-		}
-
-		if ( sky_maxs_subd[ 0 ] < -HALF_SKY_SUBDIVISIONS )
-		{
-			sky_maxs_subd[ 0 ] = -HALF_SKY_SUBDIVISIONS;
-		}
-		else if ( sky_maxs_subd[ 0 ] > HALF_SKY_SUBDIVISIONS )
-		{
-			sky_maxs_subd[ 0 ] = HALF_SKY_SUBDIVISIONS;
-		}
-
-		if ( sky_maxs_subd[ 1 ] < MIN_T )
-		{
-			sky_maxs_subd[ 1 ] = MIN_T;
-		}
-		else if ( sky_maxs_subd[ 1 ] > HALF_SKY_SUBDIVISIONS )
-		{
-			sky_maxs_subd[ 1 ] = HALF_SKY_SUBDIVISIONS;
-		}
-
-		// iterate through the subdivisions
-		for ( t = sky_mins_subd[ 1 ] + HALF_SKY_SUBDIVISIONS; t <= sky_maxs_subd[ 1 ] + HALF_SKY_SUBDIVISIONS; t++ )
-		{
-			for ( s = sky_mins_subd[ 0 ] + HALF_SKY_SUBDIVISIONS; s <= sky_maxs_subd[ 0 ] + HALF_SKY_SUBDIVISIONS; s++ )
-			{
-				MakeSkyVec( ( s - HALF_SKY_SUBDIVISIONS ) / ( float ) HALF_SKY_SUBDIVISIONS,
-				            ( t - HALF_SKY_SUBDIVISIONS ) / ( float ) HALF_SKY_SUBDIVISIONS, i, nullptr, s_skyPoints[ t ][ s ] );
-
-				s_skyTexCoords[ t ][ s ][ 0 ] = s_cloudTexCoords[ i ][ t ][ s ][ 0 ];
-				s_skyTexCoords[ t ][ s ][ 1 ] = s_cloudTexCoords[ i ][ t ][ s ][ 1 ];
-			}
-		}
-
-		// only add indexes for first stage
-		FillCloudySkySide( sky_mins_subd, sky_maxs_subd, ( bool )( stage == 0 ) );
-	}
-}
-
-static void BuildCloudData()
-{
-	int      i;
-
-	ASSERT(tess.surfaceShader->isSky);
-
-	sky_min = 1.0f / 256.0f; // FIXME: not correct?
-	sky_max = 255.0f / 256.0f;
-
-	// set up for drawing
-	tess.multiDrawPrimitives = 0;
-	tess.numIndexes = 0;
-	tess.numVertexes = 0;
-	tess.attribsSet = 0;
-
-	Tess_MapVBOs( false );
-
-	if ( tess.surfaceShader->sky.cloudHeight )
-	{
-		for ( i = 0; i < MAX_SHADER_STAGES; i++ )
-		{
-			if ( !tess.surfaceStages[ i ] )
-			{
-				break;
-			}
-
-			FillCloudBox( i );
-		}
-	}
-}
-
-/*
-** R_InitSkyTexCoords
-** Called when a sky shader is parsed
-*/
-void R_InitSkyTexCoords( float heightCloud )
-{
-	int    i, s, t;
-	float  radiusWorld = 4096;
-	float  p;
-	float  sRad, tRad;
-	vec4_t skyVec;
-	vec3_t v;
-
-	// init zfar so MakeSkyVec works even though
-	// a world hasn't been bounded
-	backEnd.viewParms.zFar = 1024;
-
-	for ( i = 0; i < 6; i++ )
-	{
-		for ( t = 0; t <= SKY_SUBDIVISIONS; t++ )
-		{
-			for ( s = 0; s <= SKY_SUBDIVISIONS; s++ )
-			{
-				// compute vector from view origin to sky side integral point
-				MakeSkyVec( ( s - HALF_SKY_SUBDIVISIONS ) / ( float ) HALF_SKY_SUBDIVISIONS,
-				            ( t - HALF_SKY_SUBDIVISIONS ) / ( float ) HALF_SKY_SUBDIVISIONS, i, nullptr, skyVec );
-
-				// compute parametric value 'p' that intersects with cloud layer
-				p = ( 1.0f / ( 2 * DotProduct( skyVec, skyVec ) ) ) *
-				    ( -2 * skyVec[ 2 ] * radiusWorld +
-				      2 * sqrt( Square( skyVec[ 2 ] ) * Square( radiusWorld ) +
-				                2 * Square( skyVec[ 0 ] ) * radiusWorld * heightCloud +
-				                Square( skyVec[ 0 ] ) * Square( heightCloud ) +
-				                2 * Square( skyVec[ 1 ] ) * radiusWorld * heightCloud +
-				                Square( skyVec[ 1 ] ) * Square( heightCloud ) +
-				                2 * Square( skyVec[ 2 ] ) * radiusWorld * heightCloud + Square( skyVec[ 2 ] ) * Square( heightCloud ) ) );
-
-				s_cloudTexP[ i ][ t ][ s ] = p;
-
-				// compute intersection point based on p
-				VectorScale( skyVec, p, v );
-				v[ 2 ] += radiusWorld;
-
-				// compute vector from world origin to intersection point 'v'
-				VectorNormalize( v );
-
-				sRad = acos( v[ 0 ] );
-				tRad = acos( v[ 1 ] );
-
-				s_cloudTexCoords[ i ][ t ][ s ][ 0 ] = sRad;
-				s_cloudTexCoords[ i ][ t ][ s ][ 1 ] = tRad;
-			}
-		}
-	}
-}
-
 //======================================================================================
+
+static void Tess_ComputeTexMatrices( shaderStage_t* pStage ) {
+	int   i;
+	vec_t* matrix;
+
+	GLimp_LogComment( "--- Tess_ComputeTexMatrices ---\n" );
+
+	for ( i = 0; i < MAX_TEXTURE_BUNDLES; i++ ) {
+		matrix = tess.svars.texMatrices[i];
+
+		RB_CalcTexMatrix( &pStage->bundle[i], matrix );
+	}
+}
 
 /*
 ================
@@ -781,88 +65,125 @@ void Tess_StageIteratorSky()
 		return;
 	}
 
-	// trebor: HACK why does this happen with cg_draw2D 0 ?
-	if ( tess.stageIteratorFunc2 == nullptr )
-	{
-		//tess.stageIteratorFunc2 = Tess_StageIteratorGeneric;
-		Sys::Error( "tess.stageIteratorFunc == NULL" );
+	// Store the current projection, modelView and modelViewProjection matrices if we're drawing the skybox in a portal
+	// since portals set up the projection matrix differently
+	matrix_t currentProjectionMatrix;
+	matrix_t currentModelViewMatrix;
+	matrix_t currentModelViewProjectionMatrix;
+	if ( backEnd.viewParms.portalLevel > 0 ) {
+		MatrixCopy( glState.projectionMatrix[glState.stackIndex], currentProjectionMatrix );
+		MatrixCopy( glState.modelViewMatrix[glState.stackIndex], currentModelViewMatrix );
+		MatrixCopy( glState.modelViewProjectionMatrix[glState.stackIndex], currentModelViewProjectionMatrix );
+		GL_LoadProjectionMatrix( backEnd.viewParms.projectionMatrixNonPortal );
 	}
+	
+	// Compute the skyboxes orientation to center it on view origin
+	orientationr_t skyboxOrientation;
+	VectorCopy( backEnd.viewParms.orientation.origin, skyboxOrientation.origin );
+	AxisCopy( backEnd.viewParms.world.axis, skyboxOrientation.axis );
 
-	GL_Cull(cullType_t::CT_TWO_SIDED);
+	MatrixSetupTransformFromVectorsFLU( skyboxOrientation.transformMatrix, skyboxOrientation.axis[0], skyboxOrientation.axis[1],
+										skyboxOrientation.axis[2], skyboxOrientation.origin );
+	MatrixAffineInverse( skyboxOrientation.transformMatrix, skyboxOrientation.viewMatrix );
+	MatrixMultiply( backEnd.viewParms.world.viewMatrix, skyboxOrientation.transformMatrix, skyboxOrientation.modelViewMatrix );
 
-	if ( tess.stageIteratorFunc2 == &Tess_StageIteratorDepthFill )
+	GL_LoadModelViewMatrix( skyboxOrientation.modelViewMatrix );
+
+	GL_Cull(cullType_t::CT_BACK_SIDED);
+
+	// r_showSky will draw the whole skybox in front of everything else
+	if ( r_showSky->integer )
 	{
-		// go through all the polygons and project them onto
-		// the sky box to see which blocks on each side need
-		// to be drawn
-		Tess_ClipSkyPolygons();
-
-		// generate the vertexes for all the clouds, which will be drawn
-		// by the generic shader routine
-		BuildCloudData();
-
-		if ( tess.numVertexes || tess.multiDrawPrimitives )
-		{
-			tess.stageIteratorFunc2();
-		}
+		glDepthRange( 0.0, 0.0 );
 	}
 	else
 	{
-		// go through all the polygons and project them onto
-		// the sky box to see which blocks on each side need
-		// to be drawn
-		Tess_ClipSkyPolygons();
+		glDepthRange( 1.0, 1.0 );
+	}
 
-		// r_showSky will let all the sky blocks be drawn in
-		// front of everything to allow developers to see how
-		// much sky is getting sucked in
+	// Setup tess for rendering
+	tess.multiDrawPrimitives = 0;
+	tess.numIndexes = 0;
+	tess.numVertexes = 0;
+	tess.attribsSet = 0;
 
-		if ( r_showSky->integer )
-		{
-			glDepthRange( 0.0, 0.0 );
-		}
-		else
-		{
-			glDepthRange( 1.0, 1.0 );
-		}
+	rb_surfaceTable[Util::ordinal( *( tr.skybox->surface ) )]( tr.skybox->surface );
+	tess.attribsSet = ATTR_POSITION;
+	GL_VertexAttribsState( tess.attribsSet );
 
-		// draw the outer skybox
-		if ( tess.surfaceShader->sky.outerbox && tess.surfaceShader->sky.outerbox != tr.blackCubeImage )
-		{
-			R_BindVBO( tess.vbo );
-			R_BindIBO( tess.ibo );
+	gl_skyboxShader->BindProgram( 0 );
 
-			gl_skyboxShader->BindProgram( 0 );
+	gl_skyboxShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 
-			gl_skyboxShader->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );  // in world space
+	gl_skyboxShader->SetRequiredVertexPointers();
 
-			gl_skyboxShader->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
-			gl_skyboxShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
+	// draw the outer skybox
+	if ( tess.surfaceShader->sky.outerbox && tess.surfaceShader->sky.outerbox != tr.blackCubeImage )
+	{
+		// bind u_ColorMap
+		GL_BindToTMU( 0, tess.surfaceShader->sky.outerbox );
 
-			gl_skyboxShader->SetRequiredVertexPointers();
+		// Only render the outer skybox at this stage
+		gl_skyboxShader->SetUniform_UseCloudMap( false );
 
-			// bind u_ColorMap
-			GL_BindToTMU( 0, tess.surfaceShader->sky.outerbox );
+		Tess_DrawElements();
+	}
 
-			DrawSkyBox();
-		}
+	// Only render clouds at these stages
+	gl_skyboxShader->SetUniform_UseCloudMap( true );
+	gl_skyboxShader->SetUniform_CloudHeight( tess.surfaceShader->sky.cloudHeight );
 
-		// generate the vertexes for all the clouds, which will be drawn
-		// by the generic shader routine
-		BuildCloudData();
+	for ( int stage = 0; stage < MAX_SHADER_STAGES; stage++ ) {
+		shaderStage_t* pStage = tess.surfaceShader->stages[stage];
 
-		if ( tess.numVertexes || tess.multiDrawPrimitives )
-		{
-			tess.stageIteratorFunc2();
+		if ( !pStage || !pStage->bundle[0].image[0] ) {
+			break;
 		}
 
-		if ( tess.stageIteratorFunc2 != Tess_StageIteratorDepthFill )
-		{
-			// back to standard depth range
-			glDepthRange( 0.0, 1.0 );
+		if ( !RB_EvalExpression( &pStage->ifExp, 1.0 ) ) {
+			continue;
+		}
 
-			// note that sky was drawn so we will draw a sun later
-			backEnd.skyRenderedThisView = true;
+		Tess_ComputeTexMatrices( pStage );
+
+		gl_skyboxShader->SetUniform_TextureMatrix( tess.svars.texMatrices[TB_COLORMAP] );
+
+		GL_BindToTMU( 1, tess.surfaceShader->stages[stage]->bundle[TB_COLORMAP].image[0] );
+
+		uint32_t alphaTestBits = pStage->stateBits & GLS_ATEST_BITS;
+
+		gl_skyboxShader->SetAlphaTesting( alphaTestBits != 0 );
+
+		// u_AlphaTest
+		if ( alphaTestBits != 0 ) {
+			gl_skyboxShader->SetUniform_AlphaTest( pStage->stateBits );
+		}
+
+		GL_State( pStage->stateBits );
+
+		switch ( pStage->type ) {
+			case stageType_t::ST_COLORMAP:
+				Tess_DrawElements();
+				break;
+
+			default:
+				break;
 		}
 	}
+
+	// back to standard depth range
+	glDepthRange( 0.0, 1.0 );
+
+	// note that sky was drawn so we will draw a sun later
+	backEnd.skyRenderedThisView = true;
+
+	// Restore matrices if we're rendering in a portal
+	if ( backEnd.viewParms.portalLevel > 0 ) {
+		MatrixCopy( currentProjectionMatrix, glState.projectionMatrix[glState.stackIndex] );
+		MatrixCopy( currentModelViewMatrix, glState.modelViewMatrix[glState.stackIndex] );
+		MatrixCopy( currentModelViewProjectionMatrix, glState.modelViewProjectionMatrix[glState.stackIndex] );
+		return;
+	}
+
+	GL_LoadModelViewMatrix( backEnd.orientation.modelViewMatrix );
 }

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -164,7 +164,7 @@ static bool Tess_SurfaceVBO( VBO_t *vbo, IBO_t *ibo, int numIndexes, int firstIn
 		return false;
 	}
 
-	if ( tess.skipVBO || tess.stageIteratorFunc == &Tess_StageIteratorSky )
+	if ( tess.skipVBO )
 	{
 		return false;
 	}


### PR DESCRIPTION
Generate a persistent mesh for the skybox consisting of a cube with 8 vertices and 12 triangles.
Old code was creating a mesh consisting of many "blocks" (2 triangles each) on the CPU and uploading it to the GPU *every frame that the sky was rendered*. Not only that, but it performed operations on mapped memory. The mesh itself normally consisted of 1k+ triangles, which in itself is not much for modern hardware, but it's far more than needed and often more than the rest of the view combined. This was horrible for perfomance.

New mesh:
![image](https://github.com/DaemonEngine/Daemon/assets/10687142/57c4887c-e6b0-42da-a30e-a6cf89fc0eb9)
Old mesh example:
![image](https://github.com/DaemonEngine/Daemon/assets/10687142/4730b3af-ba36-4839-b3ac-0ac73158c134)
![image](https://github.com/DaemonEngine/Daemon/assets/10687142/513ac910-9108-44cd-a83c-3ec28e33a29b)

Move cloud generation to fragment shader. The fragment shader will now branch on a uniform to sample different textures, which will likely be faster than switching shader programs. The skybox itself will now always be centered on the view origin. For portals, the last projection matrix obtained when portalLevel == 0 is used because portals use a different projection matrix.

NUKE sky code used for clipping (i. e. generating those sky blocks). I've left the Tess_StageIteratorDepthFill() and Render_DepthFill() there even though they're unused, since I noticed that the engine uses different shader programs for depth pre-pass, so it might be possible to repurpose these functions for a more efficient depth pre-pass.

Fixes #849 and #1021.

Reference points for testing from https://github.com/DaemonEngine/Daemon/issues/849#issuecomment-1925448467:

## classic skybox

map|scene
-|-
plat23|default spectator view

new(FPS(ms))|old(FPS(ms))|r_fastsky 1(FPS(ms))
-|-|-
220(4.54ms)|200(5ms)|200(5ms)

## cloudy skybox

map|scene
-|-
chasm|default spectator view

new(FPS(ms))|old(FPS(ms))|r_fastsky 1(FPS(ms))
-|-|-
160(6.25ms)|150(6.66ms)|150(6.66ms)

## sky portal with classic skybox

map|player viewpos|skybox viewpos
-|-|-
station15|270 37 144 121 0|956 -2450 -3763 121 0 

new(FPS(ms))|old(FPS(ms))|r_fastsky 1(FPS(ms))
-|-|-
180(5.55ms)|180(5.55ms)|200(5ms)

## sky portal with cloudy skybox

map|player viewpos|skybox viewpos
-|-|-
[atcs-2015](https://users.unvanquished.net/~sweet/pkg/map-atcs-2015_0%2Bv3.2-final.dpk)|80 -106 457 50 -2|80 -106 -13362 50 0

new(FPS(ms))|old(FPS(ms))|r_fastsky 1(FPS(ms))
-|-|-
180(5.55ms)|170(5.88ms)|190(5.26ms)

## many sky brushes

map|default spectator view
-|-
testing0|default spectator view

new(FPS(ms))|old(FPS(ms))|r_fastsky 1(FPS(ms))
-|-|-
180(5.55ms)|120(8.33ms)|180(5.55ms)

map|default spectator view
-|-
[dretchstorm2](https://users.unvanquished.net/~sweet/pkg/map-dretchstorm2_2.dpk)|default spectator view

new(FPS(ms))|old(FPS(ms))|r_fastsky 1(FPS(ms))
-|-|-
150(6.66ms)|100(10ms)|150(6.66ms)

Portals:
![unvanquished_2024-02-14_061302_000](https://github.com/DaemonEngine/Daemon/assets/10687142/36e1fd90-b27d-4b83-962f-af788bba1996)
![unvanquished_2024-02-14_061337_000](https://github.com/DaemonEngine/Daemon/assets/10687142/8de8c2ff-1c68-43c4-9a7e-b2bd930bbf44)