### PR TITLE
cg_api: use && in boolean context

### DIFF
--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -568,7 +568,7 @@ void trap_R_GetTextureSize( qhandle_t handle, int *x, int *y )
 
 qhandle_t trap_R_GenerateTexture( const byte *data, int x, int y )
 {
-	ASSERT( x * y );
+	ASSERT( x && y );
 	qhandle_t handle;
 	std::vector<byte> mydata(x * y * 4);
 	memcpy(mydata.data(), data, x * y * 4 * sizeof( byte ) );


### PR DESCRIPTION
Fixup for:

- https://github.com/DaemonEngine/Daemon/pull/1106

Fixes this warning:

```
src/shared/client/cg_api.cpp: In function ‘qhandle_t trap_R_GenerateTexture(const byte*, int, int)’:
src/shared/client/cg_api.cpp:578:19: warning: ‘*’ in boolean context, suggest ‘&&’ instead [-Wint-in-bool-context]
  578 |         ASSERT( x * y );
```