### PR TITLE
Clean up malloc usage

### DIFF
--- a/src/common/cm/cm_load.cpp
+++ b/src/common/cm/cm_load.cpp
@@ -62,10 +62,10 @@ Log::Logger cmLog(VM_STRING_PREFIX "common.cm");
 
 static std::vector<void*> allocations;
 
-void* CM_Alloc( int size )
+void* CM_Alloc( size_t size )
 {
-    void* alloc = malloc(size);
-	memset(alloc, 0, size);
+    void* alloc = calloc(size, 1);
+    if (!alloc && size) Sys::Error("CM_Alloc: Out of memory");
     allocations.push_back(alloc);
     return alloc;
 }

--- a/src/common/cm/cm_local.h
+++ b/src/common/cm/cm_local.h
@@ -276,7 +276,7 @@ struct cTriangleSoup_t
 cSurfaceCollide_t              *CM_GenerateTriangleSoupCollide( int numVertexes, vec3_t *vertexes, int numIndexes, int *indexes );
 
 
-void* CM_Alloc( int size );
+void* CM_Alloc( size_t size );
 
 // cm_plane.c
 

--- a/src/common/cm/cm_polylib.cpp
+++ b/src/common/cm/cm_polylib.cpp
@@ -63,8 +63,7 @@ winding_t      *AllocWinding( int points )
 	}
 
 	s = sizeof( vec_t ) * 3 * points + sizeof( int );
-	w = ( winding_t * ) Z_Malloc( s );
-	memset( w, 0, s );
+	w = ( winding_t * ) Z_Calloc( s );
 	return w;
 }
 

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2260,8 +2260,6 @@ static bool CL_InitRef()
 	ri.Milliseconds = Sys::Milliseconds;
 	ri.RealTime = Com_RealTime;
 
-	ri.Z_Malloc = CL_RefMalloc;
-	ri.Free = Z_Free;
 	ri.Tag_Free = CL_RefTagFree;
 	ri.Hunk_Alloc = Hunk_Alloc;
 	ri.Hunk_AllocateTempMemory = Hunk_AllocateTempMemory;

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -125,8 +125,6 @@ cvar_t *cl_autorecord;
 
 cvar_t *cl_allowDownload;
 
-cvar_t                 *cl_packetdelay; //bani
-
 cvar_t                 *cl_consoleFont;
 cvar_t                 *cl_consoleFontSize;
 cvar_t                 *cl_consoleFontScaling;
@@ -2418,9 +2416,6 @@ void CL_Init()
 	cl_consoleCommand = Cvar_Get( "cl_consoleCommand", "say", 0 );
 
 	cl_altTab = Cvar_Get( "cl_altTab", "1", 0 );
-
-	//bani
-	cl_packetdelay = Cvar_Get( "cl_packetdelay", "0", CVAR_CHEAT );
 
 	// userinfo
 	cl_rate = Cvar_Get( "rate", "25000", CVAR_USERINFO | CVAR_ARCHIVE );

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -1394,7 +1394,7 @@ static void CL_LoadRSAKeys()
 		return;
 	}
 
-	buf = (uint8_t*) Z_TagMalloc( len, memtag_t::TAG_CRYPTO );
+	buf = (uint8_t*) Z_Malloc( len );
 	FS_Read( buf, len, f );
 	FS_FCloseFile( f );
 
@@ -2215,25 +2215,6 @@ void CL_StartHunkUsers()
 	}
 }
 
-/*
-============
-CL_RefMalloc
-============
-*/
-MALLOC_LIKE void           *CL_RefMalloc( int size )
-{
-	return Z_TagMalloc( size, memtag_t::TAG_RENDERER );
-}
-
-/*
-============
-CL_RefTagFree
-============
-*/
-void CL_RefTagFree()
-{
-}
-
 int CL_ScaledMilliseconds()
 {
 	return Sys::Milliseconds() * com_timescale->value;
@@ -2260,7 +2241,6 @@ static bool CL_InitRef()
 	ri.Milliseconds = Sys::Milliseconds;
 	ri.RealTime = Com_RealTime;
 
-	ri.Tag_Free = CL_RefTagFree;
 	ri.Hunk_Alloc = Hunk_Alloc;
 	ri.Hunk_AllocateTempMemory = Hunk_AllocateTempMemory;
 	ri.Hunk_FreeTempMemory = Hunk_FreeTempMemory;

--- a/src/engine/client/hunk_allocator.cpp
+++ b/src/engine/client/hunk_allocator.cpp
@@ -277,15 +277,6 @@ void           *Hunk_AllocateTempMemory( int size )
 	void         *buf;
 	hunkHeader_t *hdr;
 
-	// return a Z_Malloc'd block if the hunk has not been initialized
-	// this allows the config and product id files ( journal files too ) to be loaded
-	// by the file system without redundant routines in the file system utilizing different
-	// memory systems
-	if ( s_hunkData == nullptr )
-	{
-		return Z_Malloc( size );
-	}
-
 	Hunk_SwapBanks();
 
 	size = PAD( size, sizeof( intptr_t ) ) + sizeof( hunkHeader_t );
@@ -329,16 +320,6 @@ Hunk_FreeTempMemory
 void Hunk_FreeTempMemory( void *buf )
 {
 	hunkHeader_t *hdr;
-
-	// free with Z_Free if the hunk has not been initialized
-	// this allows the config and product id files ( journal files too ) to be loaded
-	// by the file system without redundant routines in the file system utilizing different
-	// memory systems
-	if ( s_hunkData == nullptr )
-	{
-		Z_Free( buf );
-		return;
-	}
 
 	hdr = ( ( hunkHeader_t * ) buf ) - 1;
 

--- a/src/engine/qcommon/q_shared.cpp
+++ b/src/engine/qcommon/q_shared.cpp
@@ -33,6 +33,7 @@ Maryland 20850 USA.
 */
 
 // q_shared.c -- stateless support routines that are included in each code dll
+#include "qcommon.h"
 #include "q_shared.h"
 #include "q_unicode.h"
 
@@ -1142,9 +1143,9 @@ const char *Com_ClearForeignCharacters( const char *str )
 	static char *clean = nullptr; // much longer than needed
 	int          i, j, size;
 
-	free( clean );
+	Z_Free( clean );
 	size = strlen( str );
-	clean = (char*)malloc ( size + 1 ); // guaranteed sufficient
+	clean = (char*)Z_AllocUninit( size + 1 ); // guaranteed sufficient
 
 	i = -1;
 	j = 0;

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -549,43 +549,8 @@ extern int          time_backend; // renderer backend time
 extern int          com_frameTime;
 extern int          com_frameMsec;
 
-enum class memtag_t
-{
-  TAG_FREE,
-  TAG_GENERAL,
-  TAG_RENDERER,
-  TAG_SMALL,
-  TAG_CRYPTO,
-  TAG_STATIC
-};
+// Use malloc instead of the zone allocator...
 
-/*
-
---- low memory ----
-server vm
-server clipmap
----mark---
-renderer initialization (shaders, etc)
-UI vm
-cgame vm
-renderer map
-renderer models
-
----free---
-
-temp file loading
---- high memory ---
-
-*/
-
-// Use malloc instead of the zone allocator
-inline MALLOC_LIKE void* Z_TagMalloc(size_t size, memtag_t tag)
-{
-  Q_UNUSED(tag);
-  void* p = calloc(size, 1);
-  if (!p && size) Sys::Error("Z_TagMalloc: Out of memory");
-  return p;
-}
 // Allocations uncategorized as to whether they really need zeroing
 inline MALLOC_LIKE void* Z_Malloc(size_t size)
 {

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -541,9 +541,6 @@ extern Cvar::Cvar<bool> com_ansiColor;
 extern cvar_t       *com_unfocused;
 extern cvar_t       *com_minimized;
 
-extern cvar_t       *cl_packetdelay;
-extern cvar_t       *sv_packetdelay;
-
 // com_speeds times
 extern int          time_game;
 extern int          time_frontend;
@@ -590,10 +587,6 @@ static inline MALLOC_LIKE void* Z_TagMalloc(size_t size, memtag_t tag)
 static inline MALLOC_LIKE void* Z_Malloc(size_t size)
 {
   return calloc(size, 1);
-}
-static inline MALLOC_LIKE void* S_Malloc(size_t size)
-{
-  return malloc(size);
 }
 static inline ALLOCATOR char* CopyString(const char* str)
 {

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -579,20 +579,24 @@ temp file loading
 */
 
 // Use malloc instead of the zone allocator
-static inline MALLOC_LIKE void* Z_TagMalloc(size_t size, memtag_t tag)
+inline MALLOC_LIKE void* Z_TagMalloc(size_t size, memtag_t tag)
 {
   Q_UNUSED(tag);
-  return calloc(size, 1);
+  void* p = calloc(size, 1);
+  if (!p && size) Sys::Error("Z_TagMalloc: Out of memory");
+  return p;
 }
-static inline MALLOC_LIKE void* Z_Malloc(size_t size)
+inline MALLOC_LIKE void* Z_Malloc(size_t size)
 {
-  return calloc(size, 1);
+  void* p = calloc(size, 1);
+  if (!p && size) Sys::Error("Z_Malloc: Out of memory");
+  return p;
 }
-static inline ALLOCATOR char* CopyString(const char* str)
+inline ALLOCATOR char* CopyString(const char* str)
 {
   return strdup(str);
 }
-static inline void Z_Free(void* ptr)
+inline void Z_Free(void* ptr)
 {
   free(ptr);
 }

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -586,12 +586,28 @@ inline MALLOC_LIKE void* Z_TagMalloc(size_t size, memtag_t tag)
   if (!p && size) Sys::Error("Z_TagMalloc: Out of memory");
   return p;
 }
+// Allocations uncategorized as to whether they really need zeroing
 inline MALLOC_LIKE void* Z_Malloc(size_t size)
 {
   void* p = calloc(size, 1);
   if (!p && size) Sys::Error("Z_Malloc: Out of memory");
   return p;
 }
+// Allocates unitialized memory like malloc
+inline MALLOC_LIKE void* Z_AllocUninit(size_t size)
+{
+    void* p = malloc(size);
+    if (!p && size) Sys::Error("Z_AllocUninit: Out of memory");
+    return p;
+}
+// Allocates zeroed memory like calloc
+inline MALLOC_LIKE void* Z_Calloc(size_t size)
+{
+    void* p = calloc(size, 1);
+    if (!p && size) Sys::Error("Z_Calloc: Out of memory");
+    return p;
+}
+
 inline ALLOCATOR char* CopyString(const char* str)
 {
   return strdup(str);

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -242,10 +242,10 @@ void GLShaderManager::UpdateShaderProgramUniformLocations( GLShader *shader, sha
 	size_t numUniformBlocks = shader->_uniformBlocks.size();
 
 	// create buffer for storing uniform locations
-	shaderProgram->uniformLocations = ( GLint * ) ri.Z_Malloc( sizeof( GLint ) * numUniforms );
+	shaderProgram->uniformLocations = ( GLint * ) Z_Malloc( sizeof( GLint ) * numUniforms );
 
 	// create buffer for uniform firewall
-	shaderProgram->uniformFirewall = ( byte * ) ri.Z_Malloc( uniformSize );
+	shaderProgram->uniformFirewall = ( byte * ) Z_Malloc( uniformSize );
 
 	// update uniforms
 	for (GLUniform *uniform : shader->_uniforms)
@@ -255,7 +255,7 @@ void GLShaderManager::UpdateShaderProgramUniformLocations( GLShader *shader, sha
 
 	if( glConfig2.uniformBufferObjectAvailable ) {
 		// create buffer for storing uniform block indexes
-		shaderProgram->uniformBlockIndexes = ( GLuint * ) ri.Z_Malloc( sizeof( GLuint ) * numUniformBlocks );
+		shaderProgram->uniformBlockIndexes = ( GLuint * ) Z_Malloc( sizeof( GLuint ) * numUniformBlocks );
 
 		// update uniform blocks
 		for (GLUniformBlock *uniformBlock : shader->_uniformBlocks)

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -171,17 +171,17 @@ public:
 
 			if ( p->uniformFirewall )
 			{
-				ri.Free( p->uniformFirewall );
+				Z_Free( p->uniformFirewall );
 			}
 
 			if ( p->uniformLocations )
 			{
-				ri.Free( p->uniformLocations );
+				Z_Free( p->uniformLocations );
 			}
 
 			if ( p->uniformBlockIndexes )
 			{
-				ri.Free( p->uniformBlockIndexes );
+				Z_Free( p->uniformBlockIndexes );
 			}
 		}
 	}

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -392,7 +392,7 @@ void LoadRGBEToFloats( const char *name, float **pic, int *width, int *height )
 		Sys::Drop( "RGBE image '%s' has an invalid image size", name );
 	}
 
-	*pic = (float*) malloc( w * h * 3 * sizeof( float ) );
+	*pic = (float*) Z_AllocUninit( w * h * 3 * sizeof( float ) );
 	floatbuf = *pic;
 
 	for ( i = 0; i < ( w * h ); i++ )
@@ -461,7 +461,7 @@ static void LoadRGBEToBytes( const char *name, byte **ldrImage, int *width, int 
 		*pixbuf++ = ( byte ) 255;
 	}
 
-	free( hdrImage );
+	Z_Free( hdrImage );
 }
 
 static std::vector<std::string> R_LoadExternalLightmaps( const char *mapName )
@@ -6327,10 +6327,7 @@ unsigned int VertexCoordGenerateHash( const vec3_t xyz )
 
 vertexHash_t **NewVertexHashTable()
 {
-	vertexHash_t **hashTable = (vertexHash_t**) malloc( HASHTABLE_SIZE * sizeof( vertexHash_t * ) );
-
-	memset( hashTable, 0, HASHTABLE_SIZE * sizeof( vertexHash_t * ) );
-
+	vertexHash_t **hashTable = (vertexHash_t**) Z_Calloc( HASHTABLE_SIZE * sizeof( vertexHash_t * ) );
 	return hashTable;
 }
 
@@ -6355,12 +6352,12 @@ void FreeVertexHashTable( vertexHash_t **hashTable )
 			{
 				nextVertexHash = vertexHash->next;
 
-				free( vertexHash );
+				Z_Free( vertexHash );
 			}
 		}
 	}
 
-	free( hashTable );
+	Z_Free( hashTable );
 }
 
 vertexHash_t *FindVertexInHashTable( vertexHash_t **hashTable, const vec3_t xyz, float distance )
@@ -6418,12 +6415,7 @@ vertexHash_t *AddVertexToHashTable( vertexHash_t **hashTable, vec3_t xyz, void *
 		return nullptr;
 	}
 
-	vertexHash = (vertexHash_t*) malloc( sizeof( vertexHash_t ) );
-
-	if ( !vertexHash )
-	{
-		return nullptr;
-	}
+	vertexHash = (vertexHash_t*) Z_AllocUninit( sizeof( vertexHash_t ) );
 
 	hash = VertexCoordGenerateHash( xyz );
 

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -4970,8 +4970,6 @@ static void R_RecursivePrecacheInteractionNode( bspNode_t *node, trRefLight_t *l
 			InitLink( l, node );
 
 			InsertLink( l, &light->leafs );
-
-			light->leafs.numElements++;
 		}
 	}
 }

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -425,7 +425,7 @@ static void LoadRGBEToBytes( const char *name, byte **ldrImage, int *width, int 
 	*width = w;
 	*height = h;
 
-	*ldrImage = (byte*) ri.Z_Malloc( w * h * 4 );
+	*ldrImage = (byte*) Z_Malloc( w * h * 4 );
 	pixbuf = *ldrImage;
 
 	floatbuf = hdrImage;
@@ -554,7 +554,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 
 				tr.lightmaps.push_back( image );
 
-				ri.Free( ldrImage );
+				Z_Free( ldrImage );
 			}
 
 			if (tr.worldDeluxeMapping) {
@@ -6548,7 +6548,7 @@ void R_BuildCubeMaps()
 
 	for ( i = 0; i < 6; i++ )
 	{
-		tr.cubeTemp[ i ] = (byte*) ri.Z_Malloc( REF_CUBEMAP_SIZE * REF_CUBEMAP_SIZE * 4 );
+		tr.cubeTemp[ i ] = (byte*) Z_Malloc( REF_CUBEMAP_SIZE * REF_CUBEMAP_SIZE * 4 );
 	}
 
 	// calculate origins for our probes

--- a/src/engine/renderer/tr_curve.cpp
+++ b/src/engine/renderer/tr_curve.cpp
@@ -422,21 +422,20 @@ static srfGridMesh_t *R_CreateSurfaceGridMesh( int width, int height,
 
 	if ( r_stitchCurves->integer )
 	{
-		grid = (srfGridMesh_t*)/*ri.Hunk_Alloc */ malloc( size );
-		memset( grid, 0, size );
+		grid = (srfGridMesh_t*)/*ri.Hunk_Alloc */ Z_Calloc( size );
 
-		grid->widthLodError = (float*)/*ri.Hunk_Alloc */ malloc( width * 4 );
+		grid->widthLodError = (float*)/*ri.Hunk_Alloc */ Z_AllocUninit( width * 4 );
 		memcpy( grid->widthLodError, errorTable[ 0 ], width * 4 );
 
-		grid->heightLodError = (float*)/*ri.Hunk_Alloc */ malloc( height * 4 );
+		grid->heightLodError = (float*)/*ri.Hunk_Alloc */ Z_AllocUninit( height * 4 );
 		memcpy( grid->heightLodError, errorTable[ 1 ], height * 4 );
 
 		grid->numTriangles = numTriangles;
-		grid->triangles = (srfTriangle_t*) malloc( grid->numTriangles * sizeof( srfTriangle_t ) );
+		grid->triangles = (srfTriangle_t*) Z_AllocUninit( grid->numTriangles * sizeof( srfTriangle_t ) );
 		memcpy( grid->triangles, triangles, numTriangles * sizeof( srfTriangle_t ) );
 
 		grid->numVerts = ( width * height );
-		grid->verts = (srfVert_t*) malloc( grid->numVerts * sizeof( srfVert_t ) );
+		grid->verts = (srfVert_t*) Z_AllocUninit( grid->numVerts * sizeof( srfVert_t ) );
 	}
 	else
 	{
@@ -491,11 +490,11 @@ R_FreeSurfaceGridMesh
 */
 void R_FreeSurfaceGridMesh( srfGridMesh_t *grid )
 {
-	free( grid->widthLodError );
-	free( grid->heightLodError );
-	free( grid->triangles );
-	free( grid->verts );
-	free( grid );
+	Z_Free( grid->widthLodError );
+	Z_Free( grid->heightLodError );
+	Z_Free( grid->triangles );
+	Z_Free( grid->verts );
+	Z_Free( grid );
 }
 
 static srfTriangle_t gridtriangles[ SHADER_MAX_TRIANGLES ];

--- a/src/engine/renderer/tr_font.cpp
+++ b/src/engine/renderer/tr_font.cpp
@@ -542,14 +542,7 @@ static int RE_LoadFontFile( const char *name, void **buffer )
 				return 0;
 			}
 
-			fontData[ i ].data = malloc( length );
-
-			if ( !fontData[ i ].data )
-			{
-				ri.FS_FreeFile( tmp );
-				return 0;
-			}
-
+			fontData[ i ].data = Z_AllocUninit( length );
 			fontData[ i ].length = length;
 			fontData[ i ].count = 1;
 			*buffer = fontData[ i ].data;
@@ -581,7 +574,7 @@ static void RE_FreeFontFile( void *data )
 		{
 			if ( !--fontData[ i ].count )
 			{
-				free( fontData[ i ].data );
+				Z_Free( fontData[ i ].data );
 			}
 			break;
 		}

--- a/src/engine/renderer/tr_font.cpp
+++ b/src/engine/renderer/tr_font.cpp
@@ -458,13 +458,6 @@ void RE_RenderChunk( fontInfo_t *font, const int chunk )
 	}
 
 	out = (unsigned char*) ri.Z_Malloc( FONT_SIZE * FONT_SIZE );
-
-	if ( out == nullptr )
-	{
-		Log::Warn("RE_RenderChunk: ri.Malloc failure during output image creation." );
-		return;
-	}
-
 	memset( out, 0, FONT_SIZE * FONT_SIZE );
 
 	// calculate max height

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1728,7 +1728,7 @@ image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 	{
 		if ( mallocPtr )
 		{
-			ri.Free( mallocPtr );
+			Z_Free( mallocPtr );
 		}
 		return nullptr;
 	}
@@ -1740,7 +1740,7 @@ image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 
 	image = R_CreateImage( ( char * ) buffer, (const byte **)pic, width, height, numMips, imageParams );
 
-	ri.Free( mallocPtr );
+	Z_Free( mallocPtr );
 	return image;
 }
 
@@ -1860,9 +1860,9 @@ byte *R_Resize( byte *in, int width, int height, int newWidth, int newHeight )
 
 	byte *out;
 
-	out = (byte*) ri.Z_Malloc( newWidth * newHeight * 4 );
+	out = (byte*) Z_Malloc( newWidth * newHeight * 4 );
 	ResampleTexture( (unsigned int*) in, width, height, (unsigned int*) out, newWidth, newHeight, false );
-	ri.Free( in );
+	Z_Free( in );
 
 	return out;
 }
@@ -1881,7 +1881,7 @@ static void R_FreeCubePics( byte **pic, int count )
 	{
 		if ( pic[ count ] != nullptr )
 		{
-			ri.Free( pic[ count ] );
+			Z_Free( pic[ count ] );
 			pic[ count ] = nullptr;
 		}
 	}

--- a/src/engine/renderer/tr_image_crn.cpp
+++ b/src/engine/renderer/tr_image_crn.cpp
@@ -124,7 +124,7 @@ bool LoadInMemoryCRN(const char* name, const void* buff, size_t buffLen, byte **
         Log::Warn("CRN image '%s' has bad data", name);
         return false;
     }
-    byte* nextImage = (byte *)ri.Z_Malloc(totalSize);
+    byte* nextImage = (byte *)Z_Malloc(totalSize);
     bool success = true;
     for (unsigned i = 0; i < ti.m_levels; i++) {
         for (unsigned j = 0; j < ti.m_faces; j++) {
@@ -161,7 +161,7 @@ void LoadCRN(const char* name, byte **data, int *width, int *height,
     }
     if (!LoadInMemoryCRN(name, buff.data(), buff.size(), data, width, height, numLayers, numMips, bits)) {
         if (*data) {
-            ri.Free(*data);
+            Z_Free(*data);
             *data = nullptr; // This signals failure.
         }
     }

--- a/src/engine/renderer/tr_image_dds.cpp
+++ b/src/engine/renderer/tr_image_dds.cpp
@@ -345,7 +345,7 @@ static void R_LoadDDSImageData( const void *pImageData, const char *name, byte *
 		}
 	}
 
-	data[0] = (byte*) ri.Z_Malloc( size );
+	data[0] = (byte*) Z_AllocUninit( size );
 	memcpy( data[0], ddsd + 1, size );
 
 	if( compressed ) {

--- a/src/engine/renderer/tr_image_jpg.cpp
+++ b/src/engine/renderer/tr_image_jpg.cpp
@@ -170,7 +170,7 @@ void LoadJPG( const char *filename, unsigned char **pic, int *width, int *height
 	memcount = pixelcount * 4;
 	row_stride = cinfo.output_width * cinfo.output_components;
 
-	out = (byte*) ri.Z_Malloc( memcount );
+	out = (byte*) Z_Malloc( memcount );
 
 	*width = cinfo.output_width;
 	*height = cinfo.output_height;

--- a/src/engine/renderer/tr_image_ktx.cpp
+++ b/src/engine/renderer/tr_image_ktx.cpp
@@ -241,7 +241,7 @@ bool LoadInMemoryKTX( const char *name, void *ktxData, size_t ktxSize,
 	}
 
 	ptr = firstImageDataPtr;
-	data[ 0 ] = (byte *)ri.Z_Malloc(totalImageSize);
+	data[ 0 ] = (byte *)Z_Malloc(totalImageSize);
 
 	uint32_t imageSize{ GetImageSize( ptr, needReverseBytes ) };
 	ptr += sizeof(uint32_t);
@@ -760,7 +760,7 @@ void LoadKTX( const char *name, byte **pic, int *width, int *height,
 	}
 	if ( !LoadInMemoryKTX( name, &ktxData[0], ktxData.size(), pic, width, height, numLayers, numMips, bits ) ) {
 		if (*pic) {
-			ri.Free(*pic);
+			Z_Free(*pic);
 		}
 		*pic = nullptr; // This signals failure.
 	}

--- a/src/engine/renderer/tr_image_png.cpp
+++ b/src/engine/renderer/tr_image_png.cpp
@@ -166,7 +166,7 @@ void LoadPNG( const char *name, byte **pic, int *width, int *height,
 	// allocate the memory to hold the image
 	*width = w;
 	*height = h;
-	*pic = out = ( byte * ) ri.Z_Malloc( w * h * 4 );
+	*pic = out = ( byte * ) Z_Malloc( w * h * 4 );
 
 	row_pointers = ( png_bytep * ) ri.Hunk_AllocateTempMemory( sizeof( png_bytep ) * h );
 

--- a/src/engine/renderer/tr_image_tga.cpp
+++ b/src/engine/renderer/tr_image_tga.cpp
@@ -110,7 +110,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 		Sys::Drop( "TGA image '%s' has an invalid image size", name );
 	}
 
-	targa_rgba = (byte*) ri.Z_Malloc( numPixels );
+	targa_rgba = (byte*) Z_Malloc( numPixels );
 
 	*pic = targa_rgba;
 
@@ -164,7 +164,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 						break;
 
 					default:
-						ri.Free( targa_rgba );
+						Z_Free( targa_rgba );
 						Sys::Drop( "TGA image '%s' has illegal pixel_size (%d)", name, targa_header.pixel_size );
 				}
 			}
@@ -209,7 +209,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 							break;
 
 						default:
-							ri.Free( targa_rgba );
+							Z_Free( targa_rgba );
 							Sys::Drop( "TGA image '%s' has illegal pixel_size (%d)", name, targa_header.pixel_size );
 					}
 
@@ -268,7 +268,7 @@ void LoadTGA( const char *name, byte **pic, int *width, int *height,
 								break;
 
 							default:
-								ri.Free( targa_rgba );
+								Z_Free( targa_rgba );
 								Sys::Drop( "TGA image '%s' has illegal pixel_size (%d)", name, targa_header.pixel_size );
 						}
 

--- a/src/engine/renderer/tr_image_webp.cpp
+++ b/src/engine/renderer/tr_image_webp.cpp
@@ -35,7 +35,7 @@ bool LoadInMemoryWEBP( const char *path, const uint8_t* webpData, size_t webpSiz
 
 	const size_t stride{ *width * sizeof( u8vec4_t ) };
 	const size_t size{ *height * stride };
-	auto *out = (byte*)ri.Z_Malloc( size );
+	auto *out = (byte*)Z_Malloc( size );
 
 	// Decode into RGBA.
 	if ( !WebPDecodeRGBAInto( webpData, webpSize, out, size, stride ) )
@@ -66,7 +66,7 @@ void LoadWEBP( const char *path, byte **pic, int *width, int *height, int *, int
 		return;
 	}
 	if ( !LoadInMemoryWEBP( path, reinterpret_cast<const uint8_t*>(webpData.data()), webpData.size(), pic, width, height ) ) {
-		ri.Free( *pic );
+		Z_Free( *pic );
 		*pic = nullptr; // This signals failure.
 	}
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1530,7 +1530,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			}
 
 			GLimp_Shutdown();
-			ri.Tag_Free();
 		}
 
 		tr.registered = false;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -376,31 +376,16 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	struct link_t
 	{
 		void          *data;
-		int           numElements; // only used by sentinels
 		link_t *prev, *next;
 	};
 
-	static inline void InitLink( link_t *l, void *data )
+	inline void InitLink( link_t *l, void *data )
 	{
 		l->data = data;
 		l->prev = l->next = l;
 	}
 
-	static inline void ClearLink( link_t *l )
-	{
-		l->data = nullptr;
-		l->prev = l->next = l;
-	}
-
-	static inline void RemoveLink( link_t *l )
-	{
-		l->next->prev = l->prev;
-		l->prev->next = l->next;
-
-		l->prev = l->next = nullptr;
-	}
-
-	static inline void InsertLink( link_t *l, link_t *sentinel )
+	inline void InsertLink( link_t *l, link_t *sentinel )
 	{
 		l->next = sentinel->next;
 		l->prev = sentinel;
@@ -409,93 +394,10 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		l->prev->next = l;
 	}
 
-	static inline bool StackEmpty( link_t *l )
-	{
-		return l->next == l;
-	}
-
-	static inline link_t *StackTop( link_t *l )
-	{
-		return l->next;
-	}
-
-	static inline void StackPush( link_t *sentinel, void *data )
-	{
-		link_t *l;
-
-		l = ( link_t * ) malloc( sizeof( *l ) );
-		InitLink( l, data );
-
-		InsertLink( l, sentinel );
-	}
-
-	static inline void *StackPop( link_t *l )
-	{
-		link_t *top;
-		void  *data;
-
-		if ( l->next == l )
-		{
-			return nullptr;
-		}
-
-		top = l->next;
-
-		RemoveLink( top );
-		data = top->data;
-		free( top );
-
-		return data;
-	}
-
-	static inline void QueueInit( link_t *l )
+	inline void QueueInit( link_t *l )
 	{
 		l->data = nullptr;
-		l->numElements = 0;
 		l->prev = l->next = l;
-	}
-
-	static inline int QueueSize( link_t *l )
-	{
-		return l->numElements;
-	}
-
-	static inline bool QueueEmpty( link_t *l )
-	{
-		return l->prev == l;
-	}
-
-	static inline void EnQueue( link_t *sentinel, void *data )
-	{
-		link_t *l;
-
-		l = ( link_t * ) malloc( sizeof( *l ) );
-		InitLink( l, data );
-
-		InsertLink( l, sentinel );
-
-		sentinel->numElements++;
-	}
-
-	static inline void *DeQueue( link_t *l )
-	{
-		link_t *tail;
-		void  *data;
-
-		tail = l->prev;
-
-		RemoveLink( tail );
-		data = tail->data;
-		free( tail );
-
-		l->numElements--;
-
-		return data;
-	}
-
-	static inline link_t *QueueFront( link_t *l )
-	{
-		return l->prev;
 	}
 
 // a trRefLight_t has all the information passed in by

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -254,9 +254,6 @@ struct refimport_t
 	void            *( *Hunk_AllocateTempMemory )( int size );
 	void ( *Hunk_FreeTempMemory )( void *block );
 
-	// dynamic memory allocator for things that need to be freed
-	void            *( *Z_Malloc )( int bytes );
-	void ( *Free )( void *buf );
 	void ( *Tag_Free )();
 
 	void ( *Cmd_AddCommand )( const char *name, void ( *cmd )() );

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -254,8 +254,6 @@ struct refimport_t
 	void            *( *Hunk_AllocateTempMemory )( int size );
 	void ( *Hunk_FreeTempMemory )( void *block );
 
-	void ( *Tag_Free )();
-
 	void ( *Cmd_AddCommand )( const char *name, void ( *cmd )() );
 	void ( *Cmd_RemoveCommand )( const char *name );
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6031,8 +6031,8 @@ bool RE_LoadDynamicShader( const char *shadername, const char *shadertext )
 		while ( dptr )
 		{
 			lastdptr = dptr->next;
-			ri.Free( dptr->shadertext );
-			ri.Free( dptr );
+			Z_Free( dptr->shadertext );
+			Z_Free( dptr );
 			dptr = lastdptr;
 		}
 
@@ -6064,8 +6064,8 @@ bool RE_LoadDynamicShader( const char *shadername, const char *shadertext )
 					lastdptr->next = dptr->next;
 				}
 
-				ri.Free( dptr->shadertext );
-				ri.Free( dptr );
+				Z_Free( dptr->shadertext );
+				Z_Free( dptr );
 				return true;
 			}
 
@@ -6085,14 +6085,14 @@ bool RE_LoadDynamicShader( const char *shadername, const char *shadertext )
 	}
 
 	//create a new shader
-	dptr = ( dynamicshader_t * ) ri.Z_Malloc( sizeof( *dptr ) );
+	dptr = ( dynamicshader_t * ) Z_Malloc( sizeof( *dptr ) );
 
 	if ( lastdptr )
 	{
 		lastdptr->next = dptr;
 	}
 
-	dptr->shadertext = (char*) ri.Z_Malloc( strlen( shadertext ) + 1 );
+	dptr->shadertext = (char*) Z_AllocUninit( strlen( shadertext ) + 1 );
 
 	Q_strncpyz( dptr->shadertext, shadertext, strlen( shadertext ) + 1 );
 	dptr->next = nullptr;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6087,22 +6087,12 @@ bool RE_LoadDynamicShader( const char *shadername, const char *shadertext )
 	//create a new shader
 	dptr = ( dynamicshader_t * ) ri.Z_Malloc( sizeof( *dptr ) );
 
-	if ( !dptr )
-	{
-		Sys::Error( "Couldn't allocate struct for dynamic shader %s", shadername );
-	}
-
 	if ( lastdptr )
 	{
 		lastdptr->next = dptr;
 	}
 
 	dptr->shadertext = (char*) ri.Z_Malloc( strlen( shadertext ) + 1 );
-
-	if ( !dptr->shadertext )
-	{
-		Sys::Error( "Couldn't allocate buffer for dynamic shader %s", shadername );
-	}
 
 	Q_strncpyz( dptr->shadertext, shadertext, strlen( shadertext ) + 1 );
 	dptr->next = nullptr;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -319,9 +319,6 @@ extern cvar_t *sv_showAverageBPS; // NERVE - SMF - net debugging
 // TTimo - autodl
 extern cvar_t *sv_dl_maxRate;
 
-//bani
-extern cvar_t *sv_packetdelay;
-
 //fretn
 extern cvar_t *sv_fullmsg;
 

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -325,12 +325,7 @@ void SV_Startup()
 	SV_BoundMaxClients( 1 );
 
 	// RF, avoid trying to allocate large chunk on a fragmented zone
-	svs.clients = ( client_t * ) calloc( sizeof( client_t ) * sv_maxclients->integer, 1 );
-
-	if ( !svs.clients )
-	{
-		Sys::Error( "SV_Startup: unable to allocate svs.clients" );
-	}
+	svs.clients = ( client_t * ) Z_Calloc( sizeof( client_t ) * sv_maxclients->integer );
 
 	svs.numSnapshotEntities = sv_maxclients->integer * PACKET_BACKUP * 64;
 
@@ -378,12 +373,7 @@ void SV_ChangeMaxClients()
 	client_t* oldClients = svs.clients;
 
 	// allocate new clients
-	svs.clients = ( client_t * ) calloc( sv_maxclients->integer, sizeof( client_t ) );
-
-	if ( !svs.clients )
-	{
-		Sys::Error( "SV_Startup: unable to allocate svs.clients" );
-	}
+	svs.clients = ( client_t * ) Z_Calloc( sv_maxclients->integer * sizeof( client_t ) );
 
 	// copy the clients over
 	for ( int i = 0; i < count; i++ )
@@ -395,7 +385,7 @@ void SV_ChangeMaxClients()
 	}
 
 	// free the old clients
-	free( oldClients );
+	Z_Free( oldClients );
 
 	svs.numSnapshotEntities = sv_maxclients->integer * PACKET_BACKUP * 64;
 }
@@ -747,7 +737,7 @@ void SV_Shutdown( const char *finalmsg )
 			SV_FreeClient( &svs.clients[ index ] );
 		}
 
-		free( svs.clients );
+		Z_Free( svs.clients );
 	}
 
 	ResetStruct( svs );

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -639,9 +639,6 @@ void SV_Init()
 	// the download netcode tops at 18/20 kb/s, no need to make you think you can go above
 	sv_dl_maxRate = Cvar_Get( "sv_dl_maxRate", "42000", 0 );
 
-	//bani
-	sv_packetdelay = Cvar_Get( "sv_packetdelay", "0", CVAR_CHEAT );
-
 	// fretn - note: redirecting of clients to other servers relies on this,
 	// ET://someserver.com
 	sv_fullmsg = Cvar_Get( "sv_fullmsg", "Server is full.", 0 );

--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -80,9 +80,6 @@ cvar_t         *sv_dl_maxRate;
 
 cvar_t *sv_showAverageBPS; // NERVE - SMF - net debugging
 
-//bani
-cvar_t *sv_packetdelay;
-
 // fretn
 cvar_t *sv_fullmsg;
 


### PR DESCRIPTION
In all malloc-wrapping functions, check the result and call Sys::Error if it is null. Replace all calls to raw malloc with the checked versions. Also git rid of some redundant `memset`s.