### PR TITLE
Use static VBO for instant quad

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2204,6 +2204,7 @@ void GLShader_liquid::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 
 GLShader_motionblur::GLShader_motionblur( GLShaderManager *manager ) :
 	GLShader( "motionblur", ATTR_POSITION, manager ),
+	u_ModelViewProjectionMatrix( this ),
 	u_blurVec( this )
 {
 }
@@ -2216,6 +2217,7 @@ void GLShader_motionblur::SetShaderProgramUniforms( shaderProgram_t *shaderProgr
 
 GLShader_ssao::GLShader_ssao( GLShaderManager *manager ) :
 	GLShader( "ssao", ATTR_POSITION, manager ),
+	u_ModelViewProjectionMatrix( this ),
 	u_zFar( this )
 {
 }
@@ -2227,6 +2229,7 @@ void GLShader_ssao::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 
 GLShader_depthtile1::GLShader_depthtile1( GLShaderManager *manager ) :
 	GLShader( "depthtile1", ATTR_POSITION, manager ),
+	u_ModelViewProjectionMatrix( this ),
 	u_zFar( this )
 {
 }
@@ -2237,7 +2240,8 @@ void GLShader_depthtile1::SetShaderProgramUniforms( shaderProgram_t *shaderProgr
 }
 
 GLShader_depthtile2::GLShader_depthtile2( GLShaderManager *manager ) :
-	GLShader( "depthtile2", ATTR_POSITION, manager )
+	GLShader( "depthtile2", ATTR_POSITION, manager ),
+	u_ModelViewProjectionMatrix( this )
 {
 }
 
@@ -2266,7 +2270,8 @@ void GLShader_lighttile::SetShaderProgramUniforms( shaderProgram_t *shaderProgra
 }
 
 GLShader_fxaa::GLShader_fxaa( GLShaderManager *manager ) :
-	GLShader( "fxaa", ATTR_POSITION, manager )
+	GLShader( "fxaa", ATTR_POSITION, manager ),
+	u_ModelViewProjectionMatrix( this )
 {
 }
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2713,6 +2713,7 @@ public:
 
 class GLShader_motionblur :
 	public GLShader,
+	public u_ModelViewProjectionMatrix,
 	public u_blurVec
 {
 public:
@@ -2722,6 +2723,7 @@ public:
 
 class GLShader_ssao :
 	public GLShader,
+	public u_ModelViewProjectionMatrix,
 	public u_zFar
 {
 public:
@@ -2731,6 +2733,7 @@ public:
 
 class GLShader_depthtile1 :
 	public GLShader,
+	public u_ModelViewProjectionMatrix,
 	public u_zFar
 {
 public:
@@ -2739,7 +2742,8 @@ public:
 };
 
 class GLShader_depthtile2 :
-	public GLShader
+	public GLShader,
+	public u_ModelViewProjectionMatrix
 {
 public:
 	GLShader_depthtile2( GLShaderManager *manager );
@@ -2760,7 +2764,8 @@ public:
 };
 
 class GLShader_fxaa :
-	public GLShader
+	public GLShader,
+	public u_ModelViewProjectionMatrix
 {
 public:
 	GLShader_fxaa( GLShaderManager *manager );

--- a/src/engine/renderer/glsl_source/depthtile1_vp.glsl
+++ b/src/engine/renderer/glsl_source/depthtile1_vp.glsl
@@ -36,6 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 IN vec3 attr_Position;
 
+uniform mat4 u_ModelViewProjectionMatrix;
 uniform vec3 u_zFar;
 OUT(flat) vec3 unprojectionParams;
 
@@ -45,6 +46,5 @@ void	main()
 	unprojectionParams.y = 2.0 * (u_zFar.z - r_zNear);
 	unprojectionParams.z = 2.0 * u_zFar.z - r_zNear;
 
-	// no vertex transformation needed
-	gl_Position = vec4(attr_Position, 1.0);
+	gl_Position = u_ModelViewProjectionMatrix * vec4( attr_Position, 1.0f );
 }

--- a/src/engine/renderer/glsl_source/depthtile2_vp.glsl
+++ b/src/engine/renderer/glsl_source/depthtile2_vp.glsl
@@ -36,8 +36,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 IN vec3 attr_Position;
 
+uniform mat4 u_ModelViewProjectionMatrix;
+
 void	main()
 {
-	// no vertex transformation needed
-	gl_Position = vec4(attr_Position, 1.0);
+	gl_Position = u_ModelViewProjectionMatrix * vec4( attr_Position, 1.0f );
 }

--- a/src/engine/renderer/glsl_source/fxaa_vp.glsl
+++ b/src/engine/renderer/glsl_source/fxaa_vp.glsl
@@ -33,10 +33,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 
 /* fxaa_vp.glsl */
 
+uniform mat4 u_ModelViewProjectionMatrix;
 IN vec3 		attr_Position;
 
 void	main()
 {
-	// transform vertex position into homogenous clip-space
-	gl_Position = vec4(attr_Position, 1.0);
+	gl_Position = u_ModelViewProjectionMatrix * vec4( attr_Position, 1.0f );
 }

--- a/src/engine/renderer/glsl_source/motionblur_vp.glsl
+++ b/src/engine/renderer/glsl_source/motionblur_vp.glsl
@@ -22,10 +22,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* motionblur_vp.glsl */
 
+uniform mat4 u_ModelViewProjectionMatrix;
 IN vec3 		attr_Position;
 
 void	main()
 {
-	// no vertex transformation needed
-	gl_Position = vec4(attr_Position, 1.0);
+	gl_Position = u_ModelViewProjectionMatrix * vec4( attr_Position, 1.0f );
 }

--- a/src/engine/renderer/glsl_source/ssao_vp.glsl
+++ b/src/engine/renderer/glsl_source/ssao_vp.glsl
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 IN vec3 attr_Position;
 
+uniform mat4 u_ModelViewProjectionMatrix;
 uniform vec3 u_zFar;
 OUT(flat) vec3 unprojectionParams;
 
@@ -33,6 +34,5 @@ void	main()
 	unprojectionParams.y = 2.0 * (u_zFar.z - r_zNear);
 	unprojectionParams.z = 2.0 * u_zFar.z - r_zNear;
 
-	// no vertex transformation needed
-	gl_Position = vec4(attr_Position, 1.0);
+	gl_Position = u_ModelViewProjectionMatrix * vec4( attr_Position, 1.0f );
 }

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2838,6 +2838,9 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 
 		trRefdef_t     refdef;
 
+		// Generic shapes
+		drawSurf_t *genericQuad;
+
 		bool           hasSkybox;
 		drawSurf_t     *skybox;
 
@@ -3559,7 +3562,7 @@ inline bool checkGLErrors()
 	void Tess_AddCube( const vec3_t position, const vec3_t minSize, const vec3_t maxSize, const Color::Color& color );
 	void Tess_AddCubeWithNormals( const vec3_t position, const vec3_t minSize, const vec3_t maxSize, const Color::Color& color );
 
-	void Tess_InstantQuad( vec4_t quadVerts[ 4 ] );
+	void Tess_InstantQuad( const float x, const float y, const float width, const float height );
 	void Tess_MapVBOs( bool forceCPU );
 	void Tess_UpdateVBOs();
 

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -577,7 +577,7 @@ void Tess_AddCubeWithNormals( const vec3_t position, const vec3_t minSize, const
 Tess_InstantQuad
 ==============
 */
-void Tess_InstantQuad( vec4_t quadVerts[ 4 ] )
+void Tess_InstantQuad( const float x, const float y, const float width, const float height )
 {
 	GLimp_LogComment( "--- Tess_InstantQuad ---\n" );
 
@@ -586,47 +586,18 @@ void Tess_InstantQuad( vec4_t quadVerts[ 4 ] )
 	tess.numIndexes = 0;
 	tess.attribsSet = 0;
 
-	Tess_MapVBOs( false );
-	VectorCopy( quadVerts[ 0 ], tess.verts[ tess.numVertexes ].xyz );
-	tess.verts[ tess.numVertexes ].color = Color::White;
-	tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( 0.0f );
-	tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( 0.0f );
-	tess.numVertexes++;
+	matrix_t modelViewMatrix;
+	MatrixCopy( matrixIdentity, modelViewMatrix );
+	modelViewMatrix[12] = x;
+	modelViewMatrix[13] = y;
+	modelViewMatrix[0] = width;
+	modelViewMatrix[5] = height;
+	GL_LoadModelViewMatrix( modelViewMatrix );
 
-	VectorCopy( quadVerts[ 1 ], tess.verts[ tess.numVertexes ].xyz );
-	tess.verts[ tess.numVertexes ].color = Color::White;
-	tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( 1.0f );
-	tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( 0.0f );
-	tess.numVertexes++;
+	rb_surfaceTable[Util::ordinal( *( tr.genericQuad->surface ) )]( tr.genericQuad->surface );
+	tess.attribsSet = ATTR_POSITION | ATTR_TEXCOORD | ATTR_COLOR;
+	GL_VertexAttribsState( tess.attribsSet );
 
-	VectorCopy( quadVerts[ 2 ], tess.verts[ tess.numVertexes ].xyz );
-	tess.verts[ tess.numVertexes ].color = Color::White;
-	tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( 1.0f );
-	tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( 1.0f );
-	tess.numVertexes++;
-
-	VectorCopy( quadVerts[ 3 ], tess.verts[ tess.numVertexes ].xyz );
-	tess.verts[ tess.numVertexes ].color = Color::White;
-	tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( 0.0f );
-	tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( 1.0f );
-	tess.numVertexes++;
-
-	tess.indexes[ tess.numIndexes++ ] = 0;
-	tess.indexes[ tess.numIndexes++ ] = 1;
-	tess.indexes[ tess.numIndexes++ ] = 2;
-	tess.indexes[ tess.numIndexes++ ] = 0;
-	tess.indexes[ tess.numIndexes++ ] = 2;
-	tess.indexes[ tess.numIndexes++ ] = 3;
-
-	Tess_UpdateVBOs( );
-	GL_VertexAttribsState( ATTR_POSITION | ATTR_TEXCOORD | ATTR_COLOR );
-
-	Tess_DrawElements();
-
-	tess.multiDrawPrimitives = 0;
-	tess.numVertexes = 0;
-	tess.numIndexes = 0;
-	tess.attribsSet = 0;
 	GL_CheckErrors();
 }
 


### PR DESCRIPTION
Part 1 of changing some 2d rendering to use static VBOs.

Changes Tess_InstantQuad() to use the same VBO and calculate the modelView matrix to get the correct quad coordinates.

This would be best moved to the world VBO, but that can be done later. Doesn't do too much on its own, but with more such changes should help performance by getting rid of some buffer uploads.