### PR TITLE
tr_shader: fix again the legacy dynamic light renderer

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5202,7 +5202,7 @@ static void FinishStages()
 
 			case stageType_t::ST_ATTENUATIONMAP_XY:
 			case stageType_t::ST_ATTENUATIONMAP_Z:
-				stage->active = ( glConfig2.dynamicLight && r_dynamicLightRenderer.Get() != Util::ordinal( dynamicLightRenderer_t::LEGACY ) );
+				stage->active = ( glConfig2.dynamicLight && r_dynamicLightRenderer.Get() == Util::ordinal( dynamicLightRenderer_t::LEGACY ) );
 				break;
 
 			default:


### PR DESCRIPTION
I made a typo in:

- https://github.com/DaemonEngine/Daemon/pull/1098