### PR TITLE
renderer: use default value from shader_t and shaderStage_t

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1279,10 +1279,8 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		bool enableGlowMapping;
 
 		// Normal map scale and format.
-		bool hasNormalFormat;
-		bool hasNormalScale;
-		vec3_t normalFormat;
-		vec3_t normalScale;
+		int8_t normalFormat[ 3 ];
+		vec3_t normalScale = { 1.0f, 1.0f, 1.0f };
 
 		expression_t    normalIntensityExp;
 
@@ -1365,7 +1363,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 
 		bool       disableReliefMapping; // disable relief mapping for this material even if it's available
 		float      reliefOffsetBias; // offset the heightmap top relatively to the floor
-		float      reliefDepthScale; // per-shader relief depth scale
+		float reliefDepthScale = 1.0f; // per-shader relief depth scale
 
 		bool       noShadows;
 		bool       fogLight;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1064,12 +1064,9 @@ void Render_lightMapping( shaderStage_t *pStage )
 	// bind u_HeightMap
 	if ( pStage->enableReliefMapping )
 	{
-		float depthScale;
-		float reliefDepthScale;
+		float depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
+		depthScale *= tess.surfaceShader->reliefDepthScale;
 
-		depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
-		reliefDepthScale = tess.surfaceShader->reliefDepthScale;
-		depthScale *= reliefDepthScale == 0 ? 1 : reliefDepthScale;
 		gl_lightMappingShader->SetUniform_ReliefDepthScale( depthScale );
 		gl_lightMappingShader->SetUniform_ReliefOffsetBias( tess.surfaceShader->reliefOffsetBias );
 
@@ -1350,12 +1347,9 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *pStage,
 	// bind u_HeightMap
 	if ( pStage->enableReliefMapping )
 	{
-		float depthScale;
-		float reliefDepthScale;
+		float depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
+		depthScale *= tess.surfaceShader->reliefDepthScale;
 
-		depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
-		reliefDepthScale = tess.surfaceShader->reliefDepthScale;
-		depthScale *= reliefDepthScale == 0 ? 1 : reliefDepthScale;
 		gl_forwardLightingShader_omniXYZ->SetUniform_ReliefDepthScale( depthScale );
 		gl_forwardLightingShader_omniXYZ->SetUniform_ReliefOffsetBias( tess.surfaceShader->reliefOffsetBias );
 
@@ -1515,12 +1509,9 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *pStage,
 	// bind u_HeightMap
 	if ( pStage->enableReliefMapping )
 	{
-		float depthScale;
-		float reliefDepthScale;
+		float depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
+		depthScale *= tess.surfaceShader->reliefDepthScale;
 
-		depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
-		reliefDepthScale = tess.surfaceShader->reliefDepthScale;
-		depthScale *= reliefDepthScale == 0 ? 1 : reliefDepthScale;
 		gl_forwardLightingShader_projXYZ->SetUniform_ReliefDepthScale( depthScale );
 		gl_forwardLightingShader_projXYZ->SetUniform_ReliefOffsetBias( tess.surfaceShader->reliefOffsetBias );
 
@@ -1679,12 +1670,9 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *pStage, trRef
 	// bind u_HeightMap
 	if ( pStage->enableReliefMapping )
 	{
-		float depthScale;
-		float reliefDepthScale;
+		float depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
+		depthScale *= tess.surfaceShader->reliefDepthScale;
 
-		depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
-		reliefDepthScale = tess.surfaceShader->reliefDepthScale;
-		depthScale *= reliefDepthScale == 0 ? 1 : reliefDepthScale;
 		gl_forwardLightingShader_directionalSun->SetUniform_ReliefDepthScale( depthScale );
 		gl_forwardLightingShader_directionalSun->SetUniform_ReliefOffsetBias( tess.surfaceShader->reliefOffsetBias );
 
@@ -1882,12 +1870,9 @@ void Render_reflection_CB( shaderStage_t *pStage )
 	// bind u_HeightMap u_depthScale u_reliefOffsetBias
 	if ( pStage->enableReliefMapping )
 	{
-		float depthScale;
-		float reliefDepthScale;
+		float depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
+		depthScale *= tess.surfaceShader->reliefDepthScale;
 
-		depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
-		reliefDepthScale = tess.surfaceShader->reliefDepthScale;
-		depthScale *= reliefDepthScale == 0 ? 1 : reliefDepthScale;
 		gl_reflectionShader->SetUniform_ReliefDepthScale( depthScale );
 		gl_reflectionShader->SetUniform_ReliefOffsetBias( tess.surfaceShader->reliefOffsetBias );
 
@@ -2142,12 +2127,9 @@ void Render_liquid( shaderStage_t *pStage )
 	// bind u_HeightMap u_depthScale u_reliefOffsetBias
 	if ( pStage->enableReliefMapping )
 	{
-		float depthScale;
-		float reliefDepthScale;
+		float depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
+		depthScale *= tess.surfaceShader->reliefDepthScale;
 
-		depthScale = RB_EvalExpression( &pStage->depthScaleExp, r_reliefDepthScale->value );
-		reliefDepthScale = tess.surfaceShader->reliefDepthScale;
-		depthScale *= reliefDepthScale == 0 ? 1 : reliefDepthScale;
 		gl_liquidShader->SetUniform_ReliefDepthScale( depthScale );
 		gl_liquidShader->SetUniform_ReliefOffsetBias( tess.surfaceShader->reliefOffsetBias );
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -3229,7 +3229,7 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 		stage->type = stageType_t::ST_COLLAPSE_COLORMAP;
 	}
 
-	else if ( stages->collapseType == collapseType_t::COLLAPSE_REFLECTIONMAP )
+	else if ( stage->collapseType == collapseType_t::COLLAPSE_REFLECTIONMAP )
 	{
 		stage->type = stageType_t::ST_COLLAPSE_REFLECTIONMAP;
 	}


### PR DESCRIPTION
Use default value from `shader_t` and `shaderStage_t`.

The clearing of the global shader may be a bit slower, but being able to rely on default values makes the code easier to write.