### PR TITLE
renderer: skip the blending of tiled dynamic lights when the legacy dynamic light renderer is enabled

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -573,6 +573,7 @@ static std::string GenEngineConstants() {
 	if ( glConfig2.dynamicLight )
 	{
 		AddDefine( str, "r_dynamicLight", 1 );
+		AddDefine( str, "r_dynamicLightRenderer", r_dynamicLightRenderer.Get() );
 	}
 
 	if ( r_precomputedLighting->integer )

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -175,7 +175,8 @@ int nextIdx( inout idxs_t idxs ) {
 
 const int numLayers = MAX_REF_LIGHTS / 256;
 
-#if defined(r_dynamicLight)
+// This code is only used by the tiled dynamic light renderer.
+#if defined(r_dynamicLight) && r_dynamicLightRenderer == 1
 void computeDynamicLight( int idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse,
 		    vec4 material, inout vec4 color ) {
   vec4 center_radius = GetLight( idx, center_radius );

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -161,8 +161,8 @@ void main()
 		computeLight(lightColor, diffuse, color);
 	#endif
 
-	// Blend dynamic lights.
-	#if defined(r_dynamicLight)
+	// Blend dynamic lights, this code is only used by the tiled dynamic light renderer.
+	#if defined(r_dynamicLight) && r_dynamicLightRenderer == 1
 		computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color);
 	#endif
 


### PR DESCRIPTION
When the legacy dynamic light renderer is enabled, this code is unused, and is likely running for nothing with some dummy texture.

This code also breaks rendering on old hardware by making the compiled shader too big for the GPU ALU, while the extra code making the compiled shader too large is not meant to be used at all.