### PR TITLE
cmake: never use strict aliasing

### DIFF
--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -183,6 +183,7 @@ elseif (NACL)
     set_cxx_flag("-std=gnu++14")
 
     set_c_cxx_flag("-ffast-math")
+    set_c_cxx_flag("-fno-strict-aliasing")
     set_c_cxx_flag("-fvisibility=hidden")
     set_c_cxx_flag("-stdlib=libc++")
     set_c_cxx_flag("--pnacl-allow-exceptions")


### PR DESCRIPTION
Never use strict aliasing, do the same with nexe than with exe and dll.

Alternative to:

- https://github.com/DaemonEngine/Daemon/pull/1159

Instead of trying to always do strict aliasing, never do strict aliasing.

What matters is to have consistent behaviour, #1159 will require more testing than this one.

See:

- https://github.com/DaemonEngine/Daemon/issues/1158