### PR TITLE
Add sky surfaces to world VBO

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -2975,7 +2975,7 @@ static void R_CreateWorldVBO()
 	{
 		surface = &s_worldData.surfaces[ k ];
 
-		if ( surface->shader->isSky || surface->shader->isPortal )
+		if ( surface->shader->isPortal )
 		{
 			continue;
 		}
@@ -3050,7 +3050,7 @@ static void R_CreateWorldVBO()
 
 			shader1 = surf1->shader;
 
-			if ( shader1->isSky || shader1->isPortal )
+			if ( shader1->isPortal )
 			{
 				continue;
 			}
@@ -3112,7 +3112,7 @@ static void R_CreateWorldVBO()
 	{
 		surface = &s_worldData.surfaces[ k ];
 
-		if ( surface->shader->isSky || surface->shader->isPortal )
+		if ( surface->shader->isPortal )
 		{
 			continue;
 		}


### PR DESCRIPTION
Stops tess.vertexes from overflowing by adding all the sky surfaces to world VBO instead of doing Tess_SurfaceVertsAndTris() on them.

This essentialy moves them from RAM to VRAM. It might be better to just always draw the skybox rather than have those sky surfaces in memory.

Fixes #1096.