### PR TITLE
tr_bsp: fix a signedness comparison problem

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -469,7 +469,7 @@ static std::vector<std::string> R_LoadExternalLightmaps( const char *mapName )
 	const char *const extensions[] {".png", ".tga", ".webp", ".crn", ".jpg", ".jpeg"};
 	std::vector<std::string> files[ ARRAY_LEN( extensions ) ];
 	for ( const std::string& filename : FS::PakPath::ListFiles( mapName ) ) {
-		for ( int i = 0; i < ARRAY_LEN( extensions ); i++ )
+		for ( size_t i = 0; i < ARRAY_LEN( extensions ); i++ )
 		{
 			if ( Str::IsISuffix( extensions[ i ], filename ) )
 			{


### PR DESCRIPTION
Noticed in a CI log while looking for something else:

```
src/engine/renderer/tr_bsp.cpp: In function ‘std::vector<std::__cxx11::basic_string<char> > R_LoadExternalLightmaps(const char*)’:
src/engine/renderer/tr_bsp.cpp:472:22: warning: comparison of integer expressions of different signedness: ‘int’ and ‘long long unsigned int’ [-Wsign-compare]
  472 |   for ( int i = 0; i < ARRAY_LEN( extensions ); i++ )
```