### PR TITLE
renderer: missing break in shadowing code and other things

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -540,6 +540,7 @@ static std::string GenEngineConstants() {
 			case shadowingMode_t::SHADOWING_EVSM32:
 				// This may be wrong, but the code did that before it was rewritten.
 				AddConst( str, "VSM_EPSILON", 0.0001f );
+				break;
 			default:
 				DAEMON_ASSERT( false );
 				break;

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -527,7 +527,7 @@ static std::string GenEngineConstants() {
 				break;
 			case shadowingMode_t::SHADOWING_VSM32:
 				// GLHW_R300 should not be GLDRV_OPENGL3 anyway.
-				if ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3
+				if ( glConfig.driverType != glDriverType_t::GLDRV_OPENGL3
 					|| glConfig.hardwareType == glHardwareType_t::GLHW_R300 )
 				{
 					AddConst( str, "VSM_EPSILON", 0.0001f );

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -2381,7 +2381,8 @@ void R_AddLightInteractions()
 			{
 				continue;
 			}
-			else if ( ( r_precomputedLighting->integer || tr.worldLight != lightMode_t::MAP ) && !light->noRadiosity )
+
+			if ( ( r_precomputedLighting->integer || tr.worldLight != lightMode_t::MAP ) && !light->noRadiosity )
 			{
 				continue;
 			}
@@ -2397,7 +2398,7 @@ void R_AddLightInteractions()
 		}
 		else if ( light->l.inverseShadows )
 		{
-			if( !glConfig2.dynamicLight)
+			if ( !glConfig2.dynamicLight )
 			{
 				light->cull = CULL_OUT;
 				continue;
@@ -2594,16 +2595,19 @@ void R_AddLightBoundsToVisBounds()
 
 		if ( light->isStatic )
 		{
-			if ( !glConfig2.staticLight
-				|| ( ( r_precomputedLighting->integer || tr.worldLight != lightMode_t::MAP )
-					&& !light->noRadiosity ) )
+			if ( !glConfig2.staticLight )
+			{
+				continue;
+			}
+
+			if ( ( r_precomputedLighting->integer || tr.worldLight != lightMode_t::MAP ) && !light->noRadiosity )
 			{
 				continue;
 			}
 		}
 		else
 		{
-			if ( !r_dynamicLight.Get() )
+			if ( !glConfig2.dynamicLight )
 			{
 				continue;
 			}

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -2407,17 +2407,17 @@ void R_AddLightInteractions()
 		{
 			if ( !glConfig2.dynamicLight )
 			{
+				light->cull = cullResult_t::CULL_OUT;
 				continue;
 			}
-
-			if ( dynamicLightRenderer == dynamicLightRenderer_t::TILED )
+			else if ( dynamicLightRenderer == dynamicLightRenderer_t::TILED )
 			{
 				tr.refdef.numShaderLights++;
 				tr.pc.c_dlights++;
-			}
 
-			light->cull = cullResult_t::CULL_OUT;
-			continue;
+				light->cull = cullResult_t::CULL_OUT;
+				continue;
+			}
 		}
 
 		R_TransformShadowLight( light );


### PR DESCRIPTION
It was missing in 1872b92274fbd9533e622633c56a515a4ff899c0 from:

- https://github.com/DaemonEngine/Daemon/pull/1045