### PR TITLE
codeql: sync submodules branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -75,6 +75,10 @@ jobs:
         sudo apt-get update
         sudo apt-get -y -q --no-install-recommends install zlib1g-dev libncursesw5-dev libgeoip-dev nettle-dev libgmp-dev libcurl4-gnutls-dev libsdl2-dev libogg-dev libvorbis-dev libopusfile-dev libwebp-dev libjpeg8-dev libpng-dev libfreetype6-dev libglew-dev libopenal-dev ninja-build
         git submodule update --init --recursive
+
+        curl -sS https://gitlab.com/illwieckz/git-checkout-modules/raw/master/git-checkout-modules -o ~/git-checkout-modules
+        bash ~/git-checkout-modules --update --sub-ref="${GITHUB_HEAD_REF}:has=/sync$" --print
+
         export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
         cmake -S. -Bbuild -GNinja -DBUILD_CLIENT=ON -DBUILD_TTY_CLIENT=ON -DBUILD_SERVER=ON -DBUILD_DUMMY_APP=ON
         cmake --build build


### PR DESCRIPTION
Sync submodule branches if branch name ends with `/sync`, like we do with azure pipelines and appveyor.