### PR TITLE
tr_shader: do not cancel overbright on decals (impact marks)

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5223,6 +5223,13 @@ static void FinishStages()
 		// We should cancel overBrightBits if there is no light stage.
 		stage->shaderHasNoLight = shaderHasNoLight;
 
+		// We should not cancel overbright on decals.
+		if ( shader.sort == Util::ordinal(shaderSort_t::SS_DECAL) )
+		{
+			// HACK: Reuse that boolean.
+			stage->shaderHasNoLight = false;
+		}
+
 		// Available textures.
 		bool hasNormalMap = stage->bundle[ TB_NORMALMAP ].image[ 0 ] != nullptr;
 		bool hasHeightMap = stage->bundle[ TB_HEIGHTMAP ].image[ 0 ] != nullptr;


### PR DESCRIPTION
Fix #1126:

- https://github.com/DaemonEngine/Daemon/issues/1126

While we may assume decals should not cancel overbright (the color is added to a surface that is already lit), one may investigate if other surfaces using `blendFunc GL_ZERO GL_ONE_MINUS_SRC_COLOR` while not being decals should also not cancel overbright in a more generic way.

But this is good enough for now.