### PR TITLE
pbr: Maybe fix weird dark artifacts in PBR

### DIFF
--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -125,8 +125,9 @@ void computeDeluxeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightCol
   float G = NdotL / (NdotL * (1.0 - k) + k);
   G *= NdotV / (NdotV * (1.0 - k) + k);
 
-  color.rgb += lightColor.rgb * NdotL * diffuseColor.rgb * (1.0 - metalness);
-  color.rgb += lightColor.rgb * vec3((D * F * G) / (4.0 * NdotV));
+  vec3 diffuseBRDF = NdotL * diffuseColor.rgb * (1.0 - metalness);
+  vec3 specularBRDF = vec3((D * F * G) / max(4.0 * NdotL * NdotV, 0.0001f));
+  color.rgb += (diffuseBRDF + specularBRDF) * lightColor.rgb * NdotL;
   color.a = mix(diffuseColor.a, 1.0, FexpNV);
 #else // !USE_PHYSICAL_MAPPING
 
@@ -240,7 +241,7 @@ void computeDynamicLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4
 #endif
     }
   }
-  
+
 #if defined(r_showLightTiles)
   if (numLights > 0.0)
   {


### PR DESCRIPTION
Looking at
https://github.com/Nadrin/PBR/blob/master/data/shaders/glsl/pbr_fs.glsl, this repo does PBR slightly differently. In general, the calculations are similar until they come to adding it to the color. This change ported from this renderer appears to help remove black artifacts.

### Before
![unvanquished_2024-05-10_231751_000](https://github.com/DaemonEngine/Daemon/assets/1097524/d14c3f15-58bf-4746-ae51-6e25a610e5b5)

### After
![unvanquished_2024-05-10_231807_000](https://github.com/DaemonEngine/Daemon/assets/1097524/f0740d75-0241-484e-b5c6-c272f137c068)
