### PR TITLE
cmake: only use `-fno-strict-aliasing` on files requiring it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -879,6 +879,15 @@ function(AddApplication)
         target_link_libraries(test-${A_Target} GTest::gmock)
     endif()
 
+    if(FLAG_NO_STRICT_ALIASING)
+        foreach(NOSTRICTALIASINGFILE ${NOSTRICTALIASINGLIST})
+            if (${NOSTRICTALIASINGFILE} IN_LIST A_Files)
+                set_source_files_properties(${NOSTRICTALIASINGFILE}
+                    PROPERTIES COMPILE_FLAGS -fno-strict-aliasing)
+            endif()
+        endforeach()
+    endif()
+
     ADD_PRECOMPILED_HEADER(${A_Target}-objects)
 endfunction()
 

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -122,6 +122,10 @@ if(MINGW AND USE_BREAKPAD)
     set_linker_flag("-Wl,--build-id")
 endif()
 
+# Only check if it's available but do not set it by default,
+# it will only be used with a couple of files.
+check_CXX_compiler_flag(-fno-strict-aliasing FLAG_NO_STRICT_ALIASING)
+
 if (MSVC)
     set_c_cxx_flag("/MP")
     set_c_cxx_flag("/fp:fast")
@@ -189,7 +193,6 @@ elseif (NACL)
     set_c_cxx_flag("-O0          -g3"   DEBUG)
 else()
     set_c_cxx_flag("-ffast-math")
-    set_c_cxx_flag("-fno-strict-aliasing")
 
     # Among the required hardware features, the NX bit (No eXecute bit)
     # feature may be required for NativeClient to work. Some early

--- a/src.cmake
+++ b/src.cmake
@@ -364,4 +364,10 @@ set(DEDSERVERLIST
     ${ENGINE_DIR}/null/null_input.cpp
 )
 
+# List of known files to be built with the -fno-strict-aliasing flag.
+set(NOSTRICTALIASINGLIST
+	${ENGINE_DIR}/qcommon/msg.cpp
+	${ENGINE_DIR}/renderer/tr_bsp.cpp
+)
+
 set(WIN_RC ${ENGINE_DIR}/sys/windows-resource/icon.rc)

--- a/src.cmake
+++ b/src.cmake
@@ -94,6 +94,7 @@ set(RENDERERLIST
     ${ENGINE_DIR}/renderer/tr_animation.cpp
     ${ENGINE_DIR}/renderer/tr_backend.cpp
     ${ENGINE_DIR}/renderer/tr_bsp.cpp
+    ${ENGINE_DIR}/renderer/tr_bsp_punned.cpp
     ${ENGINE_DIR}/renderer/tr_cmds.cpp
     ${ENGINE_DIR}/renderer/tr_curve.cpp
     ${ENGINE_DIR}/renderer/tr_decals.cpp
@@ -287,6 +288,7 @@ set(QCOMMONLIST
     ${ENGINE_DIR}/qcommon/files.cpp
     ${ENGINE_DIR}/qcommon/huffman.cpp
     ${ENGINE_DIR}/qcommon/msg.cpp
+    ${ENGINE_DIR}/qcommon/msg_punned.cpp
     ${ENGINE_DIR}/qcommon/net_chan.cpp
     ${ENGINE_DIR}/qcommon/net_ip.cpp
     ${ENGINE_DIR}/qcommon/net_types.h
@@ -366,8 +368,8 @@ set(DEDSERVERLIST
 
 # List of known files to be built with the -fno-strict-aliasing flag.
 set(NOSTRICTALIASINGLIST
-	${ENGINE_DIR}/qcommon/msg.cpp
-	${ENGINE_DIR}/renderer/tr_bsp.cpp
+	${ENGINE_DIR}/qcommon/msg_punned.cpp
+	${ENGINE_DIR}/renderer/tr_bsp_punned.cpp
 )
 
 set(WIN_RC ${ENGINE_DIR}/sys/windows-resource/icon.rc)

--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -614,31 +614,6 @@ int MSG_ReadDelta( msg_t *msg, int oldV, int bits )
 	return oldV;
 }
 
-void MSG_WriteDeltaFloat( msg_t *msg, float oldV, float newV )
-{
-	if ( oldV == newV )
-	{
-		MSG_WriteBits( msg, 0, 1 );
-		return;
-	}
-
-	MSG_WriteBits( msg, 1, 1 );
-	MSG_WriteBits( msg, * ( int * ) &newV, 32 );
-}
-
-float MSG_ReadDeltaFloat( msg_t *msg, float oldV )
-{
-	if ( MSG_ReadBits( msg, 1 ) )
-	{
-		float newV;
-
-		* ( int * ) &newV = MSG_ReadBits( msg, 32 );
-		return newV;
-	}
-
-	return oldV;
-}
-
 /*
 ============================================================================
 

--- a/src/engine/qcommon/msg_punned.cpp
+++ b/src/engine/qcommon/msg_punned.cpp
@@ -1,0 +1,63 @@
+/*
+===========================================================================
+
+Daemon GPL Source Code
+Copyright (C) 1999-2010 id Software LLC, a ZeniMax Media company.
+
+This file is part of the Daemon GPL Source Code (Daemon Source Code).
+
+Daemon Source Code is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Daemon Source Code is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
+
+In addition, the Daemon Source Code is also subject to certain additional terms.
+You should have received a copy of these additional terms immediately following the
+terms and conditions of the GNU General Public License which accompanied the Daemon
+Source Code.  If not, please request a copy in writing from id Software at the address
+below.
+
+If you have questions concerning this license or the applicable additional terms, you
+may contact in writing id Software LLC, c/o ZeniMax Media Inc., Suite 120, Rockville,
+Maryland 20850 USA.
+
+===========================================================================
+*/
+
+// This file should be built with the -fno-strict-aliasing flag.
+
+#include "qcommon.h"
+
+void MSG_WriteDeltaFloat( msg_t *msg, float oldV, float newV )
+{
+	if ( oldV == newV )
+	{
+		MSG_WriteBits( msg, 0, 1 );
+		return;
+	}
+
+	MSG_WriteBits( msg, 1, 1 );
+	MSG_WriteBits( msg, * ( int * ) &newV, 32 );
+}
+
+float MSG_ReadDeltaFloat( msg_t *msg, float oldV )
+{
+	if ( MSG_ReadBits( msg, 1 ) )
+	{
+		float newV;
+
+		* ( int * ) &newV = MSG_ReadBits( msg, 32 );
+		return newV;
+	}
+
+	return oldV;
+}
+

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -6285,45 +6285,12 @@ void R_PrecacheInteractions()
 	Log::Debug("lights precaching time = %5.2f seconds", ( endTime - startTime ) / 1000.0 );
 }
 
-static const int HASHTABLE_SIZE = 7919; // 32749 // 2039    /* prime, use % */
 #define HASH_USE_EPSILON
 
 #ifdef HASH_USE_EPSILON
 #define HASH_XYZ_EPSILON                 0.01f
 #define HASH_XYZ_EPSILONSPACE_MULTIPLIER 1.f / HASH_XYZ_EPSILON
 #endif
-
-unsigned int VertexCoordGenerateHash( const vec3_t xyz )
-{
-	unsigned int hash = 0;
-
-#ifndef HASH_USE_EPSILON
-	hash += ~( * ( ( unsigned int * ) &xyz[ 0 ] ) << 15 );
-	hash ^= ( * ( ( unsigned int * ) &xyz[ 0 ] ) >> 10 );
-	hash += ( * ( ( unsigned int * ) &xyz[ 1 ] ) << 3 );
-	hash ^= ( * ( ( unsigned int * ) &xyz[ 1 ] ) >> 6 );
-	hash += ~( * ( ( unsigned int * ) &xyz[ 2 ] ) << 11 );
-	hash ^= ( * ( ( unsigned int * ) &xyz[ 2 ] ) >> 16 );
-#else
-	vec3_t xyz_epsilonspace;
-
-	VectorScale( xyz, HASH_XYZ_EPSILONSPACE_MULTIPLIER, xyz_epsilonspace );
-	xyz_epsilonspace[ 0 ] = floor( xyz_epsilonspace[ 0 ] );
-	xyz_epsilonspace[ 1 ] = floor( xyz_epsilonspace[ 1 ] );
-	xyz_epsilonspace[ 2 ] = floor( xyz_epsilonspace[ 2 ] );
-
-	hash += ~( * ( ( unsigned int * ) &xyz_epsilonspace[ 0 ] ) << 15 );
-	hash ^= ( * ( ( unsigned int * ) &xyz_epsilonspace[ 0 ] ) >> 10 );
-	hash += ( * ( ( unsigned int * ) &xyz_epsilonspace[ 1 ] ) << 3 );
-	hash ^= ( * ( ( unsigned int * ) &xyz_epsilonspace[ 1 ] ) >> 6 );
-	hash += ~( * ( ( unsigned int * ) &xyz_epsilonspace[ 2 ] ) << 11 );
-	hash ^= ( * ( ( unsigned int * ) &xyz_epsilonspace[ 2 ] ) >> 16 );
-
-#endif
-
-	hash = hash % ( HASHTABLE_SIZE );
-	return hash;
-}
 
 vertexHash_t **NewVertexHashTable()
 {

--- a/src/engine/renderer/tr_bsp_punned.cpp
+++ b/src/engine/renderer/tr_bsp_punned.cpp
@@ -1,0 +1,59 @@
+/*
+===========================================================================
+Copyright (C) 1999-2005 Id Software, Inc.
+Copyright (C) 2006-2011 Robert Beckebans <trebor_7@users.sourceforge.net>
+Copyright (C) 2009 Peter McNeill <n27@bigpond.net.au>
+
+This file is part of Daemon source code.
+
+Daemon source code is free software; you can redistribute it
+and/or modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the License,
+or (at your option) any later version.
+
+Daemon source code is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Daemon source code; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+===========================================================================
+*/
+
+// This file should be built with the -fno-strict-aliasing flag.
+
+#include "tr_local.h"
+
+unsigned int VertexCoordGenerateHash( const vec3_t xyz )
+{
+	unsigned int hash = 0;
+
+#ifndef HASH_USE_EPSILON
+	hash += ~( * ( ( unsigned int * ) &xyz[ 0 ] ) << 15 );
+	hash ^= ( * ( ( unsigned int * ) &xyz[ 0 ] ) >> 10 );
+	hash += ( * ( ( unsigned int * ) &xyz[ 1 ] ) << 3 );
+	hash ^= ( * ( ( unsigned int * ) &xyz[ 1 ] ) >> 6 );
+	hash += ~( * ( ( unsigned int * ) &xyz[ 2 ] ) << 11 );
+	hash ^= ( * ( ( unsigned int * ) &xyz[ 2 ] ) >> 16 );
+#else
+	vec3_t xyz_epsilonspace;
+
+	VectorScale( xyz, HASH_XYZ_EPSILONSPACE_MULTIPLIER, xyz_epsilonspace );
+	xyz_epsilonspace[ 0 ] = floor( xyz_epsilonspace[ 0 ] );
+	xyz_epsilonspace[ 1 ] = floor( xyz_epsilonspace[ 1 ] );
+	xyz_epsilonspace[ 2 ] = floor( xyz_epsilonspace[ 2 ] );
+
+	hash += ~( * ( ( unsigned int * ) &xyz_epsilonspace[ 0 ] ) << 15 );
+	hash ^= ( * ( ( unsigned int * ) &xyz_epsilonspace[ 0 ] ) >> 10 );
+	hash += ( * ( ( unsigned int * ) &xyz_epsilonspace[ 1 ] ) << 3 );
+	hash ^= ( * ( ( unsigned int * ) &xyz_epsilonspace[ 1 ] ) >> 6 );
+	hash += ~( * ( ( unsigned int * ) &xyz_epsilonspace[ 2 ] ) << 11 );
+	hash ^= ( * ( ( unsigned int * ) &xyz_epsilonspace[ 2 ] ) >> 16 );
+
+#endif
+
+	hash = hash % ( HASHTABLE_SIZE );
+	return hash;
+}

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -4007,6 +4007,8 @@ inline bool checkGLErrors()
 	void       R_BuildCubeMaps();
 	void       R_FindTwoNearestCubeMaps( const vec3_t position, cubemapProbe_t **cubeProbeNearest, cubemapProbe_t **cubeProbeSecondNearest );
 
+	const size_t HASHTABLE_SIZE = 7919; // 32749 // 2039 /* prime, use % */
+	unsigned int VertexCoordGenerateHash( const vec3_t xyz );
 	void       FreeVertexHashTable( vertexHash_t **hashTable );
 
 // font stuff


### PR DESCRIPTION
This flag is there since first commit and it is likely no one remembers why it has been set to begin with.

I experience no difference when removing this.

This was only used on engine build and dll/exe game. This was never used on nexe game.