### PR TITLE
readme: update compiler section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Dæmon is the standalone engine that powers the multiplayer first person shooter
 To fetch and build Dæmon, you'll need:
 `git`,
 `cmake`,
-and a C++11 compiler.
+and a C++14 compiler.
 
 The following are actively supported:
-`gcc` ≥ 4.8,
-`clang` ≥ 3.5,
+`gcc` ≥ 9,
+`clang` ≥ 11,
 Visual Studio/MSVC (at least Visual Studio 2019).
 
 ## Dependencies


### PR DESCRIPTION
I noticed the engine's README was still mentionning a C++11 compiler was needed while the Unvanquished game's README is mentionning the requirement of a C++14 compiler.

While it may be possible that the game requires an higher version than the engine, I verified and no the engine cannot run anymore if I request C++11:

```
Unvanquished/daemon/src/engine/renderer/tr_model_md5.cpp: In function ‘bool R_LoadMD5(model_t*, const char*, const char*)’:
Unvanquished/daemon/src/engine/renderer/tr_model_md5.cpp:361:39: error: ‘make_unique’ is not a member of ‘std’
  361 |                 auto texCoords = std::make_unique<vec2_t[]>( surf->numVerts );
      |                                       ^~~~~~~~~~~
Unvanquished/daemon/src/engine/renderer/tr_model_md5.cpp:361:39: note: ‘std::make_unique’ is only available from C++14 onwards
Unvanquished/daemon/src/engine/renderer/tr_model_md5.cpp:361:57: error: expected primary-expression before ‘[’ token
  361 |                 auto texCoords = std::make_unique<vec2_t[]>( surf->numVerts );
      |                                                         ^
Unvanquished/daemon/src/engine/renderer/tr_model_md5.cpp:361:58: error: expected primary-expression before ‘]’ token
  361 |                 auto texCoords = std::make_unique<vec2_t[]>( surf->numVerts );
      |                                                          ^
```

The lowest compiler versions for full C++14 support seems to be Clang 3.4 according to:

- https://clang.llvm.org/cxx_status.html

and likely GCC 5 while default in GCC 6.1 according to:

- https://gcc.gnu.org/projects/cxx-status.html#cxx14

But it is not easy to test them anymore, so I guess it's better to mention the compilers we actually use in our CI, which are GCC 9 (for both Linux and MinGW) and Clang 11 (CI uses Clang 11 for Linux, AppleClang 13 for macOS).