### PR TITLE
readme: sync the recommended MinGW compiler wording with Unvanquished

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,10 @@ Optional:
 
 ### MSYS2
 
-Also required:
-`base-devel`.
+MSYS2 is the recommended way to build using MinGW on a Windows host.
 
-64-bit: `mingw-w64-x86_64-{toolchain,cmake}`,  
-_or_ 32-bit: `mingw-w64-i686-{toolchain,cmake}`.
-
-MSYS2 is an easy way to get MingW compiler and build dependencies, the standalone MingW on Windows also works.
+Required packages for 64-bit: `mingw-w64-x86_64-gcc`, `mingw-w64-x86_64-cmake`, `make`  
+Required packages for 32-bit: `mingw-w64-i686-gcc`, `mingw-w64-i686-cmake`, `make`
 
 ## Downloading the sources for the game engine
 


### PR DESCRIPTION
Sync the recommended MinGW compiler wording with Unvanquished.

There is probably no need to mention standalone MinGW as long as we have a working recommendation.

Do we need to also recommend `base-devel`? Unvanquished was missing it.