### PR TITLE
Don't check overflow for data already in VBOs

### DIFF
--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1179,8 +1179,6 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 	int numIndexes = surf->num_triangles * 3;
 
-	Tess_CheckOverflow( surf->num_vertexes, numIndexes );
-
 	tess.attribsSet |= ATTR_POSITION | ATTR_TEXCOORD;
 
 	if ( !tess.skipTangentSpaces )
@@ -1263,6 +1261,8 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 		return;
 	}
+
+	Tess_CheckOverflow( surf->num_vertexes, numIndexes );
 
 	glIndex_t *tessIndex = tess.indexes + tess.numIndexes;
 	int *modelTriangle = model->triangles + 3 * surf->first_triangle;


### PR DESCRIPTION
Overflow only makes sense when uploading new vertices, models that already have their vertices in vram will not overflow anything.