### PR TITLE
Use std::set_new_handler to send OOM message

### DIFF
--- a/src/common/System.cpp
+++ b/src/common/System.cpp
@@ -425,26 +425,15 @@ void GenRandomBytes(void* dest, size_t size)
 #endif
 }
 
-} // namespace Sys
-
-#ifndef USING_ADDRESS_SANITIZER
-// Global operator new/delete override to not throw an exception when out of
+// Do not throw an exception when out of
 // memory. Instead, it is preferable to simply crash with an error.
-void* operator new(size_t n)
+static void ErrorOutOfMemory()
 {
-	void* p = malloc(n);
-	if (!p)
-		Sys::Error("Out of memory");
-	return p;
+	Sys::Error("Out of memory");
 }
+static int dummy = [] {
+	std::set_new_handler(ErrorOutOfMemory);
+	return 0;
+}();
 
-void operator delete(void* p) NOEXCEPT
-{
-	free(p);
-}
-
-void operator delete(void* p, size_t) NOEXCEPT
-{
-	free(p);
-}
-#endif
+} // namespace Sys


### PR DESCRIPTION
Instead of defining custom new and delete to ensure that an allocation failure results in a fatal error with the "Out of memory", use std::set_new_handler to accomplish the same. This std lib facility allows setting a custom behavior (instead of throwing std::bad_alloc) on failure of operator new.

This is preferable since we don't have to worry about proliferation of `new` variants or messing up the sanitizers.

I tested on MSVC and Linux. The former works, while the latter gets hit by the OOM killer instead of throwing an exception as before.