### PR TITLE
renderer: revamp image and shader listing

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <common/FileSystem.h>
 #include "InternalImage.h"
 #include "tr_local.h"
+#include <iomanip>
 
 int                  gl_filter_min = GL_LINEAR_MIPMAP_NEAREST;
 int                  gl_filter_max = GL_LINEAR;
@@ -60,7 +61,8 @@ unsigned int GenerateImageHashValue( const char *fname )
 	unsigned hash;
 	char letter;
 
-//  Log::Notice("tr_image::GenerateImageHashValue: '%s'", fname);
+	// better use Log::CommandInteractionMessage
+	// Log::Notice("tr_image::GenerateImageHashValue: '%s'", fname);
 
 	hash = 0;
 	i = 0;
@@ -151,313 +153,247 @@ R_ListImages_f
 */
 void R_ListImages_f()
 {
-	int        i;
-	image_t    *image;
-	int        texels;
-	int        dataSize;
-	int        imageDataSize;
-	const char *yesno[] =
-	{
-		"no ", "yes"
+	std::unordered_map<GLenum, std::string> imageTypeName = {
+		{ GL_TEXTURE_2D, "2D" },
+		{ GL_TEXTURE_3D, "3D" },
+		{ GL_TEXTURE_CUBE_MAP, "CUBE" },
 	};
+
+	typedef std::pair<const std::string, int> nameSizePair;
+	std::unordered_map<uint32_t, nameSizePair> imageFormatNameSize = {
+		// TODO: find imageDataSize multiplier
+		{ GL_RGBA, { "RGBA", 4 } },
+
+		{ GL_RGB8, { "RGB8", 3 } },
+		{ GL_RGBA8, { "RGBA8", 4 } },
+		{ GL_RGB16, { "RGB16", 6 } },
+		{ GL_RGBA16, { "RGBA16", 6 } },
+		{ GL_RGB16F, { "RGB16F", 6 } },
+		{ GL_RGB32F, { "RGB32F", 12 } },
+		{ GL_RGBA16F, { "RGBA16F", 8 } },
+		{ GL_RGBA32F, { "RGBA32F", 16 } },
+		{ GL_RGBA32UI, { "RGBA32UI", 16 } },
+		{ GL_ALPHA16F_ARB, { "A16F", 2 } },
+		{ GL_ALPHA32F_ARB, { "A32F", 4 } },
+		{ GL_R16F, { "R16F", 2 } },
+		{ GL_R32F, { "R32F", 4 } },
+		{ GL_LUMINANCE_ALPHA16F_ARB, { "LA16F", 4 } },
+		{ GL_LUMINANCE_ALPHA32F_ARB, { "LA32F", 8 } },
+		{ GL_RG16F, { "RG16F", 4 } },
+		{ GL_RG32F, { "RG32F", 8 } },
+
+		// TODO: find imageDataSize multiplier
+		{ GL_COMPRESSED_RGBA, { "RGBAC", 4 } },
+
+		{ GL_COMPRESSED_RGB_S3TC_DXT1_EXT, { "DXT1", 4 / 8 } },
+		{ GL_COMPRESSED_RGBA_S3TC_DXT1_EXT, { "DXT1a", 4 / 8 } },
+		{ GL_COMPRESSED_RGBA_S3TC_DXT3_EXT, { "DXT3", 4 / 4 } },
+		{ GL_COMPRESSED_RGBA_S3TC_DXT5_EXT, { "DXT5", 4 / 4 } },
+
+		// TODO: find imageDataSize multiplier
+		{ GL_COMPRESSED_RED_RGTC1, { "RGTC1r", 1 } },
+		// TODO: find imageDataSize multiplier
+		{ GL_COMPRESSED_SIGNED_RED_RGTC1, { "RGTC1Sr", 1 } },
+		// TODO: find imageDataSize multiplier
+		{ GL_COMPRESSED_RG_RGTC2, { "RGTC2rg", 2 } },
+		// TODO: find imageDataSize multiplier
+		{ GL_COMPRESSED_SIGNED_RG_RGTC2, { "RGTC2Srg", 2 } },
+
+		{ GL_DEPTH_COMPONENT16, { "D16", 2 } },
+		{ GL_DEPTH_COMPONENT24, { "D24", 3 } },
+		{ GL_DEPTH_COMPONENT32, { "D32", 4 } },
+		{ GL_DEPTH24_STENCIL8, { "D24S8", 4 } },
+	};
+
+	std::unordered_map<wrapTypeEnum_t, std::string> wrapTypeName = {
+		{ wrapTypeEnum_t::WT_REPEAT, "rept" },
+		{ wrapTypeEnum_t::WT_CLAMP, "clmp" },
+		{ wrapTypeEnum_t::WT_EDGE_CLAMP, "eclmp" },
+		{ wrapTypeEnum_t::WT_ZERO_CLAMP, "0clmp" },
+		{ wrapTypeEnum_t::WT_ONE_CLAMP, "1clmp" },
+		{ wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP, "a0clmp" },
+	};
+
+	const char *yesno[] = { "no", "yes" };
 	const char *filter = ri.Cmd_Argc() > 1 ? ri.Cmd_Argv(1) : nullptr;
 
-	Log::Notice("\n      -w-- -h-- -mm- -type-   -if-- wrap --name-------" );
+	// Header names
+	std::string num = "num";
+	std::string width = "width";
+	std::string height = "heigth";
+	std::string layers = "layers";
+	std::string mm = "mm";
+	std::string type = "type";
+	std::string format = "format";
+	std::string twrap = "wrap.t";
+	std::string swrap = "wrap.s";
+	std::string name = "name";
 
-	texels = 0;
-	dataSize = 0;
+	// Number sizes
+	size_t numLen = 5;
+	size_t widthLen = 5;
+	size_t heightLen = 5;
+	size_t layersLen = 5;
+	size_t mmLen = 3;
+	size_t typeLen = 4;
+	size_t formatLen = 4;
+	size_t twrapLen = 4;
+	size_t swrapLen = 4;
 
-	for ( i = 0; i < tr.images.currentElements; i++ )
+	// Header number sizes
+	numLen = std::max( numLen, num.length() );
+	widthLen = std::max( widthLen, width.length() );
+	heightLen = std::max( heightLen, height.length() );
+	layersLen = std::max( layersLen, layers.length() );
+	mmLen = std::max( mmLen, mm.length() );
+	typeLen = std::max( typeLen, type.length() );
+	formatLen = std::max( formatLen, format.length() );
+	twrapLen = std::max( twrapLen, twrap.length() );
+	swrapLen = std::max( swrapLen, swrap.length() );
+
+	// Value sizes
+	for ( const auto& kv : imageTypeName )
 	{
-		image = (image_t*) Com_GrowListElement( &tr.images, i );
-		char buffer[ MAX_TOKEN_CHARS ];
-		std::string out;
+		typeLen = std::max( typeLen, kv.second.length() );
+	}
+	
+	for ( const auto& kv : imageFormatNameSize )
+	{
+		formatLen = std::max( formatLen, kv.second.first.length() );
+	}
+
+	for ( const auto& kv: wrapTypeName )
+	{
+		// 2 for the "t." and "s." prefix length.
+		twrapLen = std::max( twrapLen, 2 + kv.second.length() );
+		swrapLen = std::max( swrapLen, 2 + kv.second.length() );
+	}
+
+	std::string separator = " ";
+	std::stringstream lineStream;
+
+	// Print header
+	lineStream << std::left;
+	lineStream << std::setw(numLen) << num << separator;
+	lineStream << std::right;
+	lineStream << std::setw(widthLen) << width << separator;
+	lineStream << std::setw(heightLen) << height << separator;
+	lineStream << std::setw(layersLen) << layers << separator;
+	lineStream << std::left;
+	lineStream << std::setw(mmLen) << mm << separator;
+	lineStream << std::setw(typeLen) << type << separator;
+	lineStream << std::setw(formatLen) << format << separator;
+	lineStream << std::setw(twrapLen) << twrap << separator;
+	lineStream << std::setw(swrapLen) << swrap << separator;
+	lineStream << name;
+
+	std::string lineSeparator( lineStream.str().length(), '-' );
+
+	Log::CommandInteractionMessage( lineSeparator );
+	Log::CommandInteractionMessage( lineStream.str() );
+	Log::CommandInteractionMessage( lineSeparator );
+
+	int texels = 0;
+	int dataSize = 0;
+
+	for ( int i = 0; i < tr.images.currentElements; i++ )
+	{
+		image_t *image = (image_t*) Com_GrowListElement( &tr.images, i );
 
 		if ( filter && !Com_Filter( filter, image->name, true ) )
 		{
 			continue;
 		}
 
-		Com_sprintf( buffer, sizeof( buffer ), "%4i: %4i %4i  %s   ",
-		           i, image->uploadWidth, image->uploadHeight, yesno[ image->filterType == filterType_t::FT_DEFAULT ] );
-		out += buffer;
-		switch ( image->type )
+		mm = yesno[ image->filterType == filterType_t::FT_DEFAULT ];
+
+		if ( !imageTypeName.count( image->type ) )
 		{
-			case GL_TEXTURE_2D:
-				texels += image->uploadWidth * image->uploadHeight;
-				imageDataSize = image->uploadWidth * image->uploadHeight;
+			Log::Debug( "Undocumented image type %i (%X) for image %s",
+				image->type, image->type, image->name );
 
-				Com_sprintf( buffer, sizeof( buffer ),  "2D   " );
-				out += buffer;
-				break;
-
-			case GL_TEXTURE_CUBE_MAP:
-				texels += image->uploadWidth * image->uploadHeight * 6;
-				imageDataSize = image->uploadWidth * image->uploadHeight * 6;
-
-				Com_sprintf( buffer, sizeof( buffer ),  "CUBE " );
-				out += buffer;
-				break;
-
-			default:
-				Log::Debug( "Undocumented image type %i for image %s", image->type, image->name );
-				Com_sprintf( buffer, sizeof( buffer ),  "%5i    ", image->type );
-				out += buffer;
-				imageDataSize = image->uploadWidth * image->uploadHeight;
-				break;
+			type = Str::Format( "0x%4X", image->type );
+		}
+		else
+		{
+			type = imageTypeName[ image->type ];
 		}
 
-		switch ( image->internalFormat )
+		int imageDataSize = image->uploadWidth * image->uploadHeight * image->numLayers;
+		texels += imageDataSize;
+		
+		if ( !imageFormatNameSize.count( image->internalFormat ) )
 		{
-			case GL_RGB8:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGB8     " );
-				out += buffer;
-				imageDataSize *= 3;
-				break;
+			Log::Debug( "Undocumented image format %i (%X) for image %s",
+				image->internalFormat, image->internalFormat, image->name );
 
-			case GL_RGBA8:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGBA8    " );
-				out += buffer;
-				imageDataSize *= 4;
-				break;
-
-			case GL_RGB16:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGB      " );
-				out += buffer;
-				imageDataSize *= 6;
-				break;
-
-			case GL_RGB16F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGB16F   " );
-				out += buffer;
-				imageDataSize *= 6;
-				break;
-
-			case GL_RGB32F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGB32F   " );
-				out += buffer;
-				imageDataSize *= 12;
-				break;
-
-			case GL_RGBA16F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGBA16F  " );
-				out += buffer;
-				imageDataSize *= 8;
-				break;
-
-			case GL_RGBA32F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGBA32F  " );
-				out += buffer;
-				imageDataSize *= 16;
-				break;
-
-			case GL_ALPHA16F_ARB:
-				Com_sprintf( buffer, sizeof( buffer ),  "A16F     " );
-				out += buffer;
-				imageDataSize *= 2;
-				break;
-
-			case GL_ALPHA32F_ARB:
-				Com_sprintf( buffer, sizeof( buffer ),  "A32F     " );
-				out += buffer;
-				imageDataSize *= 4;
-				break;
-
-			case GL_R16F:
-				Com_sprintf( buffer, sizeof( buffer ),  "R16F     " );
-				out += buffer;
-				imageDataSize *= 2;
-				break;
-
-			case GL_R32F:
-				Com_sprintf( buffer, sizeof( buffer ),  "R32F     " );
-				out += buffer;
-				imageDataSize *= 4;
-				break;
-
-			case GL_LUMINANCE_ALPHA16F_ARB:
-				Com_sprintf( buffer, sizeof( buffer ),  "LA16F    " );
-				out += buffer;
-				imageDataSize *= 4;
-				break;
-
-			case GL_LUMINANCE_ALPHA32F_ARB:
-				Com_sprintf( buffer, sizeof( buffer ),  "LA32F    " );
-				out += buffer;
-				imageDataSize *= 8;
-				break;
-
-			case GL_RG16F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RG16F    " );
-				out += buffer;
-				out += buffer;
-				imageDataSize *= 4;
-				break;
-
-			case GL_RG32F:
-				Com_sprintf( buffer, sizeof( buffer ),  "RG32F    " );
-				out += buffer;
-				imageDataSize *= 8;
-				break;
-
-			case GL_COMPRESSED_RGBA:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGBAC " );
-				out += buffer;
-				// TODO: find imageDataSize
-				break;
-
-			case GL_COMPRESSED_RGB_S3TC_DXT1_EXT:
-				Com_sprintf( buffer, sizeof( buffer ),  "DXT1     " );
-				out += buffer;
-				imageDataSize *= 4 / 8;
-				break;
-
-			case GL_COMPRESSED_RGBA_S3TC_DXT1_EXT:
-				Com_sprintf( buffer, sizeof( buffer ),  "DXT1a    " );
-				out += buffer;
-				imageDataSize *= 4 / 8;
-				break;
-
-			case GL_COMPRESSED_RGBA_S3TC_DXT3_EXT:
-				Com_sprintf( buffer, sizeof( buffer ),  "DXT3     " );
-				out += buffer;
-				imageDataSize *= 4 / 4;
-				break;
-
-			case GL_COMPRESSED_RGBA_S3TC_DXT5_EXT:
-				Com_sprintf( buffer, sizeof( buffer ),  "DXT5     " );
-				out += buffer;
-				imageDataSize *= 4 / 4;
-				break;
-
-			case GL_COMPRESSED_RED_RGTC1:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGTC1r   " );
-				out += buffer;
-				// TODO: find imageDataSize
-				break;
-
-			case GL_COMPRESSED_SIGNED_RED_RGTC1:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGTC1Sr  " );
-				out += buffer;
-				// TODO: find imageDataSize
-				break;
-
-			case GL_COMPRESSED_RG_RGTC2:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGTC2rg  " );
-				out += buffer;
-				// TODO: find imageDataSize
-				break;
-
-			case GL_COMPRESSED_SIGNED_RG_RGTC2:
-				Com_sprintf( buffer, sizeof( buffer ),  "RGTC2Srg " );
-				out += buffer;
-				// TODO: find imageDataSize
-				break;
-
-			case GL_DEPTH_COMPONENT16:
-				Com_sprintf( buffer, sizeof( buffer ),  "D16      " );
-				out += buffer;
-				imageDataSize *= 2;
-				break;
-
-			case GL_DEPTH_COMPONENT24:
-				Com_sprintf( buffer, sizeof( buffer ),  "D24      " );
-				out += buffer;
-				imageDataSize *= 3;
-				break;
-
-			case GL_DEPTH_COMPONENT32:
-				Com_sprintf( buffer, sizeof( buffer ),  "D32      " );
-				out += buffer;
-				imageDataSize *= 4;
-				break;
-
-			default:
-				Log::Debug( "Undocumented image format %i for image %s", image->internalFormat, image->name );
-				Com_sprintf( buffer, sizeof( buffer ),  "%5i    ", image->internalFormat );
-				out += buffer;
-				imageDataSize *= 4;
-				break;
+			format = Str::Format( "0x%04X", image->internalFormat);
+			imageDataSize *= 4;
+		}
+		else
+		{
+			format = imageFormatNameSize[ image->internalFormat ].first;
+			imageDataSize *= imageFormatNameSize[ image->internalFormat ].second;
 		}
 
-		switch ( image->wrapType.s )
+		if ( !wrapTypeName.count( image->wrapType.t ) )
 		{
-			case wrapTypeEnum_t::WT_REPEAT:
-				Com_sprintf( buffer, sizeof( buffer ),  "s.rept  " );
-				out += buffer;
-				break;
+			Log::Debug( "Undocumented wrapType.t %i for image %s",
+				Util::ordinal(image->wrapType.t), image->name );
 
-			case wrapTypeEnum_t::WT_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ),  "s.clmp  " );
-				out += buffer;
-				break;
-
-			case wrapTypeEnum_t::WT_EDGE_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ),  "s.eclmp " );
-				out += buffer;
-				break;
-
-			case wrapTypeEnum_t::WT_ZERO_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ),  "s.zclmp " );
-				out += buffer;
-				break;
-
-			case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ),  "s.azclmp" );
-				out += buffer;
-				break;
-
-			default:
-				Log::Debug( "Undocumented wrapType.s %i for image %s", Util::ordinal(image->wrapType.s), image->name );
-				Com_sprintf( buffer, sizeof( buffer ),  "s.%4i  ", Util::ordinal(image->wrapType.s) );
-				out += buffer;
-				break;
+			twrap = Str::Format( "t.%4i", Util::ordinal(image->wrapType.t) );
+		}
+		else
+		{
+			twrap = "t." + wrapTypeName[ image->wrapType.t ];
 		}
 
-		switch ( image->wrapType.t )
+		if ( !wrapTypeName.count( image->wrapType.s ) )
 		{
-			case wrapTypeEnum_t::WT_REPEAT:
-				Com_sprintf( buffer, sizeof( buffer ),  "t.rept  " );
-				out += buffer;
-				break;
+			Log::Debug( "Undocumented wrapType.s %i for image %s",
+				Util::ordinal(image->wrapType.s), image->name );
 
-			case wrapTypeEnum_t::WT_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ),  "t.clmp  " );
-				out += buffer;
-				break;
-
-			case wrapTypeEnum_t::WT_EDGE_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ),  "t.eclmp " );
-				out += buffer;
-				break;
-
-			case wrapTypeEnum_t::WT_ZERO_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ),  "t.zclmp " );
-				out += buffer;
-				break;
-
-			case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
-				Com_sprintf( buffer, sizeof( buffer ),  "t.azclmp" );
-				out += buffer;
-				break;
-
-			default:
-				Log::Debug( "Undocumented wrapType.t %i for image %s", Util::ordinal(image->wrapType.t), image->name );
-				Com_sprintf( buffer, sizeof( buffer ),  "t.%4i  ", Util::ordinal(image->wrapType.t));
-				out += buffer;
-				break;
+			swrap = Str::Format( "s.%4i", Util::ordinal(image->wrapType.s) );
 		}
+		else
+		{
+			swrap = "s." + wrapTypeName[ image->wrapType.s ];
+		}
+
+		name = image->name;
+
+		lineStream.clear();
+		lineStream.str("");
+
+		lineStream << std::left;
+		lineStream << std::setw(numLen) << i << separator;
+		lineStream << std::right;
+		lineStream << std::setw(widthLen) << image->uploadWidth << separator;
+		lineStream << std::setw(heightLen) << image->uploadHeight << separator;
+		lineStream << std::setw(layersLen) << image->numLayers << separator;
+		lineStream << std::left;
+		lineStream << std::setw(mmLen) << mm << separator;
+		lineStream << std::setw(typeLen) << type << separator;
+		lineStream << std::setw(formatLen) << format << separator;
+		lineStream << std::setw(twrapLen) << twrap << separator;
+		lineStream << std::setw(swrapLen) << swrap << separator;
+		lineStream << name;
+
+		Log::CommandInteractionMessage( lineStream.str() );
 
 		dataSize += imageDataSize;
-
-		Log::Notice("%s %s", out.c_str(), image->name );
 	}
 
-	Log::Notice(" ---------" );
-	Log::Notice(" %i total texels (not including mipmaps)", texels );
-	Log::Notice(" %d.%02d MB total image memory", dataSize / ( 1024 * 1024 ),
-	           ( dataSize % ( 1024 * 1024 ) ) * 100 / ( 1024 * 1024 ) );
-	Log::Notice(" %i total images", tr.images.currentElements );
+	std::string summary1 = Str::Format( "%i total texels (not including mipmaps)", texels );
+	std::string summary2 = Str::Format( "%d.%02d MB total image memory (estimated)",
+		dataSize / ( 1024 * 1024 ), ( dataSize % ( 1024 * 1024 ) ) * 100 / ( 1024 * 1024 ) );
+	std::string summary3 = Str::Format( "%i total images", tr.images.currentElements );
+
+	Log::CommandInteractionMessage( lineSeparator );
+	Log::CommandInteractionMessage( summary1 );
+	Log::CommandInteractionMessage( summary2 );
+	Log::CommandInteractionMessage( summary3 );
+	Log::CommandInteractionMessage( lineSeparator );
 }
 
 //=======================================================================
@@ -1381,6 +1317,9 @@ image_t        *R_AllocImage( const char *name, bool linkIntoHashTable )
 		r_imageHashTable[ hash ] = image;
 	}
 
+	// Default image number of layers.
+	image->numLayers = 1;
+
 	return image;
 }
 
@@ -1500,6 +1439,7 @@ image_t *R_CreateCubeImage( const char *name, const byte *pic[ 6 ], int width, i
 
 	image->width = width;
 	image->height = height;
+	image->numLayers = 6;
 
 	image->bits = imageParams.bits;
 	image->filterType = imageParams.filterType;
@@ -1519,7 +1459,7 @@ image_t *R_CreateCubeImage( const char *name, const byte *pic[ 6 ], int width, i
 R_Create3DImage
 ================
 */
-image_t *R_Create3DImage( const char *name, const byte *pic, int width, int height, int depth, const imageParams_t &imageParams )
+image_t *R_Create3DImage( const char *name, const byte *pic, int width, int height, int numLayers, const imageParams_t &imageParams )
 {
 	image_t *image;
 	const byte **pics;
@@ -1536,10 +1476,11 @@ image_t *R_Create3DImage( const char *name, const byte *pic, int width, int heig
 
 	image->width = width;
 	image->height = height;
+	image->numLayers = numLayers;
 
 	if( pic ) {
-		pics = (const byte**) ri.Hunk_AllocateTempMemory( depth * sizeof(const byte *) );
-		for( i = 0; i < depth; i++ ) {
+		pics = (const byte**) ri.Hunk_AllocateTempMemory( numLayers * sizeof(const byte *) );
+		for( i = 0; i < numLayers; i++ ) {
 			pics[i] = pic + i * width * height * sizeof(u8vec4_t);
 		}
 	} else {
@@ -1550,7 +1491,7 @@ image_t *R_Create3DImage( const char *name, const byte *pic, int width, int heig
 	image->filterType = imageParams.filterType;
 	image->wrapType = imageParams.wrapType;
 
-	R_UploadImage( pics, depth, 1, image, imageParams );
+	R_UploadImage( pics, numLayers, 1, image, imageParams );
 
 	if( pics ) {
 		ri.Hunk_FreeTempMemory( pics );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -710,7 +710,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		GLenum         type;
 		GLuint         texnum; // gl texture binding
 
-		uint16_t       width, height; // source image
+		uint16_t width, height, numLayers; // source image
 		uint16_t       uploadWidth, uploadHeight; // after power of two and picmip but not including clamp to MAX_TEXTURE_SIZE
 
 		int            frameUsed; // for texture usage in frame statistics

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "tr_local.h"
 #include "gl_shader.h"
 #include "framework/CvarSystem.h"
+#include <iomanip>
 
 static const int MAX_SHADERTABLE_HASH = 1024;
 static shaderTable_t *shaderTableHashTable[ MAX_SHADERTABLE_HASH ];
@@ -6304,105 +6305,118 @@ A second parameter will cause it to print in sorted order
 */
 void R_ListShaders_f()
 {
+	std::unordered_map<shaderType_t, std::string> shaderTypeName = {
+		{ shaderType_t::SHADER_2D, "2D" },
+		{ shaderType_t::SHADER_3D_DYNAMIC, "3D_DYNAMIC" },
+		{ shaderType_t::SHADER_3D_STATIC, "3D_STATIC" },
+		{ shaderType_t::SHADER_LIGHT, "LIGHT" },
+	};
+
+	std::unordered_map<shaderSort_t, std::string> shaderSortName = {
+		{ shaderSort_t::SS_BAD, "BAD" },
+		{ shaderSort_t::SS_PORTAL, "PORTAL" },
+		{ shaderSort_t::SS_DEPTH, "DEPTH" },
+		{ shaderSort_t::SS_ENVIRONMENT_FOG, "ENV_FOG" },
+		{ shaderSort_t::SS_ENVIRONMENT_NOFOG, "ENV_NOFOG" },
+		{ shaderSort_t::SS_OPAQUE, "OPAQUE" },
+		{ shaderSort_t::SS_DECAL, "DECAL" },
+		{ shaderSort_t::SS_SEE_THROUGH, "SEE_THROUGH" },
+		{ shaderSort_t::SS_BANNER, "BANNER" },
+		{ shaderSort_t::SS_FOG, "FOG" },
+		{ shaderSort_t::SS_UNDERWATER, "UNDERWATER" },
+		{ shaderSort_t::SS_WATER, "WATER" },
+		{ shaderSort_t::SS_FAR, "FAR" },
+		{ shaderSort_t::SS_MEDIUM, "MEDIUM" },
+		{ shaderSort_t::SS_CLOSE, "CLOSE" },
+		{ shaderSort_t::SS_BLEND0, "BLEND0" },
+		{ shaderSort_t::SS_BLEND1, "BLEND1" },
+		{ shaderSort_t::SS_BLEND2, "BLEND2" },
+		{ shaderSort_t::SS_BLEND3, "BLEND3" },
+		{ shaderSort_t::SS_BLEND6, "BLEND6" },
+		{ shaderSort_t::SS_ALMOST_NEAREST, "ALMOST_NEAREST" },
+		{ shaderSort_t::SS_NEAREST, "NEAREST" },
+		{ shaderSort_t::SS_POST_PROCESS, "POST_PROCESS" },
+	};
+
+	std::unordered_map<stageType_t, std::string> stageTypeName = {
+		{ stageType_t::ST_COLORMAP, "COLORMAP" },
+		{ stageType_t::ST_GLOWMAP, "GLOWMAP" },
+		{ stageType_t::ST_DIFFUSEMAP, "DIFFUSEMAP" },
+		{ stageType_t::ST_NORMALMAP, "NORMALMAP" },
+		{ stageType_t::ST_HEIGHTMAP, "HEIGHTMAP" },
+		{ stageType_t::ST_PHYSICALMAP, "PHYSICALMAP" },
+		{ stageType_t::ST_SPECULARMAP, "SPECULARMAP" },
+		{ stageType_t::ST_REFLECTIONMAP, "REFLECTIONMAP" },
+		{ stageType_t::ST_REFRACTIONMAP, "REFRACTIONMAP" },
+		{ stageType_t::ST_DISPERSIONMAP, "DISPERSIONMAP" },
+		{ stageType_t::ST_SKYBOXMAP, "SKYBOXMAP" },
+		{ stageType_t::ST_SCREENMAP, "SCREENMAP" },
+		{ stageType_t::ST_PORTALMAP, "PORTALMAP" },
+		{ stageType_t::ST_HEATHAZEMAP, "HEATHAZEMAP" },
+		{ stageType_t::ST_LIQUIDMAP, "LIQUIDMAP" },
+		{ stageType_t::ST_LIGHTMAP, "LIGHTMAP" },
+		{ stageType_t::ST_STYLELIGHTMAP, "STYLELIGHTMAP" },
+		{ stageType_t::ST_STYLECOLORMAP, "STYLECOLORMAP" },
+		{ stageType_t::ST_COLLAPSE_COLORMAP, "COLLAPSE_COLORMAP" },
+		{ stageType_t::ST_COLLAPSE_DIFFUSEMAP, "COLLAPSE_DIFFUSEMAP" },
+		{ stageType_t::ST_COLLAPSE_REFLECTIONMAP, "COLLAPSE_REFLECTIONMAP" },
+		{ stageType_t::ST_ATTENUATIONMAP_XY, "ATTENUATIONMAP_XY" },
+		{ stageType_t::ST_ATTENUATIONMAP_Z, "ATTENUATIONMAP_XZ" },
+	};
+
 	const char *prefix = ri.Cmd_Argc() > 1 ? ri.Cmd_Argv( 1 ) : nullptr;
 
-	std::unordered_map<shaderType_t, std::string> shaderTypeStrings;
-	shaderTypeStrings[shaderType_t::SHADER_2D] = "2D";
-	shaderTypeStrings[shaderType_t::SHADER_3D_DYNAMIC] = "3D_DYNAMIC";
-	shaderTypeStrings[shaderType_t::SHADER_3D_STATIC] = "3D_STATIC";
-	shaderTypeStrings[shaderType_t::SHADER_LIGHT] = "LIGHT";
+	// Header names
+	std::string num = "num";
+	std::string shaderType = "shaderType";
+	std::string shaderSort = "shaderSort";
+	std::string stageType = "stageType";
+	std::string interactLight = "interactLight";
+	std::string stageNumber = "stageNumber";
+	std::string shaderName = "shaderName";
 
-	std::string shaderTypeHeader = "shaderType";
-	size_t maxShaderTypeStringLen = shaderTypeHeader.length();
+	// Number sizes
+	size_t numLen = 5;
 
-	for ( const auto& kv : shaderTypeStrings )
+	// Header number sizes
+	numLen = std::max( numLen, num.length() );
+	size_t shaderTypeLen = shaderType.length();
+	size_t shaderSortLen = shaderSort.length();
+	size_t stageTypeLen = stageType.length();
+	size_t interactLightLen = interactLight.length();
+
+	// Value size
+	for ( const auto& kv : shaderTypeName )
 	{
-		maxShaderTypeStringLen = std::max( maxShaderTypeStringLen, kv.second.length() );
+		shaderTypeLen = std::max( shaderTypeLen, kv.second.length() );
 	}
 
-	std::unordered_map<shaderSort_t, std::string> shaderSortStrings;
-	shaderSortStrings[shaderSort_t::SS_BAD] = "BAD";
-	shaderSortStrings[shaderSort_t::SS_PORTAL] = "PORTAL";
-	shaderSortStrings[shaderSort_t::SS_DEPTH] = "DEPTH";
-	shaderSortStrings[shaderSort_t::SS_ENVIRONMENT_FOG] = "ENVIRONMENT_FOG";
-	shaderSortStrings[shaderSort_t::SS_ENVIRONMENT_NOFOG] = "ENVIRONMENT_NOFOG";
-	shaderSortStrings[shaderSort_t::SS_OPAQUE] = "OPAQUE";
-	shaderSortStrings[shaderSort_t::SS_DECAL] = "DECAL";
-	shaderSortStrings[shaderSort_t::SS_SEE_THROUGH] = "SEE_THROUGH";
-	shaderSortStrings[shaderSort_t::SS_BANNER] = "BANNER";
-	shaderSortStrings[shaderSort_t::SS_FOG] = "FOG";
-	shaderSortStrings[shaderSort_t::SS_UNDERWATER] = "UNDERWATER";
-	shaderSortStrings[shaderSort_t::SS_WATER] = "WATER";
-	shaderSortStrings[shaderSort_t::SS_FAR] = "FAR";
-	shaderSortStrings[shaderSort_t::SS_MEDIUM] = "MEDIUM";
-	shaderSortStrings[shaderSort_t::SS_CLOSE] = "CLOSE";
-	shaderSortStrings[shaderSort_t::SS_BLEND0] = "BLEND0";
-	shaderSortStrings[shaderSort_t::SS_BLEND1] = "BLEND1";
-	shaderSortStrings[shaderSort_t::SS_BLEND2] = "BLEND2";
-	shaderSortStrings[shaderSort_t::SS_BLEND3] = "BLEND3";
-	shaderSortStrings[shaderSort_t::SS_BLEND6] = "BLEND6";
-	shaderSortStrings[shaderSort_t::SS_ALMOST_NEAREST] = "ALMOST_NEAREST";
-	shaderSortStrings[shaderSort_t::SS_NEAREST] = "NEAREST";
-	shaderSortStrings[shaderSort_t::SS_POST_PROCESS] = "POST_PROCESS";
-
-	std::string shaderSortHeader = "shaderSort";
-	size_t maxShaderSortStringLen = shaderSortHeader.length();
-
-	for ( const auto& kv : shaderSortStrings )
+	for ( const auto& kv : shaderSortName )
 	{
-		maxShaderSortStringLen = std::max( maxShaderSortStringLen, kv.second.length() );
+		shaderSortLen = std::max( shaderSortLen, kv.second.length() );
 	}
 
-	std::unordered_map<stageType_t, std::string> stageTypeStrings;
-	stageTypeStrings[stageType_t::ST_COLORMAP] = "COLORMAP";
-	stageTypeStrings[stageType_t::ST_GLOWMAP] = "GLOWMAP";
-	stageTypeStrings[stageType_t::ST_DIFFUSEMAP] = "DIFFUSEMAP";
-	stageTypeStrings[stageType_t::ST_NORMALMAP] = "NORMALMAP";
-	stageTypeStrings[stageType_t::ST_HEIGHTMAP] = "HEIGHTMAP";
-	stageTypeStrings[stageType_t::ST_PHYSICALMAP] = "PHYSICALMAP";
-	stageTypeStrings[stageType_t::ST_SPECULARMAP] = "SPECULARMAP";
-	stageTypeStrings[stageType_t::ST_REFLECTIONMAP] = "REFLECTIONMAP";
-	stageTypeStrings[stageType_t::ST_REFRACTIONMAP] = "REFRACTIONMAP";
-	stageTypeStrings[stageType_t::ST_DISPERSIONMAP] = "DISPERSIONMAP";
-	stageTypeStrings[stageType_t::ST_SKYBOXMAP] = "SKYBOXMAP";
-	stageTypeStrings[stageType_t::ST_SCREENMAP] = "SCREENMAP";
-	stageTypeStrings[stageType_t::ST_PORTALMAP] = "PORTALMAP";
-	stageTypeStrings[stageType_t::ST_HEATHAZEMAP] = "HEATHAZEMAP";
-	stageTypeStrings[stageType_t::ST_LIQUIDMAP] = "LIQUIDMAP";
-	stageTypeStrings[stageType_t::ST_LIGHTMAP] = "LIGHTMAP";
-	stageTypeStrings[stageType_t::ST_STYLELIGHTMAP] = "STYLELIGHTMAP";
-	stageTypeStrings[stageType_t::ST_STYLECOLORMAP] = "STYLECOLORMAP";
-	stageTypeStrings[stageType_t::ST_COLLAPSE_COLORMAP] = "COLLAPSE_COLORMAP";
-	stageTypeStrings[stageType_t::ST_COLLAPSE_DIFFUSEMAP] = "COLLAPSE_DIFFUSEMAP";
-	stageTypeStrings[stageType_t::ST_COLLAPSE_REFLECTIONMAP] = "COLLAPSE_REFLECTIONMAP";
-	stageTypeStrings[stageType_t::ST_ATTENUATIONMAP_XY] = "ATTENUATIONMAP_XY";
-	stageTypeStrings[stageType_t::ST_ATTENUATIONMAP_Z] = "ATTENUATIONMAP_XZ";
-
-	std::string stageTypeHeader = "stageType";
-	size_t maxStageTypeStringLen = stageTypeHeader.length();
-
-	for ( const auto& kv : stageTypeStrings )
+	for ( const auto& kv : stageTypeName )
 	{
-		maxStageTypeStringLen = std::max( maxStageTypeStringLen, kv.second.length() );
+		stageTypeLen = std::max( stageTypeLen, kv.second.length() );
 	}
-
-	std::string interactLightHeader = "interactLight";
-	int maxInteractLightStringLen = interactLightHeader.length();
 
 	std::string separator = " ";
+	std::stringstream lineStream;
 
-	std::string header = Str::Format(
-		"%-*s" "%s%-*s" "%s%-*s" "%s%-*s" "%s%s",
-		maxShaderTypeStringLen, shaderTypeHeader,
-		separator, maxShaderSortStringLen, shaderSortHeader,
-		separator, maxInteractLightStringLen, interactLightHeader,
-		separator, maxStageTypeStringLen, stageTypeHeader,
-		separator, "stageNumber:shaderName" );
+	// Print header
+	lineStream << std::left;
+	lineStream << std::setw(numLen) << num << separator;
+	lineStream << std::setw(shaderTypeLen) << shaderType << separator;
+	lineStream << std::setw(shaderSortLen) << shaderSort << separator;
+	lineStream << std::setw(stageTypeLen) << stageType << separator;
+	lineStream << std::setw(interactLightLen) << interactLight << separator;
+	lineStream << stageNumber << ":" << shaderName;
 
-	std::string lineSeparator( header.length(), '-' );
+	std::string lineSeparator( lineStream.str().length(), '-' );
 
 	Log::CommandInteractionMessage( lineSeparator );
-	Log::CommandInteractionMessage( header );
+	Log::CommandInteractionMessage( lineStream.str() );
 	Log::CommandInteractionMessage( lineSeparator );
 
 	int stageCount = 0;
@@ -6421,49 +6435,44 @@ void R_ListShaders_f()
 		stageCount += shader->numStages;
 		highestShaderStageCount = std::max( highestShaderStageCount, shader->numStages );
 
-		std::string foundShaderTypeString = shaderTypeStrings[ shader->type ];
-		std::string foundShaderSortString = shaderSortStrings[ (shaderSort_t) shader->sort ];
-
-		std::string foundInteractLightString = shader->interactLight ? "INTERACTLIGHT" : "";
-
-		std::string shaderNameString = shader->name;
-		shaderNameString += shader->defaultShader ? " (DEFAULTED)" : "";
+		shaderType = shaderTypeName[ shader->type ];
+		shaderSort = shaderSortName[ (shaderSort_t) shader->sort ];
+		interactLight = shader->interactLight ? "INTERACTLIGHT" : "";
+		shaderName = shader->name;
+		shaderName += shader->defaultShader ? " (DEFAULTED)" : "";
 
 		for ( int j = 0; j < shader->numStages; j++ )
 		{
 			shaderStage_t *stage = shader->stages[ j ];
 
-			std::string foundStageTypeString = stageTypeStrings[ stage->type ];
+			stageType = stageTypeName[ stage->type ];
 
-			std::string line = Str::Format(
-				"%-*s" "%s%-*s" "%s%-*s" "%s%-*s" "%s%i:%s",
-				maxShaderTypeStringLen, foundShaderTypeString,
-				separator, maxShaderSortStringLen, foundShaderSortString,
-				separator, maxInteractLightStringLen, foundInteractLightString,
-				separator, maxStageTypeStringLen, foundStageTypeString,
-				separator, j, shaderNameString );
+			lineStream.clear();
+			lineStream.str("");
 
-			Log::CommandInteractionMessage( line );
+			lineStream << std::left;
+			lineStream << std::setw(numLen) << i << separator;
+			lineStream << std::setw(shaderTypeLen) << shaderType << separator;
+			lineStream << std::setw(shaderSortLen) << shaderSort << separator;
+			lineStream << std::setw(stageTypeLen) << stageType << separator;
+			lineStream << std::setw(interactLightLen) << interactLight << separator;
+			lineStream << j << ":" << shaderName;
+
+			Log::CommandInteractionMessage( lineStream.str() );
 		}
 	}
-
-	Log::CommandInteractionMessage( lineSeparator );
 
 	std::string summary = Str::Format(
 		"%i total shaders, %i total stages, largest shader has %i stages",
 		tr.numShaders, stageCount, highestShaderStageCount );
 
+	Log::CommandInteractionMessage( lineSeparator );
 	Log::CommandInteractionMessage( summary );
+	Log::CommandInteractionMessage( lineSeparator );
 }
 
 void R_ShaderExp_f()
 {
-	expression_t exp;
-
-	strcpy( shader.name, "dummy" );
-
-	Log::Notice("-----------------------" );
-
 	std::string buffer;
 
 	for ( int i = 1; i < ri.Cmd_Argc(); i++ )
@@ -6477,11 +6486,12 @@ void R_ShaderExp_f()
 	}
 
 	const char* buffer_p = buffer.c_str();
+	expression_t exp;
+
 	ParseExpression( &buffer_p, &exp );
 
-	Log::Notice("%i total ops", exp.numOps );
-	Log::Notice("%f result", RB_EvalExpression( &exp, 0 ) );
-	Log::Notice("------------------" );
+	Log::CommandInteractionMessage( Str::Format( "%i total ops", exp.numOps ) );
+	Log::CommandInteractionMessage( Str::Format( "%f result", RB_EvalExpression( &exp, 0 ) ) );
 }
 
 /*


### PR DESCRIPTION
Deep revamp of image and shader listing functions.

- Make it always use `Log::CommandInteractionMessage` to avoid being truncated by `logs.suppression.enabled`.
- More `std::string`, less `char*` and related C functions.
- More map-based decision (more generic code, and move copy-pasting risks to data instead of logic).
- Added strings for all image formats that I managed to list but were not known before.

A rewrite of the shader listing was already done by me some time ago, the rewrite of the image listing was now done in a similar way but even pushed forward, and the shader listing was then pushed to that same level.