### PR TITLE
Fix portal scissor test

### DIFF
--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1894,6 +1894,16 @@ static bool R_MirrorViewBySurface(drawSurf_t *drawSurf)
 	newParms.scissorWidth = surfRect.coords[2] - surfRect.coords[0] + 1;
 	newParms.scissorHeight = surfRect.coords[3] - surfRect.coords[1] + 1;
 
+	// Scissor width/height must not be negative, so flip the coordinates if needed
+	if ( newParms.scissorWidth < 0 ) {
+		newParms.scissorX += newParms.scissorWidth;
+		newParms.scissorWidth *= -1;
+	}
+	if ( newParms.scissorHeight < 0 ) {
+		newParms.scissorY += newParms.scissorHeight;
+		newParms.scissorHeight *= -1;
+	}
+
 	R_MirrorPoint(oldParms.orientation.origin, &surface, &camera, newParms.orientation.origin);
 	R_MirrorVector(oldParms.orientation.axis[0], &surface, &camera, newParms.orientation.axis[0]);
 	R_MirrorVector(oldParms.orientation.axis[1], &surface, &camera, newParms.orientation.axis[1]);


### PR DESCRIPTION
Width and height in glScissor() must not be negative, so if surfRect has lower x2 or y2 than x1 or y1, then flip the scissor parameters. Tested on `test-portals-recursion` on viewpos -2223 639 65 91 3.

Fixes a GL_INVALID_VALUE at https://github.com/DaemonEngine/Daemon/blob/1872b92274fbd9533e622633c56a515a4ff899c0/src/engine/renderer/tr_backend.cpp#L359