### PR TITLE
Remove vertexSkinning and vertexAnimation from GLShader_generic2D

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1591,7 +1591,7 @@ GLShader_generic2D::GLShader_generic2D( GLShaderManager *manager ) :
 
 void GLShader_generic2D::BuildShaderVertexLibNames( std::string& vertexInlines )
 {
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation vertexSprite ";
+	vertexInlines += "vertexSimple vertexSprite ";
 }
 
 void GLShader_generic2D::BuildShaderCompileMacros( std::string& compileMacros )


### PR DESCRIPTION
UI, which is what this shader is used for, doesn't have bones (vertexSkinning). It also doesn't use .md3/.mdc (vertexAnimation is used to interpolate vertices in those formats).

I'm not entirely sure if vertexSprite is unused, so I've kept it there for now.