### PR TITLE
tr_shader: do not collapse stage with tcGen environment

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4806,19 +4806,13 @@ static void CollapseStages()
 		bool alphaGen_identity =
 			stages[ i ].alphaGen == alphaGen_t::AGEN_IDENTITY;
 
-		/*
-		bool blendFunc_none = 
-			( stages[ lightStage ].stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_ZERO
-			&& ( stages[ lightStage ].stateBits & GLS_DSTBLEND_BITS ) == GLS_DSTBLEND_ONE;
-		*/
-
 		bool blendFunc_add =
-			( stages[ lightStage ].stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_ONE
-			&& ( stages[ lightStage ].stateBits & GLS_DSTBLEND_BITS ) == GLS_DSTBLEND_ONE;
+			( stages[ i ].stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_ONE
+			&& ( stages[ i ].stateBits & GLS_DSTBLEND_BITS ) == GLS_DSTBLEND_ONE;
 
 		bool blendFunc_filter =
-			( stages[ lightStage ].stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_DST_COLOR
-			&& ( stages[ lightStage ].stateBits & GLS_DSTBLEND_BITS ) == GLS_DSTBLEND_ZERO;
+			( stages[ i ].stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_DST_COLOR
+			&& ( stages[ i ].stateBits & GLS_DSTBLEND_BITS ) == GLS_DSTBLEND_ZERO;
 
 		bool tcGen_Environment = stages[ i ].tcGen_Environment;
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4820,11 +4820,14 @@ static void CollapseStages()
 			( stages[ lightStage ].stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_DST_COLOR
 			&& ( stages[ lightStage ].stateBits & GLS_DSTBLEND_BITS ) == GLS_DSTBLEND_ZERO;
 
+		bool tcGen_Environment = stages[ i ].tcGen_Environment;
+
 		if ( step == 0 )
 		{
 			if ( ( isColorStage || isCollapseColorStage )
 				&& rgbGen_identity
-				&& alphaGen_identity )
+				&& alphaGen_identity
+				&& !tcGen_Environment )
 			{
 				colorStage = i;
 				step++;
@@ -4872,7 +4875,8 @@ static void CollapseStages()
 			if ( isColorStage
 				&& rgbGen_identity
 				&& alphaGen_identity
-				&& blendFunc_add )
+				&& blendFunc_add
+				&& !tcGen_Environment )
 			{
 				bool hasGlowMap = stages[ colorStage ].bundle[ TB_GLOWMAP ].image[ 0 ] != nullptr;
 


### PR DESCRIPTION
- tr_shader: do not collapse stage with tcGen environment

Fixes a bug (regression) where the color map has a different tcGen than the light map: they should not be collapsed

This is usually used to fake reflections, by applying a baked reflection as a texture but using `tcGen environment` the texture moves on the surface while the player moves. The lightmap itself should stick to the surface.

It may be possible to edit the lightMapping code to have two coordinate systems for color map and lightmap, but this extra complexity can be uselessly costly for every surfaces while keeping the fake reflections uncollapsed only affect those surfaces.

For maximum prevention this check is also done on addition map collapse.

With bug (see the train windows):

![unvanquished_2024-03-11_161935_000](https://github.com/DaemonEngine/Daemon/assets/2311649/fdb57918-03c1-491b-99a3-7c77213bf7c2)

Without bug:

![unvanquished_2024-03-11_162321_000](https://github.com/DaemonEngine/Daemon/assets/2311649/f9c6a2a0-8c71-453b-8b31-5b06d1524f10)

The regression was introduced by myself in #1046 (I missed a check to detect a stage as not collapsible).

- tr_shader: fix blendFunc detection in collapse code

Some index was wrong, I also deleted dead code.