### PR TITLE
renderer: make screenshot command write jpeg

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -549,7 +549,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	RB_TakeScreenshot
 	==================
 	*/
-	static void RB_TakeScreenshot( int x, int y, int width, int height, const char *fileName )
+	static void RB_TakeScreenshotTGA( int x, int y, int width, int height, const char *fileName )
 	{
 		byte *buffer;
 		int  dataSize;
@@ -619,7 +619,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 		switch ( format )
 		{
 			case ssFormat_t::SSF_TGA:
-				RB_TakeScreenshot( x, y, width, height, fileName );
+				RB_TakeScreenshotTGA( x, y, width, height, fileName );
 				break;
 
 			case ssFormat_t::SSF_JPEG:
@@ -713,7 +713,8 @@ public:
 		}
 	}
 };
-ScreenshotCmd screenshotTGARegistration("screenshot", ssFormat_t::SSF_TGA, "tga");
+ScreenshotCmd screenshotRegistration("screenshot", ssFormat_t::SSF_JPEG, "jpg");
+ScreenshotCmd screenshotTGARegistration("screenshotTGA", ssFormat_t::SSF_TGA, "tga");
 ScreenshotCmd screenshotJPEGRegistration("screenshotJPEG", ssFormat_t::SSF_JPEG, "jpg");
 ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "png");
 } // namespace


### PR DESCRIPTION
I find annoying that the shortest `screenshot` command writes TGA, a format no one uses anymore to take screenshots.

I find it annoying to type `screenshotJPEG` anytime I want to take a screenshot using the command line, and the suffix prevent autocompletion to fully autocomplete it.

So, `screenshot` is now meant to use a “default format” I just decided to be jpeg, while `screenshotFORMAT` with explicit FORMAT suffix will always write screenshot in the said FORMAT.

In the future we may add a cvar to select the default format of the `screenshot` command.