### PR TITLE
Make the legacy dynamic light renderer work again

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -167,6 +167,12 @@ void GL_SelectTexture( int unit )
 
 void GL_BindToTMU( int unit, image_t *image )
 {
+	if ( !image )
+	{
+		Log::Warn("GL_BindToTMU: NULL image" );
+		image = tr.defaultImage;
+	}
+
 	int texnum = image->texnum;
 
 	if ( unit < 0 || unit > 31 )

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3549,6 +3549,7 @@ inline bool checkGLErrors()
 
 	void RB_ShowImages();
 
+	void Render_NONE( shaderStage_t *pStage );
 	void Render_NOP( shaderStage_t *pStage );
 	void Render_generic( shaderStage_t *pStage );
 	void Render_generic3D( shaderStage_t *pStage );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -611,6 +611,11 @@ static void SetRgbaGen( const shaderStage_t *pStage, colorGen_t *rgbGen, alphaGe
 
 // *INDENT-ON*
 
+void Render_NONE( shaderStage_t * )
+{
+	ASSERT_UNREACHABLE();
+}
+
 void Render_NOP( shaderStage_t * )
 {
 }

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1418,8 +1418,17 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *pStage,
 	GL_CheckErrors();
 
 	// bind u_DiffuseMap
-	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-	gl_forwardLightingShader_omniXYZ->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	if ( pStage->type == stageType_t::ST_LIGHTMAP )
+	{
+		// standalone lightmap stage: paint shadows over a white texture
+		GL_BindToTMU( 0, tr.whiteImage );
+	}
+	else
+	{
+		GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
+
+		gl_forwardLightingShader_omniXYZ->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	}
 
 	// bind u_NormalMap
 	GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
@@ -1580,8 +1589,17 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *pStage,
 	GL_CheckErrors();
 
 	// bind u_DiffuseMap
-	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-	gl_forwardLightingShader_projXYZ->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	if ( pStage->type == stageType_t::ST_LIGHTMAP )
+	{
+		// standalone lightmap stage: paint shadows over a white texture
+		GL_BindToTMU( 0, tr.whiteImage );
+	}
+	else
+	{
+		GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
+
+		gl_forwardLightingShader_projXYZ->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	}
 
 	// bind u_NormalMap
 	GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );
@@ -1744,8 +1762,17 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *pStage, trRef
 	GL_CheckErrors();
 
 	// bind u_DiffuseMap
-	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
-	gl_forwardLightingShader_directionalSun->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	if ( pStage->type == stageType_t::ST_LIGHTMAP )
+	{
+		// standalone lightmap stage: paint shadows over a white texture
+		GL_BindToTMU( 0, tr.whiteImage );
+	}
+	else
+	{
+		GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
+
+		gl_forwardLightingShader_directionalSun->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
+	}
 
 	// bind u_NormalMap
 	GL_BindToTMU( 1, pStage->bundle[ TB_NORMALMAP ].image[ 0 ] );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1081,15 +1081,10 @@ void Render_lightMapping( shaderStage_t *pStage )
 	}
 
 	// bind u_DiffuseMap
-	if ( pStage->type == stageType_t::ST_LIGHTMAP )
-	{
-		// standalone lightmap stage: paint shadows over a white texture
-		GL_BindToTMU( BIND_DIFFUSEMAP, tr.whiteImage );
-	}
-	else
-	{
-		GL_BindToTMU( BIND_DIFFUSEMAP, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
+	GL_BindToTMU( BIND_DIFFUSEMAP, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
 
+	if ( pStage->type != stageType_t::ST_LIGHTMAP )
+	{
 		gl_lightMappingShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 	}
 
@@ -1423,15 +1418,10 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *pStage,
 	GL_CheckErrors();
 
 	// bind u_DiffuseMap
-	if ( pStage->type == stageType_t::ST_LIGHTMAP )
-	{
-		// standalone lightmap stage: paint shadows over a white texture
-		GL_BindToTMU( 0, tr.whiteImage );
-	}
-	else
-	{
-		GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
+	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
 
+	if ( pStage->type != stageType_t::ST_LIGHTMAP )
+	{
 		gl_forwardLightingShader_omniXYZ->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 	}
 
@@ -1594,15 +1584,10 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *pStage,
 	GL_CheckErrors();
 
 	// bind u_DiffuseMap
-	if ( pStage->type == stageType_t::ST_LIGHTMAP )
-	{
-		// standalone lightmap stage: paint shadows over a white texture
-		GL_BindToTMU( 0, tr.whiteImage );
-	}
-	else
-	{
-		GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
+	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
 
+	if ( pStage->type != stageType_t::ST_LIGHTMAP )
+	{
 		gl_forwardLightingShader_projXYZ->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 	}
 
@@ -1767,15 +1752,10 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *pStage, trRef
 	GL_CheckErrors();
 
 	// bind u_DiffuseMap
-	if ( pStage->type == stageType_t::ST_LIGHTMAP )
-	{
-		// standalone lightmap stage: paint shadows over a white texture
-		GL_BindToTMU( 0, tr.whiteImage );
-	}
-	else
-	{
-		GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
+	GL_BindToTMU( 0, pStage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] );
 
+	if ( pStage->type != stageType_t::ST_LIGHTMAP )
+	{
 		gl_forwardLightingShader_directionalSun->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_DIFFUSEMAP ] );
 	}
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5204,6 +5204,15 @@ static void FinishStages()
 				lightStageFound = true;
 				shaderHasNoLight = false;
 				break;
+
+			case stageType_t::ST_ATTENUATIONMAP_XY:
+			case stageType_t::ST_ATTENUATIONMAP_Z:
+				if ( !glConfig2.dynamicLight || r_dynamicLightRenderer.Get() != Util::ordinal( dynamicLightRenderer_t::LEGACY ) )
+				{
+					stage->active = false;
+				}
+				break;
+
 			default:
 				break;
 		}

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5348,7 +5348,7 @@ static void SetStagesRenderers()
 	{
 		shaderStage_t *stage = &stages[ s ];
 
-		stageRendererOptions_t stageRendererOptions = { &Render_NOP, false, false };
+		stageRendererOptions_t stageRendererOptions = { &Render_NONE, false, false };
 
 		bool opaqueOrLess = shader.sort <= Util::ordinal(shaderSort_t::SS_OPAQUE);
 
@@ -5390,7 +5390,7 @@ static void SetStagesRenderers()
 				break;
 			case stageType_t::ST_ATTENUATIONMAP_XY:
 			case stageType_t::ST_ATTENUATIONMAP_Z:
-				// Not implemented yet
+				stageRendererOptions = { &Render_NOP, false, true };
 				break;
 			default:
 				Log::Warn( "Missing renderer for stage type %d", Util::ordinal(stage->type) );
@@ -5403,7 +5403,7 @@ static void SetStagesRenderers()
 		stage->doForwardLighting = stageRendererOptions.doForwardLighting;
 
 		// Disable stages that have no renderer yet.
-		if ( stage->colorRenderer == &Render_NOP )
+		if ( stage->colorRenderer == &Render_NONE )
 		{
 			stage->active = false;
 			continue;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5193,6 +5193,12 @@ static void FinishStages()
 				break;
 
 			case stageType_t::ST_LIGHTMAP:
+				// standalone lightmap stage: paint shadows over a white texture
+				stage->bundle[ TB_DIFFUSEMAP ].image[ 0 ] = tr.whiteImage;
+				lightStageFound = true;
+				shaderHasNoLight = false;
+				break;
+
 			case stageType_t::ST_DIFFUSEMAP:
 			case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
 				lightStageFound = true;


### PR DESCRIPTION
Something is wrong as the light is too dim, but it works.

About the wrongness, here with both map dynamic light, and weapon projectile dynamic light:

![unvanquished_2024-04-21_202022_000](https://github.com/DaemonEngine/Daemon/assets/2311649/24328048-a1db-4b2b-bd35-8239901cc3d6)

It should look like this:

![unvanquished_2024-04-21_204455_000](https://github.com/DaemonEngine/Daemon/assets/2311649/3af084fe-aed3-43b0-a185-dc56a2b9e8c9)
