### PR TITLE
cg_api: do nothing in trap_R_AddPolysToScene if array size is zero

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -3049,6 +3049,13 @@ int numTextures = 0;
 
 qhandle_t RE_GenerateTexture( const byte *pic, int width, int height )
 {
+	size_t size = width * height;
+
+	if ( !size ) {
+		Log::Warn("RE_GenerateTexture: image size %dx%d is 0", width, height );
+		return 0;
+	}
+
 	const char *name = va( "rocket%d", numTextures++ );
 	R_SyncRenderThread();
 

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -319,6 +319,11 @@ void trap_R_AddRefEntityToScene( const refEntity_t *re )
 
 void trap_R_AddPolyToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts )
 {
+	if (!numVerts)
+	{
+		return;
+	}
+
 	std::vector<polyVert_t> myverts(numVerts);
 	memcpy(myverts.data(), verts, numVerts * sizeof(polyVert_t));
 	cmdBuffer.SendMsg<Render::AddPolyToSceneMsg>(hShader, myverts);
@@ -343,6 +348,11 @@ void trap_R_AddPolysToScene( qhandle_t hShader, int numVerts, const polyVert_t *
 
 void trap_R_Add2dPolysIndexedToScene( polyVert_t* polys, int numPolys, int* indexes, int numIndexes, int trans_x, int trans_y, qhandle_t shader )
 {
+	if (!numIndexes)
+	{
+		return;
+	}
+
 	std::vector<polyVert_t> mypolys(numPolys);
 	std::vector<int> myindices(numIndexes);
 	memcpy(mypolys.data(), polys, numPolys * sizeof( polyVert_t ) );

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -326,8 +326,18 @@ void trap_R_AddPolyToScene( qhandle_t hShader, int numVerts, const polyVert_t *v
 
 void trap_R_AddPolysToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts, int numPolys )
 {
-	std::vector<polyVert_t> myverts(numVerts * numPolys);
-	memcpy(myverts.data(), verts, numVerts * numPolys * sizeof(polyVert_t));
+	size_t size = numVerts * numPolys;
+
+	if (!size)
+	{
+		return;
+	}
+
+	std::vector<polyVert_t> myverts(size);
+	memcpy(myverts.data(), verts, size * sizeof(polyVert_t));
+
+	/* Known to crash on Clang ≥ 14 in non-Debug native build if size is 0:
+	https://github.com/Unvanquished/Unvanquished/issues/2682 */
 	cmdBuffer.SendMsg<Render::AddPolysToSceneMsg>(hShader, myverts, numVerts, numPolys);
 }
 

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -568,6 +568,7 @@ void trap_R_GetTextureSize( qhandle_t handle, int *x, int *y )
 
 qhandle_t trap_R_GenerateTexture( const byte *data, int x, int y )
 {
+	ASSERT( x * y );
 	qhandle_t handle;
 	std::vector<byte> mydata(x * y * 4);
 	memcpy(mydata.data(), data, x * y * 4 * sizeof( byte ) );


### PR DESCRIPTION
May be a better fix for:

- https://github.com/Unvanquished/Unvanquished/issues/2682

than:

- https://github.com/Unvanquished/Unvanquished/pull/2976

Being implemented in engine shared code means the crash would be prevented for any custom game.

I now wonder if we should not add such check for any other trap calls allocating a `vector` of `polyVert_t`.