### PR TITLE
renderer: revamp shader stage collapsing

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1179,9 +1179,9 @@ enum class deluxeMode_t { NONE, GRID, MAP };
 	  ST_LIGHTMAP,
 	  ST_STYLELIGHTMAP,
 	  ST_STYLECOLORMAP,
-	  ST_COLLAPSE_lighting_PBR,   // map|diffusemap + opt:normalmap + opt:glowmap + opt:physicalmap
-	  ST_COLLAPSE_lighting_PHONG, // map|diffusemap + opt:normalmap + opt:glowmap + specularmap
-	  ST_COLLAPSE_reflection_CB,  // color cubemap + normalmap
+	  ST_COLLAPSE_COLORMAP,
+	  ST_COLLAPSE_DIFFUSEMAP,
+	  ST_COLLAPSE_REFLECTIONMAP,  // color cubemap + normalmap
 
 	  // light shader stage types
 	  ST_ATTENUATIONMAP_XY,
@@ -1192,9 +1192,9 @@ enum class deluxeMode_t { NONE, GRID, MAP };
 	{
 	  COLLAPSE_none,
 	  COLLAPSE_generic, // used before we know it's another one
-	  COLLAPSE_lighting_PHONG,
-	  COLLAPSE_lighting_PBR,
-	  COLLAPSE_reflection_CB,
+	  COLLAPSE_PHONG,
+	  COLLAPSE_PBR,
+	  COLLAPSE_REFLECTIONMAP,
 	};
 
 	struct shaderStage_t
@@ -1226,8 +1226,6 @@ enum class deluxeMode_t { NONE, GRID, MAP };
 
 		bool        tcGen_Environment;
 		bool        tcGen_Lightmap;
-
-		bool implicitLightmap;
 
 		Color::Color32Bit constantColor; // for CGEN_CONST and AGEN_CONST
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -975,7 +975,7 @@ static void Render_lightMapping( shaderStage_t *pStage )
 			// Deluxe mapping emulation from grid light for game models.
 			// Store lightGrid2 as deluxemap,
 			// the GLSL code will know how to deal with it.
-		deluxemap = tr.lightGrid2Image;
+			deluxemap = tr.lightGrid2Image;
 			break;
 
 		default:

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -895,7 +895,7 @@ static void Render_lightMapping( shaderStage_t *pStage )
 	{
 		// Use fullbright on “surfaceparm nolightmap” materials.
 	}
-	else if ( !pStage->implicitLightmap && pStage->type != stageType_t::ST_LIGHTMAP )
+	else if ( pStage->type == stageType_t::ST_COLLAPSE_COLORMAP )
 	{
 		/* Use fullbright for collapsed stages without lightmaps,
 		for example:
@@ -2789,14 +2789,13 @@ void Tess_StageIteratorGeneric()
 
 			case stageType_t::ST_LIGHTMAP:
 			case stageType_t::ST_DIFFUSEMAP:
-			case stageType_t::ST_COLLAPSE_lighting_PHONG:
-			case stageType_t::ST_COLLAPSE_lighting_PBR:
+			case stageType_t::ST_COLLAPSE_COLORMAP:
+			case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
 				Render_lightMapping( pStage );
-
 				break;
 
-			case stageType_t::ST_COLLAPSE_reflection_CB:
 			case stageType_t::ST_REFLECTIONMAP:
+			case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
 				if ( r_reflectionMapping->integer )
 				{
 					Render_reflection_CB( pStage );
@@ -2836,7 +2835,7 @@ void Tess_StageIteratorGeneric()
 				{
 					/* FIXME: workaround to display something and not crash
 					when liquidMapping is enabled, until we fix liquidMap. */
-					pStage->type = stageType_t::ST_DIFFUSEMAP;
+					pStage->type = stageType_t::ST_COLLAPSE_DIFFUSEMAP;
 					pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] = tr.whiteImage;
 					Render_lightMapping( pStage );
 				}
@@ -2906,10 +2905,10 @@ void Tess_StageIteratorPortal() {
 			case stageType_t::ST_COLORMAP:
 			case stageType_t::ST_LIGHTMAP:
 			case stageType_t::ST_DIFFUSEMAP:
-			case stageType_t::ST_COLLAPSE_lighting_PHONG:
-			case stageType_t::ST_COLLAPSE_lighting_PBR:
-			case stageType_t::ST_COLLAPSE_reflection_CB:
+			case stageType_t::ST_COLLAPSE_COLORMAP:
+			case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
 			case stageType_t::ST_REFLECTIONMAP:
+			case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
 			case stageType_t::ST_REFRACTIONMAP:
 			case stageType_t::ST_DISPERSIONMAP:
 			case stageType_t::ST_SKYBOXMAP:
@@ -2989,8 +2988,8 @@ void Tess_StageIteratorDepthFill()
 
 			case stageType_t::ST_LIGHTMAP:
 			case stageType_t::ST_DIFFUSEMAP:
-			case stageType_t::ST_COLLAPSE_lighting_PHONG:
-			case stageType_t::ST_COLLAPSE_lighting_PBR:
+			case stageType_t::ST_COLLAPSE_COLORMAP:
+			case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
 				Render_depthFill( pStage );
 				break;
 
@@ -3066,8 +3065,8 @@ void Tess_StageIteratorShadowFill()
 
 			case stageType_t::ST_LIGHTMAP:
 			case stageType_t::ST_DIFFUSEMAP:
-			case stageType_t::ST_COLLAPSE_lighting_PHONG:
-			case stageType_t::ST_COLLAPSE_lighting_PBR:
+			case stageType_t::ST_COLLAPSE_COLORMAP:
+			case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
 				Render_shadowFill( pStage );
 				break;
 
@@ -3180,8 +3179,7 @@ void Tess_StageIteratorLighting()
 			switch ( pStage->type )
 			{
 				case stageType_t::ST_DIFFUSEMAP:
-				case stageType_t::ST_COLLAPSE_lighting_PBR:
-				case stageType_t::ST_COLLAPSE_lighting_PHONG:
+				case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
 					if ( light->l.rlType == refLightType_t::RL_OMNI )
 					{
 						Render_forwardLighting_DBS_omni( pStage, attenuationXYStage, attenuationZStage, light );


### PR DESCRIPTION
This deeply rewrites the stage collapse, I needed this when implementing sRGB as I had to be sure of what I was rendering.

This also fix some bugs and uncovers some. For example our creep material is currently lacking a lightmap but because of a bug it was rendered properly. Once this is merged it will be rendered as buggy as it should be with the mistake.

This also collapse more stages. For legacy materials done this way:

```
color map
lightmap with multiplication
```

```
light map
color map with multiplication
```

They are automatically turned into diffuse stages.

While for legacy materials done this way:

```
color map
lightmap with multiplication
colormap with addition
```

```
light map
color map with multiplication
color map with addition
```

They are automatically turned into diffuse stages with glow map.

The `implicitLightmap` boolean is now removed, all diffuse maps have a light map, collapsed stages without lightmap use another stage type.

So this not only fixes bug, it make things less complex, and improve performance.

