### PR TITLE
WIP Optimisation: Use all texture units, bindless texture support

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -102,6 +102,8 @@ set(RENDERERLIST
     ${ENGINE_DIR}/renderer/tr_font.cpp
     ${ENGINE_DIR}/renderer/InternalImage.cpp
     ${ENGINE_DIR}/renderer/InternalImage.h
+    ${ENGINE_DIR}/renderer/TextureManager.cpp
+    ${ENGINE_DIR}/renderer/TextureManager.h
     ${ENGINE_DIR}/renderer/tr_image.cpp
     ${ENGINE_DIR}/renderer/tr_image.h
     ${ENGINE_DIR}/renderer/tr_image_crn.cpp

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1,0 +1,1933 @@
+﻿/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// Material.cpp
+
+#include "Material.h"
+
+#include "tr_local.h"
+
+GLSSBO materialsSSBO( "materials", 0 );
+GLIndirectBuffer commandBuffer( "drawCommands" );
+MaterialSystem materialSystem;
+
+static void ComputeDynamics( shaderStage_t* pStage ) {
+	// TODO: Move color and texMatrices stuff to a compute shader
+	switch ( pStage->rgbGen ) {
+		case colorGen_t::CGEN_IDENTITY:
+		case colorGen_t::CGEN_ONE_MINUS_VERTEX:
+		default:
+		case colorGen_t::CGEN_IDENTITY_LIGHTING:
+			/* Historically CGEN_IDENTITY_LIGHTING was done this way:
+
+			  tess.svars.color = Color::White * tr.identityLight;
+
+			But tr.identityLight is always 1.0f in Dæmon engine
+			as the as the overbright bit implementation is fully
+			software. */
+		case colorGen_t::CGEN_VERTEX:
+		case colorGen_t::CGEN_CONST:
+		case colorGen_t::CGEN_ENTITY:
+		case colorGen_t::CGEN_ONE_MINUS_ENTITY:
+		{
+			// TODO: Move this to some entity buffer once this is extended past BSP surfaces
+			if ( backEnd.currentEntity ) {
+				//
+			} else {
+				//
+			}
+			pStage->colorDynamic = false;
+
+			break;
+		}
+
+		case colorGen_t::CGEN_WAVEFORM:
+		case colorGen_t::CGEN_CUSTOM_RGB:
+		case colorGen_t::CGEN_CUSTOM_RGBs:
+		{
+			pStage->colorDynamic = true;
+			break;
+		}
+	}
+
+	switch ( pStage->alphaGen ) {
+		default:
+		case alphaGen_t::AGEN_IDENTITY:
+		case alphaGen_t::AGEN_ONE_MINUS_VERTEX:
+		case alphaGen_t::AGEN_VERTEX:
+		case alphaGen_t::AGEN_CONST: {
+		case alphaGen_t::AGEN_ENTITY:
+		case alphaGen_t::AGEN_ONE_MINUS_ENTITY:
+			// TODO: Move this to some entity buffer once this is extended past BSP surfaces
+			/* if ( backEnd.currentEntity ) {
+			} else {
+			} */
+			pStage->colorDynamic = false;
+			break;
+		}
+
+		case alphaGen_t::AGEN_WAVEFORM:
+		case alphaGen_t::AGEN_CUSTOM:
+		{
+			pStage->colorDynamic = true;
+			break;
+		}
+	}
+
+	for ( textureBundle_t& bundle : pStage->bundle ) {
+		for ( int j = 0; j < bundle.numTexMods; j++ ) {
+			switch ( bundle.texMods[j].type ) {
+				case texMod_t::TMOD_NONE:
+				case texMod_t::TMOD_SCALE:
+				case texMod_t::TMOD_TRANSFORM:
+					break;
+
+				case texMod_t::TMOD_TURBULENT:
+				case texMod_t::TMOD_ENTITY_TRANSLATE:
+				case texMod_t::TMOD_SCROLL:
+				{
+					pStage->texMatricesDynamic = true;
+					break;
+				}
+
+				case texMod_t::TMOD_STRETCH:
+				{
+					if( bundle.texMods->wave.func != genFunc_t::GF_NONE ) {
+						pStage->texMatricesDynamic = true;
+					}
+					break;
+				}
+
+				case texMod_t::TMOD_ROTATE:
+				{
+					pStage->texMatricesDynamic = true;
+					break;
+				}
+
+				case texMod_t::TMOD_SCROLL2:
+				case texMod_t::TMOD_SCALE2:
+				case texMod_t::TMOD_CENTERSCALE:
+				case texMod_t::TMOD_SHEAR:
+				{
+					if ( bundle.texMods[j].sExp.active || bundle.texMods[j].tExp.active ) {
+						pStage->texMatricesDynamic = true;
+					}
+					break;
+				}
+
+				case texMod_t::TMOD_ROTATE2:
+				{
+					if( bundle.texMods[j].rExp.active ) {
+						pStage->texMatricesDynamic = true;
+					}
+					break;
+				}
+
+				default:
+					break;
+			}
+		}
+	}
+
+	// TODO: Move this to a different buffer?
+	for ( const textureBundle_t& bundle : pStage->bundle ) {
+		if ( bundle.isVideoMap || bundle.numImages > 1 ) {
+			pStage->texturesDynamic = true;
+			break;
+		}
+	}
+
+	// Can we move this to a compute shader too?
+	// Doesn't seem to be used much if at all, so probably not worth the effort to do that
+	pStage->dynamic = pStage->dynamic || pStage->ifExp.active;
+	pStage->dynamic = pStage->dynamic || pStage->alphaExp.active || pStage->alphaTestExp.active;
+	pStage->dynamic = pStage->dynamic || pStage->rgbExp.active || pStage->redExp.active || pStage->greenExp.active || pStage->blueExp.active;
+	pStage->dynamic = pStage->dynamic || pStage->deformMagnitudeExp.active;
+	pStage->dynamic = pStage->dynamic || pStage->depthScaleExp.active || pStage->etaExp.active || pStage->etaDeltaExp.active
+		|| pStage->fogDensityExp.active || pStage->fresnelBiasExp.active || pStage->fresnelPowerExp.active
+		|| pStage->fresnelScaleExp.active || pStage->normalIntensityExp.active || pStage->refractionIndexExp.active;
+
+	pStage->dynamic = pStage->dynamic || pStage->colorDynamic || pStage->texMatricesDynamic || pStage->texturesDynamic;
+}
+
+static image_t* GetLightMap( drawSurf_t* drawSurf ) {
+	if ( static_cast<size_t>( drawSurf->lightmapNum() ) < tr.lightmaps.size() ) {
+		return tr.lightmaps[drawSurf->lightmapNum()];
+	} else {
+		return tr.whiteImage;
+	}
+}
+
+static image_t* GetDeluxeMap( drawSurf_t* drawSurf ) {
+	if ( static_cast<size_t>( drawSurf->lightmapNum() ) < tr.deluxemaps.size() ) {
+		return tr.deluxemaps[drawSurf->lightmapNum()];
+	} else {
+		return tr.blackImage;
+	}
+}
+
+static void UpdateSurfaceDataGeneric( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const int stage ) {
+	shader_t* shader = drawSurf->shader;
+	shaderStage_t* pStage = shader->stages[stage];
+
+	const uint paddedOffset = drawSurf->materialsSSBOOffset[stage] * material.shader->GetPaddedSize();
+	materials += paddedOffset;
+
+	bool updated = !drawSurf->initialized[stage] || pStage->colorDynamic || pStage->texMatricesDynamic || pStage->dynamic;
+	if ( !updated ) {
+		return;
+	}
+	drawSurf->initialized[stage] = true;
+
+	gl_genericShaderMaterial->BindProgram( material.deformIndex );
+
+	gl_genericShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_genericShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+
+	gl_genericShaderMaterial->SetUniform_AlphaTest( pStage->stateBits );
+
+	// u_InverseLightFactor
+	// We should cancel overbrightBits if there is no light,
+	// and it's not using blendFunc dst_color.
+	bool blendFunc_dstColor = ( pStage->stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_DST_COLOR;
+	float inverseLightFactor = ( pStage->shaderHasNoLight && !blendFunc_dstColor ) ? tr.mapInverseLightFactor : 1.0f;
+	gl_genericShaderMaterial->SetUniform_InverseLightFactor( inverseLightFactor );
+
+	// u_ColorModulate
+	colorGen_t rgbGen;
+	alphaGen_t alphaGen;
+	SetRgbaGen( pStage, &rgbGen, &alphaGen );
+	gl_genericShaderMaterial->SetUniform_ColorModulate( rgbGen, alphaGen );
+
+	Tess_ComputeColor( pStage );
+	gl_genericShaderMaterial->SetUniform_Color( tess.svars.color );
+
+	Tess_ComputeTexMatrices( pStage );
+	gl_genericShaderMaterial->SetUniform_TextureMatrix( tess.svars.texMatrices[TB_COLORMAP] );
+
+	// u_DeformGen
+	gl_genericShaderMaterial->SetUniform_Time( backEnd.refdef.floatTime - backEnd.currentEntity->e.shaderTime );
+
+	// bind u_ColorMap=
+	if ( pStage->type == stageType_t::ST_STYLELIGHTMAP ) {
+		gl_genericShaderMaterial->SetUniform_ColorMapBindless(
+			GL_BindToTMU( 0, GetLightMap( drawSurf ) )
+		);
+	} else {
+		gl_genericShaderMaterial->SetUniform_ColorMapBindless( BindAnimatedImage( 0, &pStage->bundle[TB_COLORMAP] ) );
+	}
+
+	bool needDepthMap = pStage->hasDepthFade || shader->autoSpriteMode;
+	if ( needDepthMap ) {
+		gl_genericShaderMaterial->SetUniform_DepthMapBindless( GL_BindToTMU( 1, tr.currentDepthImage ) );
+	}
+
+	bool hasDepthFade = pStage->hasDepthFade && !shader->autoSpriteMode;
+	if ( hasDepthFade ) {
+		gl_genericShaderMaterial->SetUniform_DepthScale( pStage->depthFadeValue );
+	}
+
+	gl_genericShaderMaterial->SetUniform_VertexInterpolation( false );
+
+	gl_genericShaderMaterial->WriteUniformsToBuffer( materials );
+}
+
+static void UpdateSurfaceDataLightMapping( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const int stage ) {
+	shader_t* shader = drawSurf->shader;
+	shaderStage_t* pStage = shader->stages[stage];
+
+	const uint paddedOffset = drawSurf->materialsSSBOOffset[stage] * material.shader->GetPaddedSize();
+	materials += paddedOffset;
+
+	bool updated = !drawSurf->initialized[stage] || pStage->colorDynamic || pStage->texMatricesDynamic || pStage->dynamic;
+	if ( !updated ) {
+		return;
+	}
+	drawSurf->initialized[stage] = true;
+
+	gl_lightMappingShaderMaterial->BindProgram( material.deformIndex );
+
+	gl_lightMappingShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+
+	lightMode_t lightMode = lightMode_t::FULLBRIGHT;
+	deluxeMode_t deluxeMode = deluxeMode_t::NONE;
+
+	/* TODO: investigate what this is. It's probably a hack to detect some
+	specific use case. Without knowing which use case this takes care about,
+	any change in the following code may break it. Or it may be a hack we
+	should drop if it is for a bug we don't have anymore. */
+	bool hack = shader->numStages > 0 && shader->stages[0]->rgbGen == colorGen_t::CGEN_VERTEX;
+
+	if ( ( shader->surfaceFlags & SURF_NOLIGHTMAP ) && !hack ) {
+		// Use fullbright on “surfaceparm nolightmap” materials.
+	} else if ( pStage->type == stageType_t::ST_COLLAPSE_COLORMAP ) {
+		/* Use fullbright for collapsed stages without lightmaps,
+		for example:
+
+		  {
+			map textures/texture_d
+			heightMap textures/texture_h
+		  }
+
+		This is doable for some complex multi-stage materials. */
+	} else if ( drawSurf->bspSurface ) {
+		lightMode = tr.worldLight;
+		deluxeMode = tr.worldDeluxe;
+
+		if ( lightMode == lightMode_t::MAP ) {
+			bool hasLightMap = static_cast<size_t>( drawSurf->lightmapNum() ) < tr.lightmaps.size();
+
+			if ( !hasLightMap ) {
+				lightMode = lightMode_t::VERTEX;
+				deluxeMode = deluxeMode_t::NONE;
+			}
+		}
+	} else {
+		lightMode = tr.modelLight;
+		deluxeMode = tr.modelDeluxe;
+	}
+
+	// u_Map, u_DeluxeMap
+	image_t* lightmap = tr.whiteImage;
+	image_t* deluxemap = tr.whiteImage;
+
+	// u_ColorModulate
+	colorGen_t rgbGen;
+	alphaGen_t alphaGen;
+	SetRgbaGen( pStage, &rgbGen, &alphaGen );
+
+	switch ( lightMode ) {
+		case lightMode_t::VERTEX:
+			// Do not rewrite pStage->rgbGen.
+			rgbGen = colorGen_t::CGEN_VERTEX;
+			tess.svars.color.SetRed( 0.0f );
+			tess.svars.color.SetGreen( 0.0f );
+			tess.svars.color.SetBlue( 0.0f );
+			break;
+
+		case lightMode_t::GRID:
+			// Store lightGrid1 as lightmap,
+			// the GLSL code will know how to deal with it.
+			lightmap = tr.lightGrid1Image;
+			break;
+
+		case lightMode_t::MAP:
+			lightmap = GetLightMap( drawSurf );
+
+			break;
+
+		default:
+			break;
+	}
+
+	switch ( deluxeMode ) {
+		case deluxeMode_t::MAP:
+			// Deluxe mapping for world surface.
+			deluxemap = GetDeluxeMap( drawSurf );
+			break;
+
+		case deluxeMode_t::GRID:
+			// Deluxe mapping emulation from grid light for game models.
+			// Store lightGrid2 as deluxemap,
+			// the GLSL code will know how to deal with it.
+			deluxemap = tr.lightGrid2Image;
+			break;
+
+		default:
+			break;
+	}
+
+	bool enableGridLighting = ( lightMode == lightMode_t::GRID );
+	bool enableGridDeluxeMapping = ( deluxeMode == deluxeMode_t::GRID );
+
+	// TODO: Update this when this is extended to MDV support
+	gl_lightMappingShaderMaterial->SetUniform_VertexInterpolation( false );
+
+	if ( glConfig2.dynamicLight ) {
+		gl_lightMappingShaderMaterial->SetUniformBlock_Lights( tr.dlightUBO );
+
+		// bind u_LightTiles
+		if ( r_dynamicLightRenderer.Get() == Util::ordinal( dynamicLightRenderer_t::TILED ) ) {
+			gl_lightMappingShaderMaterial->SetUniform_LightTilesIntBindless(
+				GL_BindToTMU( BIND_LIGHTTILES, tr.lighttileRenderImage )
+			);
+		}
+	}
+
+	// u_DeformGen
+	gl_lightMappingShaderMaterial->SetUniform_Time( backEnd.refdef.floatTime - backEnd.currentEntity->e.shaderTime );
+
+	// u_InverseLightFactor
+	/* HACK: use sign to know if there is a light or not, and
+	then if it will receive overbright multiplication or not. */
+	bool blendFunc_dstColor = ( pStage->stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_DST_COLOR;
+	bool noLight = pStage->shaderHasNoLight || lightMode == lightMode_t::FULLBRIGHT;
+	float inverseLightFactor = ( noLight && !blendFunc_dstColor ) ? tr.mapInverseLightFactor : -tr.mapInverseLightFactor;
+	gl_lightMappingShaderMaterial->SetUniform_InverseLightFactor( inverseLightFactor );
+
+	// u_ColorModulate
+	gl_lightMappingShaderMaterial->SetUniform_ColorModulate( rgbGen, alphaGen );
+
+	// u_Color
+	Tess_ComputeColor( pStage );
+	gl_lightMappingShaderMaterial->SetUniform_Color( tess.svars.color );
+
+	// u_AlphaTest
+	gl_lightMappingShaderMaterial->SetUniform_AlphaTest( pStage->stateBits );
+
+	// bind u_HeightMap
+	if ( pStage->enableReliefMapping ) {
+		float depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
+		depthScale *= shader->reliefDepthScale;
+
+		gl_lightMappingShaderMaterial->SetUniform_ReliefDepthScale( depthScale );
+		gl_lightMappingShaderMaterial->SetUniform_ReliefOffsetBias( shader->reliefOffsetBias );
+
+		// FIXME: if there is both, embedded heightmap in normalmap is used instead of standalone heightmap
+		if ( !pStage->hasHeightMapInNormalMap ) {
+			gl_lightMappingShaderMaterial->SetUniform_HeightMapBindless(
+				GL_BindToTMU( BIND_HEIGHTMAP, pStage->bundle[TB_HEIGHTMAP].image[0] )
+			);
+		}
+	}
+
+	// bind u_DiffuseMap
+	gl_lightMappingShaderMaterial->SetUniform_DiffuseMapBindless(
+		GL_BindToTMU( BIND_DIFFUSEMAP, pStage->bundle[TB_DIFFUSEMAP].image[0] )
+	);
+
+	if ( pStage->type != stageType_t::ST_LIGHTMAP ) {
+		Tess_ComputeTexMatrices( pStage );
+		gl_lightMappingShaderMaterial->SetUniform_TextureMatrix( tess.svars.texMatrices[TB_DIFFUSEMAP] );
+	}
+
+	// bind u_NormalMap
+	if ( !!r_normalMapping->integer || pStage->hasHeightMapInNormalMap ) {
+		gl_lightMappingShaderMaterial->SetUniform_NormalMapBindless(
+			GL_BindToTMU( BIND_NORMALMAP, pStage->bundle[TB_NORMALMAP].image[0] )
+		);
+	}
+
+	// bind u_NormalScale
+	if ( pStage->enableNormalMapping ) {
+		vec3_t normalScale;
+		SetNormalScale( pStage, normalScale );
+
+		gl_lightMappingShaderMaterial->SetUniform_NormalScale( normalScale );
+	}
+
+	// bind u_MaterialMap
+	if ( pStage->enableSpecularMapping || pStage->enablePhysicalMapping ) {
+		gl_lightMappingShaderMaterial->SetUniform_MaterialMapBindless(
+			GL_BindToTMU( BIND_MATERIALMAP, pStage->bundle[TB_MATERIALMAP].image[0] )
+		);
+	}
+
+	if ( pStage->enableSpecularMapping ) {
+		float specExpMin = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
+		float specExpMax = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
+
+		gl_lightMappingShaderMaterial->SetUniform_SpecularExponent( specExpMin, specExpMax );
+	}
+
+	// TODO: Move this to a per-entity buffer
+	// specular reflection
+	if ( tr.cubeHashTable != nullptr ) {
+		cubemapProbe_t* cubeProbeNearest;
+		cubemapProbe_t* cubeProbeSecondNearest;
+
+		image_t* cubeMap0 = nullptr;
+		image_t* cubeMap1 = nullptr;
+
+		float interpolation = 0.0;
+
+		bool isWorldEntity = backEnd.currentEntity == &tr.worldEntity;
+
+		if ( backEnd.currentEntity && !isWorldEntity ) {
+			R_FindTwoNearestCubeMaps( backEnd.currentEntity->e.origin, &cubeProbeNearest, &cubeProbeSecondNearest );
+		} else {
+			// FIXME position
+			R_FindTwoNearestCubeMaps( backEnd.viewParms.orientation.origin, &cubeProbeNearest, &cubeProbeSecondNearest );
+		}
+
+		if ( cubeProbeNearest == nullptr && cubeProbeSecondNearest == nullptr ) {
+			GLimp_LogComment( "cubeProbeNearest && cubeProbeSecondNearest == NULL\n" );
+
+			cubeMap0 = tr.whiteCubeImage;
+			cubeMap1 = tr.whiteCubeImage;
+		} else if ( cubeProbeNearest == nullptr ) {
+			GLimp_LogComment( "cubeProbeNearest == NULL\n" );
+
+			cubeMap0 = cubeProbeSecondNearest->cubemap;
+		} else if ( cubeProbeSecondNearest == nullptr ) {
+			GLimp_LogComment( "cubeProbeSecondNearest == NULL\n" );
+
+			cubeMap0 = cubeProbeNearest->cubemap;
+		} else {
+			float cubeProbeNearestDistance, cubeProbeSecondNearestDistance;
+
+			if ( backEnd.currentEntity && !isWorldEntity ) {
+				cubeProbeNearestDistance = Distance( backEnd.currentEntity->e.origin, cubeProbeNearest->origin );
+				cubeProbeSecondNearestDistance = Distance( backEnd.currentEntity->e.origin, cubeProbeSecondNearest->origin );
+			} else {
+				// FIXME position
+				cubeProbeNearestDistance = Distance( backEnd.viewParms.orientation.origin, cubeProbeNearest->origin );
+				cubeProbeSecondNearestDistance = Distance( backEnd.viewParms.orientation.origin, cubeProbeSecondNearest->origin );
+			}
+
+			interpolation = cubeProbeNearestDistance / ( cubeProbeNearestDistance + cubeProbeSecondNearestDistance );
+
+			if ( r_logFile->integer ) {
+				GLimp_LogComment( va( "cubeProbeNearestDistance = %f, cubeProbeSecondNearestDistance = %f, interpolation = %f\n",
+					cubeProbeNearestDistance, cubeProbeSecondNearestDistance, interpolation ) );
+			}
+
+			cubeMap0 = cubeProbeNearest->cubemap;
+			cubeMap1 = cubeProbeSecondNearest->cubemap;
+		}
+
+		/* TODO: Check why it is required to test for this, why
+		cubeProbeNearest->cubemap and cubeProbeSecondNearest->cubemap
+		can be nullptr while cubeProbeNearest and cubeProbeSecondNearest
+		are not. Maybe this is only required while cubemaps are building. */
+		if ( cubeMap0 == nullptr ) {
+			cubeMap0 = tr.whiteCubeImage;
+		}
+
+		if ( cubeMap1 == nullptr ) {
+			cubeMap1 = tr.whiteCubeImage;
+		}
+
+		// bind u_EnvironmentMap0
+		gl_lightMappingShaderMaterial->SetUniform_EnvironmentMap0Bindless(
+			GL_BindToTMU( BIND_ENVIRONMENTMAP0, cubeMap0 )
+		);
+
+		// bind u_EnvironmentMap1
+		gl_lightMappingShaderMaterial->SetUniform_EnvironmentMap1Bindless(
+			GL_BindToTMU( BIND_ENVIRONMENTMAP1, cubeMap1 )
+		);
+
+		// bind u_EnvironmentInterpolation
+		gl_lightMappingShaderMaterial->SetUniform_EnvironmentInterpolation( interpolation );
+
+		updated = true;
+	}
+
+	// bind u_LightMap
+	if ( !enableGridLighting ) {
+		gl_lightMappingShaderMaterial->SetUniform_LightMapBindless(
+			GL_BindToTMU( BIND_LIGHTMAP, lightmap )
+		);
+	} else {
+		gl_lightMappingShaderMaterial->SetUniform_LightGrid1Bindless( GL_BindToTMU( BIND_LIGHTMAP, lightmap ) );
+	}
+
+	// bind u_DeluxeMap
+	if ( !enableGridDeluxeMapping ) {
+		gl_lightMappingShaderMaterial->SetUniform_DeluxeMapBindless(
+			GL_BindToTMU( BIND_DELUXEMAP, deluxemap )
+		);
+	} else {
+		gl_lightMappingShaderMaterial->SetUniform_LightGrid2Bindless( GL_BindToTMU( BIND_DELUXEMAP, deluxemap ) );
+	}
+
+	// bind u_GlowMap
+	if ( !!r_glowMapping->integer ) {
+		gl_lightMappingShaderMaterial->SetUniform_GlowMapBindless(
+			GL_BindToTMU( BIND_GLOWMAP, pStage->bundle[TB_GLOWMAP].image[0] )
+		);
+	}
+
+	gl_lightMappingShaderMaterial->WriteUniformsToBuffer( materials );
+}
+
+static void UpdateSurfaceDataReflection( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const int stage ) {
+	shader_t* shader = drawSurf->shader;
+	shaderStage_t* pStage = shader->stages[stage];
+
+	const uint paddedOffset = drawSurf->materialsSSBOOffset[stage] * material.shader->GetPaddedSize();
+	materials += paddedOffset;
+
+	bool updated = !drawSurf->initialized[stage] || pStage->colorDynamic || pStage->texMatricesDynamic || pStage->dynamic;
+	if ( !updated ) {
+		return;
+	}
+	drawSurf->initialized[stage] = true;
+
+	gl_reflectionShaderMaterial->SetUniform_VertexInterpolation( false );
+
+	// bind u_NormalMap
+	gl_reflectionShaderMaterial->SetUniform_NormalMapBindless(
+		GL_BindToTMU( 1, pStage->bundle[TB_NORMALMAP].image[0] )
+	);
+
+	// bind u_ColorMap
+	if ( backEnd.currentEntity && ( backEnd.currentEntity != &tr.worldEntity ) ) {
+		GL_BindNearestCubeMap( gl_reflectionShaderMaterial->GetUniformLocation_ColorMap(), backEnd.currentEntity->e.origin );
+	} else {
+		GL_BindNearestCubeMap( gl_reflectionShaderMaterial->GetUniformLocation_ColorMap(), backEnd.viewParms.orientation.origin );
+	}
+
+	if ( pStage->enableNormalMapping ) {
+		vec3_t normalScale;
+		SetNormalScale( pStage, normalScale );
+
+		gl_reflectionShaderMaterial->SetUniform_NormalScale( normalScale );
+	}
+
+	// bind u_HeightMap u_depthScale u_reliefOffsetBias
+	if ( pStage->enableReliefMapping ) {
+		float depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
+		float reliefDepthScale = shader->reliefDepthScale;
+		depthScale *= reliefDepthScale == 0 ? 1 : reliefDepthScale;
+		gl_reflectionShaderMaterial->SetUniform_ReliefDepthScale( depthScale );
+		gl_reflectionShaderMaterial->SetUniform_ReliefOffsetBias( shader->reliefOffsetBias );
+
+		// FIXME: if there is both, embedded heightmap in normalmap is used instead of standalone heightmap
+		if ( !pStage->hasHeightMapInNormalMap ) {
+			gl_reflectionShaderMaterial->SetUniform_HeightMapBindless(
+				GL_BindToTMU( 15, pStage->bundle[TB_HEIGHTMAP].image[0] )
+			);
+		}
+	}
+
+	gl_reflectionShaderMaterial->WriteUniformsToBuffer( materials );
+}
+
+static void UpdateSurfaceDataSkybox( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const int stage ) {
+	shader_t* shader = drawSurf->shader;
+	shaderStage_t* pStage = shader->stages[stage];
+
+	const uint paddedOffset = drawSurf->materialsSSBOOffset[stage] * material.shader->GetPaddedSize();
+	materials += paddedOffset;
+
+	bool updated = !drawSurf->initialized[stage] || pStage->colorDynamic || pStage->texMatricesDynamic || pStage->dynamic;
+	if ( !updated ) {
+		return;
+	}
+	drawSurf->initialized[stage] = true;
+
+	gl_skyboxShaderMaterial->BindProgram( material.deformIndex );
+
+	// bind u_ColorMap
+	gl_skyboxShaderMaterial->SetUniform_ColorMapCubeBindless(
+		GL_BindToTMU( 0, pStage->bundle[TB_COLORMAP].image[0] )
+	);
+
+	// u_InverseLightFactor
+	gl_skyboxShaderMaterial->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
+
+	gl_skyboxShaderMaterial->WriteUniformsToBuffer( materials );
+}
+
+static void UpdateSurfaceDataScreen( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const int stage ) {
+	shader_t* shader = drawSurf->shader;
+	shaderStage_t* pStage = shader->stages[stage];
+
+	const uint paddedOffset = drawSurf->materialsSSBOOffset[stage] * material.shader->GetPaddedSize();
+	materials += paddedOffset;
+
+	bool updated = !drawSurf->initialized[stage] || pStage->colorDynamic || pStage->texMatricesDynamic || pStage->dynamic;
+	if ( !updated ) {
+		return;
+	}
+	drawSurf->initialized[stage] = true;
+
+	gl_screenShaderMaterial->BindProgram( pStage->deformIndex );
+
+	// bind u_CurrentMap
+	gl_screenShaderMaterial->SetUniform_CurrentMapBindless( BindAnimatedImage( 0, &drawSurf->shader->stages[stage]->bundle[TB_COLORMAP] ) );
+
+	gl_screenShaderMaterial->WriteUniformsToBuffer( materials );
+}
+
+static void UpdateSurfaceDataHeatHaze( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const int stage ) {
+	shader_t* shader = drawSurf->shader;
+	shaderStage_t* pStage = shader->stages[stage];
+
+	const uint paddedOffset = drawSurf->materialsSSBOOffset[stage] * material.shader->GetPaddedSize();
+	materials += paddedOffset;
+
+	bool updated = !drawSurf->initialized[stage] || pStage->colorDynamic || pStage->texMatricesDynamic || pStage->dynamic;
+	if ( !updated ) {
+		return;
+	}
+	drawSurf->initialized[stage] = true;
+
+	// bind u_NormalMap
+	gl_heatHazeShaderMaterial->SetUniform_NormalMapBindless(
+		GL_BindToTMU( 0, pStage->bundle[TB_NORMALMAP].image[0] )
+	);
+
+	float deformMagnitude = RB_EvalExpression( &pStage->deformMagnitudeExp, 1.0 );
+	gl_heatHazeShaderMaterial->SetUniform_DeformMagnitude( deformMagnitude );
+
+	if ( pStage->enableNormalMapping ) {
+		vec3_t normalScale;
+		SetNormalScale( pStage, normalScale );
+
+		// bind u_NormalScale
+		gl_heatHazeShaderMaterial->SetUniform_NormalScale( normalScale );
+	}
+
+	// bind u_CurrentMap
+	gl_heatHazeShaderMaterial->SetUniform_CurrentMapBindless(
+		GL_BindToTMU( 1, tr.currentRenderImage[backEnd.currentMainFBO] )
+	);
+
+	gl_heatHazeShaderMaterial->WriteUniformsToBuffer( materials );
+}
+
+static void UpdateSurfaceDataLiquid( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const int stage ) {
+	shader_t* shader = drawSurf->shader;
+	shaderStage_t* pStage = shader->stages[stage];
+
+	const uint paddedOffset = drawSurf->materialsSSBOOffset[stage] * material.shader->GetPaddedSize();
+	materials += paddedOffset;
+
+	bool updated = !drawSurf->initialized[stage] || pStage->colorDynamic || pStage->texMatricesDynamic || pStage->dynamic;
+	if ( !updated ) {
+		return;
+	}
+	drawSurf->initialized[stage] = true;
+
+	float fogDensity = RB_EvalExpression( &pStage->fogDensityExp, 0.001 );
+	vec4_t fogColor;
+	Tess_ComputeColor( pStage );
+	VectorCopy( tess.svars.color.ToArray(), fogColor );
+
+	gl_liquidShaderMaterial->SetUniform_RefractionIndex( RB_EvalExpression( &pStage->refractionIndexExp, 1.0 ) );
+	gl_liquidShaderMaterial->SetUniform_FresnelPower( RB_EvalExpression( &pStage->fresnelPowerExp, 2.0 ) );
+	gl_liquidShaderMaterial->SetUniform_FresnelScale( RB_EvalExpression( &pStage->fresnelScaleExp, 1.0 ) );
+	gl_liquidShaderMaterial->SetUniform_FresnelBias( RB_EvalExpression( &pStage->fresnelBiasExp, 0.05 ) );
+	gl_liquidShaderMaterial->SetUniform_FogDensity( fogDensity );
+	gl_liquidShaderMaterial->SetUniform_FogColor( fogColor );
+
+	gl_liquidShaderMaterial->SetUniform_UnprojectMatrix( backEnd.viewParms.unprojectionMatrix );
+	gl_liquidShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_liquidShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+
+	// NOTE: specular component is computed by shader.
+	// FIXME: physical mapping is not implemented.
+	if ( pStage->enableSpecularMapping ) {
+		float specMin = RB_EvalExpression( &pStage->specularExponentMin, r_specularExponentMin->value );
+		float specMax = RB_EvalExpression( &pStage->specularExponentMax, r_specularExponentMax->value );
+		gl_liquidShaderMaterial->SetUniform_SpecularExponent( specMin, specMax );
+	}
+
+	// bind u_CurrentMap
+	gl_liquidShaderMaterial->SetUniform_CurrentMapBindless( GL_BindToTMU( 0, tr.currentRenderImage[backEnd.currentMainFBO] ) );
+
+	// bind u_PortalMap
+	gl_liquidShaderMaterial->SetUniform_PortalMapBindless( GL_BindToTMU( 1, tr.portalRenderImage ) );
+
+	// depth texture
+	gl_liquidShaderMaterial->SetUniform_DepthMapBindless( GL_BindToTMU( 2, tr.currentDepthImage ) );
+
+	// bind u_HeightMap u_depthScale u_reliefOffsetBias
+	if ( pStage->enableReliefMapping ) {
+		float depthScale;
+		float reliefDepthScale;
+
+		depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
+		reliefDepthScale = tess.surfaceShader->reliefDepthScale;
+		depthScale *= reliefDepthScale == 0 ? 1 : reliefDepthScale;
+		gl_liquidShaderMaterial->SetUniform_ReliefDepthScale( depthScale );
+		gl_liquidShaderMaterial->SetUniform_ReliefOffsetBias( tess.surfaceShader->reliefOffsetBias );
+
+		// FIXME: if there is both, embedded heightmap in normalmap is used instead of standalone heightmap
+		if ( !pStage->hasHeightMapInNormalMap ) {
+			gl_liquidShaderMaterial->SetUniform_HeightMapBindless( GL_BindToTMU( 15, pStage->bundle[TB_HEIGHTMAP].image[0] ) );
+		}
+	}
+
+	// bind u_NormalMap
+	gl_liquidShaderMaterial->SetUniform_NormalMapBindless( GL_BindToTMU( 3, pStage->bundle[TB_NORMALMAP].image[0] ) );
+
+	// bind u_NormalScale
+	if ( pStage->enableNormalMapping ) {
+		vec3_t normalScale;
+		// FIXME: NormalIntensity default was 0.5
+		SetNormalScale( pStage, normalScale );
+
+		gl_liquidShaderMaterial->SetUniform_NormalScale( normalScale );
+	}
+
+	gl_liquidShaderMaterial->WriteUniformsToBuffer( materials );
+}
+
+/*
+* Buffer layout:
+* // Static surfaces data:
+* // Material0
+* // Surface/stage0_0:
+* uniform0_0
+* uniform0_1
+* ..
+* uniform0_x
+* optional_struct_padding
+* // Surface/stage0_1:
+* ..
+* // Surface/stage0_y:
+* uniform0_0
+* uniform0_1
+* ..
+* uniform0_x
+* optional_struct_padding
+* optional_material1_padding
+* // Material1
+* // Surface/stage1_0:
+* ..
+* // Surface/stage1_y:
+* ..
+* ..
+* // Materialz:
+* ..
+* ..
+* // Dynamic surfaces data:
+* // Same as the static layout
+*/
+// Buffer is separated into static and dynamic parts so we can just update the whole dynamic range at once
+void MaterialSystem::GenerateWorldMaterialsBuffer() {
+	Log::Debug( "Generating materials buffer" );
+
+	uint offset = 0;
+
+	materialsSSBO.BindBuffer();
+
+	// Compute data size for static surfaces
+	for ( MaterialPack& pack : materialPacks ) {
+		for ( Material& material : pack.materials ) {
+			// Any new material in the buffer must start on an offset that is an integer multiple of
+			// the padded size of the material struct
+			const uint paddedSize = material.shader->GetPaddedSize();
+			const uint padding = ( offset % paddedSize == 0 ) ? 0 : paddedSize - ( offset % paddedSize );
+
+			offset += padding;
+			material.staticMaterialsSSBOOffset = offset;
+			offset += paddedSize * material.totalStaticDrawSurfCount;
+		}
+	}
+
+	dynamicDrawSurfsOffset = offset;
+
+	// Compute data size for dynamic surfaces
+	for ( MaterialPack& pack : materialPacks ) {
+		for ( Material& material : pack.materials ) {
+			// Any new material in the buffer must start on an offset that is an integer multiple of
+			// the padded size of the material struct
+			const uint paddedSize = material.shader->GetPaddedSize();
+			const uint padding = ( offset % paddedSize == 0 ) ? 0 : paddedSize - ( offset % paddedSize );
+
+			offset += padding;
+			material.dynamicMaterialsSSBOOffset = offset;
+			offset += paddedSize * material.totalDynamicDrawSurfCount;
+		}
+	}
+
+	dynamicDrawSurfsSize = offset - dynamicDrawSurfsOffset;
+
+	// 4 bytes per component
+	glBufferData( GL_SHADER_STORAGE_BUFFER, offset * sizeof( uint32_t ), nullptr, GL_DYNAMIC_DRAW );
+	uint32_t* materialsData = materialsSSBO.MapBufferRange( offset );
+	// uint32_t* materialsData = materialsDataInitial;
+	memset( materialsData, 0, 4 * offset );
+
+	for ( uint materialPackID = 0; materialPackID < 3; materialPackID++ ) {
+		for ( Material& material : materialPacks[materialPackID].materials ) {
+
+			for ( drawSurf_t* drawSurf : material.drawSurfs ) {
+				bool hasDynamicStages = false;
+
+				for ( int stage = 0; stage < drawSurf->shader->numStages; stage++ ) {
+					shaderStage_t* pStage = drawSurf->shader->stages[stage];
+
+					if ( drawSurf->materialIDs[stage] != material.id || drawSurf->materialPackIDs[stage] != materialPackID ) {
+						continue;
+					}
+					
+					uint SSBOOffset = 0;
+					uint drawSurfCount = 0;
+					if ( pStage->dynamic ) {
+						SSBOOffset = material.dynamicMaterialsSSBOOffset;
+						drawSurfCount = material.currentDynamicDrawSurfCount;
+						material.currentDynamicDrawSurfCount++;
+					} else {
+						SSBOOffset = material.staticMaterialsSSBOOffset;
+						drawSurfCount = material.currentStaticDrawSurfCount;
+						material.currentStaticDrawSurfCount++;
+					}
+
+					drawSurf->materialsSSBOOffset[stage] = ( SSBOOffset + drawSurfCount * material.shader->GetPaddedSize() ) /
+						material.shader->GetPaddedSize();
+
+					if ( pStage->dynamic ) {
+						hasDynamicStages = true;
+					}
+
+					AddStageTextures( drawSurf, pStage, &material );
+
+					switch ( pStage->type ) {
+						case stageType_t::ST_COLORMAP:
+							// generic2D
+							UpdateSurfaceDataGeneric( materialsData, material, drawSurf, stage );
+							break;
+						case stageType_t::ST_STYLELIGHTMAP:
+						case stageType_t::ST_STYLECOLORMAP:
+							UpdateSurfaceDataGeneric( materialsData, material, drawSurf, stage );
+							break;
+						case stageType_t::ST_LIGHTMAP:
+						case stageType_t::ST_DIFFUSEMAP:
+						case stageType_t::ST_COLLAPSE_COLORMAP:
+						case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
+							UpdateSurfaceDataLightMapping( materialsData, material, drawSurf, stage );
+							break;
+						case stageType_t::ST_REFLECTIONMAP:
+						case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
+							UpdateSurfaceDataReflection( materialsData, material, drawSurf, stage );
+							break;
+						case stageType_t::ST_REFRACTIONMAP:
+						case stageType_t::ST_DISPERSIONMAP:
+							// Not implemented yet
+							break;
+						case stageType_t::ST_SKYBOXMAP:
+							UpdateSurfaceDataSkybox( materialsData, material, drawSurf, stage );
+							break;
+						case stageType_t::ST_SCREENMAP:
+							UpdateSurfaceDataScreen( materialsData, material, drawSurf, stage );
+							break;
+						case stageType_t::ST_PORTALMAP:
+							// This is supposedly used for alphagen portal and portal surfaces should never get here
+							ASSERT_UNREACHABLE();
+							break;
+						case stageType_t::ST_HEATHAZEMAP:
+							UpdateSurfaceDataHeatHaze( materialsData, material, drawSurf, stage );
+							break;
+						case stageType_t::ST_LIQUIDMAP:
+							UpdateSurfaceDataLiquid( materialsData, material, drawSurf, stage );
+							break;
+
+						default:
+							break;
+					}
+
+					tess.currentDrawSurf = drawSurf;
+
+					tess.currentSSBOOffset = tess.currentDrawSurf->materialsSSBOOffset[stage];
+					tess.materialID = tess.currentDrawSurf->materialIDs[stage];
+					tess.materialPackID = tess.currentDrawSurf->materialPackIDs[stage];
+
+					tess.multiDrawPrimitives = 0;
+					tess.numIndexes = 0;
+					tess.numVertexes = 0;
+					tess.attribsSet = 0;
+
+					rb_surfaceTable[Util::ordinal( *drawSurf->surface )]( drawSurf->surface );
+
+					pStage->colorRenderer( pStage );
+
+					if ( pStage->dynamic ) {
+						drawSurf->materialsSSBOOffset[stage] = ( SSBOOffset - dynamicDrawSurfsOffset + drawSurfCount *
+							material.shader->GetPaddedSize() ) / material.shader->GetPaddedSize();
+					}
+				}
+
+				if ( hasDynamicStages ) {
+					// We need a copy here because the memory pointed to by drawSurf will change later
+					// We'll probably need a separate buffer for entities other than world entity + ensure we don't store a drawSurf with
+					// invalid pointers
+					dynamicDrawSurfs.emplace_back( *drawSurf );
+				}
+			}
+		}
+	}
+
+	materialsSSBO.UnmapBuffer();
+}
+
+void MaterialSystem::GenerateWorldCommandBuffer() {
+	Log::Debug( "Generating world command buffer" );
+
+	uint count = 0;
+	for ( const MaterialPack& pack : materialPacks ) {
+		for ( const Material& material : pack.materials ) {
+			count += material.drawCommands.size();
+		}
+	}
+
+	if ( count == 0 ) {
+		return;
+	}
+
+	Log::Debug( "CmdBuffer size: %u", count );
+
+	commandBuffer.BindBuffer();
+	glBufferData( GL_DRAW_INDIRECT_BUFFER, count * sizeof( GLIndirectBuffer::GLIndirectCommand ), nullptr, GL_STATIC_DRAW );
+
+	GLIndirectBuffer::GLIndirectCommand* commands = commandBuffer.MapBufferRange( count );
+	// GLIndirectBuffer::GLIndirectCommand* commands = commandsInitial;
+	uint offset = 0;
+	for ( MaterialPack& pack : materialPacks ) {
+		for ( Material& material : pack.materials ) {
+			material.staticCommandOffset = offset;
+
+			for ( const DrawCommand& drawCmd : material.drawCommands ) {
+				memcpy( commands, &drawCmd.cmd, sizeof( GLIndirectBuffer::GLIndirectCommand ) );
+				commands++;
+				offset++;
+			}
+		}
+	}
+
+	commandBuffer.UnmapBuffer();
+	GL_CheckErrors();
+}
+
+static void BindShaderGeneric( Material* material ) {
+	gl_genericShaderMaterial->SetVertexAnimation( material->vertexAnimation );
+
+	gl_genericShaderMaterial->SetTCGenEnvironment( material->tcGenEnvironment );
+	gl_genericShaderMaterial->SetTCGenLightmap( material->tcGen_Lightmap );
+
+	gl_genericShaderMaterial->SetDepthFade( material->hasDepthFade );
+	gl_genericShaderMaterial->SetVertexSprite( material->vboVertexSprite );
+
+	gl_genericShaderMaterial->SetAlphaTesting( material->alphaTest );
+
+	gl_genericShaderMaterial->BindProgram( material->deformIndex );
+}
+
+static void BindShaderLightMapping( Material* material ) {
+	gl_lightMappingShaderMaterial->SetVertexAnimation( material->vertexAnimation );
+	gl_lightMappingShaderMaterial->SetBspSurface( material->bspSurface );
+
+	gl_lightMappingShaderMaterial->SetDeluxeMapping( material->enableDeluxeMapping );
+
+	gl_lightMappingShaderMaterial->SetGridLighting( material->enableGridLighting );
+
+	gl_lightMappingShaderMaterial->SetGridDeluxeMapping( material->enableGridDeluxeMapping );
+
+	gl_lightMappingShaderMaterial->SetHeightMapInNormalMap( material->hasHeightMapInNormalMap );
+
+	gl_lightMappingShaderMaterial->SetReliefMapping( material->enableReliefMapping );
+
+	gl_lightMappingShaderMaterial->SetReflectiveSpecular( material->enableNormalMapping && tr.cubeHashTable != nullptr );
+
+	gl_lightMappingShaderMaterial->SetPhysicalShading( material->enablePhysicalMapping );
+
+	gl_lightMappingShaderMaterial->BindProgram( material->deformIndex );
+}
+
+static void BindShaderReflection( Material* material ) {
+	gl_reflectionShaderMaterial->SetHeightMapInNormalMap( material->hasHeightMapInNormalMap );
+
+	gl_reflectionShaderMaterial->SetReliefMapping( material->enableReliefMapping );
+
+	// gl_reflectionShaderMaterial->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && false );
+	gl_reflectionShaderMaterial->SetVertexAnimation( material->vertexAnimation );
+
+	gl_reflectionShaderMaterial->BindProgram( material->deformIndex );
+}
+
+static void BindShaderSkybox( Material* material ) {
+	gl_skyboxShaderMaterial->BindProgram( material->deformIndex );
+}
+
+static void BindShaderScreen( Material* material ) {
+	gl_screenShaderMaterial->BindProgram( material->deformIndex );
+}
+
+static void BindShaderHeatHaze( Material* material ) {
+	// gl_heatHazeShaderMaterial->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && false );
+	gl_heatHazeShaderMaterial->SetVertexAnimation( material->vertexAnimation );
+
+	gl_heatHazeShaderMaterial->SetVertexSprite( material->vboVertexSprite );
+
+	gl_heatHazeShaderMaterial->BindProgram( material->deformIndex );
+}
+
+static void BindShaderLiquid( Material* material ) {
+	gl_liquidShaderMaterial->SetHeightMapInNormalMap( material->hasHeightMapInNormalMap );
+
+	gl_liquidShaderMaterial->SetReliefMapping( material->enableReliefMapping );
+
+	gl_liquidShaderMaterial->BindProgram( material->deformIndex );
+}
+
+static void ProcessMaterialGeneric( Material* material, shaderStage_t* pStage, shader_t* shader ) {
+	material->shader = gl_genericShaderMaterial;
+
+	material->vertexAnimation = false;
+	material->tcGenEnvironment = pStage->tcGen_Environment;
+	material->tcGen_Lightmap = pStage->tcGen_Lightmap;
+	material->vboVertexSprite = tess.vboVertexSprite;
+	material->deformIndex = pStage->deformIndex;
+
+	// gl_genericShaderMaterial->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && false );
+	gl_genericShaderMaterial->SetVertexAnimation( false );
+
+	gl_genericShaderMaterial->SetTCGenEnvironment( pStage->tcGen_Environment );
+	gl_genericShaderMaterial->SetTCGenLightmap( pStage->tcGen_Lightmap );
+
+	bool hasDepthFade = pStage->hasDepthFade && !shader->autoSpriteMode;
+	material->hasDepthFade = hasDepthFade;
+	gl_genericShaderMaterial->SetDepthFade( hasDepthFade );
+	gl_genericShaderMaterial->SetVertexSprite( tess.vboVertexSprite );
+
+	uint32_t alphaTestBits = pStage->stateBits & GLS_ATEST_BITS;
+	material->alphaTest = alphaTestBits != 0;
+	gl_genericShaderMaterial->SetAlphaTesting( alphaTestBits != 0 );
+
+	material->program = gl_genericShaderMaterial->GetProgram( pStage->deformIndex );
+}
+
+static void ProcessMaterialLightMapping( Material* material, shaderStage_t* pStage, drawSurf_t* drawSurf ) {
+	material->shader = gl_lightMappingShaderMaterial;
+
+	material->vertexAnimation = false;
+	material->bspSurface = false;
+
+	// gl_lightMappingShaderMaterial->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && false );
+
+	gl_lightMappingShaderMaterial->SetVertexAnimation( false );
+	gl_lightMappingShaderMaterial->SetBspSurface( drawSurf->bspSurface );
+
+	lightMode_t lightMode = lightMode_t::FULLBRIGHT;
+	deluxeMode_t deluxeMode = deluxeMode_t::NONE;
+
+	bool hack = tess.numSurfaceStages > 0 && tess.surfaceStages[0]->rgbGen == colorGen_t::CGEN_VERTEX;
+	if ( ( tess.surfaceShader->surfaceFlags & SURF_NOLIGHTMAP ) && !hack ) {
+		// Use fullbright on “surfaceparm nolightmap” materials.
+	} else if ( pStage->type == stageType_t::ST_COLLAPSE_COLORMAP ) {
+		/* Use fullbright for collapsed stages without lightmaps,
+		for example:
+		  {
+			map textures/texture_d
+			heightMap textures/texture_h
+		  }
+
+		This is doable for some complex multi-stage materials. */
+	} else if ( drawSurf->bspSurface ) {
+		lightMode = tr.worldLight;
+		deluxeMode = tr.worldDeluxe;
+
+		if ( lightMode == lightMode_t::MAP ) {
+			bool hasLightMap = ( drawSurf->lightmapNum() >= 0 );
+
+			if ( !hasLightMap ) {
+				lightMode = lightMode_t::VERTEX;
+				deluxeMode = deluxeMode_t::NONE;
+			}
+		}
+	} else {
+		lightMode = tr.modelLight;
+		deluxeMode = tr.modelDeluxe;
+	}
+
+	bool enableDeluxeMapping = ( deluxeMode == deluxeMode_t::MAP );
+	bool enableGridLighting = ( lightMode == lightMode_t::GRID );
+	bool enableGridDeluxeMapping = ( deluxeMode == deluxeMode_t::GRID );
+
+	DAEMON_ASSERT( !( enableDeluxeMapping && enableGridDeluxeMapping ) );
+
+	material->enableDeluxeMapping = enableDeluxeMapping;
+	material->enableGridLighting = enableGridLighting;
+	material->enableGridDeluxeMapping = enableGridDeluxeMapping;
+	material->hasHeightMapInNormalMap = pStage->hasHeightMapInNormalMap;
+	material->enableReliefMapping = pStage->enableReliefMapping;
+	material->enableNormalMapping = pStage->enableNormalMapping && tr.cubeHashTable != nullptr;
+	material->enablePhysicalMapping = pStage->enablePhysicalMapping;
+	material->deformIndex = pStage->deformIndex;
+
+	gl_lightMappingShaderMaterial->SetDeluxeMapping( enableDeluxeMapping );
+
+	gl_lightMappingShaderMaterial->SetGridLighting( enableGridLighting );
+
+	gl_lightMappingShaderMaterial->SetGridDeluxeMapping( enableGridDeluxeMapping );
+
+	gl_lightMappingShaderMaterial->SetHeightMapInNormalMap( pStage->hasHeightMapInNormalMap );
+
+	gl_lightMappingShaderMaterial->SetReliefMapping( pStage->enableReliefMapping );
+
+	gl_lightMappingShaderMaterial->SetReflectiveSpecular( pStage->enableNormalMapping && tr.cubeHashTable != nullptr );
+
+	gl_lightMappingShaderMaterial->SetPhysicalShading( pStage->enablePhysicalMapping );
+
+	material->program = gl_lightMappingShaderMaterial->GetProgram( pStage->deformIndex );
+}
+
+static void ProcessMaterialReflection( Material* material, shaderStage_t* pStage ) {
+	material->shader = gl_reflectionShaderMaterial;
+
+	material->hasHeightMapInNormalMap = pStage->hasHeightMapInNormalMap;
+	material->enableReliefMapping = pStage->enableReliefMapping;
+	material->vertexAnimation = false;
+	material->deformIndex = pStage->deformIndex;
+
+	gl_reflectionShaderMaterial->SetHeightMapInNormalMap( pStage->hasHeightMapInNormalMap );
+
+	gl_reflectionShaderMaterial->SetReliefMapping( pStage->enableReliefMapping );
+
+	// gl_reflectionShaderMaterial->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && false );
+	gl_reflectionShaderMaterial->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 && false );
+
+	material->program = gl_reflectionShaderMaterial->GetProgram( pStage->deformIndex );
+}
+
+static void ProcessMaterialSkybox( Material* material, shaderStage_t* pStage ) {
+	material->shader = gl_skyboxShaderMaterial;
+
+	material->deformIndex = pStage->deformIndex;
+
+	material->program = gl_skyboxShaderMaterial->GetProgram( pStage->deformIndex );
+}
+
+static void ProcessMaterialScreen( Material* material, shaderStage_t* pStage ) {
+	material->shader = gl_screenShaderMaterial;
+
+	material->deformIndex = pStage->deformIndex;
+
+	material->program = gl_screenShaderMaterial->GetProgram( pStage->deformIndex );
+}
+
+static void ProcessMaterialHeatHaze( Material* material, shaderStage_t* pStage, shader_t* shader ) {
+	material->shader = gl_heatHazeShaderMaterial;
+
+	material->vertexAnimation = false;
+	material->deformIndex = pStage->deformIndex;
+
+	// gl_heatHazeShaderMaterial->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && false );
+	gl_heatHazeShaderMaterial->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 && false );
+	if ( shader->autoSpriteMode ) {
+		gl_heatHazeShaderMaterial->SetVertexSprite( true );
+	} else {
+		gl_heatHazeShaderMaterial->SetVertexSprite( false );
+	}
+
+	material->program = gl_heatHazeShaderMaterial->GetProgram( pStage->deformIndex );
+}
+static void ProcessMaterialLiquid( Material* material, shaderStage_t* pStage ) {
+	material->shader = gl_liquidShaderMaterial;
+
+	material->hasHeightMapInNormalMap = pStage->hasHeightMapInNormalMap;
+	material->enableReliefMapping = pStage->enableReliefMapping;
+	material->deformIndex = pStage->deformIndex;
+
+	gl_liquidShaderMaterial->SetHeightMapInNormalMap( pStage->hasHeightMapInNormalMap );
+
+	gl_liquidShaderMaterial->SetReliefMapping( pStage->enableReliefMapping );
+
+	material->program = gl_liquidShaderMaterial->GetProgram( pStage->deformIndex );
+}
+
+void MaterialSystem::GenerateWorldMaterials() {
+	const int current_r_nocull = r_nocull->integer;
+	const int current_r_drawworld = r_drawworld->integer;
+	r_nocull->integer = 1;
+	r_drawworld->integer = 1;
+	generatingWorldCommandBuffer = true;
+
+	Log::Debug( "Generating world materials" );
+
+	R_AddWorldSurfaces();
+
+	Log::Notice( "World bounds: min: %f %f %f max: %f %f %f", tr.viewParms.visBounds[0][0], tr.viewParms.visBounds[0][1],
+		tr.viewParms.visBounds[0][2], tr.viewParms.visBounds[1][0], tr.viewParms.visBounds[1][1], tr.viewParms.visBounds[1][2] );
+	VectorCopy( tr.viewParms.visBounds[0], worldViewBounds[0] );
+	VectorCopy( tr.viewParms.visBounds[1], worldViewBounds[1] );
+
+	backEnd.currentEntity = &tr.worldEntity;
+
+	drawSurf_t* drawSurf;
+
+	uint id = 0;
+	uint previousMaterialID = 0;
+	uint packIDs[3] = { 0, 0, 0 };
+	skipDrawCommands = true;
+
+	for ( int i = 0; i < tr.refdef.numDrawSurfs; i++ ) {
+		drawSurf = &tr.refdef.drawSurfs[i];
+		if ( drawSurf->entity != &tr.worldEntity ) {
+			continue;
+		}
+
+		shader_t* shader = drawSurf->shader;
+		if ( !shader ) {
+			continue;
+		}
+
+		shader = shader->remappedShader ? shader->remappedShader : shader;
+		if ( shader->isSky || shader->isPortal ) {
+			continue;
+		}
+
+		skipSurface = false;
+		rb_surfaceTable[Util::ordinal( *( drawSurf->surface ) )]( drawSurf->surface );
+
+		// Don't add SF_SKIP surfaces
+		if ( skipSurface ) {
+			continue;
+		}
+
+		for ( int stage = 0; stage < shader->numStages; stage++ ) {
+			shaderStage_t* pStage = shader->stages[stage];
+
+			Material material;
+
+			uint materialPack = 0;
+			if ( shader->sort == Util::ordinal( shaderSort_t::SS_DEPTH ) ) {
+				materialPack = 0;
+			} else if ( shader->sort >= Util::ordinal( shaderSort_t::SS_ENVIRONMENT_FOG )
+					 && shader->sort <= Util::ordinal( shaderSort_t::SS_OPAQUE ) ) {
+				materialPack = 1;
+			} else {
+				materialPack = 2;
+			}
+			id = packIDs[materialPack];
+
+			// In surfaces with multiple stages each consecutive stage must be drawn after the previous stage,
+			// except if an opaque stage follows a transparent stage etc.
+			if ( stage > 0 ) {
+				material.useSync = true;
+				material.syncMaterial = previousMaterialID;
+			}
+
+			material.stateBits = pStage->stateBits;
+			// GLS_ATEST_BITS don't matter here as they don't change GL state
+			material.stateBits &= GLS_DEPTHFUNC_BITS | GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS | GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE
+								| GLS_COLORMASK_BITS | GLS_DEPTHMASK_TRUE;
+			material.stageType = pStage->type;
+			material.cullType = shader->cullType;
+			material.usePolygonOffset = shader->polygonOffset;
+
+			material.vbo = glState.currentVBO;
+			material.ibo = glState.currentIBO;
+
+			ComputeDynamics( pStage );
+
+			if ( pStage->texturesDynamic ) {
+				drawSurf->texturesDynamic[stage] = true;
+			}
+
+			switch ( pStage->type ) {
+				case stageType_t::ST_COLORMAP:
+					// generic2D also uses this, but it's for ui only, so skip that for now
+					ProcessMaterialGeneric( &material, pStage, drawSurf->shader );
+					break;
+				case stageType_t::ST_STYLELIGHTMAP:
+				case stageType_t::ST_STYLECOLORMAP:
+					ProcessMaterialGeneric( &material, pStage, drawSurf->shader );
+					break;
+				case stageType_t::ST_LIGHTMAP:
+				case stageType_t::ST_DIFFUSEMAP:
+				case stageType_t::ST_COLLAPSE_COLORMAP:
+				case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
+					ProcessMaterialLightMapping( &material, pStage, drawSurf );
+					break;
+				case stageType_t::ST_REFLECTIONMAP:
+				case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
+					ProcessMaterialReflection( &material, pStage );
+					break;
+				case stageType_t::ST_REFRACTIONMAP:
+				case stageType_t::ST_DISPERSIONMAP:
+					// Not implemented yet
+					break;
+				case stageType_t::ST_SKYBOXMAP:
+					ProcessMaterialSkybox( &material, pStage );
+					break;
+				case stageType_t::ST_SCREENMAP:
+					ProcessMaterialScreen( &material, pStage );
+					break;
+				case stageType_t::ST_PORTALMAP:
+					// This is supposedly used for alphagen portal and portal surfaces should never get here
+					ASSERT_UNREACHABLE();
+					break;
+				case stageType_t::ST_HEATHAZEMAP:
+					// FIXME: This requires 2 draws per surface stage rather than 1
+					ProcessMaterialHeatHaze( &material, pStage, drawSurf->shader );
+					break;
+				case stageType_t::ST_LIQUIDMAP:
+					ProcessMaterialLiquid( &material, pStage );
+					break;
+
+				default:
+					break;
+			}
+
+			std::vector<Material>& materials = materialPacks[materialPack].materials;
+			std::vector<Material>::iterator currentSearchIt = materials.begin();
+			std::vector<Material>::iterator materialIt;
+			// Look for this material in the ones we already have
+			while( true ) {
+				materialIt = std::find( currentSearchIt, materials.end(), material );
+				if ( materialIt == materials.end() ) {
+					break;
+				}
+				if ( material.useSync && materialIt->id < material.syncMaterial ) {
+					currentSearchIt = materialIt + 1;
+				} else {
+					break;
+				}
+			}
+
+			// Add it at the back if not found
+			if ( materialIt == materials.end() ) {
+				material.id = id;
+				previousMaterialID = id;
+				materials.emplace_back( material );
+				id++;
+			} else {
+				previousMaterialID = materialIt->id;
+			}
+
+			pStage->useMaterialSystem = true;
+			materials[previousMaterialID].totalDrawSurfCount++;
+			if ( pStage->dynamic ) {
+				materials[previousMaterialID].totalDynamicDrawSurfCount++;
+			} else {
+				materials[previousMaterialID].totalStaticDrawSurfCount++;
+			}
+
+			if ( std::find( materials[previousMaterialID].drawSurfs.begin(), materials[previousMaterialID].drawSurfs.end(), drawSurf )
+				 == materials[previousMaterialID].drawSurfs.end() ) {
+				materials[previousMaterialID].drawSurfs.emplace_back( drawSurf );
+			}
+
+			drawSurf->materialIDs[stage] = previousMaterialID;
+			drawSurf->materialPackIDs[stage] = materialPack;
+
+			packIDs[materialPack] = id;
+		}
+	}
+	skipDrawCommands = false;
+
+	GenerateWorldMaterialsBuffer();
+
+	uint totalCount = 0;
+	for ( MaterialPack& pack : materialPacks ) {
+		totalCount += pack.materials.size();
+	}
+	Log::Notice( "Generated %u materials from %u surfaces", totalCount, tr.refdef.numDrawSurfs );
+	/* for ( const MaterialPack& materialPack : materialPacks ) {
+		Log::Notice( "materialPack sort: %i %i", Util::ordinal( materialPack.fromSort ), Util::ordinal( materialPack.toSort ) );
+		for ( const Material& material : materialPack.materials ) {
+			Log::Notice( "id: %u, useSync: %b, sync: %u, program: %i, stateBits: %u, totalDrawSurfCount: %u, shader: %s, vbo: %s, ibo: %s"
+				", staticDrawSurfs: %u, dynamicDrawSurfs: %u, culling: %i",
+				material.id, material.useSync, material.syncMaterial, material.program, material.stateBits, material.totalDrawSurfCount,
+				material.shader->GetName(), material.vbo->name, material.ibo->name, material.currentStaticDrawSurfCount,
+				material.currentDynamicDrawSurfCount, material.cullType );
+		}
+	} */
+
+	r_nocull->integer = current_r_nocull;
+	r_drawworld->integer = current_r_drawworld;
+	AddAllWorldSurfaces();
+
+	skipDrawCommands = true;
+	GeneratePortalBoundingSpheres();
+	skipDrawCommands = false;
+
+	generatedWorldCommandBuffer = true;
+}
+
+// TODO: Dynamic command buffer for entities
+/* void GenerateCommandBuffer() {
+	uint count = 0;
+	for ( const Material& material : globalMaterials ) {
+		count += material.drawCommands.size();
+	}
+
+	if ( count == 0 ) {
+		return;
+	}
+
+	GL_CheckErrors();
+	commandBuffer.BindBuffer();
+	GL_CheckErrors();
+	glBufferData( GL_DRAW_INDIRECT_BUFFER, count * sizeof( GLIndirectBuffer::GLIndirectCommand ), nullptr, GL_STATIC_DRAW );
+	GL_CheckErrors();
+
+	GLIndirectBuffer::GLIndirectCommand* commandsInitial = commandBuffer.MapBufferRange( count );
+	GLIndirectBuffer::GLIndirectCommand* commands = commandsInitial;
+	GL_CheckErrors();
+	uint offset = 0;
+	for ( Material& material : globalMaterials ) {
+		uint drawCmdCount = 0;
+		material.commandBufferOffset = offset;
+
+		for ( const DrawCommand& drawCmd : material.drawCommands ) {
+			memcpy( commands, &drawCmd.cmd, sizeof( GLIndirectBuffer::GLIndirectCommand ) );
+			commands++;
+			offset++;
+			drawCmdCount++;
+		}
+		material.currentDrawSurfCount = drawCmdCount;
+	}
+
+	commandBuffer.UnmapBuffer();
+} */
+
+void MaterialSystem::AddAllWorldSurfaces() {
+	GenerateWorldCommandBuffer();
+
+	generatingWorldCommandBuffer = false;
+}
+
+void MaterialSystem::AddStageTextures( drawSurf_t* drawSurf, shaderStage_t* pStage, Material* material ) {
+	for ( const textureBundle_t& bundle : pStage->bundle ) {
+		if ( bundle.isVideoMap ) {
+			material->AddTexture( tr.cinematicImage[bundle.videoMapHandle]->texture );
+			continue;
+		}
+
+		// TODO: Rework numImages
+		/* for ( int i = 0; i < bundle.numImages; i++ ) {
+			material->AddTexture( bundle.image[i]->texture );
+		} */
+		for ( image_t* image : bundle.image ) {
+			if ( image ) {
+				material->AddTexture( image->texture );
+			}
+		}
+	}
+
+	// Add lightmap and deluxemap for this surface to the material as well
+
+	lightMode_t lightMode = lightMode_t::FULLBRIGHT;
+	deluxeMode_t deluxeMode = deluxeMode_t::NONE;
+
+	bool hack = drawSurf->shader->numStages > 0 && drawSurf->shader->stages[0]->rgbGen == colorGen_t::CGEN_VERTEX;
+
+	if ( ( drawSurf->shader->surfaceFlags & SURF_NOLIGHTMAP ) && !hack ) {
+		// Use fullbright on “surfaceparm nolightmap” materials.
+	} else if ( pStage->type == stageType_t::ST_COLLAPSE_COLORMAP ) {
+		/* Use fullbright for collapsed stages without lightmaps,
+		for example:
+
+		  {
+			map textures/texture_d
+			heightMap textures/texture_h
+		  }
+
+		This is doable for some complex multi-stage materials. */
+	} else if ( drawSurf->bspSurface ) {
+		lightMode = tr.worldLight;
+		deluxeMode = tr.worldDeluxe;
+
+		if ( lightMode == lightMode_t::MAP ) {
+			bool hasLightMap = static_cast< size_t >( drawSurf->lightmapNum() ) < tr.lightmaps.size();
+
+			if ( !hasLightMap ) {
+				lightMode = lightMode_t::VERTEX;
+				deluxeMode = deluxeMode_t::NONE;
+			}
+		}
+	} else {
+		lightMode = tr.modelLight;
+		deluxeMode = tr.modelDeluxe;
+	}
+
+	// u_Map, u_DeluxeMap
+	image_t* lightmap = tr.whiteImage;
+	image_t* deluxemap = tr.whiteImage;
+
+	switch ( lightMode ) {
+		case lightMode_t::VERTEX:
+			break;
+
+		case lightMode_t::GRID:
+			lightmap = tr.lightGrid1Image;
+			break;
+
+		case lightMode_t::MAP:
+			lightmap = GetLightMap( drawSurf );
+			break;
+
+		default:
+			break;
+	}
+
+	switch ( deluxeMode ) {
+		case deluxeMode_t::MAP:
+			deluxemap = GetDeluxeMap( drawSurf );
+			break;
+
+		case deluxeMode_t::GRID:
+			deluxemap = tr.lightGrid2Image;
+			break;
+
+		default:
+			break;
+	}
+
+	material->AddTexture( lightmap->texture );
+	material->AddTexture( deluxemap->texture );
+
+	if ( glConfig2.dynamicLight ) {
+		if ( r_dynamicLightRenderer.Get() == Util::ordinal( dynamicLightRenderer_t::TILED ) ) {
+			material->AddTexture( tr.lighttileRenderImage->texture );
+		}
+	}
+}
+
+void MaterialSystem::UpdateDynamicSurfaces() {
+	if ( dynamicDrawSurfsSize == 0 ) {
+		return;
+	}
+
+	materialsSSBO.BindBuffer();
+	uint32_t* materialsData = materialsSSBO.MapBufferRange( dynamicDrawSurfsOffset, dynamicDrawSurfsSize );
+	// uint32_t* materialsData = materialsDataInitial;
+	// Shader uniforms are set to 0 if they're not specified, so make sure we do that here too
+	memset( materialsData, 0, 4 * dynamicDrawSurfsSize );
+	for ( drawSurf_t& drawSurf : dynamicDrawSurfs ) {
+		for ( int stage = 0; stage < drawSurf.shader->numStages; stage++ ) {
+			shaderStage_t* pStage = drawSurf.shader->stages[stage];
+
+			Material& material = materialPacks[drawSurf.materialPackIDs[stage]].materials[drawSurf.materialIDs[stage]];
+
+			switch ( pStage->type ) {
+				case stageType_t::ST_COLORMAP:
+					// generic2D also uses this, but it's for ui only, so skip that for now
+					UpdateSurfaceDataGeneric( materialsData, material, &drawSurf, stage );
+					break;
+				case stageType_t::ST_STYLELIGHTMAP:
+				case stageType_t::ST_STYLECOLORMAP:
+					UpdateSurfaceDataGeneric( materialsData, material, &drawSurf, stage );
+					break;
+				case stageType_t::ST_LIGHTMAP:
+				case stageType_t::ST_DIFFUSEMAP:
+				case stageType_t::ST_COLLAPSE_COLORMAP:
+				case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
+					UpdateSurfaceDataLightMapping( materialsData, material, &drawSurf, stage );
+					break;
+				case stageType_t::ST_REFLECTIONMAP:
+				case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
+					UpdateSurfaceDataReflection( materialsData, material, &drawSurf, stage );
+					break;
+				case stageType_t::ST_REFRACTIONMAP:
+				case stageType_t::ST_DISPERSIONMAP:
+					// Not implemented yet
+					break;
+				case stageType_t::ST_SKYBOXMAP:
+					UpdateSurfaceDataSkybox( materialsData, material, &drawSurf, stage );
+					break;
+				case stageType_t::ST_SCREENMAP:
+					UpdateSurfaceDataScreen( materialsData, material, &drawSurf, stage );
+					break;
+				case stageType_t::ST_PORTALMAP:
+					// This is supposedly used for alphagen portal and portal surfaces should never get here
+					ASSERT_UNREACHABLE();
+					break;
+				case stageType_t::ST_HEATHAZEMAP:
+					UpdateSurfaceDataHeatHaze( materialsData, material, &drawSurf, stage );
+					break;
+				case stageType_t::ST_LIQUIDMAP:
+					UpdateSurfaceDataLiquid( materialsData, material, &drawSurf, stage );
+					break;
+
+				default:
+					break;
+			}
+		}
+	}
+	materialsSSBO.UnmapBuffer();
+}
+
+void MaterialSystem::GeneratePortalBoundingSpheres() {
+	Log::Debug( "Generating portal bounding spheres" );
+
+	for ( drawSurf_t* drawSurf : portalSurfacesTmp ) {
+		tess.numVertexes = 0;
+		rb_surfaceTable[Util::ordinal( *( drawSurf->surface ) )]( drawSurf->surface );
+		const int numVerts = tess.numVertexes;
+		vec3_t portalCenter{ 0.0, 0.0, 0.0 };
+		for ( int vertIndex = 0; vertIndex < numVerts; vertIndex++ ) {
+			VectorAdd( portalCenter, tess.verts[vertIndex].xyz, portalCenter );
+		}
+		VectorScale( portalCenter, 1.0 / numVerts, portalCenter );
+
+		float furthestDistance = 0.0;
+		for ( int vertIndex = 0; vertIndex < numVerts; vertIndex++ ) {
+			const float distance = Distance( portalCenter, tess.verts[vertIndex].xyz );
+			furthestDistance = distance > furthestDistance ? distance : furthestDistance;
+		}
+
+		portalSurfaces.emplace_back( *drawSurf );
+		drawSurfBoundingSphere sphere;
+		VectorCopy( portalCenter, sphere.origin );
+		sphere.radius = furthestDistance;
+		sphere.drawSurfID = portalSurfaces.size() - 1;
+
+		portalBounds.emplace_back( sphere );
+	}
+
+	portalSurfacesTmp.clear();
+}
+
+void MaterialSystem::Free() {
+	generatedWorldCommandBuffer = false;
+
+	dynamicDrawSurfs.clear();
+	portalSurfaces.clear();
+	portalSurfacesTmp.clear();
+	portalBounds.clear();
+	skyShaders.clear();
+	renderedMaterials.clear();
+
+	for ( MaterialPack& pack : materialPacks ) {
+		for ( Material& material : pack.materials ) {
+			material.drawCommands.clear();
+			material.drawSurfs.clear();
+		}
+		pack.materials.clear();
+	}
+}
+
+void MaterialSystem::AddDrawCommand( const uint materialID, const uint materialPackID, const uint materialsSSBOOffset,
+									 const GLuint count, const GLuint firstIndex ) {
+	// Don't add surfaces here if we're just trying to get some VBO/IBO information
+	if ( skipDrawCommands ) {
+		return;
+	}
+
+	cmd.cmd.count = count;
+	cmd.cmd.instanceCount = 1;
+	cmd.cmd.firstIndex = firstIndex;
+	cmd.cmd.baseVertex = 0;
+	cmd.cmd.baseInstance = materialsSSBOOffset;
+	cmd.materialsSSBOOffset = materialsSSBOOffset;
+
+	materialPacks[materialPackID].materials[materialID].drawCommands.emplace_back(cmd);
+	cmd.textureCount = 0;
+}
+
+void MaterialSystem::AddTexture( Texture* texture ) {
+	if ( cmd.textureCount > MAX_DRAWCOMMAND_TEXTURES ) {
+		Sys::Drop( "Exceeded max DrawCommand textures" );
+	}
+	cmd.textures[cmd.textureCount] = texture;
+	cmd.textureCount++;
+}
+
+void MaterialSystem::AddPortalSurfaces() {
+	// Very inefficient
+	// TODO: Mark portals in the cull shader and do a readback to only add portals that can actually be seen
+	std::sort( portalBounds.begin(), portalBounds.end(),
+		[]( const drawSurfBoundingSphere& lhs, const drawSurfBoundingSphere& rhs ) {
+			return Distance( backEnd.viewParms.orientation.origin, lhs.origin ) - lhs.radius <
+				   Distance( backEnd.viewParms.orientation.origin, rhs.origin ) - rhs.radius;
+		} );
+	for ( const drawSurfBoundingSphere& sphere : portalBounds ) {
+		R_MirrorViewBySurface( &portalSurfaces[sphere.drawSurfID] );
+	}
+}
+
+void MaterialSystem::RenderMaterials( const shaderSort_t fromSort, const shaderSort_t toSort ) {
+	if ( !r_drawworld->integer ) {
+		return;
+	}
+
+	if ( frameStart ) {
+		renderedMaterials.clear();
+		UpdateDynamicSurfaces();
+		frameStart = false;
+	}
+
+	materialsSSBO.BindBufferBase();
+
+	for ( MaterialPack& materialPack : materialPacks ) {
+		if ( materialPack.fromSort >= fromSort && materialPack.toSort <= toSort ) {
+			for ( Material& material : materialPack.materials ) {
+				RenderMaterial( material );
+				renderedMaterials.emplace_back( &material );
+			}
+		}
+	}
+
+	// Draw the skybox here because we skipped R_AddWorldSurfaces()
+	const bool environmentFogDraw = ( fromSort <= shaderSort_t::SS_ENVIRONMENT_FOG ) && ( toSort >= shaderSort_t::SS_ENVIRONMENT_FOG );
+	const bool environmentNoFogDraw = ( fromSort <= shaderSort_t::SS_ENVIRONMENT_NOFOG ) && toSort >= ( shaderSort_t::SS_ENVIRONMENT_NOFOG );
+	if ( tr.hasSkybox && ( environmentFogDraw || environmentNoFogDraw ) ) {
+		const bool noFogPass = toSort >= shaderSort_t::SS_ENVIRONMENT_NOFOG;
+		for ( shader_t* skyShader : skyShaders ) {
+			if ( skyShader->noFog != noFogPass ) {
+				continue;
+			}
+
+			tr.drawingSky = true;
+			Tess_Begin( Tess_StageIteratorSky, nullptr, skyShader, nullptr, false, -1, -1, false );
+			Tess_End();
+		}
+	}
+}
+
+void MaterialSystem::RenderMaterial( Material& material ) {
+	backEnd.currentEntity = &tr.worldEntity;
+
+	GL_State( material.stateBits );
+	if ( material.usePolygonOffset ) {
+		glEnable( GL_POLYGON_OFFSET_FILL );
+		GL_PolygonOffset( r_offsetFactor->value, r_offsetUnits->value );
+	} else {
+		glDisable( GL_POLYGON_OFFSET_FILL );
+	}
+	GL_Cull( material.cullType );
+
+	backEnd.orientation = backEnd.viewParms.world;
+	GL_LoadModelViewMatrix( backEnd.orientation.modelViewMatrix );
+
+	switch ( material.stageType ) {
+		case stageType_t::ST_COLORMAP:
+		case stageType_t::ST_STYLELIGHTMAP:
+		case stageType_t::ST_STYLECOLORMAP:
+			BindShaderGeneric( &material );
+
+			if ( material.tcGenEnvironment || material.vboVertexSprite ) {
+				gl_genericShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
+				gl_genericShaderMaterial->SetUniform_ViewUp( backEnd.orientation.axis[2] );
+			}
+
+			gl_genericShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+			gl_genericShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+			break;
+		case stageType_t::ST_LIGHTMAP:
+		case stageType_t::ST_DIFFUSEMAP:
+		case stageType_t::ST_COLLAPSE_COLORMAP:
+		case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
+			BindShaderLightMapping( &material );
+			if ( tr.world ) {
+				gl_lightMappingShaderMaterial->SetUniform_LightGridOrigin( tr.world->lightGridGLOrigin );
+				gl_lightMappingShaderMaterial->SetUniform_LightGridScale( tr.world->lightGridGLScale );
+			}
+			// FIXME: else
+
+			gl_lightMappingShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
+			gl_lightMappingShaderMaterial->SetUniform_numLights( backEnd.refdef.numLights );
+			gl_lightMappingShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+			gl_lightMappingShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+			break;
+		case stageType_t::ST_LIQUIDMAP:
+			BindShaderLiquid( &material );
+			gl_liquidShaderMaterial->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );
+			gl_liquidShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+			gl_liquidShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+			break;
+		case stageType_t::ST_REFLECTIONMAP:
+		case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
+			BindShaderReflection( &material );
+			gl_reflectionShaderMaterial->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );
+			gl_reflectionShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+			gl_reflectionShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+			break;
+		case stageType_t::ST_REFRACTIONMAP:
+		case stageType_t::ST_DISPERSIONMAP:
+			// Not implemented yet
+			break;
+		case stageType_t::ST_SKYBOXMAP:
+			BindShaderSkybox( &material );
+			gl_skyboxShaderMaterial->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );
+			gl_skyboxShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+			gl_skyboxShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+			break;
+		case stageType_t::ST_SCREENMAP:
+			BindShaderScreen( &material );
+			gl_screenShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+			break;
+		case stageType_t::ST_PORTALMAP:
+			// This is supposedly used for alphagen portal and portal surfaces should never get here
+			ASSERT_UNREACHABLE();
+			break;
+		case stageType_t::ST_HEATHAZEMAP:
+			// FIXME: This requires 2 draws per surface stage rather than 1
+			BindShaderHeatHaze( &material );
+
+			if ( material.vboVertexSprite ) {
+				gl_heatHazeShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
+				gl_heatHazeShaderMaterial->SetUniform_ViewUp( backEnd.orientation.axis[2] );
+			}
+
+			gl_heatHazeShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+			gl_heatHazeShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+			break;
+		default:
+			break;
+	}
+
+	R_BindVBO( material.vbo );
+	R_BindIBO( material.ibo );
+	material.shader->SetRequiredVertexPointers();
+
+	if ( !material.texturesResident ) {
+		for ( Texture* texture : material.textures ) {
+			if ( !texture->IsResident() ) {
+				texture->MakeResident();
+
+				bool resident = glIsTextureHandleResidentARB( texture->bindlessTextureHandle );
+
+				if ( resident ) {
+					continue;
+				}
+
+				for ( Material* mat : renderedMaterials ) {
+					Log::Warn( "Making material %u textures non-resident (%u)", mat->id, mat->textures.size() );
+					for ( Texture* tex : mat->textures ) {
+						if ( tex->IsResident() ) {
+							tex->MakeNonResident();
+						}
+					}
+					mat->texturesResident = false;
+				}
+
+				texture->MakeResident();
+
+				resident = glIsTextureHandleResidentARB( texture->bindlessTextureHandle );
+
+				if( !resident ) {
+					Log::Warn( "Not enough texture space! Some textures may be missing" );
+					break;
+				}
+			}
+		}
+	}
+	material.texturesResident = true;
+
+	glMultiDrawElementsIndirect( GL_TRIANGLES, GL_UNSIGNED_INT,
+		BUFFER_OFFSET( material.staticCommandOffset * sizeof( GLIndirectBuffer::GLIndirectCommand ) ),
+		material.drawCommands.size(), 0 );
+
+	if ( material.usePolygonOffset ) {
+		glDisable( GL_POLYGON_OFFSET_FILL );
+	}
+}

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -1,0 +1,202 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// Material.h
+
+#ifndef MATERIAL_H
+#define MATERIAL_H
+
+#include <vector>
+
+#include "gl_shader.h"
+#include "tr_local.h"
+
+static constexpr uint MAX_DRAWCOMMAND_TEXTURES = 64;
+
+struct DrawCommand {
+	GLIndirectBuffer::GLIndirectCommand cmd;
+	uint materialsSSBOOffset = 0;
+	uint textureCount = 0;
+	Texture* textures[MAX_DRAWCOMMAND_TEXTURES];
+
+	DrawCommand() {
+	}
+
+	DrawCommand( const DrawCommand& other ) {
+		cmd = other.cmd;
+		materialsSSBOOffset = other.materialsSSBOOffset;
+		textureCount = other.textureCount;
+		memcpy( textures, other.textures, textureCount * sizeof( Texture* ) );
+	}
+};
+
+struct Material {
+	uint materialsSSBOOffset = 0;
+	uint staticMaterialsSSBOOffset = 0;
+	uint dynamicMaterialsSSBOOffset = 0;
+	uint totalDrawSurfCount = 0;
+	uint totalStaticDrawSurfCount = 0;
+	uint totalDynamicDrawSurfCount = 0;
+	uint currentDrawSurfCount = 0;
+	uint currentStaticDrawSurfCount = 0;
+	uint currentDynamicDrawSurfCount = 0;
+
+	uint staticCommandOffset = 0;
+
+	uint id = 0;
+	bool useSync = false;
+	uint syncMaterial = 0; // Must not be drawn before the material with this id
+
+	uint32_t stateBits = 0;
+	stageType_t stageType;
+	GLuint program = 0;
+	GLShader* shader;
+
+	int deformIndex;
+	bool vertexAnimation;
+	bool tcGenEnvironment;
+	bool tcGen_Lightmap;
+	bool hasDepthFade;
+	bool vboVertexSprite;
+	bool alphaTest;
+
+	bool bspSurface;
+	bool enableDeluxeMapping;
+	bool enableGridLighting;
+	bool enableGridDeluxeMapping;
+	bool hasHeightMapInNormalMap;
+	bool enableReliefMapping;
+	bool enableNormalMapping;
+	bool enablePhysicalMapping;
+
+	cullType_t cullType;
+
+	bool usePolygonOffset = false;
+
+	VBO_t* vbo;
+	IBO_t* ibo;
+
+	std::vector<drawSurf_t*> drawSurfs;
+	std::vector<DrawCommand> drawCommands;
+	bool texturesResident = false;
+	std::vector<Texture*> textures;
+
+	bool operator==( const Material& other ) {
+		return program == other.program && stateBits == other.stateBits && vbo == other.vbo && ibo == other.ibo
+			&& stateBits == other.stateBits && cullType == other.cullType && usePolygonOffset == other.usePolygonOffset;
+	}
+
+	void AddTexture( Texture* texture ) {
+		if ( !texture->hasBindlessHandle ) {
+			texture->GenBindlessHandle();
+		}
+
+		if ( std::find( textures.begin(), textures.end(), texture ) == textures.end() ) {
+			textures.emplace_back( texture );
+		}
+	}
+};
+
+struct drawSurfBoundingSphere {
+	vec3_t origin;
+	float radius;
+
+	uint drawSurfID;
+};
+
+class MaterialSystem {
+	public:
+	bool generatedWorldCommandBuffer = false;
+	bool skipDrawCommands;
+	bool skipSurface;
+	bool generatingWorldCommandBuffer = false;
+	vec3_t worldViewBounds[2] = {};
+
+	std::vector<drawSurf_t*> portalSurfacesTmp;
+	std::vector<drawSurf_t> portalSurfaces;
+	std::vector<drawSurfBoundingSphere> portalBounds;
+	std::vector<shader_t*> skyShaders;
+
+	std::vector<Material*> renderedMaterials;
+
+	struct MaterialPack {
+		const shaderSort_t fromSort;
+		const shaderSort_t toSort;
+		std::vector<Material> materials;
+		
+		MaterialPack( const shaderSort_t newFromSort, const shaderSort_t newToSort ) :
+		fromSort( newFromSort ),
+		toSort( newToSort ) {
+		}
+	};
+
+	MaterialPack materialPacks[3]{
+		{ shaderSort_t::SS_DEPTH, shaderSort_t::SS_DEPTH },
+		{ shaderSort_t::SS_ENVIRONMENT_FOG, shaderSort_t::SS_OPAQUE },
+		{ shaderSort_t::SS_ENVIRONMENT_NOFOG, shaderSort_t::SS_POST_PROCESS }
+	};
+
+	bool frameStart = true;
+
+	void AddTexture( Texture* texture );
+	void AddDrawCommand( const uint materialID, const uint materialPackID, const uint materialsSSBOOffset,
+						 const GLuint count, const GLuint firstIndex );
+
+	void AddPortalSurfaces();
+	void RenderMaterials( const shaderSort_t fromSort, const shaderSort_t toSort );
+	void UpdateDynamicSurfaces();
+
+	void AddStageTextures( drawSurf_t* drawSurf, shaderStage_t* pStage, Material* material );
+	void GenerateWorldMaterials();
+	void GenerateWorldMaterialsBuffer();
+	void GenerateWorldCommandBuffer();
+	void GeneratePortalBoundingSpheres();
+
+	void AddAllWorldSurfaces();
+
+	void Free();
+
+	private:
+	DrawCommand cmd;
+	std::vector<drawSurf_t> dynamicDrawSurfs;
+	uint dynamicDrawSurfsOffset = 0;
+	uint dynamicDrawSurfsSize = 0;
+
+	void RenderMaterial( Material& material );
+};
+
+extern GLSSBO materialsSSBO;
+extern GLIndirectBuffer commandBuffer;
+extern MaterialSystem materialSystem;
+
+#endif // MATERIAL_H

--- a/src/engine/renderer/TextureManager.cpp
+++ b/src/engine/renderer/TextureManager.cpp
@@ -45,14 +45,6 @@ Texture::~Texture() {
 	}
 }
 
-void Texture::UpdateAdjustedPriority( const int totalFrameTextureBinds, const int totalTextureBinds ) {
-	if ( totalFrameTextureBinds == 0 || totalTextureBinds == 0 ) {
-		return;
-	}
-
-	adjustedPriority = basePriority + frameBindCounter / totalFrameTextureBinds * 0.5 + totalBindCounter / totalTextureBinds * 1.5;
-}
-
 bool Texture::IsResident() const {
 	return bindlessTextureResident;
 }
@@ -77,128 +69,46 @@ void Texture::GenBindlessHandle() {
 	hasBindlessHandle = true;
 }
 
-// TextureManager textureManager;
-
-TextureManager::TextureManager() {
-	textureUnits.reserve( glConfig2.maxTextureUnits );
-}
-
+TextureManager::TextureManager() = default;
 TextureManager::~TextureManager() = default;
 
-void TextureManager::UpdateAdjustedPriorities() {
-	for ( Texture* texture : textures ) {
-		texture->UpdateAdjustedPriority( totalFrameTextureBinds, totalTextureBinds );
-	}
-	// std::sort( textures.begin(), textures.end(), Texture::Compare() );
-
-	totalFrameTextureBinds = 0;
-}
-
-void TextureManager::BindTexture( const GLint location, Texture *texture ) {
-	texture->frameBindCounter++;
-	texture->totalBindCounter++;
-	
-	totalFrameTextureBinds++;
-	totalTextureBinds++;
-
+GLuint64 TextureManager::BindTexture( const GLint location, Texture *texture ) {
 	if( location == -1 ) {
-		return;
+		return 0;
 	}
 
 	if ( texture->IsResident() ) {
-		glUniformHandleui64ARB( location, texture->bindlessTextureHandle );
-		return;
+		return texture->bindlessTextureHandle;
 	}
 
 	if( std::find( textures.begin(), textures.end(), texture ) == textures.end() ) {
 		textures.push_back( texture );
 	}
 
-	// Use bindless textures if possible
-	if ( glConfig2.bindlessTexturesAvailable ) {
-		// Bindless textures make the texture state immutable, so generate the handle as late as possible
-		if ( !texture->hasBindlessHandle ) {
-			texture->GenBindlessHandle();
-		}
-
-		texture->MakeResident();
-
-		// Make lowest priority textures non-resident first
-		int i = textures.size() - 1;
-		while ( !glIsTextureHandleResidentARB( texture->bindlessTextureHandle ) ) {
-			if ( i < 0 ) {
-				Sys::Drop( "No texture space available" );
-			}
-
-			if ( textures[i]->IsResident() ) {
-				textures[i]->MakeNonResident();
-				texture->MakeResident();
-			}
-			i--;
-		}
-
-		glUniformHandleui64ARB( location, texture->bindlessTextureHandle );
-
-		GL_CheckErrors();
-
-		return;
+	// Bindless textures make the texture state immutable, so generate the handle as late as possible
+	if ( !texture->hasBindlessHandle ) {
+		texture->GenBindlessHandle();
 	}
 
-	int lowestPriorityTexture = 1;
-	float lowestPriority = 100000.0f;
-	GLint handle;
+	texture->MakeResident();
 
-	// Do a loop once so we don't have to search through it many times for each case
-	for ( size_t i = 0; i < textureUnits.size(); i++ ) {
-		// Already bound
-		if ( textureUnits[i] == texture ) {
-			glUniform1i( location, i + 1 );
-			if ( textureSequenceStarted ) {
-				textureSequence.insert( texture );
-			}
-			return;
+	// Make lowest priority textures non-resident first
+	int i = textures.size() - 1;
+	while ( !glIsTextureHandleResidentARB( texture->bindlessTextureHandle ) ) {
+		if ( i < 0 ) {
+			Sys::Drop( "No texture space available" );
 		}
 
-		if ( textureSequenceStarted && textureSequence.find( textureUnits[i] ) != textureSequence.end() ) {
-			continue;
+		if ( textures[i]->IsResident() ) {
+			textures[i]->MakeNonResident();
+			texture->MakeResident();
 		}
-
-		// Take note of the texture unit with the lowest priority texture
-		if ( textureUnits[i] && textureUnits[i]->adjustedPriority < lowestPriority ) {
-			lowestPriorityTexture = i;
-			lowestPriority = textureUnits[i]->adjustedPriority;
-		}
-	}
-
-	// Slot 0 is reserved for non-rendering OpenGL calls that require textures to be bound
-	if ( textureUnits.size() + 1 < (size_t) glConfig2.maxTextureUnits ) {
-		textureUnits.push_back( texture );
-		glActiveTexture( GL_TEXTURE1 + textureUnits.size() - 1 );
-		handle = textureUnits.size() - 1;
-	}
-	else {
-		// No available texture units
-		// Bind instead of the lowest priority texture
-		textureUnits[lowestPriorityTexture] = texture;
-		glActiveTexture( GL_TEXTURE1 + lowestPriorityTexture );
-		handle = lowestPriorityTexture;
-	}
-
-	glBindTexture( texture->target, texture->textureHandle );
-	glUniform1i( location, handle + 1 );
-	if ( textureSequenceStarted ) {
-		textureSequence.insert( texture );
+		i--;
 	}
 
 	GL_CheckErrors();
-}
 
-void TextureManager::AllNonResident() {
-	for ( Texture* texture : textures ) {
-		if ( texture->IsResident() ) {
-			texture->MakeNonResident();
-		}
-	}
+	return texture->bindlessTextureHandle;
 }
 
 void TextureManager::BindReservedTexture( const GLenum target, const GLuint handle ) {
@@ -206,20 +116,6 @@ void TextureManager::BindReservedTexture( const GLenum target, const GLuint hand
 	glBindTexture( target, handle );
 }
 
-// Texture units used within a texture sequence will not be bound to anything else until the texture sequence ends
-void TextureManager::StartTextureSequence() {
-	textureSequenceStarted = true;
-}
-
-void TextureManager::EndTextureSequence() {
-	textureSequenceStarted = false;
-	/* for ( const Texture* texture : textureSequence ) {
-		const_cast< Texture* >( texture )->MakeNonResident();
-	} */
-	textureSequence.clear();
-}
-
 void TextureManager::FreeTextures() {
 	textures.clear();
-	textureUnits.clear();
 }

--- a/src/engine/renderer/TextureManager.cpp
+++ b/src/engine/renderer/TextureManager.cpp
@@ -1,0 +1,225 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// TextureManager.cpp
+
+#include "TextureManager.h"
+#include "tr_local.h"
+
+Texture::Texture() {
+}
+
+Texture::~Texture() {
+	if ( bindlessTextureResident ) {
+		MakeNonResident();
+	}
+}
+
+void Texture::UpdateAdjustedPriority( const int totalFrameTextureBinds, const int totalTextureBinds ) {
+	if ( totalFrameTextureBinds == 0 || totalTextureBinds == 0 ) {
+		return;
+	}
+
+	adjustedPriority = basePriority + frameBindCounter / totalFrameTextureBinds * 0.5 + totalBindCounter / totalTextureBinds * 1.5;
+}
+
+bool Texture::IsResident() const {
+	return bindlessTextureResident;
+}
+
+void Texture::MakeResident() {
+	glMakeTextureHandleResidentARB( bindlessTextureHandle );
+	bindlessTextureResident = true;
+}
+
+void Texture::MakeNonResident() {
+	glMakeTextureHandleNonResidentARB( bindlessTextureHandle );
+	bindlessTextureResident = false;
+}
+
+void Texture::GenBindlessHandle() {
+	bindlessTextureHandle = glGetTextureHandleARB( textureHandle );
+
+	if ( bindlessTextureHandle == 0 ) {
+		Sys::Drop( "Failed to generate bindless texture handle" );
+	}
+
+	hasBindlessHandle = true;
+}
+
+// TextureManager textureManager;
+
+TextureManager::TextureManager() {
+	textureUnits.reserve( glConfig2.maxTextureUnits );
+}
+
+TextureManager::~TextureManager() = default;
+
+void TextureManager::UpdateAdjustedPriorities() {
+	for ( Texture* texture : textures ) {
+		texture->UpdateAdjustedPriority( totalFrameTextureBinds, totalTextureBinds );
+	}
+	// std::sort( textures.begin(), textures.end(), Texture::Compare() );
+
+	totalFrameTextureBinds = 0;
+}
+
+void TextureManager::BindTexture( const GLint location, Texture *texture ) {
+	texture->frameBindCounter++;
+	texture->totalBindCounter++;
+	
+	totalFrameTextureBinds++;
+	totalTextureBinds++;
+
+	if( location == -1 ) {
+		return;
+	}
+
+	if ( texture->IsResident() ) {
+		glUniformHandleui64ARB( location, texture->bindlessTextureHandle );
+		return;
+	}
+
+	if( std::find( textures.begin(), textures.end(), texture ) == textures.end() ) {
+		textures.push_back( texture );
+	}
+
+	// Use bindless textures if possible
+	if ( glConfig2.bindlessTexturesAvailable ) {
+		// Bindless textures make the texture state immutable, so generate the handle as late as possible
+		if ( !texture->hasBindlessHandle ) {
+			texture->GenBindlessHandle();
+		}
+
+		texture->MakeResident();
+
+		// Make lowest priority textures non-resident first
+		int i = textures.size() - 1;
+		while ( !glIsTextureHandleResidentARB( texture->bindlessTextureHandle ) ) {
+			if ( i < 0 ) {
+				Sys::Drop( "No texture space available" );
+			}
+
+			if ( textures[i]->IsResident() ) {
+				textures[i]->MakeNonResident();
+				texture->MakeResident();
+			}
+			i--;
+		}
+
+		glUniformHandleui64ARB( location, texture->bindlessTextureHandle );
+
+		GL_CheckErrors();
+
+		return;
+	}
+
+	int lowestPriorityTexture = 1;
+	float lowestPriority = 100000.0f;
+	GLint handle;
+
+	// Do a loop once so we don't have to search through it many times for each case
+	for ( size_t i = 0; i < textureUnits.size(); i++ ) {
+		// Already bound
+		if ( textureUnits[i] == texture ) {
+			glUniform1i( location, i + 1 );
+			if ( textureSequenceStarted ) {
+				textureSequence.insert( texture );
+			}
+			return;
+		}
+
+		if ( textureSequenceStarted && textureSequence.find( textureUnits[i] ) != textureSequence.end() ) {
+			continue;
+		}
+
+		// Take note of the texture unit with the lowest priority texture
+		if ( textureUnits[i] && textureUnits[i]->adjustedPriority < lowestPriority ) {
+			lowestPriorityTexture = i;
+			lowestPriority = textureUnits[i]->adjustedPriority;
+		}
+	}
+
+	// Slot 0 is reserved for non-rendering OpenGL calls that require textures to be bound
+	if ( textureUnits.size() + 1 < (size_t) glConfig2.maxTextureUnits ) {
+		textureUnits.push_back( texture );
+		glActiveTexture( GL_TEXTURE1 + textureUnits.size() - 1 );
+		handle = textureUnits.size() - 1;
+	}
+	else {
+		// No available texture units
+		// Bind instead of the lowest priority texture
+		textureUnits[lowestPriorityTexture] = texture;
+		glActiveTexture( GL_TEXTURE1 + lowestPriorityTexture );
+		handle = lowestPriorityTexture;
+	}
+
+	glBindTexture( texture->target, texture->textureHandle );
+	glUniform1i( location, handle + 1 );
+	if ( textureSequenceStarted ) {
+		textureSequence.insert( texture );
+	}
+
+	GL_CheckErrors();
+}
+
+void TextureManager::AllNonResident() {
+	for ( Texture* texture : textures ) {
+		if ( texture->IsResident() ) {
+			texture->MakeNonResident();
+		}
+	}
+}
+
+void TextureManager::BindReservedTexture( const GLenum target, const GLuint handle ) {
+	glActiveTexture( GL_TEXTURE0 );
+	glBindTexture( target, handle );
+}
+
+// Texture units used within a texture sequence will not be bound to anything else until the texture sequence ends
+void TextureManager::StartTextureSequence() {
+	textureSequenceStarted = true;
+}
+
+void TextureManager::EndTextureSequence() {
+	textureSequenceStarted = false;
+	/* for ( const Texture* texture : textureSequence ) {
+		const_cast< Texture* >( texture )->MakeNonResident();
+	} */
+	textureSequence.clear();
+}
+
+void TextureManager::FreeTextures() {
+	textures.clear();
+	textureUnits.clear();
+}

--- a/src/engine/renderer/TextureManager.h
+++ b/src/engine/renderer/TextureManager.h
@@ -37,15 +37,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define TEXTURE_MANAGER_H
 
 #include <vector>
-#include <unordered_set>
 #include "GL/glew.h"
-
-enum {
-	TEXTURE_PRIORITY_LOW = 0,
-	TEXTURE_PRIORITY_MEDIUM = 1,
-	TEXTURE_PRIORITY_HIGH = 2,
-	TEXTURE_PRIORITY_PERSISTENT = 5,
-};
 
 class Texture {
 	public:
@@ -53,33 +45,16 @@ class Texture {
 	GLuint64 bindlessTextureHandle = 0;
 	bool hasBindlessHandle = false;
 
-	int frameBindCounter = 0;
-	int totalBindCounter = 0;
-
 	GLenum target = GL_TEXTURE_2D;
-
-	int basePriority = 0;
-	float adjustedPriority = 0.0f;
 
 	Texture();
 	~Texture();
-
-	void UpdateAdjustedPriority( const int totalFrameTextureBinds, const int totalTextureBinds );
 
 	bool IsResident() const;
 	void MakeResident();
 	void MakeNonResident();
 
-	void GenBindlessHandle();
-
-	struct Compare {
-		bool operator() ( const Texture* lhs, const Texture* rhs ) {
-			if ( lhs->adjustedPriority != rhs->adjustedPriority ) {
-				return lhs->adjustedPriority > rhs->adjustedPriority;
-			}
-			return lhs->adjustedPriority < rhs->adjustedPriority;
-		}
-	};
+	void GenBindlessHandle();;
 
 	private:
 		bool bindlessTextureResident = false;
@@ -90,26 +65,12 @@ class TextureManager {
 	TextureManager();
 	~TextureManager();
 
-	void UpdateAdjustedPriorities();
-
-	void BindTexture( const GLint location, Texture* texture );
-	void AllNonResident();
+	GLuint64 BindTexture( const GLint location, Texture* texture );
 	void BindReservedTexture( const GLenum target, const GLuint handle );
-	void StartTextureSequence();
-	void EndTextureSequence();
 	void FreeTextures();
 
 	private:
-		std::vector<const Texture*> textureUnits;
 		std::vector<Texture*> textures;
-		std::unordered_set<const Texture*> textureSequence;
-
-		bool textureSequenceStarted;
-
-		int totalFrameTextureBinds;
-		int totalTextureBinds;
 };
 
-// extern TextureManager textureManager;
-
-#endif
+#endif // TEXTURE_MANAGER_H

--- a/src/engine/renderer/TextureManager.h
+++ b/src/engine/renderer/TextureManager.h
@@ -1,0 +1,115 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// TextureManager.h
+
+#ifndef TEXTURE_MANAGER_H
+#define TEXTURE_MANAGER_H
+
+#include <vector>
+#include <unordered_set>
+#include "GL/glew.h"
+
+enum {
+	TEXTURE_PRIORITY_LOW = 0,
+	TEXTURE_PRIORITY_MEDIUM = 1,
+	TEXTURE_PRIORITY_HIGH = 2,
+	TEXTURE_PRIORITY_PERSISTENT = 5,
+};
+
+class Texture {
+	public:
+	GLuint textureHandle = 0;
+	GLuint64 bindlessTextureHandle = 0;
+	bool hasBindlessHandle = false;
+
+	int frameBindCounter = 0;
+	int totalBindCounter = 0;
+
+	GLenum target = GL_TEXTURE_2D;
+
+	int basePriority = 0;
+	float adjustedPriority = 0.0f;
+
+	Texture();
+	~Texture();
+
+	void UpdateAdjustedPriority( const int totalFrameTextureBinds, const int totalTextureBinds );
+
+	bool IsResident() const;
+	void MakeResident();
+	void MakeNonResident();
+
+	void GenBindlessHandle();
+
+	struct Compare {
+		bool operator() ( const Texture* lhs, const Texture* rhs ) {
+			if ( lhs->adjustedPriority != rhs->adjustedPriority ) {
+				return lhs->adjustedPriority > rhs->adjustedPriority;
+			}
+			return lhs->adjustedPriority < rhs->adjustedPriority;
+		}
+	};
+
+	private:
+		bool bindlessTextureResident = false;
+};
+
+class TextureManager {
+	public:
+	TextureManager();
+	~TextureManager();
+
+	void UpdateAdjustedPriorities();
+
+	void BindTexture( const GLint location, Texture* texture );
+	void AllNonResident();
+	void BindReservedTexture( const GLenum target, const GLuint handle );
+	void StartTextureSequence();
+	void EndTextureSequence();
+	void FreeTextures();
+
+	private:
+		std::vector<const Texture*> textureUnits;
+		std::vector<Texture*> textures;
+		std::unordered_set<const Texture*> textureSequence;
+
+		bool textureSequenceStarted;
+
+		int totalFrameTextureBinds;
+		int totalTextureBinds;
+};
+
+// extern TextureManager textureManager;
+
+#endif

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -211,6 +211,8 @@ public:
 		return _compileMacros.size();
 	}
 
+	GLint GetUniformLocation( const GLchar *uniformName ) const;
+
 	shaderProgram_t        *GetProgram() const
 	{
 		return _currentProgram;
@@ -367,6 +369,11 @@ public:
 		return _name.c_str();
 	}
 
+	GLint GetLocation() const {
+		shaderProgram_t* program = _shader->GetProgram();
+		return program->uniformLocations[_locationIndex];
+	}
+
 	void UpdateShaderProgramUniformLocation( shaderProgram_t *shaderProgram )
 	{
 		shaderProgram->uniformLocations[ _locationIndex ] = glGetUniformLocation( shaderProgram->program, GetName() );
@@ -375,6 +382,26 @@ public:
 	virtual size_t GetSize()
 	{
 		return 0;
+	}
+};
+
+class GLUniformSampler : protected GLUniform {
+	protected:
+	GLUniformSampler( GLShader* shader, const char* name ) :
+		GLUniform( shader, name ) {
+	}
+
+	inline GLint GetLocation() {
+		shaderProgram_t* p = _shader->GetProgram();
+
+		ASSERT_EQ( p, glState.currentProgram );
+
+		return p->uniformLocations[_locationIndex];
+	}
+
+	public:
+	size_t GetSize() override {
+		return sizeof( GLuint64 );
 	}
 };
 
@@ -1301,6 +1328,402 @@ public:
 	void SetAlphaTesting(bool enable)
 	{
 		SetMacro( enable );
+	}
+};
+
+class u_ColorMap :
+	GLUniformSampler {
+	public:
+	u_ColorMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ColorMap" ) {
+	}
+
+	GLint GetUniformLocation_ColorMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_DepthMap :
+	GLUniformSampler {
+	public:
+	u_DepthMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_DepthMap" ) {
+	}
+
+	GLint GetUniformLocation_DepthMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_DiffuseMap :
+	GLUniformSampler {
+	public:
+	u_DiffuseMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_DiffuseMap" ) {
+	}
+
+	GLint GetUniformLocation_DiffuseMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_HeightMap :
+	GLUniformSampler {
+	public:
+	u_HeightMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_HeightMap" ) {
+	}
+
+	GLint GetUniformLocation_HeightMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_NormalMap :
+	GLUniformSampler {
+	public:
+	u_NormalMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_NormalMap" ) {
+	}
+
+	GLint GetUniformLocation_NormalMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_MaterialMap :
+	GLUniformSampler {
+	public:
+	u_MaterialMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_MaterialMap" ) {
+	}
+
+	GLint GetUniformLocation_MaterialMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_LightMap :
+	GLUniformSampler {
+	public:
+	u_LightMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_LightMap" ) {
+	}
+
+	GLint GetUniformLocation_LightMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_DeluxeMap :
+	GLUniformSampler {
+	public:
+	u_DeluxeMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_DeluxeMap" ) {
+	}
+
+	GLint GetUniformLocation_DeluxeMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_GlowMap :
+	GLUniformSampler {
+	public:
+	u_GlowMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_GlowMap" ) {
+	}
+
+	GLint GetUniformLocation_GlowMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_RandomMap :
+	GLUniformSampler {
+	public:
+	u_RandomMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_RandomMap" ) {
+	}
+
+	GLint GetUniformLocation_RandomMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_PortalMap :
+	GLUniformSampler {
+	public:
+	u_PortalMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_PortalMap" ) {
+	}
+
+	GLint GetUniformLocation_PortalMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_CloudMap :
+	GLUniformSampler {
+	public:
+	u_CloudMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_CloudMap" ) {
+	}
+
+	GLint GetUniformLocation_CloudMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_LightsTexture :
+	GLUniformSampler {
+	public:
+	u_LightsTexture( GLShader* shader ) :
+		GLUniformSampler( shader, "u_Lights" ) {
+	}
+
+	GLint GetUniformLocation_LightsTexture() {
+		return this->GetLocation();
+	}
+};
+
+class u_LightTiles :
+	GLUniformSampler {
+	public:
+	u_LightTiles( GLShader* shader ) :
+		GLUniformSampler( shader, "u_LightTiles" ) {
+	}
+
+	GLint GetUniformLocation_LightTiles() {
+		return this->GetLocation();
+	}
+};
+
+class u_LightGrid1 :
+	GLUniformSampler {
+	public:
+	u_LightGrid1( GLShader* shader ) :
+		GLUniformSampler( shader, "u_LightGrid1" ) {
+	}
+
+	GLint GetUniformLocation_LightGrid1() {
+		return this->GetLocation();
+	}
+};
+
+class u_LightGrid2 :
+	GLUniformSampler {
+	public:
+	u_LightGrid2( GLShader* shader ) :
+		GLUniformSampler( shader, "u_LightGrid2" ) {
+	}
+
+	GLint GetUniformLocation_LightGrid2() {
+		return this->GetLocation();
+	}
+};
+
+class u_EnvironmentMap0 :
+	GLUniformSampler {
+	public:
+	u_EnvironmentMap0( GLShader* shader ) :
+		GLUniformSampler( shader, "u_EnvironmentMap0" ) {
+	}
+
+	GLint GetUniformLocation_EnvironmentMap0() {
+		return this->GetLocation();
+	}
+};
+
+class u_EnvironmentMap1 :
+	GLUniformSampler {
+	public:
+	u_EnvironmentMap1( GLShader* shader ) :
+		GLUniformSampler( shader, "u_EnvironmentMap1" ) {
+	}
+
+	GLint GetUniformLocation_EnvironmentMap1() {
+		return this->GetLocation();
+	}
+};
+
+class u_CurrentMap :
+	GLUniformSampler {
+	public:
+	u_CurrentMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_CurrentMap" ) {
+	}
+
+	GLint GetUniformLocation_CurrentMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_AttenuationMapXY :
+	GLUniformSampler {
+	public:
+	u_AttenuationMapXY( GLShader* shader ) :
+		GLUniformSampler( shader, "u_AttenuationMapXY" ) {
+	}
+
+	GLint GetUniformLocation_AttenuationMapXY() {
+		return this->GetLocation();
+	}
+};
+
+class u_AttenuationMapZ :
+	GLUniformSampler {
+	public:
+	u_AttenuationMapZ( GLShader* shader ) :
+		GLUniformSampler( shader, "u_AttenuationMapZ" ) {
+	}
+
+	GLint GetUniformLocation_AttenuationMapZ() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowMap :
+	GLUniformSampler {
+	public:
+	u_ShadowMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowMap" ) {
+	}
+
+	GLint GetUniformLocation_ShadowMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowMap0 :
+	GLUniformSampler {
+	public:
+	u_ShadowMap0( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowMap0" ) {
+	}
+
+	GLint GetUniformLocation_ShadowMap0() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowMap1 :
+	GLUniformSampler {
+	public:
+	u_ShadowMap1( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowMap1" ) {
+	}
+
+	GLint GetUniformLocation_ShadowMap1() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowMap2 :
+	GLUniformSampler {
+	public:
+	u_ShadowMap2( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowMap2" ) {
+	}
+
+	GLint GetUniformLocation_ShadowMap2() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowMap3 :
+	GLUniformSampler {
+	public:
+	u_ShadowMap3( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowMap3" ) {
+	}
+
+	GLint GetUniformLocation_ShadowMap3() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowMap4 :
+	GLUniformSampler {
+	public:
+	u_ShadowMap4( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowMap4" ) {
+	}
+
+	GLint GetUniformLocation_ShadowMap4() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowClipMap :
+	GLUniformSampler {
+	public:
+	u_ShadowClipMap( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowClipMap" ) {
+	}
+
+	GLint GetUniformLocation_ShadowClipMap() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowClipMap0 :
+	GLUniformSampler {
+	public:
+	u_ShadowClipMap0( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowClipMap0" ) {
+	}
+
+	GLint GetUniformLocation_ShadowClipMap0() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowClipMap1 :
+	GLUniformSampler {
+	public:
+	u_ShadowClipMap1( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowClipMap1" ) {
+	}
+
+	GLint GetUniformLocation_ShadowClipMap1() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowClipMap2 :
+	GLUniformSampler {
+	public:
+	u_ShadowClipMap2( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowClipMap2" ) {
+	}
+
+	GLint GetUniformLocation_ShadowClipMap2() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowClipMap3 :
+	GLUniformSampler {
+	public:
+	u_ShadowClipMap3( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowClipMap3" ) {
+	}
+
+	GLint GetUniformLocation_ShadowClipMap3() {
+		return this->GetLocation();
+	}
+};
+
+class u_ShadowClipMap4 :
+	GLUniformSampler {
+	public:
+	u_ShadowClipMap4( GLShader* shader ) :
+		GLUniformSampler( shader, "u_ShadowClipMap4" ) {
+	}
+
+	GLint GetUniformLocation_ShadowClipMap4() {
+		return this->GetLocation();
 	}
 };
 
@@ -2243,6 +2666,9 @@ class u_Lights :
 // TODO: Write a more minimal 2D rendering shader.
 class GLShader_generic2D :
 	public GLShader,
+	public u_ColorMap,
+	public u_DepthMap,
+	public u_EnvironmentMap1,
 	public u_TextureMatrix,
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
@@ -2263,6 +2689,9 @@ public:
 
 class GLShader_generic :
 	public GLShader,
+	public u_ColorMap,
+	public u_DepthMap,
+	public u_EnvironmentMap1,
 	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_ViewUp,
@@ -2292,6 +2721,17 @@ public:
 
 class GLShader_lightMapping :
 	public GLShader,
+	public u_DiffuseMap,
+	public u_NormalMap,
+	public u_HeightMap,
+	public u_MaterialMap,
+	public u_LightMap,
+	public u_DeluxeMap,
+	public u_GlowMap,
+	public u_EnvironmentMap0,
+	public u_EnvironmentMap1,
+	public u_LightTiles,
+	public u_LightsTexture,
 	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_ColorModulate,
@@ -2332,6 +2772,15 @@ public:
 
 class GLShader_forwardLighting_omniXYZ :
 	public GLShader,
+	public u_DiffuseMap,
+	public u_NormalMap,
+	public u_MaterialMap,
+	public u_AttenuationMapXY,
+	public u_AttenuationMapZ,
+	public u_ShadowMap,
+	public u_ShadowClipMap,
+	public u_RandomMap,
+	public u_HeightMap,
 	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_AlphaThreshold,
@@ -2369,6 +2818,15 @@ public:
 
 class GLShader_forwardLighting_projXYZ :
 	public GLShader,
+	public u_DiffuseMap,
+	public u_NormalMap,
+	public u_MaterialMap,
+	public u_AttenuationMapXY,
+	public u_AttenuationMapZ,
+	public u_ShadowMap0,
+	public u_ShadowClipMap0,
+	public u_RandomMap,
+	public u_HeightMap,
 	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_AlphaThreshold,
@@ -2407,6 +2865,20 @@ public:
 
 class GLShader_forwardLighting_directionalSun :
 	public GLShader,
+	public u_DiffuseMap,
+	public u_NormalMap,
+	public u_MaterialMap,
+	public u_ShadowMap0,
+	public u_ShadowMap1,
+	public u_ShadowMap2,
+	public u_ShadowMap3,
+	public u_ShadowMap4,
+	public u_ShadowClipMap0,
+	public u_ShadowClipMap1,
+	public u_ShadowClipMap2,
+	public u_ShadowClipMap3,
+	public u_ShadowClipMap4,
+	public u_HeightMap,
 	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_AlphaThreshold,
@@ -2447,6 +2919,7 @@ public:
 
 class GLShader_shadowFill :
 	public GLShader,
+	public u_ColorMap,
 	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_AlphaThreshold,
@@ -2470,6 +2943,9 @@ public:
 
 class GLShader_reflection :
 	public GLShader,
+	public u_ColorMap,
+	public u_NormalMap,
+	public u_HeightMap,
 	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_ModelMatrix,
@@ -2495,6 +2971,8 @@ public:
 
 class GLShader_skybox :
 	public GLShader,
+	public u_ColorMap,
+	public u_CloudMap,
 	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_CloudHeight,
@@ -2513,6 +2991,7 @@ public:
 
 class GLShader_fogQuake3 :
 	public GLShader,
+	public u_ColorMap,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
 	public u_Color,
@@ -2533,6 +3012,8 @@ public:
 
 class GLShader_fogGlobal :
 	public GLShader,
+	public u_ColorMap,
+	public u_DepthMap,
 	public u_ViewOrigin,
 	public u_ViewMatrix,
 	public u_ModelViewProjectionMatrix,
@@ -2548,6 +3029,9 @@ public:
 
 class GLShader_heatHaze :
 	public GLShader,
+	public u_CurrentMap,
+	public u_NormalMap,
+	public u_HeightMap,
 	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_ViewUp,
@@ -2575,6 +3059,7 @@ public:
 
 class GLShader_screen :
 	public GLShader,
+	public u_CurrentMap,
 	public u_ModelViewProjectionMatrix
 {
 public:
@@ -2584,6 +3069,7 @@ public:
 
 class GLShader_portal :
 	public GLShader,
+	public u_CurrentMap,
 	public u_ModelViewMatrix,
 	public u_ModelViewProjectionMatrix,
 	public u_PortalRange
@@ -2595,6 +3081,7 @@ public:
 
 class GLShader_contrast :
 	public GLShader,
+	public u_ColorMap,
 	public u_ModelViewProjectionMatrix
 {
 public:
@@ -2604,6 +3091,8 @@ public:
 
 class GLShader_cameraEffects :
 	public GLShader,
+	public u_ColorMap,
+	public u_CurrentMap,
 	public u_ColorModulate,
 	public u_TextureMatrix,
 	public u_ModelViewProjectionMatrix,
@@ -2617,6 +3106,7 @@ public:
 
 class GLShader_blurX :
 	public GLShader,
+	public u_ColorMap,
 	public u_ModelViewProjectionMatrix,
 	public u_DeformMagnitude,
 	public u_TexScale
@@ -2628,6 +3118,7 @@ public:
 
 class GLShader_blurY :
 	public GLShader,
+	public u_ColorMap,
 	public u_ModelViewProjectionMatrix,
 	public u_DeformMagnitude,
 	public u_TexScale
@@ -2639,6 +3130,7 @@ public:
 
 class GLShader_debugShadowMap :
 	public GLShader,
+	public u_CurrentMap,
 	public u_ModelViewProjectionMatrix
 {
 public:
@@ -2648,6 +3140,13 @@ public:
 
 class GLShader_liquid :
 	public GLShader,
+	public u_CurrentMap,
+	public u_DepthMap,
+	public u_NormalMap,
+	public u_PortalMap,
+	public u_LightGrid1,
+	public u_LightGrid2,
+	public u_HeightMap,
 	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_RefractionIndex,
@@ -2676,6 +3175,8 @@ public:
 
 class GLShader_motionblur :
 	public GLShader,
+	public u_ColorMap,
+	public u_DepthMap,
 	public u_blurVec
 {
 public:
@@ -2685,6 +3186,7 @@ public:
 
 class GLShader_ssao :
 	public GLShader,
+	public u_DepthMap,
 	public u_zFar
 {
 public:
@@ -2694,6 +3196,7 @@ public:
 
 class GLShader_depthtile1 :
 	public GLShader,
+	public u_DepthMap,
 	public u_zFar
 {
 public:
@@ -2702,7 +3205,8 @@ public:
 };
 
 class GLShader_depthtile2 :
-	public GLShader
+	public GLShader,
+	public u_DepthMap
 {
 public:
 	GLShader_depthtile2( GLShaderManager *manager );
@@ -2711,10 +3215,12 @@ public:
 
 class GLShader_lighttile :
 	public GLShader,
-	public u_ModelMatrix,
+	public u_DepthMap,
+	public u_Lights,
+	public u_LightsTexture,
 	public u_numLights,
 	public u_lightLayer,
-	public u_Lights,
+	public u_ModelMatrix,
 	public u_zFar
 {
 public:
@@ -2723,7 +3229,8 @@ public:
 };
 
 class GLShader_fxaa :
-	public GLShader
+	public GLShader,
+	public u_ColorMap
 {
 public:
 	GLShader_fxaa( GLShaderManager *manager );

--- a/src/engine/renderer/tr_animation.cpp
+++ b/src/engine/renderer/tr_animation.cpp
@@ -74,7 +74,7 @@ static bool R_LoadMD5Anim( skelAnimation_t *skelAnim, const char *buffer, const 
 	md5Animation_t *anim;
 	md5Frame_t     *frame;
 	md5Channel_t   *channel;
-	char           *token;
+	const char *token;
 	int            version;
 	const char     *buf_p;
 

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -6377,7 +6377,7 @@ vertexHash_t *AddVertexToHashTable( vertexHash_t **hashTable, vec3_t xyz, void *
 	return vertexHash;
 }
 
-void GL_BindNearestCubeMap( const vec3_t xyz )
+void GL_BindNearestCubeMap( GLint location, const vec3_t xyz )
 {
 	float          distance, maxDistance;
 	cubemapProbe_t *cubeProbe;
@@ -6413,7 +6413,7 @@ void GL_BindNearestCubeMap( const vec3_t xyz )
 		}
 	}
 
-	GL_Bind( tr.autoCubeImage );
+	GL_BindToTMU( location, tr.autoCubeImage );
 }
 
 void R_FindTwoNearestCubeMaps( const vec3_t position, cubemapProbe_t **cubeProbeNearest, cubemapProbe_t **cubeProbeSecondNearest )

--- a/src/engine/renderer/tr_curve.cpp
+++ b/src/engine/renderer/tr_curve.cpp
@@ -422,21 +422,20 @@ static srfGridMesh_t *R_CreateSurfaceGridMesh( int width, int height,
 
 	if ( r_stitchCurves->integer )
 	{
-		grid = (srfGridMesh_t*)/*ri.Hunk_Alloc */ malloc( size );
-		memset( grid, 0, size );
+		grid = (srfGridMesh_t*)/*ri.Hunk_Alloc */ Z_Calloc( size );
 
-		grid->widthLodError = (float*)/*ri.Hunk_Alloc */ malloc( width * 4 );
+		grid->widthLodError = (float*)/*ri.Hunk_Alloc */ Z_AllocUninit( width * 4 );
 		memcpy( grid->widthLodError, errorTable[ 0 ], width * 4 );
 
-		grid->heightLodError = (float*)/*ri.Hunk_Alloc */ malloc( height * 4 );
+		grid->heightLodError = (float*)/*ri.Hunk_Alloc */ Z_AllocUninit( height * 4 );
 		memcpy( grid->heightLodError, errorTable[ 1 ], height * 4 );
 
 		grid->numTriangles = numTriangles;
-		grid->triangles = (srfTriangle_t*) malloc( grid->numTriangles * sizeof( srfTriangle_t ) );
+		grid->triangles = (srfTriangle_t*) Z_AllocUninit( grid->numTriangles * sizeof( srfTriangle_t ) );
 		memcpy( grid->triangles, triangles, numTriangles * sizeof( srfTriangle_t ) );
 
 		grid->numVerts = ( width * height );
-		grid->verts = (srfVert_t*) malloc( grid->numVerts * sizeof( srfVert_t ) );
+		grid->verts = (srfVert_t*) Z_AllocUninit( grid->numVerts * sizeof( srfVert_t ) );
 	}
 	else
 	{
@@ -491,11 +490,11 @@ R_FreeSurfaceGridMesh
 */
 void R_FreeSurfaceGridMesh( srfGridMesh_t *grid )
 {
-	free( grid->widthLodError );
-	free( grid->heightLodError );
-	free( grid->triangles );
-	free( grid->verts );
-	free( grid );
+	Z_Free( grid->widthLodError );
+	Z_Free( grid->heightLodError );
+	Z_Free( grid->triangles );
+	Z_Free( grid->verts );
+	Z_Free( grid );
 }
 
 static srfTriangle_t gridtriangles[ SHADER_MAX_TRIANGLES ];

--- a/src/engine/renderer/tr_font.cpp
+++ b/src/engine/renderer/tr_font.cpp
@@ -137,16 +137,14 @@ FT_Bitmap      *R_RenderGlyph( FT_GlyphSlot glyph, glyphInfo_t *glyphOut )
 	{
 		size = pitch * height;
 
-		bit2 = (FT_Bitmap*) ri.Z_Malloc( sizeof( FT_Bitmap ) );
+		bit2 = (FT_Bitmap*) Z_Malloc( sizeof( FT_Bitmap ) );
 
 		bit2->width = width;
 		bit2->rows = height;
 		bit2->pitch = pitch;
 		bit2->pixel_mode = ft_pixel_mode_grays;
-		bit2->buffer = (unsigned char*) ri.Z_Malloc( pitch * height );
+		bit2->buffer = (unsigned char*) Z_Calloc( size );
 		bit2->num_grays = 256;
-
-		memset( bit2->buffer, 0, size );
 
 		FT_Outline_Translate( &glyph->outline, -left, -bottom );
 
@@ -207,8 +205,8 @@ static glyphInfo_t *RE_ConstructGlyphInfo( unsigned char *imageOut, int *xOut, i
 
 		if ( calcHeight )
 		{
-			ri.Free( bitmap->buffer );
-			ri.Free( bitmap );
+			Z_Free( bitmap->buffer );
+			Z_Free( bitmap );
 			return &glyph;
 		}
 
@@ -225,8 +223,8 @@ static glyphInfo_t *RE_ConstructGlyphInfo( unsigned char *imageOut, int *xOut, i
 		if ( *yOut + *maxHeight + 1 >= ( FONT_SIZE - 1 ) )
 		{
 			*xOut = -1;
-			ri.Free( bitmap->buffer );
-			ri.Free( bitmap );
+			Z_Free( bitmap->buffer );
+			Z_Free( bitmap );
 			return nullptr;
 		}
 
@@ -292,8 +290,8 @@ static glyphInfo_t *RE_ConstructGlyphInfo( unsigned char *imageOut, int *xOut, i
 
 		*xOut += scaledWidth + 1;
 
-		ri.Free( bitmap->buffer );
-		ri.Free( bitmap );
+		Z_Free( bitmap->buffer );
+		Z_Free( bitmap );
 
 		return &glyph;
 	}
@@ -411,7 +409,7 @@ static void RE_StoreImage( fontInfo_t *font, int chunk, int page, int from, int 
 		max = 255 / max;
 	}
 
-	buffer = ( unsigned char * ) ri.Z_Malloc( scaledSize * 4 );
+	buffer = ( unsigned char * ) Z_AllocUninit( scaledSize * 4 );
 	for ( i = j = 0; i < scaledSize; i++ )
 	{
 		buffer[ j++ ] = 255;
@@ -425,7 +423,7 @@ static void RE_StoreImage( fontInfo_t *font, int chunk, int page, int from, int 
 
 	image = R_CreateGlyph( fileName, buffer, FONT_SIZE, y );
 
-	ri.Free( buffer );
+	Z_Free( buffer );
 
 	h = RE_RegisterShaderFromImage( fileName, image );
 
@@ -457,15 +455,7 @@ void RE_RenderChunk( fontInfo_t *font, const int chunk )
 		return;
 	}
 
-	out = (unsigned char*) ri.Z_Malloc( FONT_SIZE * FONT_SIZE );
-
-	if ( out == nullptr )
-	{
-		Log::Warn("RE_RenderChunk: ri.Malloc failure during output image creation." );
-		return;
-	}
-
-	memset( out, 0, FONT_SIZE * FONT_SIZE );
+	out = (unsigned char*) Z_Calloc( FONT_SIZE * FONT_SIZE );
 
 	// calculate max height
 	maxHeight = 0;
@@ -479,13 +469,12 @@ void RE_RenderChunk( fontInfo_t *font, const int chunk )
 	// no glyphs? just return
 	if ( !rendered )
 	{
-		ri.Free( out );
+		Z_Free( out );
 		font->glyphBlock[ chunk ] = nullGlyphs;
 		return;
 	}
 
-	glyphs = font->glyphBlock[ chunk ] = (glyphInfo_t*) ri.Z_Malloc( sizeof( glyphBlock_t ) );
-	memset( glyphs, 0, sizeof( glyphBlock_t ) );
+	glyphs = font->glyphBlock[ chunk ] = (glyphInfo_t*) Z_Calloc( sizeof( glyphBlock_t ) );
 
 	xOut = yOut = 0;
 	rendered = false;
@@ -519,7 +508,7 @@ void RE_RenderChunk( fontInfo_t *font, const int chunk )
 	{
 		RE_StoreImage( font, chunk, page, lastStart, 256, out, yOut + maxHeight + 1 );
 	}
-	ri.Free( out );
+	Z_Free( out );
 }
 
 static int RE_LoadFontFile( const char *name, void **buffer )
@@ -553,14 +542,7 @@ static int RE_LoadFontFile( const char *name, void **buffer )
 				return 0;
 			}
 
-			fontData[ i ].data = malloc( length );
-
-			if ( !fontData[ i ].data )
-			{
-				ri.FS_FreeFile( tmp );
-				return 0;
-			}
-
+			fontData[ i ].data = Z_AllocUninit( length );
 			fontData[ i ].length = length;
 			fontData[ i ].count = 1;
 			*buffer = fontData[ i ].data;
@@ -592,7 +574,7 @@ static void RE_FreeFontFile( void *data )
 		{
 			if ( !--fontData[ i ].count )
 			{
-				free( fontData[ i ].data );
+				Z_Free( fontData[ i ].data );
 			}
 			break;
 		}
@@ -667,8 +649,7 @@ fontInfo_t* RE_RegisterFont( const char *fontName, int pointSize )
 		fdOffset = 0;
 		fdFile = (byte*) faceData;
 
-		glyphs = font->glyphBlock[0] = (glyphInfo_t*) ri.Z_Malloc( sizeof( glyphBlock_t ) );
-		memset( glyphs, 0, sizeof( glyphBlock_t ) );
+		glyphs = font->glyphBlock[0] = (glyphInfo_t*) Z_Calloc( sizeof( glyphBlock_t ) );
 
 		for ( i = 0; i < GLYPHS_PER_FONT; i++ )
 		{
@@ -790,7 +771,7 @@ void RE_UnregisterFont_Internal( fontHandle_t handle )
 	{
 		if ( registeredFont[ handle ].glyphBlock[ i ] && registeredFont[ handle ].glyphBlock[ i ] != nullGlyphs )
 		{
-			ri.Free( registeredFont[ handle ].glyphBlock[ i ] );
+			Z_Free( registeredFont[ handle ].glyphBlock[ i ] );
 			registeredFont[ handle ].glyphBlock[ i ] = nullptr;
 		}
 	}

--- a/src/engine/renderer/tr_image_crn.cpp
+++ b/src/engine/renderer/tr_image_crn.cpp
@@ -124,7 +124,7 @@ bool LoadInMemoryCRN(const char* name, const void* buff, size_t buffLen, byte **
         Log::Warn("CRN image '%s' has bad data", name);
         return false;
     }
-    byte* nextImage = (byte *)ri.Z_Malloc(totalSize);
+    byte* nextImage = (byte *)Z_Malloc(totalSize);
     bool success = true;
     for (unsigned i = 0; i < ti.m_levels; i++) {
         for (unsigned j = 0; j < ti.m_faces; j++) {
@@ -161,7 +161,7 @@ void LoadCRN(const char* name, byte **data, int *width, int *height,
     }
     if (!LoadInMemoryCRN(name, buff.data(), buff.size(), data, width, height, numLayers, numMips, bits)) {
         if (*data) {
-            ri.Free(*data);
+            Z_Free(*data);
             *data = nullptr; // This signals failure.
         }
     }

--- a/src/engine/renderer/tr_image_dds.cpp
+++ b/src/engine/renderer/tr_image_dds.cpp
@@ -345,7 +345,7 @@ static void R_LoadDDSImageData( const void *pImageData, const char *name, byte *
 		}
 	}
 
-	data[0] = (byte*) ri.Z_Malloc( size );
+	data[0] = (byte*) Z_AllocUninit( size );
 	memcpy( data[0], ddsd + 1, size );
 
 	if( compressed ) {

--- a/src/engine/renderer/tr_image_jpg.cpp
+++ b/src/engine/renderer/tr_image_jpg.cpp
@@ -170,7 +170,7 @@ void LoadJPG( const char *filename, unsigned char **pic, int *width, int *height
 	memcount = pixelcount * 4;
 	row_stride = cinfo.output_width * cinfo.output_components;
 
-	out = (byte*) ri.Z_Malloc( memcount );
+	out = (byte*) Z_Malloc( memcount );
 
 	*width = cinfo.output_width;
 	*height = cinfo.output_height;

--- a/src/engine/renderer/tr_image_ktx.cpp
+++ b/src/engine/renderer/tr_image_ktx.cpp
@@ -241,7 +241,7 @@ bool LoadInMemoryKTX( const char *name, void *ktxData, size_t ktxSize,
 	}
 
 	ptr = firstImageDataPtr;
-	data[ 0 ] = (byte *)ri.Z_Malloc(totalImageSize);
+	data[ 0 ] = (byte *)Z_Malloc(totalImageSize);
 
 	uint32_t imageSize{ GetImageSize( ptr, needReverseBytes ) };
 	ptr += sizeof(uint32_t);
@@ -760,7 +760,7 @@ void LoadKTX( const char *name, byte **pic, int *width, int *height,
 	}
 	if ( !LoadInMemoryKTX( name, &ktxData[0], ktxData.size(), pic, width, height, numLayers, numMips, bits ) ) {
 		if (*pic) {
-			ri.Free(*pic);
+			Z_Free(*pic);
 		}
 		*pic = nullptr; // This signals failure.
 	}

--- a/src/engine/renderer/tr_image_png.cpp
+++ b/src/engine/renderer/tr_image_png.cpp
@@ -166,7 +166,7 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 	// allocate the memory to hold the image
 	*width = w;
 	*height = h;
-	*pic = out = ( byte * ) ri.Z_Malloc( w * h * 4 );
+	*pic = out = ( byte * ) Z_Malloc( w * h * 4 );
 
 	row_pointers = ( png_bytep * ) ri.Hunk_AllocateTempMemory( sizeof( png_bytep ) * h );
 

--- a/src/engine/renderer/tr_image_tga.cpp
+++ b/src/engine/renderer/tr_image_tga.cpp
@@ -110,7 +110,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 		Sys::Drop( "TGA image '%s' has an invalid image size", name );
 	}
 
-	targa_rgba = (byte*) ri.Z_Malloc( numPixels );
+	targa_rgba = (byte*) Z_Malloc( numPixels );
 
 	*pic = targa_rgba;
 
@@ -164,7 +164,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 						break;
 
 					default:
-						ri.Free( targa_rgba );
+						Z_Free( targa_rgba );
 						Sys::Drop( "TGA image '%s' has illegal pixel_size (%d)", name, targa_header.pixel_size );
 				}
 			}
@@ -209,7 +209,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 							break;
 
 						default:
-							ri.Free( targa_rgba );
+							Z_Free( targa_rgba );
 							Sys::Drop( "TGA image '%s' has illegal pixel_size (%d)", name, targa_header.pixel_size );
 					}
 
@@ -268,7 +268,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 								break;
 
 							default:
-								ri.Free( targa_rgba );
+								Z_Free( targa_rgba );
 								Sys::Drop( "TGA image '%s' has illegal pixel_size (%d)", name, targa_header.pixel_size );
 						}
 

--- a/src/engine/renderer/tr_image_webp.cpp
+++ b/src/engine/renderer/tr_image_webp.cpp
@@ -35,7 +35,7 @@ bool LoadInMemoryWEBP( const char *path, const uint8_t* webpData, size_t webpSiz
 
 	const size_t stride{ *width * sizeof( u8vec4_t ) };
 	const size_t size{ *height * stride };
-	auto *out = (byte*)ri.Z_Malloc( size );
+	auto *out = (byte*)Z_Malloc( size );
 
 	// Decode into RGBA.
 	if ( !WebPDecodeRGBAInto( webpData, webpSize, out, size, stride ) )
@@ -66,7 +66,7 @@ void LoadWEBP( const char *path, byte **pic, int *width, int *height, int *, int
 		return;
 	}
 	if ( !LoadInMemoryWEBP( path, reinterpret_cast<const uint8_t*>(webpData.data()), webpData.size(), pic, width, height ) ) {
-		ri.Free( *pic );
+		Z_Free( *pic );
 		*pic = nullptr; // This signals failure.
 	}
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -41,7 +41,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_glAllowSoftware;
 	cvar_t      *r_glExtendedValidation;
 
-	cvar_t      *r_verbose;
 	cvar_t      *r_ignore;
 
 	cvar_t      *r_znear;
@@ -50,7 +49,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_smp;
 	cvar_t      *r_showSmp;
 	cvar_t      *r_skipBackEnd;
-	cvar_t      *r_skipLightBuffer;
 
 	cvar_t      *r_measureOverdraw;
 
@@ -58,7 +56,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_lodBias;
 	cvar_t      *r_lodScale;
-	cvar_t      *r_lodTest;
 
 	cvar_t      *r_norefresh;
 	cvar_t      *r_drawentities;
@@ -82,6 +79,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_dynamicLightCastShadows;
 	cvar_t      *r_precomputedLighting;
 	Cvar::Cvar<int> r_mapOverBrightBits("r_mapOverBrightBits", "default map light color shift", Cvar::NONE, 2);
+	Cvar::Cvar<bool> r_forceLegacyOverBrightClamping("r_forceLegacyOverBrightClamping", "clamp over bright of legacy maps (enable multiplied color clamping and normalization)", Cvar::NONE, false);
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	cvar_t      *r_lightStyles;
 	cvar_t      *r_exportTextures;
@@ -91,7 +89,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_ext_occlusion_query;
 	cvar_t      *r_ext_draw_buffers;
-	cvar_t      *r_ext_vertex_array_object;
 	cvar_t      *r_ext_half_float_pixel;
 	cvar_t      *r_ext_texture_float;
 	cvar_t      *r_ext_texture_integer;
@@ -109,7 +106,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_checkGLErrors;
 	cvar_t      *r_logFile;
 
-	cvar_t      *r_depthbits;
 	cvar_t      *r_colorbits;
 
 	cvar_t      *r_drawBuffer;
@@ -122,7 +118,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_softShadowsPP;
 	cvar_t      *r_shadowBlur;
 
-	cvar_t      *r_shadowMapQuality;
 	cvar_t      *r_shadowMapSizeUltra;
 	cvar_t      *r_shadowMapSizeVeryHigh;
 	cvar_t      *r_shadowMapSizeHigh;
@@ -135,16 +130,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_shadowMapSizeSunMedium;
 	cvar_t      *r_shadowMapSizeSunLow;
 
-	cvar_t      *r_shadowOffsetFactor;
-	cvar_t      *r_shadowOffsetUnits;
 	cvar_t      *r_shadowLodBias;
 	cvar_t      *r_shadowLodScale;
 	cvar_t      *r_noShadowPyramids;
 	cvar_t      *r_cullShadowPyramidFaces;
-	cvar_t      *r_cullShadowPyramidCurves;
-	cvar_t      *r_cullShadowPyramidTriangles;
 	cvar_t      *r_debugShadowMaps;
-	cvar_t      *r_noShadowFrustums;
 	cvar_t      *r_noLightFrustums;
 	cvar_t      *r_shadowMapLinearFilter;
 	cvar_t      *r_lightBleedReduction;
@@ -156,7 +146,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_mode;
 	cvar_t      *r_nobind;
 	cvar_t      *r_singleShader;
-	cvar_t      *r_colorMipLevels;
 	cvar_t      *r_picMip;
 	cvar_t      *r_imageMaxDimension;
 	cvar_t      *r_ignoreMaterialMinDimension;
@@ -186,12 +175,14 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_halfLambertLighting;
 	cvar_t      *r_rimLighting;
 	cvar_t      *r_rimExponent;
+
+	Cvar::Cvar<bool> r_highPrecisionRendering("r_highPrecisionRendering", "use high precision frame buffers for rendering and blending", Cvar::NONE, true);
+
 	cvar_t      *r_gamma;
 	cvar_t      *r_lockpvs;
 	cvar_t      *r_noportals;
 	cvar_t      *r_portalOnly;
 
-	cvar_t      *r_portalSky;
 	cvar_t      *r_max_portal_levels;
 
 	cvar_t      *r_subdivisions;
@@ -207,7 +198,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_showImages;
 
-	cvar_t      *r_forceFog;
 	cvar_t      *r_wolfFog;
 	cvar_t      *r_noFog;
 
@@ -222,7 +212,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_showTris;
 	cvar_t      *r_showSky;
-	cvar_t      *r_showShadowVolumes;
 	cvar_t      *r_showShadowLod;
 	cvar_t      *r_showShadowMaps;
 	cvar_t      *r_showSkeleton;
@@ -239,7 +228,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_showDeluxeMaps;
 	cvar_t      *r_showNormalMaps;
 	cvar_t      *r_showMaterialMaps;
-	cvar_t      *r_showAreaPortals;
 	cvar_t      *r_showCubeProbes;
 	cvar_t      *r_showBspNodes;
 	cvar_t      *r_showParallelShadowSplits;
@@ -252,7 +240,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_vboLighting;
 	cvar_t      *r_vboModels;
 	cvar_t      *r_vboVertexSkinning;
-	cvar_t      *r_vboDeformVertexes;
 
 	cvar_t      *r_mergeLeafSurfaces;
 
@@ -566,7 +553,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	RB_TakeScreenshot
 	==================
 	*/
-	static void RB_TakeScreenshot( int x, int y, int width, int height, const char *fileName )
+	static void RB_TakeScreenshotTGA( int x, int y, int width, int height, const char *fileName )
 	{
 		byte *buffer;
 		int  dataSize;
@@ -636,7 +623,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 		switch ( format )
 		{
 			case ssFormat_t::SSF_TGA:
-				RB_TakeScreenshot( x, y, width, height, fileName );
+				RB_TakeScreenshotTGA( x, y, width, height, fileName );
 				break;
 
 			case ssFormat_t::SSF_JPEG:
@@ -730,7 +717,8 @@ public:
 		}
 	}
 };
-ScreenshotCmd screenshotTGARegistration("screenshot", ssFormat_t::SSF_TGA, "tga");
+ScreenshotCmd screenshotRegistration("screenshot", ssFormat_t::SSF_JPEG, "jpg");
+ScreenshotCmd screenshotTGARegistration("screenshotTGA", ssFormat_t::SSF_TGA, "tga");
 ScreenshotCmd screenshotJPEGRegistration("screenshotJPEG", ssFormat_t::SSF_JPEG, "jpg");
 ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "png");
 } // namespace
@@ -818,7 +806,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		GL_ClearStencil( 0 );
 
 		GL_FrontFace( GL_CCW );
-		GL_CullFace( GL_FRONT );
+		glCullFace( GL_FRONT );
 
 		glState.faceCulling = CT_TWO_SIDED;
 		glDisable( GL_CULL_FACE );
@@ -1089,7 +1077,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		// latched and archived variables
 		r_ext_occlusion_query = Cvar_Get( "r_ext_occlusion_query", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_ext_draw_buffers = Cvar_Get( "r_ext_draw_buffers", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_ext_vertex_array_object = Cvar_Get( "r_ext_vertex_array_object", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_ext_half_float_pixel = Cvar_Get( "r_ext_half_float_pixel", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_ext_texture_float = Cvar_Get( "r_ext_texture_float", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_ext_texture_integer = Cvar_Get( "r_ext_texture_integer", "1", CVAR_CHEAT | CVAR_LATCH );
@@ -1102,7 +1089,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_arb_uniform_buffer_object = Cvar_Get( "r_arb_uniform_buffer_object", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_arb_texture_gather = Cvar_Get( "r_arb_texture_gather", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_arb_gpu_shader5 = Cvar_Get( "r_arb_gpu_shader5", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_arb_bindless_texture = Cvar_Get( "r_arb_bindless_texture", "1", CVAR_CHEAT | CVAR_LATCH );
+		r_arb_bindless_texture = Cvar_Get( "r_arb_bindless_texture", "0", CVAR_LATCH );
 
 		r_picMip = Cvar_Get( "r_picMip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_imageMaxDimension = Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
@@ -1110,9 +1097,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_ignoreMaterialMaxDimension = Cvar_Get( "r_ignoreMaterialMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_replaceMaterialMinDimensionIfPresentWithMaxDimension
 			= Cvar_Get( "r_replaceMaterialMinDimensionIfPresentWithMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
-		r_colorMipLevels = Cvar_Get( "r_colorMipLevels", "0", CVAR_LATCH );
 		r_colorbits = Cvar_Get( "r_colorbits", "0",  CVAR_LATCH );
-		r_depthbits = Cvar_Get( "r_depthbits", "0",  CVAR_LATCH );
 		r_mode = Cvar_Get( "r_mode", "-2", CVAR_LATCH | CVAR_ARCHIVE );
 		r_customwidth = Cvar_Get( "r_customwidth", "1600", CVAR_LATCH | CVAR_ARCHIVE );
 		r_customheight = Cvar_Get( "r_customheight", "1024", CVAR_LATCH | CVAR_ARCHIVE );
@@ -1120,6 +1105,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_dynamicLightCastShadows = Cvar_Get( "r_dynamicLightCastShadows", "1", 0 );
 		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_CHEAT | CVAR_LATCH );
 		Cvar::Latch( r_mapOverBrightBits );
+		Cvar::Latch( r_forceLegacyOverBrightClamping );
 		Cvar::Latch( r_lightMode );
 		r_lightStyles = Cvar_Get( "r_lightStyles", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_exportTextures = Cvar_Get( "r_exportTextures", "0", 0 );
@@ -1136,8 +1122,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		and/or old hardware and drastically reduce first startup time. */
 		r_lazyShaders = Cvar_Get( "r_lazyShaders", "1", 0 );
 
-		r_forceFog = Cvar_Get( "r_forceFog", "0", CVAR_CHEAT /* | CVAR_LATCH */ );
-		AssertCvarRange( r_forceFog, 0.0f, 1.0f, false );
 		r_wolfFog = Cvar_Get( "r_wolfFog", "1", CVAR_CHEAT );
 		r_noFog = Cvar_Get( "r_noFog", "0", CVAR_CHEAT );
 
@@ -1180,7 +1164,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_vboLighting = Cvar_Get( "r_vboLighting", "1", CVAR_CHEAT );
 		r_vboModels = Cvar_Get( "r_vboModels", "1", CVAR_LATCH );
 		r_vboVertexSkinning = Cvar_Get( "r_vboVertexSkinning", "1",  CVAR_LATCH );
-		r_vboDeformVertexes = Cvar_Get( "r_vboDeformVertexes", "1",  CVAR_LATCH );
 
 		r_mergeLeafSurfaces = Cvar_Get( "r_mergeLeafSurfaces", "1",  CVAR_LATCH );
 
@@ -1212,16 +1195,13 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		r_drawworld = Cvar_Get( "r_drawworld", "1", CVAR_CHEAT );
 		r_portalOnly = Cvar_Get( "r_portalOnly", "0", CVAR_CHEAT );
-		r_portalSky = Cvar_Get( "cg_skybox", "1", 0 );
 		r_max_portal_levels = Cvar_Get( "r_max_portal_levels", "5", 0 );
 
 		r_showSmp = Cvar_Get( "r_showSmp", "0", CVAR_CHEAT );
 		r_skipBackEnd = Cvar_Get( "r_skipBackEnd", "0", CVAR_CHEAT );
-		r_skipLightBuffer = Cvar_Get( "r_skipLightBuffer", "0", CVAR_CHEAT );
 
 		r_measureOverdraw = Cvar_Get( "r_measureOverdraw", "0", CVAR_CHEAT );
 		r_lodScale = Cvar_Get( "r_lodScale", "5", CVAR_CHEAT );
-		r_lodTest = Cvar_Get( "r_lodTest", "0.5", CVAR_CHEAT );
 		r_norefresh = Cvar_Get( "r_norefresh", "0", CVAR_CHEAT );
 		r_drawentities = Cvar_Get( "r_drawentities", "1", CVAR_CHEAT );
 		r_drawpolies = Cvar_Get( "r_drawpolies", "1", CVAR_CHEAT );
@@ -1229,7 +1209,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_nocull = Cvar_Get( "r_nocull", "0", CVAR_CHEAT );
 		r_novis = Cvar_Get( "r_novis", "0", CVAR_CHEAT );
 		r_speeds = Cvar_Get( "r_speeds", "0", 0 );
-		r_verbose = Cvar_Get( "r_verbose", "0", CVAR_CHEAT );
 		r_logFile = Cvar_Get( "r_logFile", "0", CVAR_CHEAT );
 		r_debugSurface = Cvar_Get( "r_debugSurface", "0", CVAR_CHEAT );
 		r_nobind = Cvar_Get( "r_nobind", "0", CVAR_CHEAT );
@@ -1257,6 +1236,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_rimExponent = Cvar_Get( "r_rimExponent", "3", CVAR_CHEAT | CVAR_LATCH );
 		AssertCvarRange( r_rimExponent, 0.5, 8.0, false );
 
+		Cvar::Latch( r_highPrecisionRendering );
+
 		r_drawBuffer = Cvar_Get( "r_drawBuffer", "GL_BACK", CVAR_CHEAT );
 		r_lockpvs = Cvar_Get( "r_lockpvs", "0", CVAR_CHEAT );
 		r_noportals = Cvar_Get( "r_noportals", "0", CVAR_CHEAT );
@@ -1269,9 +1250,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_softShadowsPP = Cvar_Get( "r_softShadowsPP", "0",  CVAR_LATCH );
 
 		r_shadowBlur = Cvar_Get( "r_shadowBlur", "2",  CVAR_LATCH );
-
-		r_shadowMapQuality = Cvar_Get( "r_shadowMapQuality", "3",  CVAR_LATCH );
-		AssertCvarRange( r_shadowMapQuality, 0, 4, true );
 
 		r_shadowMapSizeUltra = Cvar_Get( "r_shadowMapSizeUltra", "1024",  CVAR_LATCH );
 		AssertCvarRange( r_shadowMapSizeUltra, 32, 2048, true );
@@ -1315,15 +1293,10 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		sunShadowMapResolutions[ 3 ] = r_shadowMapSizeSunMedium->integer;
 		sunShadowMapResolutions[ 4 ] = r_shadowMapSizeSunLow->integer;
 
-		r_shadowOffsetFactor = Cvar_Get( "r_shadowOffsetFactor", "0", CVAR_CHEAT );
-		r_shadowOffsetUnits = Cvar_Get( "r_shadowOffsetUnits", "0", CVAR_CHEAT );
 		r_shadowLodBias = Cvar_Get( "r_shadowLodBias", "0", CVAR_CHEAT );
 		r_shadowLodScale = Cvar_Get( "r_shadowLodScale", "0.8", CVAR_CHEAT );
 		r_noShadowPyramids = Cvar_Get( "r_noShadowPyramids", "0", CVAR_CHEAT );
 		r_cullShadowPyramidFaces = Cvar_Get( "r_cullShadowPyramidFaces", "0", CVAR_CHEAT );
-		r_cullShadowPyramidCurves = Cvar_Get( "r_cullShadowPyramidCurves", "1", CVAR_CHEAT );
-		r_cullShadowPyramidTriangles = Cvar_Get( "r_cullShadowPyramidTriangles", "1", CVAR_CHEAT );
-		r_noShadowFrustums = Cvar_Get( "r_noShadowFrustums", "0", CVAR_CHEAT );
 		r_noLightFrustums = Cvar_Get( "r_noLightFrustums", "1", CVAR_CHEAT );
 
 		r_maxPolys = Cvar_Get( "r_maxpolys", "10000", CVAR_LATCH );  // 600 in vanilla Q3A
@@ -1334,7 +1307,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		r_showTris = Cvar_Get( "r_showTris", "0", CVAR_CHEAT );
 		r_showSky = Cvar_Get( "r_showSky", "0", CVAR_CHEAT );
-		r_showShadowVolumes = Cvar_Get( "r_showShadowVolumes", "0", CVAR_CHEAT );
 		r_showShadowLod = Cvar_Get( "r_showShadowLod", "0", CVAR_CHEAT );
 		r_showShadowMaps = Cvar_Get( "r_showShadowMaps", "0", CVAR_CHEAT );
 		r_showSkeleton = Cvar_Get( "r_showSkeleton", "0", CVAR_CHEAT );
@@ -1351,7 +1323,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_showDeluxeMaps = Cvar_Get( "r_showDeluxeMaps", "0", CVAR_CHEAT | CVAR_LATCH );
 		r_showNormalMaps = Cvar_Get( "r_showNormalMaps", "0", CVAR_CHEAT | CVAR_LATCH );
 		r_showMaterialMaps = Cvar_Get( "r_showMaterialMaps", "0", CVAR_CHEAT | CVAR_LATCH );
-		r_showAreaPortals = Cvar_Get( "r_showAreaPortals", "0", CVAR_CHEAT );
 		r_showCubeProbes = Cvar_Get( "r_showCubeProbes", "0", CVAR_CHEAT );
 		r_showBspNodes = Cvar_Get( "r_showBspNodes", "0", CVAR_CHEAT );
 		r_showParallelShadowSplits = Cvar_Get( "r_showParallelShadowSplits", "0", CVAR_CHEAT | CVAR_LATCH );
@@ -1564,7 +1535,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			}
 
 			GLimp_Shutdown();
-			ri.Tag_Free();
 		}
 
 		tr.registered = false;

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -104,6 +104,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_arb_uniform_buffer_object;
 	cvar_t      *r_arb_texture_gather;
 	cvar_t      *r_arb_gpu_shader5;
+	cvar_t      *r_arb_bindless_texture;
 
 	cvar_t      *r_checkGLErrors;
 	cvar_t      *r_logFile;
@@ -330,6 +331,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 			Q_strlwr( renderer_buffer );
 
 			// OpenGL driver constants
+			glGetIntegerv( GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &temp );
+			glConfig2.maxTextureUnits = temp;
+
 			glGetIntegerv( GL_MAX_TEXTURE_SIZE, &temp );
 			glConfig.maxTextureSize = temp;
 
@@ -829,7 +833,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		// in a multitexture environment
 		if ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 )
 		{
-			for ( i = 31; i >= 0; i-- )
+			for ( i = glConfig2.maxTextureUnits - 1; i >= 0; i-- )
 			{
 				GL_SelectTexture( i );
 				GL_TextureMode( r_textureMode->string );
@@ -1098,6 +1102,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_arb_uniform_buffer_object = Cvar_Get( "r_arb_uniform_buffer_object", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_arb_texture_gather = Cvar_Get( "r_arb_texture_gather", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_arb_gpu_shader5 = Cvar_Get( "r_arb_gpu_shader5", "1", CVAR_CHEAT | CVAR_LATCH );
+		r_arb_bindless_texture = Cvar_Get( "r_arb_bindless_texture", "1", CVAR_CHEAT | CVAR_LATCH );
 
 		r_picMip = Cvar_Get( "r_picMip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_imageMaxDimension = Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -31,6 +31,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "botlib/bot_debug.h"
 #include "tr_public.h"
 #include "iqm.h"
+#include "TextureManager.h"
 
 #define GLEW_NO_GLU
 #include <GL/glew.h>
@@ -709,6 +710,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 
 		GLenum         type;
 		GLuint         texnum; // gl texture binding
+		Texture        *texture;
 
 		uint16_t       width, height; // source image
 		uint16_t       uploadWidth, uploadHeight; // after power of two and picmip but not including clamp to MAX_TEXTURE_SIZE
@@ -2737,6 +2739,8 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 
 		world_t    *world;
 
+		TextureManager textureManager;
+
 		const byte *externalVisData; // from RE_SetWorldVisData, shared with CM_Load
 
 		image_t    *defaultImage;
@@ -2988,6 +2992,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_arb_uniform_buffer_object;
 	extern cvar_t *r_arb_texture_gather;
 	extern cvar_t *r_arb_gpu_shader5;
+	extern cvar_t *r_arb_bindless_texture;
 
 	extern cvar_t *r_nobind; // turns off binding to appropriate textures
 	extern cvar_t *r_singleShader; // make most world faces use default shader
@@ -3248,12 +3253,12 @@ inline bool checkGLErrors()
 	====================================================================
 	*/
 	void GL_Bind( image_t *image );
-	void GL_BindNearestCubeMap( const vec3_t xyz );
+	void GL_BindNearestCubeMap( GLint location, const vec3_t xyz );
 	void GL_Unbind( image_t *image );
-	void BindAnimatedImage( textureBundle_t *bundle );
+	void BindAnimatedImage( GLint location, textureBundle_t *bundle );
 	void GL_TextureFilter( image_t *image, filterType_t filterType );
 	void GL_BindProgram( shaderProgram_t *program );
-	void GL_BindToTMU( int unit, image_t *image );
+	void GL_BindToTMU( GLint unit, image_t *image );
 	void GL_BindNullProgram();
 	void GL_SetDefaultState();
 	void GL_SelectTexture( int unit );

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -2787,7 +2787,6 @@ static void R_DebugGraphics()
 
 		GL_BindProgram( nullptr );
 
-		GL_SelectTexture( 0 );
 		GL_Bind( tr.whiteImage );
 
 		GL_Cull( cullType_t::CT_FRONT_SIDED );

--- a/src/engine/renderer/tr_model_md3.cpp
+++ b/src/engine/renderer/tr_model_md3.cpp
@@ -243,14 +243,14 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 
 	// create VBO surfaces from md3 surfaces
 	{
-		growList_t      vboSurfaces;
 		srfVBOMDVMesh_t *vboSurf;
 		vboData_t       data;
 		glIndex_t       *indexes;
 
 		int             f;
 
-		Com_InitGrowList( &vboSurfaces, 10 );
+		std::vector<srfVBOMDVMesh_t *> vboSurfaces;
+		vboSurfaces.reserve( 10 );
 
 		for ( i = 0, surf = mdvModel->surfaces; i < mdvModel->numSurfaces; i++, surf++ )
 		{
@@ -338,7 +338,7 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 			// create surface
 
 			vboSurf = (srfVBOMDVMesh_t*) ri.Hunk_Alloc( sizeof( *vboSurf ), ha_pref::h_low );
-			Com_AddToGrowList( &vboSurfaces, vboSurf );
+			vboSurfaces.push_back( vboSurf );
 
 			vboSurf->surfaceType = surfaceType_t::SF_VBO_MDVMESH;
 			vboSurf->mdvModel = mdvModel;
@@ -364,15 +364,10 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 		}
 
 		// move VBO surfaces list to hunk
-		mdvModel->numVBOSurfaces = vboSurfaces.currentElements;
-		mdvModel->vboSurfaces = (srfVBOMDVMesh_t**) ri.Hunk_Alloc( mdvModel->numVBOSurfaces * sizeof( *mdvModel->vboSurfaces ), ha_pref::h_low );
-
-		for ( i = 0; i < mdvModel->numVBOSurfaces; i++ )
-		{
-			mdvModel->vboSurfaces[ i ] = ( srfVBOMDVMesh_t * ) Com_GrowListElement( &vboSurfaces, i );
-		}
-
-		Com_DestroyGrowList( &vboSurfaces );
+		mdvModel->numVBOSurfaces = vboSurfaces.size();
+		size_t allocSize = vboSurfaces.size() * sizeof( vboSurfaces[ 0 ] );
+		mdvModel->vboSurfaces = (srfVBOMDVMesh_t**) ri.Hunk_Alloc( allocSize, ha_pref::h_low );
+		memcpy( mdvModel->vboSurfaces, vboSurfaces.data(), allocSize );
 	}
 
 	return true;

--- a/src/engine/renderer/tr_model_md5.cpp
+++ b/src/engine/renderer/tr_model_md5.cpp
@@ -97,15 +97,10 @@ bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 	int           version;
 	shader_t      *sh;
 	const char    *buf_p;
-	char          *token;
+	const char *token;
 	vec3_t        boneOrigin;
 	quat_t        boneQuat;
 	matrix_t      boneMat;
-
-	int           numRemaining;
-	growList_t    sortedTriangles;
-	growList_t    vboTriangles;
-	growList_t    vboSurfaces;
 
 	int           numBoneReferences;
 	int           boneReferences[ MAX_BONES ];
@@ -576,87 +571,74 @@ bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 	}
 
 	// split the surfaces into VBO surfaces by the maximum number of GPU vertex skinning bones
-	Com_InitGrowList( &vboSurfaces, 10 );
+	std::vector<srfVBOMD5Mesh_t *> vboSurfaces;
+	vboSurfaces.reserve( 10 );
+	std::vector<skelTriangle_t> vboTriangles;
+	vboTriangles.reserve( 1000 );
+	std::vector<skelTriangle_t> sortedTriangles;
+	sortedTriangles.reserve( 1000 );
 
     surf = md5->surfaces;
 	for (unsigned i = 0; i < md5->numSurfaces; i++, surf++ )
 	{
 		// sort triangles
-		Com_InitGrowList( &sortedTriangles, 1000 );
+		sortedTriangles.resize( 0 );
 
         tri = surf->triangles;
 		for (unsigned j = 0; j < surf->numTriangles; j++, tri++ )
 		{
-			skelTriangle_t *sortTri = (skelTriangle_t*) malloc( sizeof( *sortTri ) );
+			skelTriangle_t sortTri;
 
 			for (unsigned k = 0; k < 3; k++ )
 			{
-				sortTri->indexes[ k ] = tri->indexes[ k ];
-				sortTri->vertexes[ k ] = &surf->verts[ tri->indexes[ k ] ];
+				sortTri.indexes[ k ] = tri->indexes[ k ];
+				sortTri.vertexes[ k ] = &surf->verts[ tri->indexes[ k ] ];
 			}
 
-			sortTri->referenced = false;
+			sortTri.referenced = false;
 
-			Com_AddToGrowList( &sortedTriangles, sortTri );
+			sortedTriangles.push_back( sortTri );
 		}
 
-		numRemaining = sortedTriangles.currentElements;
+		size_t numRemaining = sortedTriangles.size();
 
 		while ( numRemaining )
 		{
 			numBoneReferences = 0;
 			memset( boneReferences, 0, sizeof( boneReferences ) );
 
-			Com_InitGrowList( &vboTriangles, 1000 );
+			vboTriangles.resize( 0 );
 
-			for (int j = 0; j < sortedTriangles.currentElements; j++ )
+			for ( skelTriangle_t &sortTri : sortedTriangles )
 			{
-				skelTriangle_t *sortTri = (skelTriangle_t*) Com_GrowListElement( &sortedTriangles, j );
-
-				if ( sortTri->referenced )
+				if ( sortTri.referenced )
 				{
 					continue;
 				}
 
-				if ( AddTriangleToVBOTriangleList( &vboTriangles, sortTri, &numBoneReferences, boneReferences ) )
+				if ( R_AddTriangleToVBOTriangleList( &sortTri, &numBoneReferences, boneReferences ) )
 				{
-					sortTri->referenced = true;
+					sortTri.referenced = true;
+					vboTriangles.push_back( sortTri );
 				}
 			}
 
-			if ( !vboTriangles.currentElements )
+			if ( vboTriangles.empty() )
 			{
 				Log::Warn("R_LoadMD5: could not add triangles to a remaining VBO surfaces for model '%s'", modName );
-				Com_DestroyGrowList( &vboTriangles );
 				break;
 			}
 
-			AddSurfaceToVBOSurfacesList( &vboSurfaces, &vboTriangles, md5, surf, i, boneReferences );
-			numRemaining -= vboTriangles.currentElements;
-
-			Com_DestroyGrowList( &vboTriangles );
+			R_AddSurfaceToVBOSurfacesList( vboSurfaces, vboTriangles, md5, surf, i, boneReferences );
+			numRemaining -= vboTriangles.size();
 		}
-
-		for (int j = 0; j < sortedTriangles.currentElements; j++ )
-		{
-			skelTriangle_t *sortTri = (skelTriangle_t*) Com_GrowListElement( &sortedTriangles, j );
-
-			free( sortTri );
-		}
-
-		Com_DestroyGrowList( &sortedTriangles );
 	}
 
 	// move VBO surfaces list to hunk
-	md5->numVBOSurfaces = vboSurfaces.currentElements;
-	md5->vboSurfaces = (srfVBOMD5Mesh_t**) ri.Hunk_Alloc( md5->numVBOSurfaces * sizeof( *md5->vboSurfaces ), ha_pref::h_low );
-
-	for ( unsigned i = 0; i < md5->numVBOSurfaces; i++ )
-	{
-		md5->vboSurfaces[ i ] = ( srfVBOMD5Mesh_t * ) Com_GrowListElement( &vboSurfaces, i );
-	}
-
-	Com_DestroyGrowList( &vboSurfaces );
+	md5->numVBOSurfaces = vboSurfaces.size();
+	size_t allocSize = vboSurfaces.size() * sizeof( vboSurfaces[ 0 ] );
+	md5->vboSurfaces = (srfVBOMD5Mesh_t**) ri.Hunk_Alloc( allocSize, ha_pref::h_low );
+	memcpy( md5->vboSurfaces, vboSurfaces.data(), allocSize );
 
 	return true;
 }

--- a/src/engine/renderer/tr_model_skel.h
+++ b/src/engine/renderer/tr_model_skel.h
@@ -25,8 +25,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "tr_local.h"
 
-bool AddTriangleToVBOTriangleList( growList_t *vboTriangles, skelTriangle_t *tri, int *numBoneReferences, int boneReferences[ MAX_BONES ] );
+bool R_AddTriangleToVBOTriangleList(
+	const skelTriangle_t *tri, int *numBoneReferences, int boneReferences[ MAX_BONES ] );
 
-void     AddSurfaceToVBOSurfacesList( growList_t *vboSurfaces, growList_t *vboTriangles, md5Model_t *md5, md5Surface_t *surf, int skinIndex, int boneReferences[ MAX_BONES ] );
+void R_AddSurfaceToVBOSurfacesList(
+	std::vector<srfVBOMD5Mesh_t *> &vboSurfaces, const std::vector<skelTriangle_t> &vboTriangles,
+	md5Model_t *md5, md5Surface_t *surf, int skinIndex, int boneReferences[ MAX_BONES ] );
 
 #endif // TR_MODEL_SKEL_H

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -257,11 +257,6 @@ struct refimport_t
 	void            *( *Hunk_AllocateTempMemory )( int size );
 	void ( *Hunk_FreeTempMemory )( void *block );
 
-	// dynamic memory allocator for things that need to be freed
-	void            *( *Z_Malloc )( int bytes );
-	void ( *Free )( void *buf );
-	void ( *Tag_Free )();
-
 	void ( *Cmd_AddCommand )( const char *name, void ( *cmd )() );
 	void ( *Cmd_RemoveCommand )( const char *name );
 

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -63,6 +63,8 @@ struct glconfig2_t
 	std::string glEnabledExtensionsString;
 	std::string glMissingExtensionsString;
 
+	int maxTextureUnits;
+
 	int      maxCubeMapTextureSize;
 
 	bool occlusionQueryAvailable;
@@ -82,6 +84,7 @@ struct glconfig2_t
 	bool textureFloatAvailable;
 	bool textureIntegerAvailable;
 	bool textureRGAvailable;
+	bool bindlessTexturesAvailable;
 	bool gpuShader4Available;
 	bool textureGatherAvailable;
 	int      maxDrawBuffers;

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -429,6 +429,9 @@ void RE_AddDynamicLightToSceneET( const vec3_t org, float radius, float intensit
 	light->l.color[ 1 ] = g;
 	light->l.color[ 2 ] = b;
 
+	// Cancel overBright on dynamic lights.
+	VectorScale( light->l.color, tr.mapInverseLightFactor, light->l.color );
+
 	light->l.inverseShadows = (flags & REF_INVERSE_DLIGHT) != 0;
 	light->l.noShadows = !r_dynamicLightCastShadows->integer && !light->l.inverseShadows;
 

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -123,7 +123,7 @@ void Tess_StageIteratorSky()
 		GL_State( GLS_DEFAULT );
 
 		// bind u_ColorMap
-		GL_BindToTMU( 0, tess.surfaceShader->sky.outerbox );
+		GL_BindToTMU( gl_skyboxShader->GetUniformLocation_ColorMap(), tess.surfaceShader->sky.outerbox );
 
 		// Only render the outer skybox at this stage
 		gl_skyboxShader->SetUniform_UseCloudMap( false );
@@ -150,7 +150,7 @@ void Tess_StageIteratorSky()
 
 		gl_skyboxShader->SetUniform_TextureMatrix( tess.svars.texMatrices[TB_COLORMAP] );
 
-		GL_BindToTMU( 1, tess.surfaceShader->stages[stage]->bundle[TB_COLORMAP].image[0] );
+		GL_BindToTMU( gl_skyboxShader->GetUniformLocation_CloudMap(), tess.surfaceShader->stages[stage]->bundle[TB_COLORMAP].image[0] );
 
 		uint32_t alphaTestBits = pStage->stateBits & GLS_ATEST_BITS;
 

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -115,6 +115,9 @@ void Tess_StageIteratorSky()
 
 	gl_skyboxShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 
+	// u_InverseLightFactor
+	gl_skyboxShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
+
 	gl_skyboxShader->SetRequiredVertexPointers();
 
 	// draw the outer skybox
@@ -123,7 +126,9 @@ void Tess_StageIteratorSky()
 		GL_State( GLS_DEFAULT );
 
 		// bind u_ColorMap
-		GL_BindToTMU( gl_skyboxShader->GetUniformLocation_ColorMap(), tess.surfaceShader->sky.outerbox );
+		gl_skyboxShader->SetUniform_ColorMapCubeBindless(
+			GL_BindToTMU( 0, tess.surfaceShader->sky.outerbox )
+		);
 
 		// Only render the outer skybox at this stage
 		gl_skyboxShader->SetUniform_UseCloudMap( false );
@@ -135,12 +140,8 @@ void Tess_StageIteratorSky()
 	gl_skyboxShader->SetUniform_UseCloudMap( true );
 	gl_skyboxShader->SetUniform_CloudHeight( tess.surfaceShader->sky.cloudHeight );
 
-	for ( int stage = 0; stage < MAX_SHADER_STAGES; stage++ ) {
+	for ( int stage = 0; stage < tess.numSurfaceStages; stage++ ) {
 		shaderStage_t* pStage = tess.surfaceShader->stages[stage];
-
-		if ( !pStage || !pStage->bundle[0].image[0] ) {
-			break;
-		}
 
 		if ( !RB_EvalExpression( &pStage->ifExp, 1.0 ) ) {
 			continue;
@@ -150,7 +151,9 @@ void Tess_StageIteratorSky()
 
 		gl_skyboxShader->SetUniform_TextureMatrix( tess.svars.texMatrices[TB_COLORMAP] );
 
-		GL_BindToTMU( gl_skyboxShader->GetUniformLocation_CloudMap(), tess.surfaceShader->stages[stage]->bundle[TB_COLORMAP].image[0] );
+		gl_skyboxShader->SetUniform_CloudMapBindless(
+			GL_BindToTMU( 1, tess.surfaceShader->stages[stage]->bundle[TB_COLORMAP].image[0] )
+		);
 
 		uint32_t alphaTestBits = pStage->stateBits & GLS_ATEST_BITS;
 

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -48,7 +48,7 @@ Tess_EndBegin
 void Tess_EndBegin()
 {
 	Tess_End();
-	Tess_Begin( tess.stageIteratorFunc, tess.stageIteratorFunc2, tess.surfaceShader, tess.lightShader, tess.skipTangentSpaces, tess.skipVBO,
+	Tess_Begin( tess.stageIteratorFunc, tess.stageIteratorFunc2, tess.surfaceShader, tess.lightShader, tess.skipTangentSpaces,
 	            tess.lightmapNum, tess.fogNum, tess.bspSurface );
 }
 
@@ -112,7 +112,7 @@ void Tess_CheckOverflow( int verts, int indexes )
 		Sys::Drop( "Tess_CheckOverflow: indexes > std::max (%d > %d)", indexes, SHADER_MAX_INDEXES );
 	}
 
-	Tess_Begin( tess.stageIteratorFunc, tess.stageIteratorFunc2, tess.surfaceShader, tess.lightShader, tess.skipTangentSpaces, tess.skipVBO,
+	Tess_Begin( tess.stageIteratorFunc, tess.stageIteratorFunc2, tess.surfaceShader, tess.lightShader, tess.skipTangentSpaces,
 	            tess.lightmapNum, tess.fogNum, tess.bspSurface );
 }
 
@@ -160,11 +160,6 @@ static void Tess_SurfaceVertsAndTris( const srfVert_t *verts, const srfTriangle_
 static bool Tess_SurfaceVBO( VBO_t *vbo, IBO_t *ibo, int numIndexes, int firstIndex )
 {
 	if ( !vbo || !ibo )
-	{
-		return false;
-	}
-
-	if ( tess.skipVBO )
 	{
 		return false;
 	}
@@ -577,7 +572,7 @@ void Tess_AddCubeWithNormals( const vec3_t position, const vec3_t minSize, const
 Tess_InstantQuad
 ==============
 */
-void Tess_InstantQuad( vec4_t quadVerts[ 4 ] )
+void Tess_InstantQuad( const float x, const float y, const float width, const float height )
 {
 	GLimp_LogComment( "--- Tess_InstantQuad ---\n" );
 
@@ -586,47 +581,18 @@ void Tess_InstantQuad( vec4_t quadVerts[ 4 ] )
 	tess.numIndexes = 0;
 	tess.attribsSet = 0;
 
-	Tess_MapVBOs( false );
-	VectorCopy( quadVerts[ 0 ], tess.verts[ tess.numVertexes ].xyz );
-	tess.verts[ tess.numVertexes ].color = Color::White;
-	tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( 0.0f );
-	tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( 0.0f );
-	tess.numVertexes++;
+	matrix_t modelViewMatrix;
+	MatrixCopy( matrixIdentity, modelViewMatrix );
+	modelViewMatrix[12] = x;
+	modelViewMatrix[13] = y;
+	modelViewMatrix[0] = width;
+	modelViewMatrix[5] = height;
+	GL_LoadModelViewMatrix( modelViewMatrix );
 
-	VectorCopy( quadVerts[ 1 ], tess.verts[ tess.numVertexes ].xyz );
-	tess.verts[ tess.numVertexes ].color = Color::White;
-	tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( 1.0f );
-	tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( 0.0f );
-	tess.numVertexes++;
+	rb_surfaceTable[Util::ordinal( *( tr.genericQuad->surface ) )]( tr.genericQuad->surface );
+	tess.attribsSet = ATTR_POSITION | ATTR_TEXCOORD | ATTR_COLOR;
+	GL_VertexAttribsState( tess.attribsSet );
 
-	VectorCopy( quadVerts[ 2 ], tess.verts[ tess.numVertexes ].xyz );
-	tess.verts[ tess.numVertexes ].color = Color::White;
-	tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( 1.0f );
-	tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( 1.0f );
-	tess.numVertexes++;
-
-	VectorCopy( quadVerts[ 3 ], tess.verts[ tess.numVertexes ].xyz );
-	tess.verts[ tess.numVertexes ].color = Color::White;
-	tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( 0.0f );
-	tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( 1.0f );
-	tess.numVertexes++;
-
-	tess.indexes[ tess.numIndexes++ ] = 0;
-	tess.indexes[ tess.numIndexes++ ] = 1;
-	tess.indexes[ tess.numIndexes++ ] = 2;
-	tess.indexes[ tess.numIndexes++ ] = 0;
-	tess.indexes[ tess.numIndexes++ ] = 2;
-	tess.indexes[ tess.numIndexes++ ] = 3;
-
-	Tess_UpdateVBOs( );
-	GL_VertexAttribsState( ATTR_POSITION | ATTR_TEXCOORD | ATTR_COLOR );
-
-	Tess_DrawElements();
-
-	tess.multiDrawPrimitives = 0;
-	tess.numVertexes = 0;
-	tess.numIndexes = 0;
-	tess.attribsSet = 0;
 	GL_CheckErrors();
 }
 
@@ -1213,8 +1179,6 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 	int numIndexes = surf->num_triangles * 3;
 
-	Tess_CheckOverflow( surf->num_vertexes, numIndexes );
-
 	tess.attribsSet |= ATTR_POSITION | ATTR_TEXCOORD;
 
 	if ( !tess.skipTangentSpaces )
@@ -1297,6 +1261,8 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 		return;
 	}
+
+	Tess_CheckOverflow( surf->num_vertexes, numIndexes );
 
 	glIndex_t *tessIndex = tess.indexes + tess.numIndexes;
 	int *modelTriangle = model->triangles + 3 * surf->first_triangle;

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -522,7 +522,7 @@ VBO_t *R_CreateDynamicVBO( const char *name, int numVertexes, uint32_t stateBits
 	vbo = (VBO_t*) ri.Hunk_Alloc( sizeof( *vbo ), ha_pref::h_low );
 	memset( vbo, 0, sizeof( *vbo ) );
 
-	Com_AddToGrowList( &tr.vbos, vbo );
+	tr.vbos.push_back( vbo );
 
 	Q_strncpyz( vbo->name, name, sizeof( vbo->name ) );
 
@@ -573,7 +573,7 @@ VBO_t *R_CreateStaticVBO( const char *name, vboData_t data, vboLayout_t layout )
 	VBO_t *vbo = (VBO_t*) ri.Hunk_Alloc( sizeof( *vbo ), ha_pref::h_low );
 	memset( vbo, 0, sizeof( *vbo ) );
 
-	Com_AddToGrowList( &tr.vbos, vbo );
+	tr.vbos.push_back( vbo );
 
 	Q_strncpyz( vbo->name, name, sizeof( vbo->name ) );
 
@@ -637,7 +637,7 @@ VBO_t *R_CreateStaticVBO2( const char *name, int numVertexes, shaderVertex_t *ve
 	vbo = ( VBO_t * ) ri.Hunk_Alloc( sizeof( *vbo ), ha_pref::h_low );
 	memset( vbo, 0, sizeof( *vbo ) );
 
-	Com_AddToGrowList( &tr.vbos, vbo );
+	tr.vbos.push_back( vbo );
 
 	Q_strncpyz( vbo->name, name, sizeof( vbo->name ) );
 
@@ -688,7 +688,7 @@ IBO_t *R_CreateDynamicIBO( const char *name, int numIndexes )
 	R_SyncRenderThread();
 
 	ibo = (IBO_t*) ri.Hunk_Alloc( sizeof( *ibo ), ha_pref::h_low );
-	Com_AddToGrowList( &tr.ibos, ibo );
+	tr.ibos.push_back( ibo );
 
 	Q_strncpyz( ibo->name, name, sizeof( ibo->name ) );
 
@@ -738,7 +738,7 @@ IBO_t *R_CreateStaticIBO( const char *name, glIndex_t *indexes, int numIndexes )
 	R_SyncRenderThread();
 
 	ibo = ( IBO_t * ) ri.Hunk_Alloc( sizeof( *ibo ), ha_pref::h_low );
-	Com_AddToGrowList( &tr.ibos, ibo );
+	tr.ibos.push_back( ibo );
 
 	Q_strncpyz( ibo->name, name, sizeof( ibo->name ) );
 
@@ -782,7 +782,7 @@ IBO_t *R_CreateStaticIBO2( const char *name, int numTriangles, glIndex_t *indexe
 	R_SyncRenderThread();
 
 	ibo = ( IBO_t * ) ri.Hunk_Alloc( sizeof( *ibo ), ha_pref::h_low );
-	Com_AddToGrowList( &tr.ibos, ibo );
+	tr.ibos.push_back( ibo );
 
 	Q_strncpyz( ibo->name, name, sizeof( ibo->name ) );
 	ibo->indexesNum = numTriangles * 3;
@@ -900,6 +900,65 @@ void R_BindNullIBO()
 		glState.currentIBO = nullptr;
 		glState.vertexAttribPointersSet = 0;
 	}
+}
+
+static void R_InitGenericVBOs() {
+	// Min and max coordinates of the quad
+	static const vec3_t min = { 0.0f, 0.0f, 0.0f };
+	static const vec3_t max = { 1.0f, 1.0f, 0.0f };
+	/*
+		Quad is a static mesh with 4 vertices and 2 triangles
+
+		 z
+		 ^
+		 |     1------2
+		 |   y |      |
+		 |  /  |      |
+		 | /   |      |
+		 |/    0------3
+		 0---------->x
+		   Verts:
+		   0: 0.0 0.0 0.0
+		   1: 0.0 1.0 0.0
+		   2: 1.0 1.0 0.0
+		   3: 1.0 0.0 0.0
+		   Surfs:
+		   0: 0 2 1 / 0 3 2
+	*/
+
+	drawSurf_t* genericQuad;
+	genericQuad = ( drawSurf_t* ) ri.Hunk_Alloc( sizeof( *genericQuad ), ha_pref::h_low );
+	genericQuad->entity = &tr.worldEntity;
+	srfVBOMesh_t* surface;
+	surface = ( srfVBOMesh_t* ) ri.Hunk_Alloc( sizeof( *surface ), ha_pref::h_low );
+	surface->surfaceType = surfaceType_t::SF_VBO_MESH;
+	surface->numVerts = 4;
+	surface->numIndexes = 6;
+	surface->firstIndex = 0;
+	vec3_t v0 = { min[0], min[1], min[2] };
+	vec3_t v1 = { min[0], max[1], min[2] };
+	vec3_t v2 = { max[0], max[1], min[2] };
+	vec3_t v3 = { max[0], min[1], min[2] };
+
+	shaderVertex_t verts[4];
+	VectorCopy( v0, verts[0].xyz );
+	VectorCopy( v1, verts[1].xyz );
+	VectorCopy( v2, verts[2].xyz );
+	VectorCopy( v3, verts[3].xyz );
+	
+	for ( int i = 0; i < 4; i++ ) {
+		verts[i].color = Color::White;
+		verts[i].texCoords[0] = floatToHalf( i < 2 ? 0.0f : 1.0f );
+		verts[i].texCoords[1] = floatToHalf( i > 0 && i < 3 ? 1.0f : 0.0f );
+	}
+	surface->vbo = R_CreateStaticVBO2( "generic_VBO", surface->numVerts, verts, ATTR_POSITION | ATTR_TEXCOORD | ATTR_COLOR );
+
+	glIndex_t indexes[6] = { 0, 2, 1,  0, 3, 2 }; // Front
+
+	surface->ibo = R_CreateStaticIBO( "generic_IBO", indexes, surface->numIndexes );
+	genericQuad->surface = ( surfaceType_t* ) surface;
+
+	tr.genericQuad = genericQuad;
 }
 
 static void R_InitUnitCubeVBO()
@@ -1024,8 +1083,8 @@ void R_InitVBOs()
 
 	Log::Debug("------- R_InitVBOs -------" );
 
-	Com_InitGrowList( &tr.vbos, 100 );
-	Com_InitGrowList( &tr.ibos, 100 );
+	tr.vbos.reserve( 100 );
+	tr.ibos.reserve( 100 );
 
 	tess.vertsBuffer = ( shaderVertex_t * ) Com_Allocate_Aligned( 64, SHADER_MAX_VERTEXES * sizeof( shaderVertex_t ) );
 	tess.indexesBuffer = ( glIndex_t * ) Com_Allocate_Aligned( 64, SHADER_MAX_INDEXES * sizeof( glIndex_t ) );
@@ -1042,6 +1101,8 @@ void R_InitVBOs()
 		tess.ibo = R_CreateDynamicIBO( "tessVertexArray_IBO", SHADER_MAX_INDEXES );
 	}
 
+
+	R_InitGenericVBOs();
 
 	R_InitUnitCubeVBO();
 	R_InitTileVBO();
@@ -1066,10 +1127,6 @@ R_ShutdownVBOs
 */
 void R_ShutdownVBOs()
 {
-	int   i;
-	VBO_t *vbo;
-	IBO_t *ibo;
-
 	Log::Debug("------- R_ShutdownVBOs -------" );
 
 	if( !glConfig2.mapBufferRangeAvailable ) {
@@ -1101,28 +1158,24 @@ void R_ShutdownVBOs()
 
 	glDeleteBuffers( 1, &tr.colorGradePBO );
 
-	for ( i = 0; i < tr.vbos.currentElements; i++ )
+	for ( VBO_t *vbo : tr.vbos )
 	{
-		vbo = ( VBO_t * ) Com_GrowListElement( &tr.vbos, i );
-
 		if ( vbo->vertexesVBO )
 		{
 			glDeleteBuffers( 1, &vbo->vertexesVBO );
 		}
 	}
 
-	for ( i = 0; i < tr.ibos.currentElements; i++ )
+	for ( IBO_t *ibo : tr.ibos )
 	{
-		ibo = ( IBO_t * ) Com_GrowListElement( &tr.ibos, i );
-
 		if ( ibo->indexesVBO )
 		{
 			glDeleteBuffers( 1, &ibo->indexesVBO );
 		}
 	}
 
-	Com_DestroyGrowList( &tr.vbos );
-	Com_DestroyGrowList( &tr.ibos );
+	tr.vbos.clear();
+	tr.ibos.clear();
 
 	Com_Free_Aligned( tess.vertsBuffer );
 	Com_Free_Aligned( tess.indexesBuffer );
@@ -1297,40 +1350,33 @@ R_ListVBOs_f
 */
 void R_ListVBOs_f()
 {
-	int   i;
-	VBO_t *vbo;
-	IBO_t *ibo;
 	int   vertexesSize = 0;
 	int   indexesSize = 0;
 
 	Log::Notice(" size          name" );
 	Log::Notice("----------------------------------------------------------" );
 
-	for ( i = 0; i < tr.vbos.currentElements; i++ )
+	for ( VBO_t *vbo : tr.vbos )
 	{
-		vbo = ( VBO_t * ) Com_GrowListElement( &tr.vbos, i );
-
 		Log::Notice("%d.%02d MB %s", vbo->vertexesSize / ( 1024 * 1024 ),
 		           ( vbo->vertexesSize % ( 1024 * 1024 ) ) * 100 / ( 1024 * 1024 ), vbo->name );
 
 		vertexesSize += vbo->vertexesSize;
 	}
 
-	for ( i = 0; i < tr.ibos.currentElements; i++ )
+	for ( IBO_t *ibo : tr.ibos)
 	{
-		ibo = ( IBO_t * ) Com_GrowListElement( &tr.ibos, i );
-
 		Log::Notice("%d.%02d MB %s", ibo->indexesSize / ( 1024 * 1024 ),
 		           ( ibo->indexesSize % ( 1024 * 1024 ) ) * 100 / ( 1024 * 1024 ), ibo->name );
 
 		indexesSize += ibo->indexesSize;
 	}
 
-	Log::Notice(" %i total VBOs", tr.vbos.currentElements );
+	Log::Notice(" %i total VBOs", tr.vbos.size() );
 	Log::Notice(" %d.%02d MB total vertices memory", vertexesSize / ( 1024 * 1024 ),
 	           ( vertexesSize % ( 1024 * 1024 ) ) * 100 / ( 1024 * 1024 ) );
 
-	Log::Notice(" %i total IBOs", tr.ibos.currentElements );
+	Log::Notice(" %i total IBOs", tr.ibos.size() );
 	Log::Notice(" %d.%02d MB total triangle indices memory", indexesSize / ( 1024 * 1024 ),
 	           ( indexesSize % ( 1024 * 1024 ) ) * 100 / ( 1024 * 1024 ) );
 }

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1931,6 +1931,9 @@ static void GLimp_InitExtensions()
 	// made required in OpenGL 3.2
 	glConfig2.syncAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_sync, r_arb_sync->value );
 
+	// not required by any OpenGL version
+	glConfig2.bindlessTexturesAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_bindless_texture, r_arb_bindless_texture->value );
+
 	GL_CheckErrors();
 }
 


### PR DESCRIPTION
Makes the engine use all texture units and rather than rebinding textures each time sets the correct uniform. Shaders have been modified to return the location for the correct uniform (this is needed because normal and bindless textures use different functions, so making it otherwise would be too convoluted).

Adds support for bindless textures. Bindless textures control texture residency instead of binding them.

Both approaches use texture priority which depends on the textures overall usage and usage during last frame.
Texture priority right now is just calculated as frame bind percentage (amount of times this texture was bound during the last frame / total texture binds last frame) * 0.5 + total bind percentage (amount of times this texture was bound in total / total texture binds) * 1.5.

If there's no available texture units ~~or bindless texture is not made resident~~ then it will replace the lowest priority texture unit ~~or make the lowest priority texture non-resident~~.
Currently disabled for bindless as making whatever texture was last added non-resident has better performance than sorting them every time. Another planned change might get rid of these priorities anyway.

This currently doesn't do anything for bound textures and even slightly lowers their performance when there's a lot of texture bindings. However, using bindless textures gives a slight performance improvement instead. (that is why this pr is draft)
I'll likely have to retain some of the old functionality for this reason. It is possible that using a UBO would still improve performance even without bindless textures, but that requires GLSL 4.00 so still won't be supported by all devices.