### PR TITLE
Implement compute shaders support, make fragment shader non-mandatory

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -836,11 +836,7 @@ std::string     GLShaderManager::BuildGPUShaderText( Str::StringRef mainShaderNa
 			continue;
 		}
 
-		const std::string::iterator beginIt = std::find_if( line.begin(), line.end(),
-			[]( unsigned char character ) {
-				return !std::isspace( character );
-			} );
-		if ( beginIt - line.begin() != int( position ) ) { // Signed/unsigned CI bullshit
+		if ( line.find_first_not_of( " \t" ) != position ) {
 			shaderMain += line + "\n";
 			continue;
 		}

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -106,13 +106,17 @@ protected:
 	const uint32_t                 _vertexAttribsRequired;
 	uint32_t                       _vertexAttribs; // can be set by uniforms
 	GLShaderManager                 *_shaderManager;
-	size_t                         _uniformStorageSize;
 
-	std::string                    _fragmentShaderText;
+	bool                           _hasVertexShader;
 	std::string                    _vertexShaderText;
+	bool                           _hasFragmentShader;
+	std::string                    _fragmentShaderText;
+	bool                           _hasComputeShader;
+	std::string                    _computeShaderText;
 	std::vector< shaderProgram_t > _shaderPrograms;
 
 
+	size_t                         _uniformStorageSize;
 	std::vector< GLUniform * >      _uniforms;
 	std::vector< GLUniformBlock * > _uniformBlocks;
 	std::vector< GLCompileMacro * > _compileMacros;
@@ -121,7 +125,8 @@ protected:
 
 
 
-	GLShader( const std::string &name, uint32_t vertexAttribsRequired, GLShaderManager *manager ) :
+	GLShader( const std::string &name, uint32_t vertexAttribsRequired, GLShaderManager *manager,
+			  const bool hasVertexShader = true, const bool hasFragmentShader = true, const bool hasComputeShader = false ) :
 		_name( name ),
 		_mainShaderName( name ),
 		_activeMacros( 0 ),
@@ -130,11 +135,15 @@ protected:
 		_vertexAttribsRequired( vertexAttribsRequired ),
 		_vertexAttribs( 0 ),
 		_shaderManager( manager ),
+		_hasVertexShader( hasVertexShader ),
+		_hasFragmentShader( hasFragmentShader ),
+		_hasComputeShader( hasComputeShader ),
 		_uniformStorageSize( 0 )
 	{
 	}
 
-	GLShader( const std::string &name, const std::string &mainShaderName, uint32_t vertexAttribsRequired, GLShaderManager *manager ) :
+	GLShader( const std::string &name, const std::string &mainShaderName, uint32_t vertexAttribsRequired, GLShaderManager *manager,
+			  const bool hasVertexShader = true, const bool hasFragmentShader = true, const bool hasComputeShader = false ) :
 		_name( name ),
 		_mainShaderName( mainShaderName ),
 		_activeMacros( 0 ),
@@ -143,6 +152,9 @@ protected:
 		_vertexAttribsRequired( vertexAttribsRequired ),
 		_vertexAttribs( 0 ),
 		_shaderManager( manager ),
+		_hasVertexShader( hasVertexShader ),
+		_hasFragmentShader( hasFragmentShader ),
+		_hasComputeShader( hasComputeShader ),
 		_uniformStorageSize( 0 )
 	{
 	}
@@ -167,6 +179,10 @@ public:
 			if ( p->FS )
 			{
 				glDeleteShader( p->FS );
+			}
+
+			if ( p->CS ) {
+				glDeleteShader( p->CS );
 			}
 
 			if ( p->uniformFirewall )
@@ -229,12 +245,15 @@ public:
 protected:
 	bool         GetCompileMacrosString( size_t permutation, std::string &compileMacrosOut ) const;
 	virtual void BuildShaderVertexLibNames( std::string& /*vertexInlines*/ ) { };
-	virtual void BuildShaderFragmentLibNames( std::string& /*vertexInlines*/ ) { };
+	virtual void BuildShaderFragmentLibNames( std::string& /*fragmentInlines*/ ) { };
+	virtual void BuildShaderComputeLibNames( std::string& /*computeInlines*/ ) {};
 	virtual void BuildShaderCompileMacros( std::string& /*vertexInlines*/ ) { };
 	virtual void SetShaderProgramUniforms( shaderProgram_t* /*shaderProgram*/ ) { };
 	int          SelectProgram();
 public:
 	void BindProgram( int deformIndex );
+	void DispatchCompute( const GLuint globalWorkgroupX, const GLuint globalWorkgroupY, const GLuint globalWorkgroupZ );
+	void DispatchComputeIndirect( const GLintptr indirectBuffer );
 	void SetRequiredVertexPointers();
 
 	bool IsMacroSet( int bit )
@@ -280,6 +299,7 @@ class GLShaderManager
 
 public:
 	GLHeader GLVersionDeclaration;
+	GLHeader GLComputeVersionDeclaration;
 	GLHeader GLCompatHeader;
 	GLHeader GLVertexHeader;
 	GLHeader GLFragmentHeader;

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -102,6 +102,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_arb_texture_gather;
 	cvar_t      *r_arb_gpu_shader5;
 	Cvar::Cvar<bool> r_arb_depth_clamp("r_arb_depth_clamp", "Use GL_ARB_depth_clamp if available", Cvar::NONE, true);
+	cvar_t      *r_arb_compute_shader;
 
 	cvar_t      *r_checkGLErrors;
 	cvar_t      *r_logFile;
@@ -1090,6 +1091,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_arb_texture_gather = Cvar_Get( "r_arb_texture_gather", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_arb_gpu_shader5 = Cvar_Get( "r_arb_gpu_shader5", "1", CVAR_CHEAT | CVAR_LATCH );
 		Cvar::Latch(r_arb_depth_clamp);
+		r_arb_compute_shader = Cvar_Get( "r_arb_compute_shader", "1", CVAR_CHEAT | CVAR_LATCH );
 
 		r_picMip = Cvar_Get( "r_picMip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_imageMaxDimension = Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1392,7 +1392,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	struct shaderProgram_t
 	{
 		GLuint    program;
-		GLuint    VS, FS;
+		GLuint    VS, FS, CS;
 		uint32_t  attribs; // vertex array attributes
 		GLint    *uniformLocations;
 		GLuint   *uniformBlockIndexes;
@@ -2897,6 +2897,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_arb_texture_gather;
 	extern cvar_t *r_arb_gpu_shader5;
 	extern Cvar::Cvar<bool> r_arb_depth_clamp;
+	extern cvar_t *r_arb_compute_shader;
 
 	extern cvar_t *r_nobind; // turns off binding to appropriate textures
 	extern cvar_t *r_singleShader; // make most world faces use default shader

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -84,6 +84,7 @@ struct glconfig2_t
 	bool textureFloatAvailable;
 	bool textureIntegerAvailable;
 	bool textureRGAvailable;
+	bool computeShaderAvailable;
 	bool gpuShader4Available;
 	bool gpuShader5Available;
 	bool textureGatherAvailable;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1949,6 +1949,9 @@ static void GLimp_InitExtensions()
 	// made required in OpenGL 3.2
 	glConfig2.depthClampAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_depth_clamp, r_arb_depth_clamp.Get() );
 
+	// made required in OpenGL 4.3
+	glConfig2.computeShaderAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_compute_shader, r_arb_compute_shader->value );
+
 	GL_CheckErrors();
 }
 


### PR DESCRIPTION
Requires #1124.

Cherry-picked from #1137 to split a large pr up a bit.

Adds some code to allow using compute shaders. Shaders can now have either of vertex, fragment, or compute shaders enabled/disabled.