### PR TITLE
Print NaCl exception message + fault injection command

### DIFF
--- a/src/common/Command.cpp
+++ b/src/common/Command.cpp
@@ -523,3 +523,70 @@ namespace Cmd {
         return complete(argNum, args, prefix);
     }
 }
+
+class InjectFaultCmd : public Cmd::StaticCmd
+{
+public:
+    InjectFaultCmd() : StaticCmd(
+        VM_STRING_PREFIX "injectFault", "make the program error and crash") {}
+
+    void Run(const Cmd::Args& args) const override
+    {
+        bool useThread = Str::IsIEqual(args.ArgVector().back(), "thread");
+        if (useThread) {
+            std::thread(&DoFault, Cmd::Args(std::vector<std::string>(args.begin(), args.end() - 1)))
+                .detach();
+        } else {
+            if (!DoFault(args)) {
+                Print("Usage: %s (drop | error | segfault | intdiv | floatdiv | unreachable"
+                      " | exception | throw | terminate | abort | freeze <seconds>) [thread]",
+                      args.Argv(0));
+            }
+        }
+    }
+
+private:
+    static bool DoFault(const Cmd::Args& args)
+    {
+        float freezeDuration;
+        if (args.Argc() == 3 && Str::IsIEqual(args.Argv(1), "freeze") &&
+                Cvar::ParseCvarValue(args.Argv(2), freezeDuration)) {
+            int start = Sys::Milliseconds();
+            while (Sys::Milliseconds() < start + freezeDuration * 1000.0f) {} // spin cpu
+            return true;
+        } else if (args.Argc() != 2) {
+            return false;
+        }
+
+        std::string how = Str::ToLower(args.Argv(1));
+        if (how == "drop") {
+            Sys::Drop("drop from injectFault command");
+        } else if (how == "error") {
+            Sys::Error("error from injectFault command");
+        } else if (how == "segfault") {
+            volatile auto p = (volatile char*)1;
+            *p = 'x';
+        } else if (how == "intdiv") {
+            volatile int n = 0;
+            n = n / n;
+        } else if (how == "floatdiv") {
+            volatile float x = 0;
+            x = x / x;
+        } else if (how == "unreachable") { // May print the usage string :)
+            UNREACHABLE();
+        } else if (how == "exception") { // std::exception
+            std::vector<int> v;
+            (void) v.at(0);
+        } else if (how == "throw") { // other exception
+            throw 2;
+        } else if (how == "terminate") { // std::terminate without an exception
+            std::thread t([]{});
+        } else if (how == "abort") {
+            std::abort();
+        } else {
+            return false;
+        }
+        return true;
+    }
+};
+static InjectFaultCmd injectFaultRegistration;

--- a/src/common/System.cpp
+++ b/src/common/System.cpp
@@ -376,7 +376,8 @@ void OSExit(int exitCode) {
 		// _exit runs full shutdown for DLLs including global destructors, ewww
 		TerminateProcess(GetCurrentProcess(), exitCode);
 		// There are rumors of TerminateProcess returning: https://crbug.com/820518. Crash to be sure
-		*(volatile char*)1 = 123;
+		volatile auto p = (volatile char*)1;
+		*p = 123;
 		ASSERT_UNREACHABLE();
 #else
 		_exit(exitCode);

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -52,7 +52,6 @@ Maryland 20850 USA.
 #include <common/FileSystem.h>
 
 cvar_t *com_speeds;
-cvar_t *com_developer;
 cvar_t *com_timescale;
 cvar_t *com_dropsim; // 0.0 to 1.0, simulated packet drops
 
@@ -514,72 +513,6 @@ int Com_Milliseconds()
 
 //============================================================================
 
-/*
-=============
-Com_Error_f
-
-Just throw a fatal error to
-test error shutdown procedures
-=============
-*/
-NORETURN static void Com_Error_f()
-{
-	if ( Cmd_Argc() > 1 )
-	{
-		Sys::Drop( "Testing drop error" );
-	}
-	else
-	{
-		Sys::Error( "Testing fatal error" );
-	}
-}
-
-/*
-=============
-Com_Freeze_f
-
-Just freeze in place for a given number of seconds to test
-error recovery
-=============
-*/
-static void Com_Freeze_f()
-{
-	float s;
-	int   start, now;
-
-	if ( Cmd_Argc() != 2 )
-	{
-		Log::Notice( "freeze <seconds>" );
-		return;
-	}
-
-	s = atof( Cmd_Argv( 1 ) );
-
-	start = Com_Milliseconds();
-
-	while (true)
-	{
-		now = Com_Milliseconds();
-
-		if ( ( now - start ) * 0.001 > s )
-		{
-			break;
-		}
-	}
-}
-
-/*
-=================
-Com_Crash_f
-
-A way to force a bus error for development reasons
-=================
-*/
-static void Com_Crash_f()
-{
-	* ( volatile int * ) 0 = 0x12345678;
-}
-
 void Com_In_Restart_f()
 {
 	IN_Restart();
@@ -607,8 +540,6 @@ void Com_Init()
 	//
 	// init commands and vars
 	//
-	com_developer = Cvar_Get( "developer", "0", CVAR_TEMP );
-
 	com_timescale = Cvar_Get( "timescale", "1", CVAR_CHEAT | CVAR_SYSTEMINFO );
 	com_dropsim = Cvar_Get( "com_dropsim", "0", CVAR_CHEAT );
 	com_speeds = Cvar_Get( "com_speeds", "0", 0 );
@@ -618,13 +549,6 @@ void Com_Init()
 
 	com_unfocused = Cvar_Get( "com_unfocused", "0", CVAR_ROM );
 	com_minimized = Cvar_Get( "com_minimized", "0", CVAR_ROM );
-
-	if ( com_developer && com_developer->integer )
-	{
-		Cmd_AddCommand( "error", Com_Error_f );
-		Cmd_AddCommand( "crash", Com_Crash_f );
-		Cmd_AddCommand( "freeze", Com_Freeze_f );
-	}
 
 	Cmd_AddCommand( "writeconfig", Com_WriteConfig_f );
 #ifdef BUILD_GRAPHICAL_CLIENT

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -527,7 +527,6 @@ bool       Com_ServerRunning();
 // if match is nullptr, all set commands will be executed, otherwise
 // only a set with the exact name.  Only used during startup.
 
-extern cvar_t       *com_developer;
 extern cvar_t       *com_speeds;
 extern cvar_t       *com_timescale;
 extern cvar_t       *com_sv_running;


### PR DESCRIPTION
Stacked (hehe) on #1063.

In #716 I removed the code for NaCl exception messages in favor of letting it crash with an nice stack trace. But we can have our cake and eat it too. Here's an example of an NaCl crash dump including the custom terminate handler (which logs the exception message), as well as the stack leading to the error below


```
Thread 0 (crashed)
 0  main.nexe!abort [abort.c : 21 + 0x0]
    rax = 0x0000000000000000   rdx = 0x0000000000000000
    rcx = 0x000000000ffc13e0   rbx = 0x0000000000000000
    rsi = 0x0000000000000000   rdi = 0x00000000fffe6d68
    rbp = 0x00000000fffeff80   rsp = 0x00000000fffe6d90
     r8 = 0x0000000000000000    r9 = 0x0000000000000000
    r10 = 0x0000000000000000   r11 = 0x000006e700582760
    r12 = 0x00000000fd3c4738   r13 = 0x00000000fffe6fa0
    r14 = 0x00000000fd3d97b0   r15 = 0x000006e700000000
    rip = 0x0000000000582796
    Found by: given as instruction pointer in context
 1  main.nexe!TerminateHandler() [VMMain.cpp : 141 + 0x20]
    rbx = 0x0000000000000002   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe6db0   r12 = 0x00000000fd3c4738
    r13 = 0x00000000fffe6fa0   r14 = 0x00000000fd3d97b0
    r15 = 0x000006e700000000   rip = 0x00000000001e7580
    Found by: call frame info
 2  main.nexe!std::__terminate(void (*)()) [cxa_handlers.cpp : 68 + 0x40]
    rbx = 0x00000000fd3d97d0   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe6df0   r12 = 0x00000000fd3c4738
    r13 = 0x00000000fffe6fa0   r14 = 0x00000000fd3d97b0
    r15 = 0x000006e700000000   rip = 0x00000000005779e0
    Found by: call frame info
 3  main.nexe!__cxa_throw [cxa_exception.cpp : 149 + 0x20]
    rbx = 0x00000000fd3d97d0   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe6e10   r12 = 0x00000000fd3c4738
    r13 = 0x00000000fffe6fa0   r14 = 0x00000000fd3d97b0
    r15 = 0x000006e700000000   rip = 0x0000000000577dc0
    Found by: call frame info
 4  main.nexe!InjectFaultCmd::DoFault(Cmd::Args const&) [vector : 312 + 0x20]
    rbx = 0x00000000fd3d97d0   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe6e30   r12 = 0x00000000fd3c4738
    r13 = 0x00000000fffe6fa0   r14 = 0x00000000fffe6fa0
    r15 = 0x000006e700000000   rip = 0x00000000001eb160
    Found by: call frame info
 5  main.nexe!InjectFaultCmd::Run(Cmd::Args const&) const [Command.cpp : 540 + 0x16]
    rbx = 0x0000000000000000   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe6e80   r12 = 0x00000000fd3c4738
    r13 = 0x00000000fffe6fa0   r14 = 0x00000000fd3c472c
    r15 = 0x000006e700000000   rip = 0x00000000001ea460
    Found by: call frame info
 6  main.nexe!Cmd::ExecuteSyscall(Util::Reader&, IPC::Channel&) [CommonProxies.cpp : 116 + 0x55]
    rbx = 0x0000000000000000   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe6ee0   r12 = 0x0000000000000000
    r13 = 0x0000000000000064   r14 = 0x0000000000000000
    r15 = 0x000006e700000000   rip = 0x00000000001ce580
    Found by: call frame info
 7  main.nexe!VM::VMHandleSyscall(unsigned int, Util::Reader) [CommonProxies.cpp : 138 + 0x20]
    rbx = 0x0000000000000000   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffe6fe0   r12 = 0x00000000fffefed0
    r13 = 0x0000000000000064   r14 = 0x0000000000000000
    r15 = 0x000006e700000000   rip = 0x0000000000026b60
    Found by: call frame info
 8  main.nexe!main [VMMain.cpp : 71 + 0x20]
    rbx = 0x00000000fd3c4818   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffefe90   r12 = 0x00000000fffefed0
    r13 = 0x0000000000000064   r14 = 0x00000000fffefeb0
    r15 = 0x000006e700000000   rip = 0x00000000001e7f60
    Found by: call frame info
 9  main.nexe!_start [start.c : 68 + 0x39]
    rbx = 0x0000000000000028   rbp = 0x00000000fffeff80
    rsp = 0x00000000fffeff40   r12 = 0x00000000fffeffbc
    r13 = 0x0000000000000002   r14 = 0x0000000000000028
    r15 = 0x000006e700000000   rip = 0x0000000000582d00
    Found by: call frame info
```

To do before merging:
- Test native exe more
- Make sure that if Log::Warn blows up it won't prevent us from getting a stack trace