### PR TITLE
WIP: Increase max network packet sizes

### DIFF
--- a/src/engine/qcommon/net_chan.cpp
+++ b/src/engine/qcommon/net_chan.cpp
@@ -59,7 +59,7 @@ to the new value before sending out any replies.
 
 */
 
-static const int MAX_PACKETLEN = 1400; // max size of a network packet
+static const int MAX_PACKETLEN = 265000; // max size of a network packet
 
 static const int FRAGMENT_SIZE = ( MAX_PACKETLEN - 100 );
 

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -166,7 +166,7 @@ void       NET_LeaveMulticast6();
 void       NET_Sleep( int msec );
 
 //----(SA)  increased for larger submodel entity counts
-#define MAX_MSGLEN           32768 // max length of a message, which may
+#define MAX_MSGLEN           262144 // max length of a message, which may
 //#define   MAX_MSGLEN              16384       // max length of a message, which may
 // be fragmented into multiple packets
 #define MAX_DOWNLOAD_WINDOW  8 // max of eight download frames


### PR DESCRIPTION
Increase the maximum length of a network message from 32768 bytes to 262144. Also increased max packet length from 1400 bytes to 265000 bytes, because packet fragmenting is not working correctly with larger message sizes.

This allows for more entities on the map, and brings the soft limit on the amount of buildings from ~250 to ~2k.

Tested with https://users.unvanquished.net/~sweet/layouts/spacetracks/humanpve1.dat (layout for map `spacetracks`): doesn't crash anymore, the game loads fine.

I'm getting a stack overflow when trying to connect to a server for some reason though.
