### PR TITLE
common/ipc: skip variables for native code on nacl

### DIFF
--- a/src/common/IPC/Primitives.cpp
+++ b/src/common/IPC/Primitives.cpp
@@ -82,6 +82,8 @@ enum NaClDescTypeTag {
   NACL_DESC_NULL
 };
 #define NACL_DESC_TYPE_MAX (NACL_DESC_NULL + 1)
+
+#if !defined(__native_client__)
 static const int NACL_DESC_TYPE_END_TAG  = (0xff);
 
 struct NaClInternalRealHeader {
@@ -96,6 +98,8 @@ struct NaClInternalHeader {
 };
 
 static const uint32_t NACL_HANDLE_TRANSFER_PROTOCOL = 0xd3c0de01;
+#endif
+
 // End of imported definitions
 
 namespace IPC {


### PR DESCRIPTION
Something I found while unifying compiler flags between native builds and nacl builds.

```
Unvanquished/daemon/src/common/IPC/Primitives.cpp:85:18: warning: 
      unused variable 'NACL_DESC_TYPE_END_TAG' [-Wunused-const-variable]
static const int NACL_DESC_TYPE_END_TAG  = (0xff);
                 ^
Unvanquished/daemon/src/common/IPC/Primitives.cpp:98:23: warning: 
      unused variable 'NACL_HANDLE_TRANSFER_PROTOCOL' [-Wunused-const-variable]
static const uint32_t NACL_HANDLE_TRANSFER_PROTOCOL = 0xd3c0de01;
                      ^
2 warnings generated.
```