### PR TITLE
Fix screen shader texture

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3154,6 +3154,8 @@ void RB_RenderBloom()
 		Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
 						  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 
+		GL_BindToTMU( 0, tr.blackImage );
+
 		gl_screenShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 
 		Tess_DrawElements();


### PR DESCRIPTION
Bind tr.blackImage for gl_screenShader when rendering bloom, to avoid having undefined texture data:
![image](https://github.com/DaemonEngine/Daemon/assets/10687142/2d35e41c-cad5-4fcb-ad47-fb1df5c18076)

We've been getting lucky that we didn't have any bad texture reads, but with #1105 those sometimes happen here, likely because of bindless textures working slightly differently.