### PR TITLE
renderer: use `GL_DEPTH_CLAMP` only if `GL_ARB_depth_clamp` is available

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -101,6 +101,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_arb_uniform_buffer_object;
 	cvar_t      *r_arb_texture_gather;
 	cvar_t      *r_arb_gpu_shader5;
+	Cvar::Cvar<bool> r_arb_depth_clamp("r_arb_depth_clamp", "Use GL_ARB_depth_clamp if available", Cvar::NONE, true);
 
 	cvar_t      *r_checkGLErrors;
 	cvar_t      *r_logFile;
@@ -1088,6 +1089,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_arb_uniform_buffer_object = Cvar_Get( "r_arb_uniform_buffer_object", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_arb_texture_gather = Cvar_Get( "r_arb_texture_gather", "1", CVAR_CHEAT | CVAR_LATCH );
 		r_arb_gpu_shader5 = Cvar_Get( "r_arb_gpu_shader5", "1", CVAR_CHEAT | CVAR_LATCH );
+		Cvar::Latch(r_arb_depth_clamp);
 
 		r_picMip = Cvar_Get( "r_picMip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_imageMaxDimension = Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2898,6 +2898,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_arb_uniform_buffer_object;
 	extern cvar_t *r_arb_texture_gather;
 	extern cvar_t *r_arb_gpu_shader5;
+	extern Cvar::Cvar<bool> r_arb_depth_clamp;
 
 	extern cvar_t *r_nobind; // turns off binding to appropriate textures
 	extern cvar_t *r_singleShader; // make most world faces use default shader

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -99,6 +99,7 @@ struct glconfig2_t
 	bool uniformBufferObjectAvailable;
 	bool mapBufferRangeAvailable;
 	bool syncAvailable;
+	bool depthClampAvailable;
 
 	bool dynamicLight;
 	bool staticLight;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -660,7 +660,10 @@ static void Render_generic2D( shaderStage_t *pStage )
 	BindAnimatedImage( &pStage->bundle[ TB_COLORMAP ] );
 	gl_generic2DShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
 
-	glEnable( GL_DEPTH_CLAMP );
+	if ( glConfig2.depthClampAvailable )
+	{
+		glEnable( GL_DEPTH_CLAMP );
+	}
 
 	if ( hasDepthFade )
 	{
@@ -676,7 +679,10 @@ static void Render_generic2D( shaderStage_t *pStage )
 
 	Tess_DrawElements();
 
-	glDisable( GL_DEPTH_CLAMP );
+	if ( glConfig2.depthClampAvailable )
+	{
+		glDisable( GL_DEPTH_CLAMP );
+	}
 
 	GL_CheckErrors();
 }

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1943,6 +1943,9 @@ static void GLimp_InitExtensions()
 	// made required in OpenGL 3.2
 	glConfig2.syncAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_sync, r_arb_sync->value );
 
+	// made required in OpenGL 3.2
+	glConfig2.depthClampAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_depth_clamp, r_arb_depth_clamp.Get() );
+
 	GL_CheckErrors();
 }
 


### PR DESCRIPTION
Use `GL_DEPTH_CLAMP` only if `GL_ARB_depth_clamp` is available.

The `GL_ARB_depth_clamp` extension was only made required in OpenGL 3.2.