### PR TITLE
Stop reporting garbage serverinfos to cgame

### DIFF
--- a/src/engine/client/cl_serverlist.cpp
+++ b/src/engine/client/cl_serverlist.cpp
@@ -870,6 +870,7 @@ static void CL_ClearPing( int n )
 	}
 
 	cl_pinglist[ n ].adr.port = 0;
+	cl_pinglist[ n ].info[ 0 ] = '\0';
 }
 
 /*


### PR DESCRIPTION
For a server without a successful serverinfo reply, the engine would report a garbage infostring left over from the last ping query to have used the same space in the array.