### PR TITLE
renderer: remove the `USE_ALPHA_TESTING` macro and build less shader permutations

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1581,8 +1581,7 @@ GLShader_generic2D::GLShader_generic2D( GLShaderManager *manager ) :
 	u_Color( this ),
 	u_DepthScale( this ),
 	GLDeformStage( this ),
-	GLCompileMacro_USE_DEPTH_FADE( this ),
-	GLCompileMacro_USE_ALPHA_TESTING( this )
+	GLCompileMacro_USE_DEPTH_FADE( this )
 {
 }
 
@@ -1623,8 +1622,7 @@ GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	GLCompileMacro_USE_VERTEX_SPRITE( this ),
 	GLCompileMacro_USE_TCGEN_ENVIRONMENT( this ),
 	GLCompileMacro_USE_TCGEN_LIGHTMAP( this ),
-	GLCompileMacro_USE_DEPTH_FADE( this ),
-	GLCompileMacro_USE_ALPHA_TESTING( this )
+	GLCompileMacro_USE_DEPTH_FADE( this )
 {
 }
 
@@ -1976,8 +1974,7 @@ GLShader_skybox::GLShader_skybox( GLShaderManager *manager ) :
 	u_ModelViewProjectionMatrix( this ),
 	u_InverseLightFactor( this ),
 	u_VertexInterpolation( this ),
-	GLDeformStage( this ),
-	GLCompileMacro_USE_ALPHA_TESTING( this )
+	GLDeformStage( this )
 {
 }
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -798,7 +798,6 @@ protected:
 	  LIGHT_DIRECTIONAL,
 	  USE_DEPTH_FADE,
 	  USE_PHYSICAL_MAPPING,
-	  USE_ALPHA_TESTING
 	};
 
 public:
@@ -1274,31 +1273,6 @@ public:
 	}
 
 	void SetPhysicalShading( bool enable )
-	{
-		SetMacro( enable );
-	}
-};
-
-class GLCompileMacro_USE_ALPHA_TESTING :
-	GLCompileMacro
-{
-public:
-	GLCompileMacro_USE_ALPHA_TESTING(GLShader *shader) :
-		GLCompileMacro(shader)
-	{
-	}
-
-	const char *GetName() const override
-	{
-		return "USE_ALPHA_TESTING";
-	}
-
-	EGLCompileMacro GetType() const override
-	{
-		return USE_ALPHA_TESTING;
-	}
-
-	void SetAlphaTesting(bool enable)
 	{
 		SetMacro( enable );
 	}
@@ -2281,8 +2255,7 @@ class GLShader_generic2D :
 	public u_Color,
 	public u_DepthScale,
 	public GLDeformStage,
-	public GLCompileMacro_USE_DEPTH_FADE,
-	public GLCompileMacro_USE_ALPHA_TESTING
+	public GLCompileMacro_USE_DEPTH_FADE
 {
 public:
 	GLShader_generic2D( GLShaderManager *manager );
@@ -2312,8 +2285,7 @@ class GLShader_generic :
 	public GLCompileMacro_USE_VERTEX_SPRITE,
 	public GLCompileMacro_USE_TCGEN_ENVIRONMENT,
 	public GLCompileMacro_USE_TCGEN_LIGHTMAP,
-	public GLCompileMacro_USE_DEPTH_FADE,
-	public GLCompileMacro_USE_ALPHA_TESTING
+	public GLCompileMacro_USE_DEPTH_FADE
 {
 public:
 	GLShader_generic( GLShaderManager *manager );
@@ -2539,8 +2511,7 @@ class GLShader_skybox :
 	public u_ModelViewProjectionMatrix,
 	public u_InverseLightFactor,
 	public u_VertexInterpolation,
-	public GLDeformStage,
-	public GLCompileMacro_USE_ALPHA_TESTING
+	public GLDeformStage
 {
 public:
 	GLShader_skybox( GLShaderManager *manager );

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -43,13 +43,11 @@ void	main()
 {
 	vec4 color = texture2D(u_ColorMap, var_TexCoords);
 
-#if defined(USE_ALPHA_TESTING)
 	if( abs(color.a + u_AlphaThreshold) <= 1.0 )
 	{
 		discard;
 		return;
 	}
-#endif
 
 #if defined(USE_DEPTH_FADE) || defined(USE_VERTEX_SPRITE)
 	float depth = texture2D(u_DepthMap, gl_FragCoord.xy / r_FBufSize).x;

--- a/src/engine/renderer/glsl_source/skybox_fp.glsl
+++ b/src/engine/renderer/glsl_source/skybox_fp.glsl
@@ -67,13 +67,11 @@ void	main()
 		color = texture2D( u_CloudMap, st ).rgba;
 	}
 	
-	#if defined(USE_ALPHA_TESTING)
-		if( abs(color.a + u_AlphaThreshold) <= 1.0 )
-			{
-				discard;
-				return;
-			}
-	#endif
+	if( abs(color.a + u_AlphaThreshold) <= 1.0 )
+	{
+		discard;
+		return;
+	}
 
 	color.rgb *= u_InverseLightFactor;
 

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1891,11 +1891,10 @@ static void RB_SetupLightForLighting( trRefLight_t *light )
 							gl_genericShader->SetVertexSprite( false );
 							gl_genericShader->SetTCGenLightmap( false );
 							gl_genericShader->SetDepthFade( false );
-							gl_genericShader->SetAlphaTesting( false );
 							gl_genericShader->BindProgram( 0 );
 
 							// set uniforms
-							//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+							gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 							gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 							gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -2766,10 +2765,9 @@ void RB_RunVisTests( )
 		gl_genericShader->SetTCGenEnvironment( false );
 		gl_genericShader->SetTCGenLightmap( false );
 		gl_genericShader->SetDepthFade( false );
-		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
-		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_Color( Color::White );
 
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CONST, alphaGen_t::AGEN_CONST );
@@ -3387,14 +3385,13 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetTCGenEnvironment( false );
 		gl_genericShader->SetTCGenLightmap( false );
 		gl_genericShader->SetDepthFade( false );
-		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CUSTOM_RGB, alphaGen_t::AGEN_CUSTOM );
 
 		gl_genericShader->SetRequiredVertexPointers();
@@ -3548,14 +3545,13 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetTCGenEnvironment( false );
 		gl_genericShader->SetTCGenLightmap( false );
 		gl_genericShader->SetDepthFade( false );
-		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -3673,14 +3669,13 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetTCGenEnvironment( false );
 		gl_genericShader->SetTCGenLightmap( false );
 		gl_genericShader->SetDepthFade( false );
-		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -3750,13 +3745,12 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetTCGenEnvironment( false );
 		gl_genericShader->SetTCGenLightmap( false );
 		gl_genericShader->SetDepthFade( false );
-		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -3978,14 +3972,13 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetTCGenEnvironment( false );
 		gl_genericShader->SetTCGenLightmap( false );
 		gl_genericShader->SetDepthFade( false );
-		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CUSTOM_RGB, alphaGen_t::AGEN_CUSTOM );
 
 		// bind u_ColorMap
@@ -4095,10 +4088,10 @@ static void RB_RenderDebugUtils()
 			gl_genericShader->SetTCGenEnvironment( false );
 			gl_genericShader->SetTCGenLightmap( false );
 			gl_genericShader->SetDepthFade( false );
-			gl_genericShader->SetAlphaTesting( false );
 			gl_genericShader->BindProgram( 0 );
 
-			//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+			// set uniforms
+			gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 			gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 			gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -4171,10 +4164,10 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetTCGenEnvironment( false );
 		gl_genericShader->SetTCGenLightmap( false );
 		gl_genericShader->SetDepthFade( false );
-		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
-		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+		// set uniforms
+		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -4268,11 +4261,10 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetTCGenEnvironment( false );
 		gl_genericShader->SetTCGenLightmap( false );
 		gl_genericShader->SetDepthFade( false );
-		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		// set uniforms
-		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CUSTOM_RGB, alphaGen_t::AGEN_CUSTOM );
 
 		// bind u_ColorMap
@@ -4558,14 +4550,13 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetTCGenEnvironment( false );
 		gl_genericShader->SetTCGenLightmap( false );
 		gl_genericShader->SetDepthFade( false );
-		gl_genericShader->SetAlphaTesting( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -4653,7 +4644,6 @@ void DebugDrawBegin( debugDrawMode_t mode, float size ) {
 	gl_genericShader->SetTCGenEnvironment( false );
 	gl_genericShader->SetTCGenLightmap( false );
 	gl_genericShader->SetDepthFade( false );
-	gl_genericShader->SetAlphaTesting( false );
 	gl_genericShader->BindProgram( 0 );
 
 	GL_State( GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA );
@@ -4662,7 +4652,7 @@ void DebugDrawBegin( debugDrawMode_t mode, float size ) {
 	GL_VertexAttribsState( ATTR_POSITION | ATTR_COLOR | ATTR_TEXCOORD );
 
 	// set uniforms
-	//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+	gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 	gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 	gl_genericShader->SetUniform_Color( colorClear );
 
@@ -5783,13 +5773,12 @@ void RB_ShowImages()
 	gl_genericShader->SetTCGenEnvironment( false );
 	gl_genericShader->SetTCGenLightmap( false );
 	gl_genericShader->SetDepthFade( false );
-	gl_genericShader->SetAlphaTesting( false );
 	gl_genericShader->BindProgram( 0 );
 
 	GL_Cull( cullType_t::CT_TWO_SIDED );
 
 	// set uniforms
-	//gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+	gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 	gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 	gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -131,6 +131,9 @@ void Tess_StageIteratorSky()
 		// Only render the outer skybox at this stage
 		gl_skyboxShader->SetUniform_UseCloudMap( false );
 
+		// u_AlphaThreshold
+		gl_skyboxShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+
 		Tess_DrawElements();
 	}
 
@@ -150,14 +153,8 @@ void Tess_StageIteratorSky()
 
 		GL_BindToTMU( 1, pStage->bundle[TB_COLORMAP].image[0] );
 
-		uint32_t alphaTestBits = pStage->stateBits & GLS_ATEST_BITS;
-
-		gl_skyboxShader->SetAlphaTesting( alphaTestBits != 0 );
-
-		// u_AlphaTest
-		if ( alphaTestBits != 0 ) {
-			gl_skyboxShader->SetUniform_AlphaTest( pStage->stateBits );
-		}
+		// u_AlphaThreshold
+		gl_skyboxShader->SetUniform_AlphaTest( pStage->stateBits );
 
 		GL_State( pStage->stateBits );
 


### PR DESCRIPTION
There is no need to set the `USE_ALPHA_TESTING` macro if `GLS_ATEST_NONE` is set when there is no alpha testing to do, the alpha testing computation will just know there is nothing to do.

This reduces:

- GLSL shader permutation to build.
- GLSL shader changes between textures.

The cost of doing that addition and that test in all case in GLSL should be faster than switching back and forth to a GLSL shader permutation.

This also obviously simplifies code.

I noticed this when investigating this (it will _NOT_ fix it):

- https://github.com/DaemonEngine/Daemon/issues/1172

I noticed there was a difference between `generic` and `lightMapping` where `lightMapping` did not used on that `USE_ALPHA_TESTING` macro already.