### PR TITLE
qcommon: let the framerate flirt with the limits

### DIFF
--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -862,25 +862,39 @@ void Com_Frame()
 	}
 
 	Com_EventLoop();
+
+	// It must be called at least once.
+	IN_Frame();
+
 	com_frameTime = Sys::Milliseconds();
 
-	if ( lastTime > com_frameTime )
-	{
-		lastTime = com_frameTime; // possible on first frame
-	}
+	// lastTime can be greater than com_frameTime on first frame.
+	lastTime = std::min( lastTime, com_frameTime );
 
 	msec = com_frameTime - lastTime;
 
-	IN_Frame(); // must be called at least once
+	// For framerates up to 250fps, sleep until 1ms is remaining
+	// use extra margin of 2ms when looking for an higher framerate.
+	int margin = minMsec > 3 ? 1 : 2;
 
 	while ( msec < minMsec )
 	{
-		//give cycles back to the OS
-		Sys::SleepFor(std::chrono::milliseconds(std::min(minMsec - msec, 50)));
-		IN_Frame();
+		// Never sleep more than 50ms.
+		// Never sleep when there is only “margin” left or less remaining.
+		int sleep = std::min( std::max( minMsec - msec - margin, 0 ), 50 );
+
+		if ( sleep )
+		{
+			// Give cycles back to the OS.
+			Sys::SleepFor( std::chrono::milliseconds( sleep ) );
+		}
 
 		Com_EventLoop();
+
+		IN_Frame();
+
 		com_frameTime = Sys::Milliseconds();
+
 		msec = com_frameTime - lastTime;
 	}
 


### PR DESCRIPTION
Let the framerate flirt with the limits.

Basically the idea is to not sleep the remaining time to fill the expected frametime, but to let enough time after sleeping to process events in a loop until the expected frametime is reached.

It makes the framerate less jaggy, and actually provides to the user what they expect.