### PR TITLE
tr_shader: do not collapse lightmap having custom depthFunc

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4809,6 +4809,10 @@ static void CollapseStages()
 			( stages[ i ].stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_DST_COLOR
 			&& ( stages[ i ].stateBits & GLS_DSTBLEND_BITS ) == GLS_DSTBLEND_ZERO;
 
+		// Do not collapse lightmap with custom depthFunc.
+		bool depthFunc_lequal =
+			( stages[ i ].stateBits & GLS_DEPTHFUNC_BITS ) == 0;
+
 		bool tcGen_Environment = stages[ i ].tcGen_Environment;
 
 		if ( step == 0 )
@@ -4837,12 +4841,9 @@ static void CollapseStages()
 		{
 			if ( isLightStage
 				&& rgbGen_identity
-				&& alphaGen_identity )
+				&& alphaGen_identity
+				&& depthFunc_lequal )
 			{
-				/* We may ignore “depthFunc equal” that seems to be
-				required for standalone lightmap when colormap has
-				“depthWrite” since they will be collapsed and
-				processed at once. */
 				lightStage = i;
 				lightMapCount++;
 				step++;


### PR DESCRIPTION
Do not collapse lightmap having custom `depthFunc`.

This fixes the glass material in USS Tremor 1.1 (regression):

```
textures/usstremor_custom_src/glass_01
{
	qer_editorimage textures/usstremor_custom_src/glass_01
	qer_trans 0.5
	surfaceparm trans
    surfaceparm lightfilter
    surfaceparm alphashadow
    {
      map textures/usstremor_custom_src/glass_01
      blendFunc GL_DST_COLOR GL_ZERO
      rgbGen identity
    }
    {
      map $lightmap
      rgbGen identity
      blendFunc GL_DST_COLOR GL_ZERO
      depthFunc equal
    }	
}
```

Before:

![unvanquished_2024-04-06_013805_000](https://github.com/DaemonEngine/Daemon/assets/2311649/be98dec6-e47c-4685-b97b-6f7c10e3189c)

After:

![unvanquished_2024-04-06_014009_000](https://github.com/DaemonEngine/Daemon/assets/2311649/5ff5aa20-e0d9-48e6-96aa-012729568dc4)