### PR TITLE
common: also do pedantic shutdown when running Clang sanitizers

### DIFF
--- a/src/common/Compiler.h
+++ b/src/common/Compiler.h
@@ -103,11 +103,21 @@ int CountTrailingZeroes(unsigned long long x);
 // Work around lack of constexpr
 #define CONSTEXPR constexpr
 
-#ifdef __SANITIZE_ADDRESS__ // Detects GCC asan
+#if defined(__SANITIZE_ADDRESS__) // Detects GCC and MSVC AddressSanitizer
 #   define USING_ADDRESS_SANITIZER
+#   define USING_SANITIZER
+#elif defined(__SANITIZE_THREAD__) // Detects GCC ThreadSanitizer
+#   define USING_SANITIZER
 #elif defined(__has_feature)
-#   if __has_feature(address_sanitizer) // Detects Clang asan
+#   if __has_feature(address_sanitizer) // Detects Clang AddressSanitizer
 #       define USING_ADDRESS_SANITIZER
+#       define USING_SANITIZER
+#   elif __has_feature(leak_sanitizer) // Detects Clang LeakSanitizer
+#       define USING_SANITIZER
+#   elif __has_feature(memory_sanitizer) // Detects Clang MemorySanitizer
+#       define USING_SANITIZER
+#   elif __has_feature(thread_sanitizer) // Detects Clang ThreadSanitizer
+#       define USING_SANITIZER
 #   endif
 #endif
 

--- a/src/common/System.cpp
+++ b/src/common/System.cpp
@@ -64,7 +64,7 @@ namespace Sys {
 // This option can be turned on when debugging memory management
 #ifdef BUILD_ENGINE
 Cvar::Cvar<bool> pedanticShutdown("common.pedanticShutdown", "run useless shutdown procedures before exit", Cvar::NONE,
-#ifdef __SANITIZE_ADDRESS__
+#ifdef USING_SANITIZER
 	true);
 #else
 	false);


### PR DESCRIPTION
Also detect MemorySanitizer and ThreadSanitizer.

Without this, the linker complains about `new` and `delete` being redefined when linking with `-fsanitize=leak`, `-fsanitize=memory` or `-fsanitize=thread`.

Previously we were only caring about linking with `-fsanitize=address`.