### PR TITLE
renderer: set unordered_map static and const

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -153,14 +153,14 @@ R_ListImages_f
 */
 void R_ListImages_f()
 {
-	std::unordered_map<GLenum, std::string> imageTypeName = {
+	static const std::unordered_map<GLenum, std::string> imageTypeName = {
 		{ GL_TEXTURE_2D, "2D" },
 		{ GL_TEXTURE_3D, "3D" },
 		{ GL_TEXTURE_CUBE_MAP, "CUBE" },
 	};
 
 	typedef std::pair<const std::string, int> nameSizePair;
-	std::unordered_map<uint32_t, nameSizePair> imageFormatNameSize = {
+	static const std::unordered_map<uint32_t, nameSizePair> imageFormatNameSize = {
 		// TODO: find imageDataSize multiplier
 		{ GL_RGBA, { "RGBA", 4 } },
 
@@ -205,7 +205,7 @@ void R_ListImages_f()
 		{ GL_DEPTH24_STENCIL8, { "D24S8", 4 } },
 	};
 
-	std::unordered_map<wrapTypeEnum_t, std::string> wrapTypeName = {
+	static const std::unordered_map<wrapTypeEnum_t, std::string> wrapTypeName = {
 		{ wrapTypeEnum_t::WT_REPEAT, "rept" },
 		{ wrapTypeEnum_t::WT_CLAMP, "clmp" },
 		{ wrapTypeEnum_t::WT_EDGE_CLAMP, "eclmp" },
@@ -316,7 +316,7 @@ void R_ListImages_f()
 		}
 		else
 		{
-			type = imageTypeName[ image->type ];
+			type = imageTypeName.at( image->type );
 		}
 
 		int imageDataSize = image->uploadWidth * image->uploadHeight * image->numLayers;
@@ -332,8 +332,8 @@ void R_ListImages_f()
 		}
 		else
 		{
-			format = imageFormatNameSize[ image->internalFormat ].first;
-			imageDataSize *= imageFormatNameSize[ image->internalFormat ].second;
+			format = imageFormatNameSize.at( image->internalFormat ).first;
+			imageDataSize *= imageFormatNameSize.at( image->internalFormat ).second;
 		}
 
 		if ( !wrapTypeName.count( image->wrapType.t ) )
@@ -345,7 +345,7 @@ void R_ListImages_f()
 		}
 		else
 		{
-			twrap = "t." + wrapTypeName[ image->wrapType.t ];
+			twrap = "t." + wrapTypeName.at( image->wrapType.t );
 		}
 
 		if ( !wrapTypeName.count( image->wrapType.s ) )
@@ -357,7 +357,7 @@ void R_ListImages_f()
 		}
 		else
 		{
-			swrap = "s." + wrapTypeName[ image->wrapType.s ];
+			swrap = "s." + wrapTypeName.at( image->wrapType.s );
 		}
 
 		name = image->name;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6321,14 +6321,14 @@ A second parameter will cause it to print in sorted order
 */
 void R_ListShaders_f()
 {
-	std::unordered_map<shaderType_t, std::string> shaderTypeName = {
+	static const std::unordered_map<shaderType_t, std::string> shaderTypeName = {
 		{ shaderType_t::SHADER_2D, "2D" },
 		{ shaderType_t::SHADER_3D_DYNAMIC, "3D_DYNAMIC" },
 		{ shaderType_t::SHADER_3D_STATIC, "3D_STATIC" },
 		{ shaderType_t::SHADER_LIGHT, "LIGHT" },
 	};
 
-	std::unordered_map<shaderSort_t, std::string> shaderSortName = {
+	static const std::unordered_map<shaderSort_t, std::string> shaderSortName = {
 		{ shaderSort_t::SS_BAD, "BAD" },
 		{ shaderSort_t::SS_PORTAL, "PORTAL" },
 		{ shaderSort_t::SS_DEPTH, "DEPTH" },
@@ -6354,7 +6354,7 @@ void R_ListShaders_f()
 		{ shaderSort_t::SS_POST_PROCESS, "POST_PROCESS" },
 	};
 
-	std::unordered_map<stageType_t, std::string> stageTypeName = {
+	static const std::unordered_map<stageType_t, std::string> stageTypeName = {
 		{ stageType_t::ST_COLORMAP, "COLORMAP" },
 		{ stageType_t::ST_GLOWMAP, "GLOWMAP" },
 		{ stageType_t::ST_DIFFUSEMAP, "DIFFUSEMAP" },
@@ -6451,8 +6451,26 @@ void R_ListShaders_f()
 		stageCount += shader->numStages;
 		highestShaderStageCount = std::max( highestShaderStageCount, shader->numStages );
 
-		shaderType = shaderTypeName[ shader->type ];
-		shaderSort = shaderSortName[ (shaderSort_t) shader->sort ];
+		if ( !shaderTypeName.count( shader->type ) )
+		{
+			Log::Debug( "Undocumented shader type %i for shader %s",
+				Util::ordinal( shader->type ), shader->name );
+		}
+		else
+		{
+			shaderType = shaderTypeName.at( shader->type );
+		}
+
+		if ( !shaderSortName.count( (shaderSort_t) shader->sort ) )
+		{
+			Log::Debug( "Undocumented shader sort %f for shader %s",
+				shader->sort, shader->name );
+		}
+		else
+		{
+			shaderSort = shaderSortName.at( (shaderSort_t) shader->sort );
+		}
+
 		interactLight = shader->interactLight ? "INTERACTLIGHT" : "";
 		shaderName = shader->name;
 		shaderName += shader->defaultShader ? " (DEFAULTED)" : "";
@@ -6461,7 +6479,15 @@ void R_ListShaders_f()
 		{
 			shaderStage_t *stage = shader->stages[ j ];
 
-			stageType = stageTypeName[ stage->type ];
+			if ( !stageTypeName.count( stage->type ) )
+			{
+				Log::Debug( "Undocumented stage type %i for shader stage %s:%d",
+					Util::ordinal( stage->type ), shader->name, j );
+			}
+			else
+			{
+				stageType = stageTypeName.at( stage->type );
+			}
 
 			lineStream.clear();
 			lineStream.str("");


### PR DESCRIPTION
This is not critical since it's used in debug command print functions, but why not. Those `unordered_map` are never modified so there is no need to rebuild them on every function call.