### PR TITLE
VM-side cache for cvars registered there

### DIFF
--- a/src/common/Cvar.cpp
+++ b/src/common/Cvar.cpp
@@ -41,7 +41,7 @@ namespace Cvar {
     }
 
     bool CvarProxy::Register(std::string description) {
-        return ::Cvar::Register(this, name, std::move(description), flags, std::move(defaultValue));
+        return ::Cvar::Register(this, name, std::move(description), flags, defaultValue);
     }
 
     bool ParseCvarValue(Str::StringRef value, bool& result) {

--- a/src/shared/CommonProxies.cpp
+++ b/src/shared/CommonProxies.cpp
@@ -333,10 +333,11 @@ namespace Cvar{
 
     void CallOnValueChangedSyscall(Util::Reader& reader, IPC::Channel& channel) {
         IPC::HandleMsg<VM::OnValueChangedMsg>(channel, std::move(reader), [](std::string name, std::string value, bool& success, std::string& description) {
-            auto map = GetCvarMap();
+            CvarMap& map = GetCvarMap();
             auto it = map.find(name);
 
             if (it == map.end()) {
+                Log::Warn("Cvar '%' not registered here", name);
                 success = true;
                 description = "";
                 return;


### PR DESCRIPTION
For improving the performance of Cvar::GetValue.

Also I uncovered another funny performance bug where setting a VM cvar was O(N) in the number of cvars.