### PR TITLE
renderer: expression_t is always allocated as part of structs, ext->numOps always 0 if ext is invalid

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -146,7 +146,7 @@ static void ComputeDynamics( shaderStage_t* pStage ) {
 				case texMod_t::TMOD_CENTERSCALE:
 				case texMod_t::TMOD_SHEAR:
 				{
-					if ( bundle.texMods[i].sExp.active || bundle.texMods[i].tExp.active ) {
+					if ( bundle.texMods[i].sExp.numOps || bundle.texMods[i].tExp.numOps ) {
 						pStage->texMatricesDynamic = true;
 					}
 					break;
@@ -154,7 +154,7 @@ static void ComputeDynamics( shaderStage_t* pStage ) {
 
 				case texMod_t::TMOD_ROTATE2:
 				{
-					if( bundle.texMods[i].rExp.active ) {
+					if( bundle.texMods[i].rExp.numOps ) {
 						pStage->texMatricesDynamic = true;
 					}
 					break;
@@ -176,13 +176,13 @@ static void ComputeDynamics( shaderStage_t* pStage ) {
 
 	// Can we move this to a compute shader too?
 	// Doesn't seem to be used much if at all, so probably not worth the effort to do that
-	pStage->dynamic = pStage->dynamic || pStage->ifExp.active;
-	pStage->dynamic = pStage->dynamic || pStage->alphaExp.active || pStage->alphaTestExp.active;
-	pStage->dynamic = pStage->dynamic || pStage->rgbExp.active || pStage->redExp.active || pStage->greenExp.active || pStage->blueExp.active;
-	pStage->dynamic = pStage->dynamic || pStage->deformMagnitudeExp.active;
-	pStage->dynamic = pStage->dynamic || pStage->depthScaleExp.active || pStage->etaExp.active || pStage->etaDeltaExp.active
-		|| pStage->fogDensityExp.active || pStage->fresnelBiasExp.active || pStage->fresnelPowerExp.active
-		|| pStage->fresnelScaleExp.active || pStage->normalIntensityExp.active || pStage->refractionIndexExp.active;
+	pStage->dynamic = pStage->dynamic || pStage->ifExp.numOps;
+	pStage->dynamic = pStage->dynamic || pStage->alphaExp.numOps || pStage->alphaTestExp.numOps;
+	pStage->dynamic = pStage->dynamic || pStage->rgbExp.numOps || pStage->redExp.numOps || pStage->greenExp.numOps || pStage->blueExp.numOps;
+	pStage->dynamic = pStage->dynamic || pStage->deformMagnitudeExp.numOps;
+	pStage->dynamic = pStage->dynamic || pStage->depthScaleExp.numOps || pStage->etaExp.numOps || pStage->etaDeltaExp.numOps
+		|| pStage->fogDensityExp.numOps || pStage->fresnelBiasExp.numOps || pStage->fresnelPowerExp.numOps
+		|| pStage->fresnelScaleExp.numOps || pStage->normalIntensityExp.numOps || pStage->refractionIndexExp.numOps;
 
 	pStage->dynamic = pStage->dynamic || pStage->colorDynamic || pStage->texMatricesDynamic || pStage->texturesDynamic;
 }

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -941,8 +941,6 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	{
 		expOperation_t ops[ MAX_EXPRESSION_OPS ];
 		uint8_t        numOps;
-
-		bool       active; // no parsing problems
 	};
 
 	struct waveForm_t

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -940,7 +940,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	struct expression_t
 	{
 		expOperation_t ops[ MAX_EXPRESSION_OPS ];
-		uint8_t numOps;
+		size_t numOps;
 	};
 
 	struct waveForm_t

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -940,7 +940,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	struct expression_t
 	{
 		expOperation_t ops[ MAX_EXPRESSION_OPS ];
-		uint8_t        numOps;
+		uint8_t numOps;
 	};
 
 	struct waveForm_t

--- a/src/engine/renderer/tr_shade_calc.cpp
+++ b/src/engine/renderer/tr_shade_calc.cpp
@@ -224,19 +224,6 @@ const char* GetOpName(opcode_t type);
 
 float RB_EvalExpression( const expression_t *exp, float defaultValue )
 {
-	int                     i;
-	expOperation_t          op;
-	expOperation_t          ops[ MAX_EXPRESSION_OPS ];
-	int                     numOps;
-	float                   value;
-	float                   value1;
-	float                   value2;
-
-	numOps = 0;
-	value = 0;
-	value1 = 0;
-	value2 = 0;
-
 	ASSERT( exp );
 
 	if ( !exp->numOps )
@@ -244,12 +231,19 @@ float RB_EvalExpression( const expression_t *exp, float defaultValue )
 		return defaultValue;
 	}
 
+	expOperation_t ops[ MAX_EXPRESSION_OPS ];
+
+	int numOps = 0;
+	float value = 0.0;
+	float value1 = 0.0;
+	float value2 = 0.0;
+
 	// http://www.qiksearch.com/articles/cs/postfix-evaluation/
 	// http://www.kyz.uklinux.net/evaluate/
 
-	for ( i = 0; i < exp->numOps; i++ )
+	for ( int i = 0; i < exp->numOps; i++ )
 	{
-		op = exp->ops[ i ];
+		expOperation_t op = exp->ops[ i ];
 
 		switch ( op.type )
 		{

--- a/src/engine/renderer/tr_shade_calc.cpp
+++ b/src/engine/renderer/tr_shade_calc.cpp
@@ -233,7 +233,7 @@ float RB_EvalExpression( const expression_t *exp, float defaultValue )
 
 	expOperation_t ops[ MAX_EXPRESSION_OPS ];
 
-	int numOps = 0;
+	size_t numOps = 0;
 	float value = 0.0;
 	float value1 = 0.0;
 	float value2 = 0.0;
@@ -241,7 +241,7 @@ float RB_EvalExpression( const expression_t *exp, float defaultValue )
 	// http://www.qiksearch.com/articles/cs/postfix-evaluation/
 	// http://www.kyz.uklinux.net/evaluate/
 
-	for ( int i = 0; i < exp->numOps; i++ )
+	for ( size_t i = 0; i < exp->numOps; i++ )
 	{
 		expOperation_t op = exp->ops[ i ];
 

--- a/src/engine/renderer/tr_shade_calc.cpp
+++ b/src/engine/renderer/tr_shade_calc.cpp
@@ -237,7 +237,9 @@ float RB_EvalExpression( const expression_t *exp, float defaultValue )
 	value1 = 0;
 	value2 = 0;
 
-	if ( !exp || !exp->active )
+	ASSERT( exp );
+
+	if ( !exp->numOps )
 	{
 		return defaultValue;
 	}

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -703,7 +703,11 @@ static void ParseExpression( const char **text, expression_t *exp )
 	numInFixOps = 0;
 	numTmpOps = 0;
 
+	// A ext->numOps equals to 0 means empty or invalid expression.
 	exp->numOps = 0;
+
+	// The numOps will only be written to exp->numOps if there is no parsing error.
+	uint8_t numOps = 0;
 
 	// push left parenthesis on the stack
 	op.type = opcode_t::OP_LPAREN;
@@ -802,7 +806,7 @@ static void ParseExpression( const char **text, expression_t *exp )
 		// if current operator in infix is digit
 		if ( IsOperand( op.type ) )
 		{
-			exp->ops[ exp->numOps++ ] = op;
+			exp->ops[ numOps++ ] = op;
 		}
 		// if current operator in infix is left parenthesis
 		else if ( op.type == opcode_t::OP_LPAREN )
@@ -828,7 +832,7 @@ static void ParseExpression( const char **text, expression_t *exp )
 					{
 						if ( GetOpPrecedence( op2.type ) >= GetOpPrecedence( op.type ) )
 						{
-							exp->ops[ exp->numOps++ ] = op2;
+							exp->ops[ numOps++ ] = op2;
 							numTmpOps--;
 						}
 						else
@@ -862,7 +866,7 @@ static void ParseExpression( const char **text, expression_t *exp )
 
 					if ( op2.type != opcode_t::OP_LPAREN )
 					{
-						exp->ops[ exp->numOps++ ] = op2;
+						exp->ops[ numOps++ ] = op2;
 						numTmpOps--;
 					}
 					else
@@ -876,7 +880,7 @@ static void ParseExpression( const char **text, expression_t *exp )
 	}
 
 	// everything went ok
-	exp->active = true;
+	exp->numOps = numOps;
 }
 
 /*

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -691,17 +691,17 @@ static void ParseExpression( const char **text, expression_t *exp )
 	expOperation_t op, op2;
 
 	expOperation_t inFixOps[ MAX_EXPRESSION_OPS ];
-	int numInFixOps = 0;
+	size_t numInFixOps = 0;
 
 	// convert stack
 	expOperation_t tmpOps[ MAX_EXPRESSION_OPS ];
-	int numTmpOps = 0;
+	size_t numTmpOps = 0;
 
 	// A ext->numOps equals to 0 means empty or invalid expression.
 	exp->numOps = 0;
 
 	// The numOps will only be written to exp->numOps if there is no parsing error.
-	uint8_t numOps = 0;
+	size_t numOps = 0;
 
 	// push left parenthesis on the stack
 	op.type = opcode_t::OP_LPAREN;
@@ -773,7 +773,7 @@ static void ParseExpression( const char **text, expression_t *exp )
 	op.value = 0;
 	inFixOps[ numInFixOps++ ] = op;
 
-	for ( int i = 0; i < ( numInFixOps - 1 ); i++ )
+	for ( size_t i = 0; i < ( numInFixOps - 1 ); i++ )
 	{
 		op = inFixOps[ i ];
 		op2 = inFixOps[ i + 1 ];
@@ -793,7 +793,7 @@ static void ParseExpression( const char **text, expression_t *exp )
 	// convert infix representation to postfix
 	//
 
-	for ( int i = 0; i < numInFixOps; i++ )
+	for ( size_t i = 0; i < numInFixOps; i++ )
 	{
 		op = inFixOps[ i ];
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -688,20 +688,14 @@ ParseExpression
 */
 static void ParseExpression( const char **text, expression_t *exp )
 {
-	int            i;
-	char           *token;
-
 	expOperation_t op, op2;
 
 	expOperation_t inFixOps[ MAX_EXPRESSION_OPS ];
-	int            numInFixOps;
+	int numInFixOps = 0;
 
 	// convert stack
 	expOperation_t tmpOps[ MAX_EXPRESSION_OPS ];
-	int            numTmpOps;
-
-	numInFixOps = 0;
-	numTmpOps = 0;
+	int numTmpOps = 0;
 
 	// A ext->numOps equals to 0 means empty or invalid expression.
 	exp->numOps = 0;
@@ -716,7 +710,7 @@ static void ParseExpression( const char **text, expression_t *exp )
 
 	while ( true )
 	{
-		token = ParseExpressionElement( text );
+		char *token = ParseExpressionElement( text );
 
 		if ( token[ 0 ] == 0 || token[ 0 ] == ',' )
 		{
@@ -779,7 +773,7 @@ static void ParseExpression( const char **text, expression_t *exp )
 	op.value = 0;
 	inFixOps[ numInFixOps++ ] = op;
 
-	for ( i = 0; i < ( numInFixOps - 1 ); i++ )
+	for ( int i = 0; i < ( numInFixOps - 1 ); i++ )
 	{
 		op = inFixOps[ i ];
 		op2 = inFixOps[ i + 1 ];
@@ -799,7 +793,7 @@ static void ParseExpression( const char **text, expression_t *exp )
 	// convert infix representation to postfix
 	//
 
-	for ( i = 0; i < numInFixOps; i++ )
+	for ( int i = 0; i < numInFixOps; i++ )
 	{
 		op = inFixOps[ i ];
 


### PR DESCRIPTION
As far as I know,

- `expression_t` is always allocated as part of structs (`texModInfo_t`, `shaderStage_t`),
- `ext->numOps` is always `0` if `ext` is invalid.