### PR TITLE
renderer: disable heat haze stage at load time

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1990,11 +1990,6 @@ void Render_heatHaze( shaderStage_t *pStage )
 
 	GLimp_LogComment( "--- Render_heatHaze ---\n" );
 
-	if ( r_heatHaze->integer == 0 )
-	{
-		return;
-	}
-
 	// remove alpha test
 	stateBits = pStage->stateBits;
 	stateBits &= ~GLS_ATEST_BITS;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5185,10 +5185,7 @@ static void FinishStages()
 
 			case stageType_t::ST_REFLECTIONMAP:
 			case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
-				if ( !r_reflectionMapping->integer )
-				{
-					stage->active = false;
-				}
+				stage->active = r_reflectionMapping->integer;
 				break;
 
 			case stageType_t::ST_STYLELIGHTMAP:
@@ -5211,10 +5208,7 @@ static void FinishStages()
 
 			case stageType_t::ST_ATTENUATIONMAP_XY:
 			case stageType_t::ST_ATTENUATIONMAP_Z:
-				if ( !glConfig2.dynamicLight || r_dynamicLightRenderer.Get() != Util::ordinal( dynamicLightRenderer_t::LEGACY ) )
-				{
-					stage->active = false;
-				}
+				stage->active = ( glConfig2.dynamicLight && r_dynamicLightRenderer.Get() != Util::ordinal( dynamicLightRenderer_t::LEGACY ) );
 				break;
 
 			default:

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5171,6 +5171,10 @@ static void FinishStages()
 				stage->active = false;
 				break;
 
+			case stageType_t::ST_HEATHAZEMAP:
+				stage->active = r_heatHaze->integer;
+				break;
+
 			case stageType_t::ST_LIQUIDMAP:
 				if ( !r_liquidMapping->integer )
 				{


### PR DESCRIPTION
Disable heat haze stage at load time, instead of iterating it and skipping it at render time.