### PR TITLE
WIP: renderer: introduce `IF_FITSCREEN` to rescale image to the smaller size larger than screen

### DIFF
--- a/src/engine/renderer/InternalImage.cpp
+++ b/src/engine/renderer/InternalImage.cpp
@@ -105,6 +105,30 @@ int R_GetImageCustomScalingStep( const image_t *image, const imageParams_t &imag
 		return 0;
 	}
 
+	// Consider the larger edge as the "image dimension"
+	int scaledDimension = std::max( image->width, image->height );
+
+	int scalingStep = 0;
+
+	// Scale down the image size until it's not smaller than screen.
+	if ( image->bits & IF_FITSCREEN )
+	{
+		int largerSide = std::max( glConfig.vidWidth, glConfig.vidHeight );
+
+		if ( scaledDimension > largerSide )
+		{
+			while ( scaledDimension > largerSide )
+			{
+				scaledDimension >>= 1;
+				scalingStep++;
+			}
+
+			// We need the larger image size before it becomes smaller than screen.
+			scaledDimension <<= 1;
+			scalingStep--;
+		}
+	}
+
 	int materialMinDimension = r_ignoreMaterialMinDimension->integer ? 0 : imageParams.minDimension;
 	int materialMaxDimension = r_ignoreMaterialMaxDimension->integer ? 0 : imageParams.maxDimension;
 
@@ -129,10 +153,6 @@ int R_GetImageCustomScalingStep( const image_t *image, const imageParams_t &imag
 	{
 		maxDimension = std::min( maxDimension, r_imageMaxDimension->integer );
 	}
-
-	// Consider the larger edge as the "image dimension"
-	int scaledDimension = std::max( image->width, image->height );
-	int scalingStep = 0;
 
 	// 1st priority: scaledDimension >= minDimension
 	// 2nd priority: scaledDimension <= maxDimension

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -539,6 +539,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	{
 	  IF_NONE,
 	  IF_NOPICMIP = BIT( 0 ),
+	  IF_FITCREEN = BIT( 1 ),
 	  IF_NORMALMAP = BIT( 2 ),
 	  IF_RGBA16F = BIT( 3 ),
 	  IF_RGBA32F = BIT( 4 ),


### PR DESCRIPTION
Introduce `IF_FITSCREEN` to rescale image to the smaller size larger than screen.

The idea behind this feature is that we have images that should not be rescaled smaller than screen to look good:

- minimaps,
- UI background,
- levelshot,
- etc.

So for them we use `IF_PICMIP`, either directly in code, either with material keyword `nopicmip`.

But then this stupid thing happen, let's imagine someone playing on a low end device with not a lot of GPU memory and a 800×600 screen:

```
]/listImages
------------------------------------------------------------------
num   width heigth layers mm  type format   wrap.t   wrap.s   name
------------------------------------------------------------------
63      100   2230      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/bg
64       20   1200      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/black
65     2082   1371      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/duel
66       20   1200      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/black2
67     2500   1667      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/circles1
68     2500   1667      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/circles2
69     3500    886      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/fog
121    3840   2160      1 no  2D   DXT1     t.clmp   s.clmp   meta/chasm/chasm
```

The 4K levelshot is fully loaded in GPU memory just to display it on a `800×600` screen!

Here is what happens once this feature is implemented AND (not done yet) the related images are configured to use `IF_FITSCREEN`:

```
]/listImages
------------------------------------------------------------------
num   width heigth layers mm  type format   wrap.t   wrap.s   name
------------------------------------------------------------------
63       50   1115      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/bg
64       20   1200      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/black
65     1041    685      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/duel
66       20   1200      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/black2
67     1250    833      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/circles1
68     1250    833      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/circles2
69      875    221      1 no  2D   DXT5     t.clmp   s.clmp   ui/assets/background/fog
121     960    540      1 no  2D   DXT1     t.clmp   s.clmp   meta/chasm/chasm
```

This is far better!

So this feature scales down images flagged with `IF_FITSCREEN` to the smaller size larger than screen, this way the image is never underscaled compared to the screen, while not being too much large for nothing.