### PR TITLE
Fix dynamic light blockiness and strength

### DIFF
--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -186,13 +186,19 @@ void computeDynamicLight( int idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffu
   if( color_type.w == 0.0 ) {
     // point light
     L = center_radius.xyz - P;
-    attenuation = 1.0 / (1.0 + 8.0 * length(L) / center_radius.w);
+    // 2.57 ~= 8.0 ^ ( 1.0 / 2.2 ), adjusted after overbright changes
+    float t = 1.0 + 2.57 * length(L) / center_radius.w;
+    // Quadratic attenuation function instead of linear because of overbright changes
+    attenuation = 1.0 / ( t * t );
     L = normalize(L);
   } else if( color_type.w == 1.0 ) {
     // spot light
     vec4 direction_angle = GetLight( idx, direction_angle );
     L = center_radius.xyz - P;
-    attenuation = 1.0 / (1.0 + 8.0 * length(L) / center_radius.w);
+    // 2.57 ~= 8.0 ^ ( 1.0 / 2.2 ), adjusted after overbright changes
+    float t = 1.0 + 2.57 * length(L) / center_radius.w;
+    // Quadratic attenuation function instead of linear because of overbright changes
+    attenuation = 1.0 / ( t * t );
     L = normalize( L );
 
     if( dot( L, direction_angle.xyz ) <= direction_angle.w ) {

--- a/src/engine/renderer/glsl_source/lighttile_fp.glsl
+++ b/src/engine/renderer/glsl_source/lighttile_fp.glsl
@@ -157,7 +157,7 @@ void main() {
   for( int i = u_lightLayer; i < u_numLights; i += numLayers ) {
     light l = GetLight( i );
     vec3 center = ( u_ModelMatrix * vec4( l.center, 1.0 ) ).xyz;
-    float radius = 2.0 * l.radius;
+    float radius = max( 2.0 * l.radius, 2.0 * 32.0 ); // Avoid artifacts with weak light sources
 
     // todo: better checks for spotlights
     lightOutsidePlane( plane1, center, radius );


### PR DESCRIPTION
Sets a minimum radius for light culling to avoid blocky artifacts. Still sort of a hack, but it works better than what we had.
Also made attenuation quadratic rather than linear for dynamic lights since that is more correct without broken gamma (previous incorrect lighting was essentially doing distance ^ 4.2 due to gamma correction). In the same pr because without the correct attenuation the blockiness is still there.

Before and after for light culling:
![unvanquished_2024-04-30_002814_000](https://github.com/DaemonEngine/Daemon/assets/10687142/e304b1ee-bbb3-4bfa-b104-fb3bd1e36430)
![unvanquished_2024-04-30_002707_000](https://github.com/DaemonEngine/Daemon/assets/10687142/26280558-a262-44ec-9443-c4db0983c281)

I've chosen the 2.0 * 32.0 value for the minimum radius because it fixes the blockiness issues with the smallest scale lights that we have. Simply always increasing radius results in too many tiles getting the light source.

This also fixes the same issue with https://users.unvanquished.net/~modi/res-psaw_dev%2Bishq1.dpk, however it's more difficult to capture a screenshot of that.

Fixes #791.