### PR TITLE
Shorten name of light clamping worldspawn key

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -674,7 +674,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 					lightMapBuffer[( index * 4 ) + 2 ] = buf_p[( ( x + ( y * internalLightMapSize ) ) * 3 ) + 2 ];
 					lightMapBuffer[( index * 4 ) + 3 ] = 255;
 
-					if ( tr.forceLegacyMapOverBrightClamping )
+					if ( tr.forceLegacyOverBrightClamping )
 					{
 						R_ColorShiftLightingBytes( &lightMapBuffer[( index * 4 ) + 0 ] );
 					}
@@ -1041,7 +1041,7 @@ static void ParseFace( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf, in
 		cv->verts[ i ].lightColor = Color::Adapt( verts[ i ].color );
 
 
-		if ( tr.forceLegacyMapOverBrightClamping )
+		if ( tr.forceLegacyOverBrightClamping )
 		{
 			R_ColorShiftLightingBytes( cv->verts[ i ].lightColor.ToArray() );
 		}
@@ -1251,7 +1251,7 @@ static void ParseMesh( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf )
 
 		points[ i ].lightColor = Color::Adapt( verts[ i ].color );
 
-		if ( tr.forceLegacyMapOverBrightClamping )
+		if ( tr.forceLegacyOverBrightClamping )
 		{
 			R_ColorShiftLightingBytes( points[ i ].lightColor.ToArray() );
 		}
@@ -1378,7 +1378,7 @@ static void ParseTriSurf( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf,
 
 			cv->verts[ i ].lightColor = Color::Adapt( verts[ i ].color );
 
-		if ( tr.forceLegacyMapOverBrightClamping )
+		if ( tr.forceLegacyOverBrightClamping )
 		{
 			R_ColorShiftLightingBytes( cv->verts[ i ].lightColor.ToArray() );
 		}
@@ -4169,7 +4169,7 @@ void R_LoadLightGrid( lump_t *l )
 		tmpDirected[ 2 ] = in->directed[ 2 ];
 		tmpDirected[ 3 ] = 255;
 
-		if ( tr.forceLegacyMapOverBrightClamping )
+		if ( tr.forceLegacyOverBrightClamping )
 		{
 			R_ColorShiftLightingBytes( tmpAmbient );
 			R_ColorShiftLightingBytes( tmpDirected );
@@ -4424,10 +4424,10 @@ void R_LoadEntities( lump_t *l, std::string &externalEntities )
 			tr.mapOverBrightBits = Math::Clamp( atof( value ), 0.0, 3.0 );
 		}
 
-		// Force forceLegacyMapOverBrightClamping even if r_forceLegacyMapOverBrightClamping is false.
-		else if ( !Q_stricmp( keyname, "forceLegacyMapOverBrightClamping" ) && !Q_stricmp( value, "1" ) )
+		// Force forceLegacyOverBrightClamping even if r_forceLegacyOverBrightClamping is false.
+		else if ( !Q_stricmp( keyname, "forceLegacyOverBrightClamping" ) && !Q_stricmp( value, "1" ) )
 		{
-			tr.forceLegacyMapOverBrightClamping = true;
+			tr.forceLegacyOverBrightClamping = true;
 		}
 
 		// check for deluxe mapping provided by NetRadiant's q3map2
@@ -7086,7 +7086,7 @@ void RE_LoadWorldMap( const char *name )
 
 	/* Used in GLSL code for the GLSL implementation
 	without color clamping and normalization. */
-	if ( !tr.forceLegacyMapOverBrightClamping )
+	if ( !tr.forceLegacyOverBrightClamping )
 	{
 		tr.mapLightFactor = pow( 2, tr.mapOverBrightBits );
 		tr.mapInverseLightFactor = 1.0f / tr.mapLightFactor;

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1737,7 +1737,7 @@ image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 		return nullptr;
 	}
 
-	if ( imageParams.bits & IF_LIGHTMAP && tr.forceLegacyMapOverBrightClamping )
+	if ( imageParams.bits & IF_LIGHTMAP && tr.forceLegacyOverBrightClamping )
 	{
 		R_ProcessLightmap( pic[ 0 ], width, height, imageParams.bits );
 	}
@@ -2968,7 +2968,7 @@ void R_InitImages()
 	always 1.0f. We can entirely remove it. */
 
 	tr.mapOverBrightBits = r_mapOverBrightBits.Get();
-	tr.forceLegacyMapOverBrightClamping = r_forceLegacyMapOverBrightClamping.Get();
+	tr.forceLegacyOverBrightClamping = r_forceLegacyOverBrightClamping.Get();
 
 	// create default texture and white texture
 	R_CreateBuiltinImages();

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -82,7 +82,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_dynamicLightCastShadows;
 	cvar_t      *r_precomputedLighting;
 	Cvar::Cvar<int> r_mapOverBrightBits("r_mapOverBrightBits", "default map light color shift", Cvar::NONE, 2);
-	Cvar::Cvar<bool> r_forceLegacyMapOverBrightClamping("r_forceLegacyMapOverBrightClamping", "clamp over bright of legacy maps (enable multiplied color clamping and normalization)", Cvar::NONE, false);
+	Cvar::Cvar<bool> r_forceLegacyOverBrightClamping("r_forceLegacyOverBrightClamping", "clamp over bright of legacy maps (enable multiplied color clamping and normalization)", Cvar::NONE, false);
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	cvar_t      *r_lightStyles;
 	cvar_t      *r_exportTextures;
@@ -1119,7 +1119,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_dynamicLightCastShadows = Cvar_Get( "r_dynamicLightCastShadows", "1", 0 );
 		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_CHEAT | CVAR_LATCH );
 		Cvar::Latch( r_mapOverBrightBits );
-		Cvar::Latch( r_forceLegacyMapOverBrightClamping );
+		Cvar::Latch( r_forceLegacyOverBrightClamping );
 		Cvar::Latch( r_lightMode );
 		r_lightStyles = Cvar_Get( "r_lightStyles", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_exportTextures = Cvar_Get( "r_exportTextures", "0", 0 );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2832,7 +2832,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		// 1 / mapLightFactor
 		float mapInverseLightFactor;
 		// May have to be true on some legacy maps: clamp and normalize multiplied colors.
-		bool forceLegacyMapOverBrightClamping;
+		bool forceLegacyOverBrightClamping;
 
 		orientationr_t orientation; // for current entity
 
@@ -2959,7 +2959,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_dynamicLightCastShadows;
 	extern cvar_t *r_precomputedLighting;
 	extern Cvar::Cvar<int> r_mapOverBrightBits;
-	extern Cvar::Cvar<bool> r_forceLegacyMapOverBrightClamping;
+	extern Cvar::Cvar<bool> r_forceLegacyOverBrightClamping;
 	extern Cvar::Range<Cvar::Cvar<int>> r_lightMode;
 	extern cvar_t *r_lightStyles;
 	extern cvar_t *r_exportTextures;


### PR DESCRIPTION
q3map2 finds @illwieckz's names too verbose :stuck_out_tongue: 

When q3map2 sees the key "forceLegacyMapOverBrightClamping" in the worldspawn entity, it protests that it is too long and shuts down. Shorten that to "forceLegacyOverBrightClamping".