### PR TITLE
Add variant of -connect command line argument that needn't be last

### DIFF
--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -461,9 +461,7 @@ static void ParseCmdline(int argc, char** argv, cmdlineArgs_t& cmdlineArgs)
 			}
 
 			// Make it forwardable.
-			cmdlineArgs.commands.append(argv[i] + 1);
-			cmdlineArgs.commands.push_back(' ');
-			cmdlineArgs.commands.append(Cmd::Escape(argv[i + 1]));
+			cmdlineArgs.commands = "connect " + Cmd::Escape(argv[i + 1]);
 
 			if (argc > i + 2) {
 				// It is necessary to ignore following arguments because the command line may have
@@ -471,6 +469,18 @@ static void ParseCmdline(int argc, char** argv, cmdlineArgs_t& cmdlineArgs)
 				Log::Warn("Ignoring extraneous arguments after -connect URI");
 			}
 			break;
+		}
+
+		// Variant that does not discard subsequent arguments. This can be used if the argument is sent
+		// by our updater which can validate the inputs
+		if (Str::IsIEqual("-connect-trusted", argv[i])) {
+			if (argc < i + 2) {
+				Log::Warn("Missing command line parameter for -connect-trusted");
+				break;
+			}
+
+			cmdlineArgs.commands = "connect " + Cmd::Escape(argv[i + 1]);
+			i++;
 		}
 
 		if (!strcmp(argv[i], "--help") || !strcmp(argv[i], "-help") || !strcmp(argv[i], "-h")) {


### PR DESCRIPTION
Intended to be used with a protocol handler that routes through the updater. If the updater gets the "URL" first, it can validate it so we don't need to ignore further arguments as a defense against bad input.

This improves on -connect in case the user uses the command line customization feature of the updater like %command% -foo +bar. The -connect2 arg could be inserted in %command% without cutting off the rest.

I'm intentionally leaving the original variant in; it may be useful to have both possibilities.