### PR TITLE
tr_shader: properly flag shader based lightmaps with IF_NOPICMIP and IF_LIGHTMAP

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -2147,6 +2147,8 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			else
 			{
 				loadMap = true;
+				imageBits |= IF_LIGHTMAP;
+				imageBits |= IF_NOPICMIP;
 			}
 		}
 		// clampmap <name>
@@ -2874,6 +2876,7 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			}
 			else if ( !Q_stricmp( token, "lightmap" ) )
 			{
+				imageBits |= IF_LIGHTMAP;
 				imageBits |= IF_NOPICMIP;
 				stage->tcGen_Lightmap = true;
 				stage->tcGen_Environment = false;


### PR DESCRIPTION
Properly flag shader based lightmaps with IF_NOPICMIP and IF_LIGHTMAP.

This is a cherry pick from that old branch that have many commits unmerged yet:

- https://github.com/DaemonEngine/Daemon/pull/394