### PR TITLE
Begin migrating engine cvars to new-style

### DIFF
--- a/src/common/Cvar.h
+++ b/src/common/Cvar.h
@@ -42,6 +42,7 @@ namespace Cvar {
         USERINFO   = BIT(1), // The cvar is sent to the server as part of the client state
         SERVERINFO = BIT(2), // The cvar is sent to the client when doing server status request and in a config string (mostly for mapname)
         SYSTEMINFO = BIT(3), // The cvar is sent to the client when changed, to synchronize some global game options (for example pmove config)
+        INIT       = BIT(4), // The cvar can only be set from the command line (or before the flag is added)
         ROM        = BIT(6), // The cvar cannot be changed by the user
         TEMPORARY  = BIT(8), // The cvar is temporary and is not to be archived (overrides archive flags)
         CHEAT      = BIT(9), // The cvar is a cheat and should stay at its default value on pure servers.

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2326,6 +2326,12 @@ void CL_ShutdownRef()
 CL_Init
 ====================
 */
+static Cvar::Cvar<int> cvar_snaps(
+	"snaps", "snapshots per second that the client wants from the server", Cvar::USERINFO, 40);
+static Cvar::Cvar<std::string> cvar_password(
+	"password", "client's password to get into the server", Cvar::USERINFO, "");
+static Cvar::Cvar<std::string> cvar_name(
+	"name", "player display name", Cvar::USERINFO | Cvar::ARCHIVE, UNNAMED_PLAYER);
 void CL_Init()
 {
 	PrintBanner( "Client Initialization" )
@@ -2417,11 +2423,7 @@ void CL_Init()
 	cl_packetdelay = Cvar_Get( "cl_packetdelay", "0", CVAR_CHEAT );
 
 	// userinfo
-	Cvar_Get( "name", UNNAMED_PLAYER, CVAR_USERINFO | CVAR_ARCHIVE );
 	cl_rate = Cvar_Get( "rate", "25000", CVAR_USERINFO | CVAR_ARCHIVE );
-	Cvar_Get( "snaps", "40", CVAR_USERINFO  );
-
-	Cvar_Get( "password", "", CVAR_USERINFO );
 
 #if defined(USE_MUMBLE)
 	cl_useMumble = Cvar_Get( "cl_useMumble", "0",  CVAR_LATCH );

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2105,16 +2105,6 @@ void CL_Frame( int msec )
 	cls.framecount++;
 }
 
-/*
-================
-CL_SetRecommended_f
-================
-*/
-void CL_SetRecommended_f()
-{
-	Com_SetRecommended();
-}
-
 static bool CL_InitRef();
 /*
 ============
@@ -2468,8 +2458,6 @@ void CL_Init()
 
 	Cmd_AddCommand( "updatescreen", SCR_UpdateScreen );
 	// done.
-
-	Cmd_AddCommand( "setRecommended", CL_SetRecommended_f );
 
 	SCR_Init();
 

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -75,9 +75,7 @@ cvar_t *cl_timeNudge;
 cvar_t *cl_showTimeDelta;
 
 cvar_t *cl_shownet = nullptr; // NERVE - SMF - This is referenced in msg.c and we need to make sure it is nullptr
-cvar_t *cl_shownuments; // DHM - Nerve
 cvar_t *cl_showSend;
-cvar_t *cl_showServerCommands; // NERVE - SMF
 
 Cvar::Cvar<bool> cvar_demo_status_isrecording(
     "demo.status.isrecording",
@@ -127,7 +125,6 @@ cvar_t *cl_autorecord;
 
 cvar_t *cl_allowDownload;
 
-cvar_t                 *cl_packetloss; //bani
 cvar_t                 *cl_packetdelay; //bani
 
 cvar_t                 *cl_consoleFont;
@@ -146,8 +143,6 @@ cvar_t             *cl_aviMotionJpeg;
 // XreaL END
 
 cvar_t             *cl_rate;
-
-cvar_t             *cl_cgameSyscallStats;
 
 clientActive_t     cl;
 clientConnection_t clc;
@@ -2356,8 +2351,6 @@ void CL_Init()
 
 	cl_timeNudge = Cvar_Get( "cl_timeNudge", "0", CVAR_TEMP );
 	cl_shownet = Cvar_Get( "cl_shownet", "0", CVAR_TEMP );
-	cl_shownuments = Cvar_Get( "cl_shownuments", "0", CVAR_TEMP );
-	cl_showServerCommands = Cvar_Get( "cl_showServerCommands", "0", 0 );
 	cl_showSend = Cvar_Get( "cl_showSend", "0", CVAR_TEMP );
 	cl_showTimeDelta = Cvar_Get( "cl_showTimeDelta", "0", CVAR_TEMP );
 	cl_activeAction = Cvar_Get( "activeAction", "", CVAR_TEMP );
@@ -2421,7 +2414,6 @@ void CL_Init()
 	cl_altTab = Cvar_Get( "cl_altTab", "1", 0 );
 
 	//bani
-	cl_packetloss = Cvar_Get( "cl_packetloss", "0", CVAR_CHEAT );
 	cl_packetdelay = Cvar_Get( "cl_packetdelay", "0", CVAR_CHEAT );
 
 	// userinfo
@@ -2435,8 +2427,6 @@ void CL_Init()
 	cl_useMumble = Cvar_Get( "cl_useMumble", "0",  CVAR_LATCH );
 	cl_mumbleScale = Cvar_Get( "cl_mumbleScale", "0.0254", 0 );
 #endif
-
-	cl_cgameSyscallStats = Cvar_Get( "cl_cgameSyscallStats", "0", 0 );
 
 	//
 	// register our commands

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -384,9 +384,7 @@ extern cvar_t *cl_noprint;
 extern cvar_t *cl_maxpackets;
 extern cvar_t *cl_packetdup;
 extern cvar_t *cl_shownet;
-extern cvar_t *cl_shownuments; // DHM - Nerve
 extern cvar_t *cl_showSend;
-extern cvar_t *cl_showServerCommands; // NERVE - SMF
 extern cvar_t *cl_timeNudge;
 extern cvar_t *cl_showTimeDelta;
 
@@ -440,8 +438,6 @@ extern cvar_t *cl_consoleFontSize;
 extern cvar_t *cl_consoleFontScaling;
 extern cvar_t *cl_consoleFontKerning;
 extern cvar_t *cl_consoleCommand;
-
-extern cvar_t *cl_cgameSyscallStats;
 
 extern cvar_t *con_scrollLock;
 

--- a/src/engine/framework/CrashDump.cpp
+++ b/src/engine/framework/CrashDump.cpp
@@ -100,7 +100,9 @@ static std::string CrashServerPath() {
     return FS::Path::Build(FS::GetLibPath(), name);
 }
 
-static Cvar::Cvar<bool> enableBreakpad("common.breakpad.enabled", "If enabled on startup, starts a process for recording crash dumps", Cvar::TEMPORARY, true);
+static Cvar::Cvar<bool> enableBreakpad(
+    "common.breakpad.enabled", "If enabled on startup, starts a process for recording crash dumps",
+    Cvar::INIT | Cvar::TEMPORARY, true);
 
 #ifdef _WIN32
 

--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -245,12 +245,17 @@ namespace Cvar {
             cvarRecord_t* cvar = it->second;
 
             if (not (cvar->flags & CVAR_USER_CREATED)) {
-                if (cvar->flags & (CVAR_ROM | CVAR_INIT) and not rom) {
+                if (cvar->flags & CVAR_ROM and not rom) {
                     Log::Notice("%s is read only.", cvarName.c_str());
                     return;
                 }
 
-                if (rom and warnRom and not (cvar->flags & (CVAR_ROM | CVAR_INIT))) {
+                if (cvar->flags & INIT and not rom) {
+                    Log::Notice("%s can only be set at program initalization.", cvarName);
+                    return;
+                }
+
+                if (rom and warnRom and not (cvar->flags & (CVAR_ROM | INIT))) {
                     Log::Notice("SetValueForce called on non-ROM cvar '%s'", cvarName.c_str());
                 }
 
@@ -423,6 +428,18 @@ namespace Cvar {
         } //TODO else what?
 
         return false; // not found
+    }
+
+    bool GetFlags(const std::string& cvarName, int& flags) {
+        CvarMap& cvars = GetCvarMap();
+
+        auto it = cvars.find(cvarName);
+        if (it == cvars.end()) {
+            return false;
+        }
+
+        flags = it->second->flags;
+        return true;
     }
 
     bool ClearFlags(const std::string& cvarName, int flags) {
@@ -713,7 +730,7 @@ namespace Cvar {
                     cvarFlags += (var->flags & SYSTEMINFO) ? "s" : "_";
                     cvarFlags += (var->flags & USERINFO) ? "U" : "_";
                     cvarFlags += (var->flags & ROM) ? "R" : "_";
-                    cvarFlags += (var->flags & CVAR_INIT) ? "I" : "_";
+                    cvarFlags += (var->flags & INIT) ? "I" : "_";
                     cvarFlags += (var->flags & TEMPORARY) ? "T" : (var->flags & USER_ARCHIVE) ? "A" : "_";
                     cvarFlags += (var->flags & (CVAR_LATCH | INTERNAL_LATCH)) ? "L" : "_";
                     cvarFlags += (var->flags & CHEAT) ? "C" : "_";

--- a/src/engine/framework/CvarSystem.h
+++ b/src/engine/framework/CvarSystem.h
@@ -69,6 +69,9 @@ namespace Cvar {
     // Returns a list of cvars matching the prefix as well as their description
     Cmd::CompletionResult Complete(Str::StringRef prefix);
 
+    // Returns true if the cvar exists. Outputs to flags
+    bool GetFlags(const std::string& cvarName, int& flags);
+
     // Alter flags, returns true if the variable exists
     bool ClearFlags(const std::string& cvarName, int flags);
 
@@ -100,7 +103,6 @@ namespace Cvar {
     // Remove eventually
     //CVAR_UNSAFE, not sure <- no support for now
     //CVAR_USER_CREATED is kept for now but not really needed
-    //CVAR_INIT is no longer supported, will be implemented by the proxy
 
     //CVAR_NORESTART is not used will be killed
     //CVAR_TEMP seems useless, don't put the CVAR_ARCHIVE and CVAR_CHEAT

--- a/src/engine/framework/LogSystem.cpp
+++ b/src/engine/framework/LogSystem.cpp
@@ -108,9 +108,9 @@ namespace Log {
 
     //TODO add a Callback on these that will make the logFile open a new file or something?
     Cvar::Cvar<bool> useLogFile("logs.logFile.active", "are the logs sent in the logfile", Cvar::NONE, true);
-    Cvar::Cvar<std::string> logFileName("logs.logFile.filename", "the name of the logfile", Cvar::NONE, "daemon.log");
-    Cvar::Cvar<bool> overwrite("logs.logFile.overwrite", "if true the logfile is deleted at each run else the logs are just appended", Cvar::NONE, true);
-    Cvar::Cvar<bool> forceFlush("logs.logFile.forceFlush", "are all the logs flushed immediately (more accurate but slower)", Cvar::NONE, false);
+    Cvar::Cvar<std::string> logFileName("logs.logFile.filename", "the name of the logfile", Cvar::INIT | Cvar::TEMPORARY, "daemon.log");
+    Cvar::Cvar<bool> overwrite("logs.logFile.overwrite", "if true the logfile is deleted at each run else the logs are just appended", Cvar::INIT | Cvar::TEMPORARY, true);
+    Cvar::Cvar<bool> forceFlush("logs.logFile.forceFlush", "are all the logs flushed immediately (more accurate but slower)", Cvar::INIT | Cvar::TEMPORARY, false);
     class LogFileTarget: public Target {
         public:
             LogFileTarget() {

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -699,13 +699,9 @@ static void Init(int argc, char** argv)
 	// At this point we can safely open the log file since there are no existing
 	// instances running on this homepath.
 	EarlyCvar("logs.logFile.active", cmdlineArgs);
-	EarlyCvar("logs.logFile.filename", cmdlineArgs);
-	EarlyCvar("logs.logFile.overwrite", cmdlineArgs);
-	EarlyCvar("logs.logFile.forceFlush", cmdlineArgs);
 	Log::OpenLogFile();
 
 	if (CreateCrashDumpPath()) {
-		EarlyCvar("common.breakpad.enabled", cmdlineArgs);
 		// This may fork(), and then exec() *in the parent process*,
 		// so threads must not be created before this point.
 		BreakpadInit();

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -580,27 +580,6 @@ static void Com_Crash_f()
 	* ( volatile int * ) 0 = 0x12345678;
 }
 
-void Com_SetRecommended()
-{
-	cvar_t   *r_highQualityVideo;
-	bool goodVideo;
-
-	// will use this for recommended settings as well.. do i outside the lower check so it gets done even with command line stuff
-	r_highQualityVideo = Cvar_Get( "r_highQualityVideo", "1", 0 );
-	goodVideo = ( r_highQualityVideo && r_highQualityVideo->integer );
-
-	if ( goodVideo )
-	{
-		Log::Notice( "Found high quality video and slow CPU" );
-		Cmd::BufferCommandText("preset preset_fast.cfg");
-	}
-	else
-	{
-		Log::Notice( "Found low quality video and slow CPU" );
-		Cmd::BufferCommandText("preset preset_fastest.cfg");
-	}
-}
-
 void Com_In_Restart_f()
 {
 	IN_Restart();

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -1486,12 +1486,6 @@ inline float DotProduct( const vec3_t x, const vec3_t y )
 #define CVAR_SYSTEMINFO          BIT(3)    /*< these cvars will be duplicated on all clients */
 
 /**
- * don't allow change from console at all,
- * but can be set from the command line
- */
-#define CVAR_INIT                BIT(4)
-
-/**
  * will only change when C code next does a Cvar_Get(),
  * so it can't be changed without proper initialization.
  * modified will be set, even though the value hasn't changed yet

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -518,7 +518,6 @@ unsigned   Com_BlockChecksum( const void *buffer, int length );
 char       *Com_MD5File( const char *filename, int length );
 void       Com_MD5Buffer( const char *pubkey, int size, char *buffer, int bufsize );
 
-void       Com_SetRecommended();
 bool       Com_AreCheatsAllowed();
 bool       Com_IsClient();
 bool       Com_IsDedicatedServer();

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -29,6 +29,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // and try to memcpy over that or binary write an std::string to a file.
 static_assert(std::is_pod<GLBinaryHeader>::value, "Value must be a pod while code in this cpp file reads and writes this object to file as binary.");
 
+// set via command line args only since this allows arbitrary code execution
+static Cvar::Cvar<std::string> shaderpath(
+	"shaderpath", "path to load GLSL source files at runtime", Cvar::INIT | Cvar::TEMPORARY, "");
+
 extern std::unordered_map<std::string, std::string> shadermap;
 // shaderKind's value will be determined later based on command line setting or absence of.
 ShaderKind shaderKind = ShaderKind::Unknown;
@@ -207,11 +211,7 @@ namespace // Implementation details
 
 std::string GetShaderPath()
 {
-	std::string shaderPath;
-	auto shaderPathVar = Cvar_Get("shaderpath", "", CVAR_INIT);
-	if (shaderPathVar->string != nullptr)
-		shaderPath = shaderPathVar->string;
-	return shaderPath;
+	return shaderpath.Get();
 }
 
 GLShaderManager::~GLShaderManager()

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -41,7 +41,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_glAllowSoftware;
 	cvar_t      *r_glExtendedValidation;
 
-	cvar_t      *r_verbose;
 	cvar_t      *r_ignore;
 
 	cvar_t      *r_znear;
@@ -50,7 +49,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_smp;
 	cvar_t      *r_showSmp;
 	cvar_t      *r_skipBackEnd;
-	cvar_t      *r_skipLightBuffer;
 
 	cvar_t      *r_measureOverdraw;
 
@@ -58,7 +56,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_lodBias;
 	cvar_t      *r_lodScale;
-	cvar_t      *r_lodTest;
 
 	cvar_t      *r_norefresh;
 	cvar_t      *r_drawentities;
@@ -92,7 +89,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_ext_occlusion_query;
 	cvar_t      *r_ext_draw_buffers;
-	cvar_t      *r_ext_vertex_array_object;
 	cvar_t      *r_ext_half_float_pixel;
 	cvar_t      *r_ext_texture_float;
 	cvar_t      *r_ext_texture_integer;
@@ -109,7 +105,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_checkGLErrors;
 	cvar_t      *r_logFile;
 
-	cvar_t      *r_depthbits;
 	cvar_t      *r_colorbits;
 
 	cvar_t      *r_drawBuffer;
@@ -122,7 +117,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_softShadowsPP;
 	cvar_t      *r_shadowBlur;
 
-	cvar_t      *r_shadowMapQuality;
 	cvar_t      *r_shadowMapSizeUltra;
 	cvar_t      *r_shadowMapSizeVeryHigh;
 	cvar_t      *r_shadowMapSizeHigh;
@@ -135,16 +129,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_shadowMapSizeSunMedium;
 	cvar_t      *r_shadowMapSizeSunLow;
 
-	cvar_t      *r_shadowOffsetFactor;
-	cvar_t      *r_shadowOffsetUnits;
 	cvar_t      *r_shadowLodBias;
 	cvar_t      *r_shadowLodScale;
 	cvar_t      *r_noShadowPyramids;
 	cvar_t      *r_cullShadowPyramidFaces;
-	cvar_t      *r_cullShadowPyramidCurves;
-	cvar_t      *r_cullShadowPyramidTriangles;
 	cvar_t      *r_debugShadowMaps;
-	cvar_t      *r_noShadowFrustums;
 	cvar_t      *r_noLightFrustums;
 	cvar_t      *r_shadowMapLinearFilter;
 	cvar_t      *r_lightBleedReduction;
@@ -156,7 +145,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_mode;
 	cvar_t      *r_nobind;
 	cvar_t      *r_singleShader;
-	cvar_t      *r_colorMipLevels;
 	cvar_t      *r_picMip;
 	cvar_t      *r_imageMaxDimension;
 	cvar_t      *r_ignoreMaterialMinDimension;
@@ -194,7 +182,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_noportals;
 	cvar_t      *r_portalOnly;
 
-	cvar_t      *r_portalSky;
 	cvar_t      *r_max_portal_levels;
 
 	cvar_t      *r_subdivisions;
@@ -210,7 +197,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_showImages;
 
-	cvar_t      *r_forceFog;
 	cvar_t      *r_wolfFog;
 	cvar_t      *r_noFog;
 
@@ -225,7 +211,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 	cvar_t      *r_showTris;
 	cvar_t      *r_showSky;
-	cvar_t      *r_showShadowVolumes;
 	cvar_t      *r_showShadowLod;
 	cvar_t      *r_showShadowMaps;
 	cvar_t      *r_showSkeleton;
@@ -242,7 +227,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_showDeluxeMaps;
 	cvar_t      *r_showNormalMaps;
 	cvar_t      *r_showMaterialMaps;
-	cvar_t      *r_showAreaPortals;
 	cvar_t      *r_showCubeProbes;
 	cvar_t      *r_showBspNodes;
 	cvar_t      *r_showParallelShadowSplits;
@@ -255,7 +239,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_vboLighting;
 	cvar_t      *r_vboModels;
 	cvar_t      *r_vboVertexSkinning;
-	cvar_t      *r_vboDeformVertexes;
 
 	cvar_t      *r_mergeLeafSurfaces;
 
@@ -1089,7 +1072,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		// latched and archived variables
 		r_ext_occlusion_query = Cvar_Get( "r_ext_occlusion_query", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_ext_draw_buffers = Cvar_Get( "r_ext_draw_buffers", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_ext_vertex_array_object = Cvar_Get( "r_ext_vertex_array_object", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_ext_half_float_pixel = Cvar_Get( "r_ext_half_float_pixel", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_ext_texture_float = Cvar_Get( "r_ext_texture_float", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_ext_texture_integer = Cvar_Get( "r_ext_texture_integer", "1", CVAR_CHEAT | CVAR_LATCH );
@@ -1109,9 +1091,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_ignoreMaterialMaxDimension = Cvar_Get( "r_ignoreMaterialMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_replaceMaterialMinDimensionIfPresentWithMaxDimension
 			= Cvar_Get( "r_replaceMaterialMinDimensionIfPresentWithMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
-		r_colorMipLevels = Cvar_Get( "r_colorMipLevels", "0", CVAR_LATCH );
 		r_colorbits = Cvar_Get( "r_colorbits", "0",  CVAR_LATCH );
-		r_depthbits = Cvar_Get( "r_depthbits", "0",  CVAR_LATCH );
 		r_mode = Cvar_Get( "r_mode", "-2", CVAR_LATCH | CVAR_ARCHIVE );
 		r_customwidth = Cvar_Get( "r_customwidth", "1600", CVAR_LATCH | CVAR_ARCHIVE );
 		r_customheight = Cvar_Get( "r_customheight", "1024", CVAR_LATCH | CVAR_ARCHIVE );
@@ -1136,8 +1116,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		and/or old hardware and drastically reduce first startup time. */
 		r_lazyShaders = Cvar_Get( "r_lazyShaders", "1", 0 );
 
-		r_forceFog = Cvar_Get( "r_forceFog", "0", CVAR_CHEAT /* | CVAR_LATCH */ );
-		AssertCvarRange( r_forceFog, 0.0f, 1.0f, false );
 		r_wolfFog = Cvar_Get( "r_wolfFog", "1", CVAR_CHEAT );
 		r_noFog = Cvar_Get( "r_noFog", "0", CVAR_CHEAT );
 
@@ -1180,7 +1158,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_vboLighting = Cvar_Get( "r_vboLighting", "1", CVAR_CHEAT );
 		r_vboModels = Cvar_Get( "r_vboModels", "1", CVAR_LATCH );
 		r_vboVertexSkinning = Cvar_Get( "r_vboVertexSkinning", "1",  CVAR_LATCH );
-		r_vboDeformVertexes = Cvar_Get( "r_vboDeformVertexes", "1",  CVAR_LATCH );
 
 		r_mergeLeafSurfaces = Cvar_Get( "r_mergeLeafSurfaces", "1",  CVAR_LATCH );
 
@@ -1212,16 +1189,13 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		r_drawworld = Cvar_Get( "r_drawworld", "1", CVAR_CHEAT );
 		r_portalOnly = Cvar_Get( "r_portalOnly", "0", CVAR_CHEAT );
-		r_portalSky = Cvar_Get( "cg_skybox", "1", 0 );
 		r_max_portal_levels = Cvar_Get( "r_max_portal_levels", "5", 0 );
 
 		r_showSmp = Cvar_Get( "r_showSmp", "0", CVAR_CHEAT );
 		r_skipBackEnd = Cvar_Get( "r_skipBackEnd", "0", CVAR_CHEAT );
-		r_skipLightBuffer = Cvar_Get( "r_skipLightBuffer", "0", CVAR_CHEAT );
 
 		r_measureOverdraw = Cvar_Get( "r_measureOverdraw", "0", CVAR_CHEAT );
 		r_lodScale = Cvar_Get( "r_lodScale", "5", CVAR_CHEAT );
-		r_lodTest = Cvar_Get( "r_lodTest", "0.5", CVAR_CHEAT );
 		r_norefresh = Cvar_Get( "r_norefresh", "0", CVAR_CHEAT );
 		r_drawentities = Cvar_Get( "r_drawentities", "1", CVAR_CHEAT );
 		r_drawpolies = Cvar_Get( "r_drawpolies", "1", CVAR_CHEAT );
@@ -1229,7 +1203,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_nocull = Cvar_Get( "r_nocull", "0", CVAR_CHEAT );
 		r_novis = Cvar_Get( "r_novis", "0", CVAR_CHEAT );
 		r_speeds = Cvar_Get( "r_speeds", "0", 0 );
-		r_verbose = Cvar_Get( "r_verbose", "0", CVAR_CHEAT );
 		r_logFile = Cvar_Get( "r_logFile", "0", CVAR_CHEAT );
 		r_debugSurface = Cvar_Get( "r_debugSurface", "0", CVAR_CHEAT );
 		r_nobind = Cvar_Get( "r_nobind", "0", CVAR_CHEAT );
@@ -1271,9 +1244,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_softShadowsPP = Cvar_Get( "r_softShadowsPP", "0",  CVAR_LATCH );
 
 		r_shadowBlur = Cvar_Get( "r_shadowBlur", "2",  CVAR_LATCH );
-
-		r_shadowMapQuality = Cvar_Get( "r_shadowMapQuality", "3",  CVAR_LATCH );
-		AssertCvarRange( r_shadowMapQuality, 0, 4, true );
 
 		r_shadowMapSizeUltra = Cvar_Get( "r_shadowMapSizeUltra", "1024",  CVAR_LATCH );
 		AssertCvarRange( r_shadowMapSizeUltra, 32, 2048, true );
@@ -1317,15 +1287,10 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		sunShadowMapResolutions[ 3 ] = r_shadowMapSizeSunMedium->integer;
 		sunShadowMapResolutions[ 4 ] = r_shadowMapSizeSunLow->integer;
 
-		r_shadowOffsetFactor = Cvar_Get( "r_shadowOffsetFactor", "0", CVAR_CHEAT );
-		r_shadowOffsetUnits = Cvar_Get( "r_shadowOffsetUnits", "0", CVAR_CHEAT );
 		r_shadowLodBias = Cvar_Get( "r_shadowLodBias", "0", CVAR_CHEAT );
 		r_shadowLodScale = Cvar_Get( "r_shadowLodScale", "0.8", CVAR_CHEAT );
 		r_noShadowPyramids = Cvar_Get( "r_noShadowPyramids", "0", CVAR_CHEAT );
 		r_cullShadowPyramidFaces = Cvar_Get( "r_cullShadowPyramidFaces", "0", CVAR_CHEAT );
-		r_cullShadowPyramidCurves = Cvar_Get( "r_cullShadowPyramidCurves", "1", CVAR_CHEAT );
-		r_cullShadowPyramidTriangles = Cvar_Get( "r_cullShadowPyramidTriangles", "1", CVAR_CHEAT );
-		r_noShadowFrustums = Cvar_Get( "r_noShadowFrustums", "0", CVAR_CHEAT );
 		r_noLightFrustums = Cvar_Get( "r_noLightFrustums", "1", CVAR_CHEAT );
 
 		r_maxPolys = Cvar_Get( "r_maxpolys", "10000", CVAR_LATCH );  // 600 in vanilla Q3A
@@ -1336,7 +1301,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		r_showTris = Cvar_Get( "r_showTris", "0", CVAR_CHEAT );
 		r_showSky = Cvar_Get( "r_showSky", "0", CVAR_CHEAT );
-		r_showShadowVolumes = Cvar_Get( "r_showShadowVolumes", "0", CVAR_CHEAT );
 		r_showShadowLod = Cvar_Get( "r_showShadowLod", "0", CVAR_CHEAT );
 		r_showShadowMaps = Cvar_Get( "r_showShadowMaps", "0", CVAR_CHEAT );
 		r_showSkeleton = Cvar_Get( "r_showSkeleton", "0", CVAR_CHEAT );
@@ -1353,7 +1317,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_showDeluxeMaps = Cvar_Get( "r_showDeluxeMaps", "0", CVAR_CHEAT | CVAR_LATCH );
 		r_showNormalMaps = Cvar_Get( "r_showNormalMaps", "0", CVAR_CHEAT | CVAR_LATCH );
 		r_showMaterialMaps = Cvar_Get( "r_showMaterialMaps", "0", CVAR_CHEAT | CVAR_LATCH );
-		r_showAreaPortals = Cvar_Get( "r_showAreaPortals", "0", CVAR_CHEAT );
 		r_showCubeProbes = Cvar_Get( "r_showCubeProbes", "0", CVAR_CHEAT );
 		r_showBspNodes = Cvar_Get( "r_showBspNodes", "0", CVAR_CHEAT );
 		r_showParallelShadowSplits = Cvar_Get( "r_showParallelShadowSplits", "0", CVAR_CHEAT | CVAR_LATCH );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2928,23 +2928,19 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_glExtendedValidation;
 
 	extern cvar_t *r_ignore; // used for debugging anything
-	extern cvar_t *r_verbose; // used for verbose debug spew
 
 	extern Cvar::Cvar<bool> r_dpBlend;
 
 	extern cvar_t *r_znear; // near Z clip plane
 	extern cvar_t *r_zfar;
 
-	extern cvar_t *r_depthbits; // number of desired depth bits
 	extern cvar_t *r_colorbits; // number of desired color bits, only relevant for fullscreen
 
 	extern cvar_t *r_measureOverdraw; // enables stencil buffer overdraw measurement
 
 	extern cvar_t *r_lodBias; // push/pull LOD transitions
 	extern cvar_t *r_lodScale;
-	extern cvar_t *r_lodTest;
 
-	extern cvar_t *r_forceFog;
 	extern cvar_t *r_wolfFog;
 	extern cvar_t *r_noFog;
 
@@ -2985,7 +2981,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 
 	extern cvar_t *r_ext_occlusion_query; // these control use of specific extensions
 	extern cvar_t *r_ext_draw_buffers;
-	extern cvar_t *r_ext_vertex_array_object;
 	extern cvar_t *r_ext_half_float_pixel;
 	extern cvar_t *r_ext_texture_float;
 	extern cvar_t *r_ext_texture_integer;
@@ -3001,7 +2996,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 
 	extern cvar_t *r_nobind; // turns off binding to appropriate textures
 	extern cvar_t *r_singleShader; // make most world faces use default shader
-	extern cvar_t *r_colorMipLevels; // development aid to see texture mip usage
 	extern cvar_t *r_picMip; // controls picmip values
 	extern cvar_t *r_imageMaxDimension;
 	extern cvar_t *r_ignoreMaterialMinDimension;
@@ -3043,7 +3037,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_softShadowsPP;
 	extern cvar_t *r_shadowBlur;
 
-	extern cvar_t *r_shadowMapQuality;
 	extern cvar_t *r_shadowMapSizeUltra;
 	extern cvar_t *r_shadowMapSizeVeryHigh;
 	extern cvar_t *r_shadowMapSizeHigh;
@@ -3056,16 +3049,11 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_shadowMapSizeSunMedium;
 	extern cvar_t *r_shadowMapSizeSunLow;
 
-	extern cvar_t *r_shadowOffsetFactor;
-	extern cvar_t *r_shadowOffsetUnits;
 	extern cvar_t *r_shadowLodBias;
 	extern cvar_t *r_shadowLodScale;
 	extern cvar_t *r_noShadowPyramids;
 	extern cvar_t *r_cullShadowPyramidFaces;
-	extern cvar_t *r_cullShadowPyramidCurves;
-	extern cvar_t *r_cullShadowPyramidTriangles;
 	extern cvar_t *r_debugShadowMaps;
-	extern cvar_t *r_noShadowFrustums;
 	extern cvar_t *r_noLightFrustums;
 	extern cvar_t *r_shadowMapLinearFilter;
 	extern cvar_t *r_lightBleedReduction;
@@ -3077,7 +3065,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_lockpvs;
 	extern cvar_t *r_noportals;
 	extern cvar_t *r_portalOnly;
-	extern cvar_t *r_portalSky;
 	extern cvar_t *r_max_portal_levels;
 
 	extern cvar_t *r_subdivisions;
@@ -3086,7 +3073,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_smp;
 	extern cvar_t *r_showSmp;
 	extern cvar_t *r_skipBackEnd;
-	extern cvar_t *r_skipLightBuffer;
 
 	extern cvar_t *r_checkGLErrors;
 
@@ -3102,7 +3088,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 
 	extern cvar_t *r_showTris; // enables wireframe rendering of the world
 	extern cvar_t *r_showSky; // forces sky in front of all surfaces
-	extern cvar_t *r_showShadowVolumes;
 	extern cvar_t *r_showShadowLod;
 	extern cvar_t *r_showShadowMaps;
 	extern cvar_t *r_showSkeleton;
@@ -3119,7 +3104,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_showDeluxeMaps;
 	extern cvar_t *r_showNormalMaps;
 	extern cvar_t *r_showMaterialMaps;
-	extern cvar_t *r_showAreaPortals;
 	extern cvar_t *r_showCubeProbes;
 	extern cvar_t *r_showBspNodes;
 	extern cvar_t *r_showParallelShadowSplits;
@@ -3132,7 +3116,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_vboLighting;
 	extern cvar_t *r_vboModels;
 	extern cvar_t *r_vboVertexSkinning;
-	extern cvar_t *r_vboDeformVertexes;
 
 	extern cvar_t *r_mergeLeafSurfaces;
 

--- a/src/engine/sys/sdl_input.cpp
+++ b/src/engine/sys/sdl_input.cpp
@@ -53,7 +53,6 @@ static SDL_GameController *gamepad = nullptr;
 static cvar_t       *in_nograb;
 
 static cvar_t       *in_joystick = nullptr;
-static cvar_t       *in_joystickDebug = nullptr;
 static cvar_t       *in_joystickThreshold = nullptr;
 static cvar_t       *in_joystickNo = nullptr;
 static cvar_t       *in_joystickUseAnalog = nullptr;
@@ -1308,7 +1307,6 @@ void IN_Init( void *windowData )
 	in_nograb = Cvar_Get( "in_nograb", "0", 0 );
 
 	in_joystick = Cvar_Get( "in_joystick", "0",  CVAR_LATCH );
-	in_joystickDebug = Cvar_Get( "in_joystickDebug", "0", CVAR_TEMP );
 	in_joystickThreshold = Cvar_Get( "in_joystickThreshold", "0.15", 0 );
 	in_gameControllerTriggerDeadzone = Cvar_Get( "in_gameControllerTriggerDeadzone", "0.5", 0);
 


### PR DESCRIPTION
I am working on migrating the engine cvars from `cvar_t` to `Cvar::Cvar` with the help of a script, like I did for all gamelogic cvars. These are the first steps (written by hand except for the deleting unused cvars commit).

I tested that INIT works as expected, ROM cvars are getting set, and `rate` (a USERINFO cvar) works.