### PR TITLE
common: include cstring in Util.h to provide memcpy

### DIFF
--- a/src/common/Util.h
+++ b/src/common/Util.h
@@ -32,6 +32,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define COMMON_UTIL_H_
 
 #include <algorithm>
+#include <cstring>
 #include <memory>
 #include <tuple>
 #include <type_traits>


### PR DESCRIPTION
Include `cstring` in `Util.h` to provide `memcpy`.

QodeQL failed to build Unvanquished because of:

```
FAILED: CMakeFiles/cgame-native-dll.dir/src/cgame/cg_key_name.cpp.o 
/usr/bin/c++ -DARCH_STRING=amd64 -DBUILD_CGAME -DBUILD_VM -DBUILD_VM_IN_PROCESS -DDAEMON_ARCH_amd64 -DDAEMON_BUILD_Release -DGLM_FORCE_EXPLICIT_CTOR -DNACL_ANDROID=0 -DNACL_ARCH_STRING=amd64 -DNACL_BUILD_ARCH=x86 -DNACL_BUILD_SUBARCH=64 -DNACL_LINUX=1 -DNACL_OSX=0 -DNACL_WINDOWS=0 -DRC_MAX_LAYERS_DEF=63 -DRC_MAX_NEIS_DEF=16 -DRMLUI_STATIC_LIB -DTHIS_IS_NOT_A_DEBUG_BUILD -DTINYGETTEXT_UTF8_ONLY -DVM_NAME=cgame -Dcgame_native_dll_EXPORTS -IUnvanquished/daemon/src -IUnvanquished/daemon/libs -IUnvanquished/daemon/libs/zlib -IUnvanquished/daemon/libs/nacl -IUnvanquished/libs -IUnvanquished/src -I/usr/include/freetype2 -IUnvanquished/libs/RmlUi/Include -I/usr/include/lua5.2 -IUnvanquished/libs/recastnavigation/Detour/Include -IUnvanquished/l
In file included from Unvanquished/daemon/src/common/KeyIdentification.h:36,
                 from Unvanquished/src/cgame/cg_key_name.h:27,
                 from Unvanquished/src/cgame/cg_key_name.cpp:24:
Unvanquished/daemon/src/common/Util.h: In instantiation of ‘ToT Util::bit_cast(FromT) [with ToT = int; FromT = float]’:
Unvanquished/daemon/src/common/Endian.h:175:40:   required from here
Unvanquished/daemon/src/common/Util.h:54:15: error: ‘memcpy’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
```

This is likely a fixup for:

- https://github.com/DaemonEngine/Daemon/pull/1155