### PR TITLE
tr_image: correct bundle image pointer

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -3025,7 +3025,7 @@ void RE_GetTextureSize( int textureID, int *width, int *height )
 		return;
 	}
 
-	baseImage = shader->stages[ 0 ]->bundle->image[ 0 ];
+	baseImage = shader->stages[ 0 ]->bundle[ 0 ].image[ 0 ];
 	if ( !baseImage )
 	{
 		Log::Debug( "%sRE_GetTextureSize: shader %s is missing base image",


### PR DESCRIPTION
I noticed it while working on #1099:

- https://github.com/DaemonEngine/Daemon/pull/1099

On other parts of the code like `tr_cmds.cpp` we already have:

```c++
image = shader->stages[ 0 ]->bundle[ 0 ].image[ 0 ];
```

And every image access are done everywhere else as `bundle[ i ].image`.

So doing `shader->stages[ 0 ]->bundle->image[ 0 ]` looks wrong and likely worked by luck.