### PR TITLE
Remove redundant cullFace

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -240,16 +240,6 @@ void GL_ColorMask( GLboolean red, GLboolean green, GLboolean blue, GLboolean alp
 	}
 }
 
-void GL_CullFace( GLenum mode )
-{
-	if ( glState.cullFace != ( signed ) mode )
-	{
-		glState.cullFace = mode;
-
-		glCullFace( mode );
-	}
-}
-
 void GL_DepthFunc( GLenum func )
 {
 	if ( glState.depthFunc != ( signed ) func )
@@ -411,11 +401,11 @@ void GL_Cull( cullType_t cullType )
 
 		if ( cullType == cullType_t::CT_BACK_SIDED )
 		{
-			GL_CullFace( GL_BACK );
+			glCullFace( GL_BACK );
 		}
 		else
 		{
-			GL_CullFace( GL_FRONT );
+			glCullFace( GL_FRONT );
 		}
 	}
 	glState.faceCulling = cullType;

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -801,7 +801,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		GL_ClearStencil( 0 );
 
 		GL_FrontFace( GL_CCW );
-		GL_CullFace( GL_FRONT );
+		glCullFace( GL_FRONT );
 
 		glState.faceCulling = CT_TWO_SIDED;
 		glDisable( GL_CULL_FACE );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2564,7 +2564,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		double clearDepth;
 		int    clearStencil;
 		int    colorMaskRed, colorMaskGreen, colorMaskBlue, colorMaskAlpha;
-		int    cullFace;
 		int    depthFunc;
 		int    depthMask;
 		int    drawBuffer;
@@ -2584,7 +2583,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		matrix_t        modelViewProjectionMatrix[ MAX_GLSTACK ];
 
 		bool        finishCalled;
-		cullType_t      faceCulling; // FIXME redundant cullFace
+		cullType_t      faceCulling;
 		uint32_t        glStateBits;
 		uint32_t        glStateBitsMask; // GLS_ bits set to 1 will not be changed in GL_State
 		uint32_t        vertexAttribsState;
@@ -3259,7 +3258,6 @@ inline bool checkGLErrors()
 	void GL_ClearDepth( GLclampd depth );
 	void GL_ClearStencil( GLint s );
 	void GL_ColorMask( GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha );
-	void GL_CullFace( GLenum mode );
 	void GL_DepthFunc( GLenum func );
 	void GL_DepthMask( GLboolean flag );
 	void GL_DrawBuffer( GLenum mode );


### PR DESCRIPTION
Remove some redundant code.

`cullFace` is never needed because the check against the current state is already done when comparing `culltype` to `glState.faceCulling` in GL_Cull().