### PR TITLE
Reset GL_State when rendering outer skybox

### DIFF
--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -120,6 +120,8 @@ void Tess_StageIteratorSky()
 	// draw the outer skybox
 	if ( tess.surfaceShader->sky.outerbox && tess.surfaceShader->sky.outerbox != tr.blackCubeImage )
 	{
+		GL_State( GLS_DEFAULT );
+
 		// bind u_ColorMap
 		GL_BindToTMU( 0, tess.surfaceShader->sky.outerbox );
 


### PR DESCRIPTION
Fixes #1047.

![image](https://github.com/DaemonEngine/Daemon/assets/10687142/1891a7f0-0539-432c-a583-3228f7d86886)