### PR TITLE
tr_shade: do not use reflective specular code on PBR material

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -961,6 +961,9 @@ void Render_lightMapping( shaderStage_t *pStage )
 
 	DAEMON_ASSERT( !( enableDeluxeMapping && enableGridDeluxeMapping ) );
 
+	// Not implemented yet in PBR code.
+	bool enableReflectiveSpecular = pStage->enableSpecularMapping && tr.cubeHashTable != nullptr;
+
 	GL_State( stateBits );
 
 	// choose right shader program ----------------------------------
@@ -982,7 +985,7 @@ void Render_lightMapping( shaderStage_t *pStage )
 
 	gl_lightMappingShader->SetReliefMapping( pStage->enableReliefMapping );
 
-	gl_lightMappingShader->SetReflectiveSpecular( pStage->enableNormalMapping && tr.cubeHashTable != nullptr );
+	gl_lightMappingShader->SetReflectiveSpecular( enableReflectiveSpecular );
 
 	gl_lightMappingShader->SetPhysicalShading( pStage->enablePhysicalMapping );
 
@@ -1114,8 +1117,7 @@ void Render_lightMapping( shaderStage_t *pStage )
 		gl_lightMappingShader->SetUniform_SpecularExponent( specExpMin, specExpMax );
 	}
 
-	// specular reflection
-	if ( tr.cubeHashTable != nullptr )
+	if ( enableReflectiveSpecular )
 	{
 		cubemapProbe_t *cubeProbeNearest;
 		cubemapProbe_t *cubeProbeSecondNearest;


### PR DESCRIPTION
It is not implemented yet and the shader permutation is disabled.

It now makes possible to run `buildcubemaps` command even when there are PBR materials in the scene, to not crash while attempting to render those PBR materials with a shader permutation that doesn't exist.

To test the reflective specular code, one should:

- load a map with specular maps
- have `r_smp` disabled (there are some crashes when generating cubemaps otherwise)
- type `/buildcubemaps` in console

The rendering is assumed to be wrong (it blinks to black), but the `buildcubemaps` command runs.