### PR TITLE
q_shared: drop the old PPC `frsqrte` code.

### DIFF
--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -378,14 +378,6 @@ extern const quat_t   quatIdentity;
 #if defined( idx86_sse )
 		// SSE rsqrt relative error bound: 3.7 * 10^-4
 		_mm_store_ss( &y, _mm_rsqrt_ss( _mm_load_ss( &number ) ) );
-#elif idppc
-
-		// error bound: ???
-#ifdef __GNUC__
-		asm( "frsqrte %0, %1" : "=f"( y ) : "f"( number ) );
-#else
-		y = __frsqrte( number );
-#endif
 #else
 		y = Q_uintBitsToFloat( 0x5f3759df - (Q_floatBitsToUint( number ) >> 1) );
 		y *= ( 1.5f - ( x * y * y ) ); // initial iteration


### PR DESCRIPTION
Drop the old PowerPC `frsqrte` (Floating Reciprocal Square Root Estimate) code.

The `idppc` definition was never set and was a relic from ioq3.

PowerPC isn't supported by the engine and will probably never be.

The Apple GCC implementation of `__frsqrte` was just the same as the one that was used for GCC:

- https://opensource.apple.com/source/gcc/gcc-5363/more-hdrs/ppc_intrinsics.h.auto.html

There is no plan to support Apple 32-bit PowerPC.

The non-GCC `__frsqte` code was likely the one from XL C++ for AIX:

- https://www.ibm.com/docs/en/xl-c-and-cpp-aix/13.1.0?topic=functions-frsqrte-frsqrtes

There is no plan to support AIX.

PPC64 may be supported in the future, interest in it has been expressed as some Talos people have expressed their desire to see someone port the game to their platform, but this effort was not possible due to limitations of NaCl. This possibility may or may not be reconsidered once the game is migrated to Wasm. It is not known if PPC64 uses the same syntax so we better not write mistakes and delete that code.

Among PPC platforms that had some specific code in our code base was the Xbox 360 but there is no plan to support Xbox 360 and the related code has already been dropped:

- https://github.com/DaemonEngine/Daemon/pull/802