### PR TITLE
NUKE client-side vertex arrays

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -907,7 +907,7 @@ static void RB_RenderDrawSurfaces( shaderSort_t fromSort, shaderSort_t toSort,
 				Tess_End();
 			}
 
-			Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, lightmapNum, fogNum, bspSurface );
+			Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, lightmapNum, fogNum, bspSurface );
 
 			oldShader = shader;
 			oldLightmapNum = lightmapNum;
@@ -1269,7 +1269,7 @@ static void RB_RenderInteractions()
 			Tess_End();
 
 			// begin a new batch
-			Tess_Begin( Tess_StageIteratorLighting, nullptr, shader, light->shader, false, false, -1, 0 );
+			Tess_Begin( Tess_StageIteratorLighting, nullptr, shader, light->shader, false, -1, 0 );
 
 			// change the modelview matrix if needed
 			if ( entity != oldEntity )
@@ -2249,7 +2249,7 @@ static void RB_RenderInteractionsShadowMapped()
 								}
 
 								// we don't need tangent space calculations here
-								Tess_Begin( Tess_StageIteratorShadowFill, nullptr, shader, light->shader, true, false, -1, 0 );
+								Tess_Begin( Tess_StageIteratorShadowFill, nullptr, shader, light->shader, true, -1, 0 );
 							}
 
 							break;
@@ -2428,7 +2428,7 @@ static void RB_RenderInteractionsShadowMapped()
 									}
 
 									// we don't need tangent space calculations here
-									Tess_Begin( Tess_StageIteratorShadowFill, nullptr, shader, light->shader, true, false, -1, 0 );
+									Tess_Begin( Tess_StageIteratorShadowFill, nullptr, shader, light->shader, true, -1, 0 );
 								}
 
 								break;
@@ -2581,7 +2581,7 @@ static void RB_RenderInteractionsShadowMapped()
 				}
 
 				// begin a new batch
-				Tess_Begin( Tess_StageIteratorLighting, nullptr, shader, light->shader, light->l.inverseShadows, false, -1, 0 );
+				Tess_Begin( Tess_StageIteratorLighting, nullptr, shader, light->shader, light->l.inverseShadows, -1, 0 );
 			}
 
 			// change the modelview matrix if needed
@@ -3398,7 +3398,7 @@ static void RB_RenderDebugUtils()
 			VectorMA( vec3_origin, 16, left, left );
 			VectorMA( vec3_origin, 16, up, up );
 
-			Tess_Begin( Tess_StageIteratorDebug, nullptr, nullptr, nullptr, true, true, 0, 0 );
+			Tess_Begin( Tess_StageIteratorDebug, nullptr, nullptr, nullptr, true, 0, 0 );
 
 			if ( light->isStatic && light->frustumVBO && light->frustumIBO )
 			{
@@ -4016,7 +4016,7 @@ static void RB_RenderDebugUtils()
 		gl_reflectionShader->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
 		gl_reflectionShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 
-		Tess_Begin( Tess_StageIteratorDebug, nullptr, nullptr, nullptr, true, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorDebug, nullptr, nullptr, nullptr, true, -1, 0 );
 
 		for ( j = 0; j < tr.cubeProbes.currentElements; j++ )
 		{
@@ -4074,7 +4074,7 @@ static void RB_RenderDebugUtils()
 
 			R_FindTwoNearestCubeMaps( backEnd.viewParms.orientation.origin, &cubeProbeNearest, &cubeProbeSecondNearest );
 
-			Tess_Begin( Tess_StageIteratorDebug, nullptr, nullptr, nullptr, true, false, -1, 0 );
+			Tess_Begin( Tess_StageIteratorDebug, nullptr, nullptr, nullptr, true, -1, 0 );
 
 			if ( cubeProbeNearest == nullptr && cubeProbeSecondNearest == nullptr )
 			{
@@ -4150,7 +4150,7 @@ static void RB_RenderDebugUtils()
 
 		for ( z = 0; z < tr.world->lightGridBounds[ 2 ]; z++ ) {
 			for ( y = 0; y < tr.world->lightGridBounds[ 1 ]; y++ ) {
-				Tess_Begin( Tess_StageIteratorDebug, nullptr, nullptr, nullptr, true, false, -1, 0 );
+				Tess_Begin( Tess_StageIteratorDebug, nullptr, nullptr, nullptr, true, -1, 0 );
 
 				for ( x = 0; x < tr.world->lightGridBounds[ 0 ]; x++ ) {
 					vec3_t origin;
@@ -4530,7 +4530,7 @@ static void RB_RenderDebugUtils()
 
 		GL_CheckErrors();
 
-		Tess_Begin( Tess_StageIteratorDebug, nullptr, nullptr, nullptr, true, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorDebug, nullptr, nullptr, nullptr, true, -1, 0 );
 
 		for ( i = 0, dp = backEnd.refdef.decalProjectors; i < backEnd.refdef.numDecalProjectors; i++, dp++ )
 		{
@@ -5000,11 +5000,11 @@ const RenderCommand *StretchPicCommand::ExecuteSelf( ) const
 		}
 
 		backEnd.currentEntity = &backEnd.entity2D;
-		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, -1, 0 );
 	}
 
 	if( !tess.indexes ) {
-		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, -1, 0 );
 	}
 
 	Tess_CheckOverflow( 4, 6 );
@@ -5088,7 +5088,7 @@ const RenderCommand *Poly2dCommand::ExecuteSelf( ) const
 		}
 
 		backEnd.currentEntity = &backEnd.entity2D;
-		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, -1, 0 );
 	}
 
 	Tess_CheckOverflow( numverts, ( numverts - 2 ) * 3 );
@@ -5140,11 +5140,11 @@ const RenderCommand *Poly2dIndexedCommand::ExecuteSelf( ) const
 		}
 
 		backEnd.currentEntity = &backEnd.entity2D;
-		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, -1, 0 );
 	}
 
 	if( !tess.verts ) {
-		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, -1, 0 );
 	}
 
 	Tess_CheckOverflow( numverts, numIndexes );
@@ -5235,11 +5235,11 @@ const RenderCommand *RotatedPicCommand::ExecuteSelf( ) const
 		}
 
 		backEnd.currentEntity = &backEnd.entity2D;
-		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, -1, 0 );
 	}
 
 	if( !tess.indexes ) {
-		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, -1, 0 );
 	}
 
 	Tess_CheckOverflow( 4, 6 );
@@ -5326,11 +5326,11 @@ const RenderCommand *GradientPicCommand::ExecuteSelf( ) const
 		}
 
 		backEnd.currentEntity = &backEnd.entity2D;
-		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, -1, 0 );
 	}
 
 	if( !tess.indexes ) {
-		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, false, -1, 0 );
+		Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, false, -1, 0 );
 	}
 
 	Tess_CheckOverflow( 4, 6 );
@@ -5546,7 +5546,7 @@ const RenderCommand *PreparePortalCommand::ExecuteSelf( ) const
 	glState.glStateBitsMask = GLS_COLORMASK_BITS;
 
 	Tess_Begin( Tess_StageIteratorPortal, nullptr, shader,
-		    nullptr, false, false, -1, -1 );
+		    nullptr, false, -1, -1 );
 	rb_surfaceTable[Util::ordinal(*(surface->surface))](surface->surface );
 	Tess_End();
 
@@ -5562,7 +5562,7 @@ const RenderCommand *PreparePortalCommand::ExecuteSelf( ) const
 	glState.glStateBitsMask = GLS_DEPTHMASK_TRUE | GLS_COLORMASK_BITS | GLS_DEPTHFUNC_ALWAYS;
 
 	Tess_Begin( Tess_StageIteratorPortal, nullptr, shader,
-		    nullptr, false, false, -1, -1 );
+		    nullptr, false, -1, -1 );
 	rb_surfaceTable[Util::ordinal(*(surface->surface))](surface->surface );
 	Tess_End();
 
@@ -5613,7 +5613,7 @@ const RenderCommand *FinalisePortalCommand::ExecuteSelf( ) const
 	glStencilOp( GL_KEEP, GL_KEEP, GL_KEEP );
 
 	Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader,
-		nullptr, false, false, surface->lightmapNum(), surface->fogNum(), true );
+		nullptr, false, surface->lightmapNum(), surface->fogNum(), true );
 	rb_surfaceTable[Util::ordinal( *( surface->surface ) )]( surface->surface );
 	Tess_End();
 
@@ -5623,7 +5623,7 @@ const RenderCommand *FinalisePortalCommand::ExecuteSelf( ) const
 	glState.glStateBitsMask = GLS_COLORMASK_BITS | GLS_DEPTHFUNC_ALWAYS;
 
 	Tess_Begin( Tess_StageIteratorPortal, nullptr, shader,
-		    nullptr, false, false, -1, -1 );
+		    nullptr, false, -1, -1 );
 	rb_surfaceTable[Util::ordinal(*(surface->surface))](surface->surface );
 	Tess_End();
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3459,7 +3459,6 @@ inline bool checkGLErrors()
 		shader_t    *lightShader;
 
 		bool    skipTangentSpaces;
-		bool    skipVBO;
 		int16_t     lightmapNum;
 		int16_t     fogNum;
 		bool        bspSurface;
@@ -3508,7 +3507,6 @@ inline bool checkGLErrors()
 	                 void ( *stageIteratorFunc2 )(),
 	                 shader_t *surfaceShader, shader_t *lightShader,
 	                 bool skipTangentSpaces,
-	                 bool skipVBO,
 	                 int lightmapNum,
 	                 int fogNum,
 	                 bool bspSurface = false );

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1634,7 +1634,7 @@ static bool SurfIsOffscreen( const drawSurf_t *drawSurf, screenRect_t& surfRect 
 		tr.orientation = tr.viewParms.world;
 	}
 
-	Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, true, true, -1, 0 );
+	Tess_Begin( Tess_StageIteratorGeneric, nullptr, shader, nullptr, true, -1, 0 );
 	rb_surfaceTable[ Util::ordinal(*drawSurf->surface) ]( drawSurf->surface );
 
 	// Tr3B: former assertion

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -506,7 +506,6 @@ void Tess_Begin( void ( *stageIteratorFunc )(),
                  void ( *stageIteratorFunc2 )(),
                  shader_t *surfaceShader, shader_t *lightShader,
                  bool skipTangentSpaces,
-                 bool skipVBO,
                  int lightmapNum,
                  int fogNum,
                  bool bspSurface )
@@ -555,7 +554,6 @@ void Tess_Begin( void ( *stageIteratorFunc )(),
 	}
 
 	tess.skipTangentSpaces = skipTangentSpaces;
-	tess.skipVBO = skipVBO;
 	tess.lightmapNum = lightmapNum;
 	tess.fogNum = fogNum;
 	tess.bspSurface = bspSurface;

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -48,7 +48,7 @@ Tess_EndBegin
 void Tess_EndBegin()
 {
 	Tess_End();
-	Tess_Begin( tess.stageIteratorFunc, tess.stageIteratorFunc2, tess.surfaceShader, tess.lightShader, tess.skipTangentSpaces, tess.skipVBO,
+	Tess_Begin( tess.stageIteratorFunc, tess.stageIteratorFunc2, tess.surfaceShader, tess.lightShader, tess.skipTangentSpaces,
 	            tess.lightmapNum, tess.fogNum, tess.bspSurface );
 }
 
@@ -112,7 +112,7 @@ void Tess_CheckOverflow( int verts, int indexes )
 		Sys::Drop( "Tess_CheckOverflow: indexes > std::max (%d > %d)", indexes, SHADER_MAX_INDEXES );
 	}
 
-	Tess_Begin( tess.stageIteratorFunc, tess.stageIteratorFunc2, tess.surfaceShader, tess.lightShader, tess.skipTangentSpaces, tess.skipVBO,
+	Tess_Begin( tess.stageIteratorFunc, tess.stageIteratorFunc2, tess.surfaceShader, tess.lightShader, tess.skipTangentSpaces,
 	            tess.lightmapNum, tess.fogNum, tess.bspSurface );
 }
 
@@ -160,11 +160,6 @@ static void Tess_SurfaceVertsAndTris( const srfVert_t *verts, const srfTriangle_
 static bool Tess_SurfaceVBO( VBO_t *vbo, IBO_t *ibo, int numIndexes, int firstIndex )
 {
 	if ( !vbo || !ibo )
-	{
-		return false;
-	}
-
-	if ( tess.skipVBO )
 	{
 		return false;
 	}


### PR DESCRIPTION
Use VBOs/IBOs everywhere. Avoid unnecessary data transfers to the GPU. The ability to use client-side vertex arrays is also removed in 3.2+ core OpenGL.
`skipVBO` set by portals is never used because portal surfaces are skipped when building the world VBO, so their vbo/ibo is never set.