### PR TITLE
Use the correct amount of texture units

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -148,7 +148,7 @@ void GL_SelectTexture( int unit )
 		return;
 	}
 
-	if ( unit >= 0 && unit <= 31 )
+	if ( unit >= 0 && unit < glConfig2.maxTextureUnits )
 	{
 		glActiveTexture( GL_TEXTURE0 + unit );
 
@@ -175,7 +175,7 @@ void GL_BindToTMU( int unit, image_t *image )
 
 	int texnum = image->texnum;
 
-	if ( unit < 0 || unit > 31 )
+	if ( unit < 0 || unit >= glConfig2.maxTextureUnits )
 	{
 		Sys::Drop( "GL_BindToTMU: unit %i is out of range\n", unit );
 	}

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -57,10 +57,10 @@ void GL_Bind( image_t *image )
 		texnum = tr.blackImage->texnum;
 	}
 
-	if ( glState.currenttextures[ glState.currenttmu ] != texnum )
+	if ( tr.currenttextures[ glState.currenttmu ] != texnum )
 	{
 		image->frameUsed = tr.frameCount;
-		glState.currenttextures[ glState.currenttmu ] = texnum;
+		tr.currenttextures[ glState.currenttmu ] = texnum;
 		glBindTexture( image->type, texnum );
 	}
 }
@@ -69,7 +69,7 @@ void GL_Unbind( image_t *image )
 {
 	GLimp_LogComment( "--- GL_Unbind() ---\n" );
 
-	glState.currenttextures[ glState.currenttmu ] = 0;
+	tr.currenttextures[ glState.currenttmu ] = 0;
 	glBindTexture( image->type, 0 );
 }
 
@@ -180,7 +180,7 @@ void GL_BindToTMU( int unit, image_t *image )
 		Sys::Drop( "GL_BindToTMU: unit %i is out of range\n", unit );
 	}
 
-	if ( glState.currenttextures[ unit ] == texnum )
+	if ( tr.currenttextures[ unit ] == texnum )
 	{
 		return;
 	}

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2993,7 +2993,7 @@ void R_ShutdownImages()
 		glDeleteTextures( 1, &image->texnum );
 	}
 
-	memset( glState.currenttextures, 0, sizeof( glState.currenttextures ) );
+	glState.currenttextures.clear();
 
 	tr.images.clear();
 	tr.lightmaps.clear();

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2993,7 +2993,7 @@ void R_ShutdownImages()
 		glDeleteTextures( 1, &image->texnum );
 	}
 
-	glState.currenttextures.clear();
+	tr.currenttextures.clear();
 
 	tr.images.clear();
 	tr.lightmaps.clear();

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -814,7 +814,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		GL_CheckErrors();
 
-		glState.currenttextures.resize( glConfig2.maxTextureUnits );
+		tr.currenttextures.resize( glConfig2.maxTextureUnits );
 
 		// initialize downstream texture units if we're running
 		// in a multitexture environment

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -317,6 +317,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 			Q_strlwr( renderer_buffer );
 
 			// OpenGL driver constants
+			glGetIntegerv( GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &temp );
+			glConfig2.maxTextureUnits = temp;
+
 			glGetIntegerv( GL_MAX_TEXTURE_SIZE, &temp );
 			glConfig.maxTextureSize = temp;
 
@@ -794,8 +797,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 	*/
 	void GL_SetDefaultState()
 	{
-		int i;
-
 		GLimp_LogComment( "--- GL_SetDefaultState ---\n" );
 
 		GL_ClearDepth( 1.0f );
@@ -813,11 +814,13 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		GL_CheckErrors();
 
+		glState.currenttextures.resize( glConfig2.maxTextureUnits );
+
 		// initialize downstream texture units if we're running
 		// in a multitexture environment
 		if ( glConfig.driverType == glDriverType_t::GLDRV_OPENGL3 )
 		{
-			for ( i = 31; i >= 0; i-- )
+			for ( int i = 0; i < glConfig2.maxTextureUnits; i++ )
 			{
 				GL_SelectTexture( i );
 				GL_TextureMode( r_textureMode->string );
@@ -875,7 +878,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		glState.stackIndex = 0;
 
-		for ( i = 0; i < MAX_GLSTACK; i++ )
+		for ( int i = 0; i < MAX_GLSTACK; i++ )
 		{
 			MatrixIdentity( glState.modelViewMatrix[ i ] );
 			MatrixIdentity( glState.projectionMatrix[ i ] );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2477,8 +2477,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		float  polygonOffsetFactor, polygonOffsetUnits;
 		vec2_t tileStep;
 
-		// Maximum reported is 192, see https://opengl.gpuinfo.org/displaycapability.php?name=GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS
-		std::vector<int> currenttextures;
 		int    currenttmu;
 
 		int stackIndex;
@@ -2643,6 +2641,9 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		world_t    *world;
 
 		const byte *externalVisData; // from RE_SetWorldVisData, shared with CM_Load
+
+		// Maximum reported is 192, see https://opengl.gpuinfo.org/displaycapability.php?name=GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS
+		std::vector<int> currenttextures;
 
 		image_t    *defaultImage;
 		image_t    *cinematicImage[ MAX_IN_GAME_VIDEOS ];

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2477,7 +2477,8 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		float  polygonOffsetFactor, polygonOffsetUnits;
 		vec2_t tileStep;
 
-		int    currenttextures[ 32 ];
+		// Maximum reported is 192, see https://opengl.gpuinfo.org/displaycapability.php?name=GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS
+		std::vector<int> currenttextures;
 		int    currenttmu;
 
 		int stackIndex;

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -63,6 +63,8 @@ struct glconfig2_t
 	std::string glEnabledExtensionsString;
 	std::string glMissingExtensionsString;
 
+	int maxTextureUnits;
+
 	int      maxCubeMapTextureSize;
 
 	bool occlusionQueryAvailable;


### PR DESCRIPTION
Query the actual max amount of texture units with GL_MAX_COMBINED_TEXTURE_UNITS instead of a magic number, and use an std::vector with this capacity.