### PR TITLE
cg_api: implement `trap_CM_BatchMarkFragments` to process all impact marks in one call

### DIFF
--- a/src/engine/client/cg_api.h
+++ b/src/engine/client/cg_api.h
@@ -86,9 +86,26 @@ enum class MouseMode
 	SystemCursor, // The input is sent as positions, the cursor should be rendered by the system
 };
 
+using markMsgInput_t = std::pair<
+	std::vector<std::array<float, 3>>, // points
+	std::array<float, 3> // projection
+>;
+
+using markMsgOutput_t = std::pair<
+	std::vector<std::array<float, 3>>, // points
+	std::vector<markFragment_t>
+>;
+
 void            trap_SendClientCommand( const char *s );
 void            trap_UpdateScreen();
 int             trap_CM_MarkFragments( int numPoints, const vec3_t *points, const vec3_t projection, int maxPoints, vec3_t pointBuffer, int maxFragments, markFragment_t *fragmentBuffer );
+
+void trap_CM_BatchMarkFragments(
+	unsigned maxPoints,
+	unsigned maxFragments,
+	const std::vector<markMsgInput_t> &markMsgInput,
+	std::vector<markMsgOutput_t> &markMsgOutput );
+
 void            trap_S_StartSound( vec3_t origin, int entityNum, soundChannel_t entchannel, sfxHandle_t sfx );
 void            trap_S_StartLocalSound( sfxHandle_t sfx, soundChannel_t channelNum );
 void            trap_S_ClearLoopingSounds( bool killall );

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -132,6 +132,7 @@ enum cgameImport_t
   CG_SENDCLIENTCOMMAND,
   CG_UPDATESCREEN,
   CG_CM_MARKFRAGMENTS,
+  CG_CM_BATCHMARKFRAGMENTS,
   CG_GETCURRENTSNAPSHOTNUMBER,
   CG_GETSNAPSHOT,
   CG_GETCURRENTCMDNUMBER,
@@ -245,6 +246,15 @@ using UpdateScreenMsg = IPC::SyncMessage<
 using CMMarkFragmentsMsg = IPC::SyncMessage<
 	IPC::Message<IPC::Id<VM::QVM, CG_CM_MARKFRAGMENTS>, std::vector<std::array<float, 3>>, std::array<float, 3>, int, int>,
 	IPC::Reply<std::vector<std::array<float, 3>>, std::vector<markFragment_t>>
+>;
+using CMBatchMarkFragments = IPC::SyncMessage<
+	IPC::Message<
+		IPC::Id<VM::QVM, CG_CM_BATCHMARKFRAGMENTS>,
+		unsigned,
+		unsigned,
+		std::vector<markMsgInput_t>>,
+	IPC::Reply<
+		std::vector<markMsgOutput_t>>
 >;
 // TODO send all snapshots at the beginning of the frame
 using GetCurrentSnapshotNumberMsg = IPC::SyncMessage<

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -64,6 +64,18 @@ int trap_CM_MarkFragments( int numPoints, const vec3_t *points, const vec3_t pro
 	return myfragmentBuffer.size();
 }
 
+void trap_CM_BatchMarkFragments(
+	unsigned maxPoints, //per mark
+	unsigned maxFragments, //per mark
+	const std::vector<markMsgInput_t> &markMsgInput,
+	std::vector<markMsgOutput_t> &markMsgOutput )
+{
+	if (!markMsgInput.empty())
+	{
+		VM::SendMsg<CMBatchMarkFragments>(maxPoints, maxFragments, markMsgInput, markMsgOutput);
+	}
+}
+
 void trap_GetCurrentSnapshotNumber( int *snapshotNumber, int *serverTime )
 {
 	VM::SendMsg<GetCurrentSnapshotNumberMsg>(*snapshotNumber, *serverTime);


### PR DESCRIPTION
Engine counterpart of:

- https://github.com/Unvanquished/Unvanquished/pull/2981