### PR TITLE
Support graphics cards without `ARB_half_float_vertex`

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4615,10 +4615,18 @@ void DebugDrawVertex(const vec3_t pos, unsigned int color, const vec2_t uv) {
 	tess.verts[ tess.numVertexes ].xyz[ 1 ] = pos[ 1 ];
 	tess.verts[ tess.numVertexes ].xyz[ 2 ] = pos[ 2 ];
 	tess.verts[ tess.numVertexes ].color = colors;
+
 	if( uv ) {
-		tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( uv[ 0 ] );
-		tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( uv[ 1 ] );
+		if ( glConfig2.halfFloatVertexAvailable )
+		{
+			floatToHalf2( uv, tess.verts[ tess.numVertexes ].f16TexCoords );
+		}
+		else
+		{
+			Vector2Copy( uv, tess.verts[ tess.numVertexes ].texCoords );
+		}
 	}
+
 	tess.indexes[ tess.numIndexes ] = tess.numVertexes;
 	tess.numVertexes++;
 	tess.numIndexes++;
@@ -5006,32 +5014,42 @@ const RenderCommand *StretchPicCommand::ExecuteSelf( ) const
 	tess.verts[ numVerts ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 0 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts ].texCoords[ 1 ] = floatToHalf( t1 );
-
 	tess.verts[ numVerts + 1 ].xyz[ 0 ] = x + w;
 	tess.verts[ numVerts + 1 ].xyz[ 1 ] = y;
 	tess.verts[ numVerts + 1 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 1 ].color = backEnd.color2D;
-
-	tess.verts[ numVerts + 1 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 1 ].texCoords[ 1 ] = floatToHalf( t1 );
 
 	tess.verts[ numVerts + 2 ].xyz[ 0 ] = x + w;
 	tess.verts[ numVerts + 2 ].xyz[ 1 ] = y + h;
 	tess.verts[ numVerts + 2 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 2 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts + 2 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 2 ].texCoords[ 1 ] = floatToHalf( t2 );
-
 	tess.verts[ numVerts + 3 ].xyz[ 0 ] = x;
 	tess.verts[ numVerts + 3 ].xyz[ 1 ] = y + h;
 	tess.verts[ numVerts + 3 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 3 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts + 3 ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts + 3 ].texCoords[ 1 ] = floatToHalf( t2 );
+	if ( glConfig2.halfFloatVertexAvailable )
+	{
+		tess.verts[ numVerts ].f16TexCoords[ 0 ] = floatToHalf( s1 );
+		tess.verts[ numVerts ].f16TexCoords[ 1 ] = floatToHalf( t1 );
+
+		tess.verts[ numVerts + 1 ].f16TexCoords[ 0 ] = floatToHalf( s2 );
+		tess.verts[ numVerts + 1 ].f16TexCoords[ 1 ] = floatToHalf( t1 );
+
+		tess.verts[ numVerts + 2 ].f16TexCoords[ 0 ] = floatToHalf( s2 );
+		tess.verts[ numVerts + 2 ].f16TexCoords[ 1 ] = floatToHalf( t2 );
+
+		tess.verts[ numVerts + 3 ].f16TexCoords[ 0 ] = floatToHalf( s1 );
+		tess.verts[ numVerts + 3 ].f16TexCoords[ 1 ] = floatToHalf( t2 );
+	}
+	else
+	{
+		Vector2Set( tess.verts[ numVerts ].texCoords, s1, t1 );
+		Vector2Set( tess.verts[ numVerts + 1 ].texCoords, s2, t1 );
+		Vector2Set( tess.verts[ numVerts + 2 ].texCoords, s2, t2 );
+		Vector2Set( tess.verts[ numVerts + 3 ].texCoords, s1, t2 );
+	}
 
 	return this + 1;
 }
@@ -5085,8 +5103,14 @@ const RenderCommand *Poly2dCommand::ExecuteSelf( ) const
 		tess.verts[ tess.numVertexes ].xyz[ 1 ] = verts[ i ].xyz[ 1 ];
 		tess.verts[ tess.numVertexes ].xyz[ 2 ] = 0.0f;
 
-		tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( verts[ i ].st[ 0 ] );
-		tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( verts[ i ].st[ 1 ] );
+		if ( glConfig2.halfFloatVertexAvailable )
+		{
+			floatToHalf2( verts[ i ].st, tess.verts[ tess.numVertexes ].f16TexCoords );
+		}
+		else
+		{
+			Vector2Copy( verts[ i ].st, tess.verts[ tess.numVertexes ].texCoords );
+		}
 
 		tess.verts[ tess.numVertexes ].color = Color::Adapt( verts[ i ].modulate );
 		tess.numVertexes++;
@@ -5142,8 +5166,14 @@ const RenderCommand *Poly2dIndexedCommand::ExecuteSelf( ) const
 		tess.verts[ tess.numVertexes ].xyz[ 1 ] = verts[ i ].xyz[ 1 ] + translation[ 1 ];
 		tess.verts[ tess.numVertexes ].xyz[ 2 ] = 0.0f;
 
-		tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( verts[ i ].st[ 0 ] );
-		tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( verts[ i ].st[ 1 ] );
+		if ( glConfig2.halfFloatVertexAvailable )
+		{
+			floatToHalf2( verts[ i ].st, tess.verts[ tess.numVertexes ].f16TexCoords );
+		}
+		else
+		{
+			Vector2Copy( verts[ i ].st, tess.verts[ tess.numVertexes ].texCoords );
+		}
 
 		tess.verts[ tess.numVertexes ].color = Color::Adapt( verts[ i ].modulate );
 		tess.numVertexes++;
@@ -5245,32 +5275,42 @@ const RenderCommand *RotatedPicCommand::ExecuteSelf( ) const
 	tess.verts[ numVerts ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 0 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts ].texCoords[ 1 ] = floatToHalf( t1 );
-
 	tess.verts[ numVerts + 1 ].xyz[ 0 ] = mx + cw - sh;
 	tess.verts[ numVerts + 1 ].xyz[ 1 ] = my - sw - ch;
 	tess.verts[ numVerts + 1 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 1 ].color = backEnd.color2D;
-
-	tess.verts[ numVerts + 1 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 1 ].texCoords[ 1 ] = floatToHalf( t1 );
 
 	tess.verts[ numVerts + 2 ].xyz[ 0 ] = mx + cw + sh;
 	tess.verts[ numVerts + 2 ].xyz[ 1 ] = my - sw + ch;
 	tess.verts[ numVerts + 2 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 2 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts + 2 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 2 ].texCoords[ 1 ] = floatToHalf( t2 );
-
 	tess.verts[ numVerts + 3 ].xyz[ 0 ] = mx - cw + sh;
 	tess.verts[ numVerts + 3 ].xyz[ 1 ] = my + sw + ch;
 	tess.verts[ numVerts + 3 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 3 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts + 3 ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts + 3 ].texCoords[ 1 ] = floatToHalf( t2 );
+	if ( glConfig2.halfFloatVertexAvailable )
+	{
+		tess.verts[ numVerts ].f16TexCoords[ 0 ] = floatToHalf( s1 );
+		tess.verts[ numVerts ].f16TexCoords[ 1 ] = floatToHalf( t1 );
+
+		tess.verts[ numVerts + 1 ].f16TexCoords[ 0 ] = floatToHalf( s2 );
+		tess.verts[ numVerts + 1 ].f16TexCoords[ 1 ] = floatToHalf( t1 );
+
+		tess.verts[ numVerts + 2 ].f16TexCoords[ 0 ] = floatToHalf( s2 );
+		tess.verts[ numVerts + 2 ].f16TexCoords[ 1 ] = floatToHalf( t2 );
+
+		tess.verts[ numVerts + 3 ].f16TexCoords[ 0 ] = floatToHalf( s1 );
+		tess.verts[ numVerts + 3 ].f16TexCoords[ 1 ] = floatToHalf( t2 );
+	}
+	else
+	{
+		Vector2Set( tess.verts[ numVerts ].texCoords, s1, t1 );
+		Vector2Set( tess.verts[ numVerts + 1 ].texCoords, s2, t1 );
+		Vector2Set( tess.verts[ numVerts + 2 ].texCoords, s2, t2 );
+		Vector2Set( tess.verts[ numVerts + 3 ].texCoords, s1, t2 );
+	}
 
 	return this + 1;
 }
@@ -5329,29 +5369,39 @@ const RenderCommand *GradientPicCommand::ExecuteSelf( ) const
 	tess.verts[ numVerts ].xyz[ 1 ] = y;
 	tess.verts[ numVerts ].xyz[ 2 ] = 0.0f;
 
-	tess.verts[ numVerts ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts ].texCoords[ 1 ] = floatToHalf( t1 );
-
 	tess.verts[ numVerts + 1 ].xyz[ 0 ] = x + w;
 	tess.verts[ numVerts + 1 ].xyz[ 1 ] = y;
 	tess.verts[ numVerts + 1 ].xyz[ 2 ] = 0.0f;
-
-	tess.verts[ numVerts + 1 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 1 ].texCoords[ 1 ] = floatToHalf( t1 );
 
 	tess.verts[ numVerts + 2 ].xyz[ 0 ] = x + w;
 	tess.verts[ numVerts + 2 ].xyz[ 1 ] = y + h;
 	tess.verts[ numVerts + 2 ].xyz[ 2 ] = 0.0f;
 
-	tess.verts[ numVerts + 2 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 2 ].texCoords[ 1 ] = floatToHalf( t2 );
-
 	tess.verts[ numVerts + 3 ].xyz[ 0 ] = x;
 	tess.verts[ numVerts + 3 ].xyz[ 1 ] = y + h;
 	tess.verts[ numVerts + 3 ].xyz[ 2 ] = 0.0f;
 
-	tess.verts[ numVerts + 3 ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts + 3 ].texCoords[ 1 ] = floatToHalf( t2 );
+	if ( glConfig2.halfFloatVertexAvailable )
+	{
+		tess.verts[ numVerts ].f16TexCoords[ 0 ] = floatToHalf( s1 );
+		tess.verts[ numVerts ].f16TexCoords[ 1 ] = floatToHalf( t1 );
+
+		tess.verts[ numVerts + 1 ].f16TexCoords[ 0 ] = floatToHalf( s2 );
+		tess.verts[ numVerts + 1 ].f16TexCoords[ 1 ] = floatToHalf( t1 );
+
+		tess.verts[ numVerts + 2 ].f16TexCoords[ 0 ] = floatToHalf( s2 );
+		tess.verts[ numVerts + 2 ].f16TexCoords[ 1 ] = floatToHalf( t2 );
+
+		tess.verts[ numVerts + 3 ].f16TexCoords[ 0 ] = floatToHalf( s1 );
+		tess.verts[ numVerts + 3 ].f16TexCoords[ 1 ] = floatToHalf( t2 );
+	}
+	else
+	{
+		Vector2Set( tess.verts[ numVerts ].texCoords, s1, t1 );
+		Vector2Set( tess.verts[ numVerts + 1 ].texCoords, s2, t1 );
+		Vector2Set( tess.verts[ numVerts + 2 ].texCoords, s2, t2 );
+		Vector2Set( tess.verts[ numVerts + 3 ].texCoords, s1, t2 );
+	}
 
 	return this + 1;
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1016,6 +1016,15 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			Log::Notice("%sMissing OpenGL extensions: %s", Color::ToString( Color::Red ), glConfig2.glMissingExtensionsString );
 		}
 
+		if ( glConfig2.halfFloatVertexAvailable )
+		{
+			Log::Notice("%sUsing half-float vertex format.", Color::ToString( Color::Green ));
+		}
+		else
+		{
+			Log::Notice("%sMissing half-float vertex format.", Color::ToString( Color::Red ));
+		}
+
 		if ( glConfig.hardwareType == glHardwareType_t::GLHW_R300 )
 		{
 			Log::Notice("%sUsing ATI R300 approximations.", Color::ToString( Color::Red ));

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -138,7 +138,7 @@ static inline void floatToHalf2( const vec2_t in, f16vec2_t out )
 	out[ 1 ] = floatToHalf( in[ 1 ] );
 }
 
-static inline void floatToHalf( const vec4_t in, f16vec4_t out )
+static inline void floatToHalf4( const vec4_t in, f16vec4_t out )
 {
 	out[ 0 ] = floatToHalf( in[ 0 ] );
 	out[ 1 ] = floatToHalf( in[ 1 ] );
@@ -159,7 +159,7 @@ static inline void halfToFloat2( const f16vec2_t in, vec2_t out )
 	out[ 1 ] = halfToFloat( in[ 1 ] );
 }
 
-static inline void halfToFloat( const f16vec4_t in, vec4_t out )
+static inline void halfToFloat4( const f16vec4_t in, vec4_t out )
 {
 	out[ 0 ] = halfToFloat( in[ 0 ] );
 	out[ 1 ] = halfToFloat( in[ 1 ] );

--- a/src/engine/renderer/tr_model_iqm.cpp
+++ b/src/engine/renderer/tr_model_iqm.cpp
@@ -481,7 +481,7 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 	size += header->num_vertexes * 3 * sizeof(float);	// normals
 	size += header->num_vertexes * 3 * sizeof(float);	// tangents
 	size += header->num_vertexes * 3 * sizeof(float);	// bitangents
-	size += header->num_vertexes * 2 * sizeof(f16_t);	// texcoords
+	size += header->num_vertexes * 2 * sizeof(f16_t);	// f16TexCoords
 	size += header->num_vertexes * 4 * sizeof(byte);	// blendIndexes
 	size += header->num_vertexes * 4 * sizeof(byte);	// blendWeights
 	size += header->num_vertexes * 4 * sizeof(byte);	// colors
@@ -541,8 +541,8 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 	IQModel->bitangents = (float *)ptr;
 	ptr = IQModel->bitangents + 3 * header->num_vertexes;
 
-	IQModel->texcoords = (f16_t *)ptr;
-	ptr = IQModel->texcoords + 2 * header->num_vertexes;
+	IQModel->f16TexCoords = (f16_t *)ptr;
+	ptr = IQModel->f16TexCoords + 2 * header->num_vertexes;
 
 	IQModel->blendIndexes = (byte *)ptr;
 	ptr = IQModel->blendIndexes + 4 * header->num_vertexes;
@@ -725,7 +725,7 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 			break;
 		case IQM_TEXCOORD:
 			for( int j = 0; j < n; j++ ) {
-				IQModel->texcoords[ j ] = floatToHalf( ((float *)IQMPtr( header, vertexarray->offset ))[ j ] );
+				IQModel->f16TexCoords[ j ] = floatToHalf( ((float *)IQMPtr( header, vertexarray->offset ))[ j ] );
 			}
 			break;
 		case IQM_BLENDINDEXES:
@@ -803,7 +803,7 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 		vboData.qtangent = qtangentbuf;
 		vboData.numFrames = 0;
 		vboData.color = (u8vec4_t *)IQModel->colors;
-		vboData.st = (f16vec2_t *)IQModel->texcoords;
+		vboData.f16st = (f16vec2_t *)IQModel->f16TexCoords;
 		vboData.boneIndexes = (int (*)[4])indexbuf;
 		vboData.boneWeights = (vec4_t *)weightbuf;
 		vboData.numVerts = IQModel->num_vertexes;

--- a/src/engine/renderer/tr_model_md3.cpp
+++ b/src/engine/renderer/tr_model_md3.cpp
@@ -258,7 +258,7 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 			data.xyz = ( vec3_t * ) ri.Hunk_AllocateTempMemory( sizeof( *data.xyz ) * mdvModel->numFrames * surf->numVerts );
 			data.qtangent = ( i16vec4_t * ) ri.Hunk_AllocateTempMemory( sizeof( i16vec4_t ) * mdvModel->numFrames * surf->numVerts );
 			data.numFrames = mdvModel->numFrames;
-			data.st = ( f16vec2_t * ) ri.Hunk_AllocateTempMemory( sizeof( f16vec2_t ) * surf->numVerts );
+			data.f16st = ( f16vec2_t * ) ri.Hunk_AllocateTempMemory( sizeof( f16vec2_t ) * surf->numVerts );
 			data.numVerts = surf->numVerts;
 
 			// feed vertex XYZ
@@ -273,8 +273,7 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 			// feed vertex texcoords
 			for ( j = 0; j < surf->numVerts; j++ )
 			{
-				data.st[ j ][ 0 ] = floatToHalf( surf->st[ j ].st[ 0 ] );
-				data.st[ j ][ 1 ] = floatToHalf( surf->st[ j ].st[ 1 ] );
+				floatToHalf2( surf->st[ j ].st, data.f16st[ j ] );
 			}
 
 			// calc and feed tangent spaces
@@ -351,7 +350,7 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 			// vertex layout includes a color field, which is zeroed by default.
 			vboSurf->vbo->attribBits |= ATTR_COLOR;
 			
-			ri.Hunk_FreeTempMemory( data.st );
+			ri.Hunk_FreeTempMemory( data.f16st );
 			ri.Hunk_FreeTempMemory( data.qtangent );
 			ri.Hunk_FreeTempMemory( data.xyz );
 

--- a/src/engine/renderer/tr_model_md5.cpp
+++ b/src/engine/renderer/tr_model_md5.cpp
@@ -380,7 +380,7 @@ bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 			{
 				token = COM_ParseExt2( &buf_p, false );
 				texCoords[ j ][ k ] = atof( token );
-				v->texCoords[ k ] = floatToHalf( texCoords[ j ][ k ] );
+				v->f16TexCoords[ k ] = floatToHalf( texCoords[ j ][ k ] );
 			}
 
 			// skip )

--- a/src/engine/renderer/tr_model_skel.cpp
+++ b/src/engine/renderer/tr_model_skel.cpp
@@ -124,7 +124,7 @@ srfVBOMD5Mesh_t *R_GenerateMD5VBOSurface(
 	data.qtangent = ( i16vec4_t * ) ri.Hunk_AllocateTempMemory( sizeof( i16vec4_t ) * vertexesNum );
 	data.boneIndexes = ( int (*)[ 4 ] ) ri.Hunk_AllocateTempMemory( sizeof( *data.boneIndexes ) * vertexesNum );
 	data.boneWeights = ( vec4_t * ) ri.Hunk_AllocateTempMemory( sizeof( *data.boneWeights ) * vertexesNum );
-	data.st = ( f16vec2_t * ) ri.Hunk_AllocateTempMemory( sizeof( f16vec2_t ) * vertexesNum );
+	data.f16st = ( f16vec2_t * ) ri.Hunk_AllocateTempMemory( sizeof( f16vec2_t ) * vertexesNum );
 	data.numVerts = vertexesNum;
 
 	indexes = ( glIndex_t * ) ri.Hunk_AllocateTempMemory( indexesNum * sizeof( glIndex_t ) );
@@ -160,7 +160,8 @@ srfVBOMD5Mesh_t *R_GenerateMD5VBOSurface(
 		R_TBNtoQtangents( surf->verts[ j ].tangent, surf->verts[ j ].binormal,
 				  surf->verts[ j ].normal, data.qtangent[ j ] );
 		
-		Vector2Copy( surf->verts[ j ].texCoords, data.st[ j ] );
+		// Model only supports half float for now.
+		Vector2Copy( surf->verts[ j ].f16TexCoords, data.f16st[ j ] );
 
 		for (unsigned k = 0; k < MAX_WEIGHTS; k++ )
 		{
@@ -186,7 +187,7 @@ srfVBOMD5Mesh_t *R_GenerateMD5VBOSurface(
 	vboSurf->vbo->attribBits |= ATTR_COLOR;
 
 	ri.Hunk_FreeTempMemory( indexes );
-	ri.Hunk_FreeTempMemory( data.st );
+	ri.Hunk_FreeTempMemory( data.f16st );
 	ri.Hunk_FreeTempMemory( data.boneWeights );
 	ri.Hunk_FreeTempMemory( data.boneIndexes );
 	ri.Hunk_FreeTempMemory( data.qtangent );

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -47,6 +47,7 @@ extern Cvar::Modified<Cvar::Cvar<bool>> r_fullscreen;
 struct glconfig2_t
 {
 	bool textureCompressionRGTCAvailable;
+	bool halfFloatVertexAvailable;
 
 	int glHighestMajor;
 	int glHighestMinor;

--- a/src/engine/renderer/tr_shade_calc.cpp
+++ b/src/engine/renderer/tr_shade_calc.cpp
@@ -487,7 +487,7 @@ static void ComputeCorner( int firstVertex, int numVertexes )
 			for( int j = 0; j < 4; j++ )
 			{
 				vec4_t &tc = tcs[ j ];
-				halfToFloat( v[ j ].f16TexCoords, tc );
+				halfToFloat4( v[ j ].f16TexCoords, tc );
 				VectorAdd( tc, midtc, midtc );
 				midtc[ 3 ] += tc[ 3 ];
 			}
@@ -506,7 +506,7 @@ static void ComputeCorner( int firstVertex, int numVertexes )
 				{
 					tc[ 3 ] = -tc[ 3 ];
 				}
-				floatToHalf( tc, v[ j ].f16TexCoords );
+				floatToHalf4( tc, v[ j ].f16TexCoords );
 			}
 		}
 		else
@@ -583,7 +583,7 @@ static void AutospriteDeform( int firstVertex, int numVertexes, int numIndexes )
 		if ( glConfig2.halfFloatVertexAvailable )
 		{
 			f16vec4_t f16Orientation;
-			floatToHalf( orientation, f16Orientation );
+			floatToHalf4( orientation, f16Orientation );
 
 			Vector4Copy( f16Orientation, v[ 0 ].f16SpriteOrientation );
 			Vector4Copy( f16Orientation, v[ 1 ].f16SpriteOrientation );
@@ -740,7 +740,7 @@ static void Autosprite2Deform( int firstVertex, int numVertexes, int numIndexes 
 
 			if ( glConfig2.halfFloatVertexAvailable )
 			{
-				floatToHalf( orientation, v1->f16SpriteOrientation );
+				floatToHalf4( orientation, v1->f16SpriteOrientation );
 			}
 			else
 			{

--- a/src/engine/renderer/tr_shade_calc.cpp
+++ b/src/engine/renderer/tr_shade_calc.cpp
@@ -473,43 +473,31 @@ quads, rebuild them as forward facing sprites
 */
 static void ComputeCorner( int firstVertex, int numVertexes )
 {
-	int i, j;
-	shaderVertex_t *v;
-	vec4_t tc, midtc;
-
-	for ( i = 0; i < numVertexes; i += 4 ) {
+	for ( int i = 0; i < numVertexes; i += 4 ) {
 		// find the midpoint
-		v = &tess.verts[ firstVertex + i ];
+		shaderVertex_t *v = &tess.verts[ firstVertex + i ];
 
+		vec4_t midtc;
 		Vector4Set( midtc, 0.0f, 0.0f, 0.0f, 0.0f );
 
 		if ( glConfig2.halfFloatVertexAvailable )
 		{
-			for( j = 0; j < 4; j++ )
+			vec4_t tcs[ 4 ];
+
+			for( int j = 0; j < 4; j++ )
 			{
+				vec4_t &tc = tcs[ j ];
 				halfToFloat( v[ j ].f16TexCoords, tc );
 				VectorAdd( tc, midtc, midtc );
 				midtc[ 3 ] += tc[ 3 ];
 			}
-		}
-		else
-		{
-			for( j = 0; j < 4; j++ )
-			{
-				Vector4Copy( v[ j ].texCoords, tc );
-				VectorAdd( tc, midtc, midtc );
-				midtc[ 3 ] += tc[ 3 ];
-			}
-		}
 
-		midtc[ 0 ] = 0.25f * midtc[ 0 ];
-		midtc[ 1 ] = 0.25f * midtc[ 1 ];
+			midtc[ 0 ] = 0.25f * midtc[ 0 ];
+			midtc[ 1 ] = 0.25f * midtc[ 1 ];
 
-		if ( glConfig2.halfFloatVertexAvailable )
-		{
-			for ( j = 0; j < 4; j++ )
+			for ( int j = 0; j < 4; j++ )
 			{
-				halfToFloat( v[ j ].f16TexCoords, tc );
+				vec4_t &tc = tcs[ j ];
 				if( tc[ 0 ] < midtc[ 0 ] )
 				{
 					tc[ 2 ] = -tc[ 2 ];
@@ -523,7 +511,19 @@ static void ComputeCorner( int firstVertex, int numVertexes )
 		}
 		else
 		{
-			for ( j = 0; j < 4; j++ )
+			vec4_t tc;
+
+			for( int j = 0; j < 4; j++ )
+			{
+				Vector4Copy( v[ j ].texCoords, tc );
+				VectorAdd( tc, midtc, midtc );
+				midtc[ 3 ] += tc[ 3 ];
+			}
+
+			midtc[ 0 ] = 0.25f * midtc[ 0 ];
+			midtc[ 1 ] = 0.25f * midtc[ 1 ];
+
+			for ( int j = 0; j < 4; j++ )
 			{
 				Vector4Copy( v[ j ].texCoords, tc );
 				if( tc[ 0 ] < midtc[ 0 ] )

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -476,8 +476,8 @@ void Tess_AddSprite( const vec3_t center, const Color::Color32Bit color, float r
 
 		if ( glConfig2.halfFloatVertexAvailable )
 		{
-			floatToHalf( texCoord, tess.verts[ ndx + i ].f16TexCoords );
-			floatToHalf( orientation, tess.verts[ ndx + i ].f16SpriteOrientation );
+			floatToHalf4( texCoord, tess.verts[ ndx + i ].f16TexCoords );
+			floatToHalf4( orientation, tess.verts[ ndx + i ].f16SpriteOrientation );
 		}
 		else
 		{

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -159,11 +159,22 @@ static void Tess_SurfaceVertsAndTris( const srfVert_t *verts, const srfTriangle_
 		VectorCopy( vert->xyz, tess.verts[ tess.numVertexes + i ].xyz );
 		Vector4Copy( vert->qtangent, tess.verts[ tess.numVertexes + i ].qtangents );
 
-		tess.verts[ tess.numVertexes + i ].texCoords[ 0 ] = floatToHalf( vert->st[ 0 ] );
-		tess.verts[ tess.numVertexes + i ].texCoords[ 1 ] = floatToHalf( vert->st[ 1 ] );
+		if ( glConfig2.halfFloatVertexAvailable )
+		{
+			tess.verts[ tess.numVertexes + i ].f16TexCoords[ 0 ] = floatToHalf( vert->st[ 0 ] );
+			tess.verts[ tess.numVertexes + i ].f16TexCoords[ 1 ] = floatToHalf( vert->st[ 1 ] );
 
-		tess.verts[ tess.numVertexes + i ].texCoords[ 2 ] = floatToHalf( vert->lightmap[ 0 ] );
-		tess.verts[ tess.numVertexes + i ].texCoords[ 3 ] = floatToHalf( vert->lightmap[ 1 ] );
+			tess.verts[ tess.numVertexes + i ].f16TexCoords[ 2 ] = floatToHalf( vert->lightmap[ 0 ] );
+			tess.verts[ tess.numVertexes + i ].f16TexCoords[ 3 ] = floatToHalf( vert->lightmap[ 1 ] );
+		}
+		else
+		{
+			tess.verts[ tess.numVertexes + i ].texCoords[ 0 ] = vert->st[ 0 ];
+			tess.verts[ tess.numVertexes + i ].texCoords[ 1 ] = vert->st[ 1 ];
+
+			tess.verts[ tess.numVertexes + i ].texCoords[ 2 ] = vert->lightmap[ 0 ];
+			tess.verts[ tess.numVertexes + i ].texCoords[ 3 ] = vert->lightmap[ 1 ];
+		}
 
 		tess.verts[ tess.numVertexes + i ].color = vert->lightColor;
 	}
@@ -280,17 +291,27 @@ void Tess_AddQuadStampExt( vec3_t origin, vec3_t left, vec3_t up, const Color::C
 	Vector4Copy( qtangents, tess.verts[ ndx + 3 ].qtangents );
 
 	// standard square texture coordinates
-	tess.verts[ ndx ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ ndx ].texCoords[ 1 ] = floatToHalf( t1 );
+	if ( glConfig2.halfFloatVertexAvailable )
+	{
+		tess.verts[ ndx ].f16TexCoords[ 0 ] = floatToHalf( s1 );
+		tess.verts[ ndx ].f16TexCoords[ 1 ] = floatToHalf( t1 );
 
-	tess.verts[ ndx + 1 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ ndx + 1 ].texCoords[ 1 ] = floatToHalf( t1 );
+		tess.verts[ ndx + 1 ].f16TexCoords[ 0 ] = floatToHalf( s2 );
+		tess.verts[ ndx + 1 ].f16TexCoords[ 1 ] = floatToHalf( t1 );
 
-	tess.verts[ ndx + 2 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ ndx + 2 ].texCoords[ 1 ] = floatToHalf( t2 );
+		tess.verts[ ndx + 2 ].f16TexCoords[ 0 ] = floatToHalf( s2 );
+		tess.verts[ ndx + 2 ].f16TexCoords[ 1 ] = floatToHalf( t2 );
 
-	tess.verts[ ndx + 3 ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ ndx + 3 ].texCoords[ 1 ] = floatToHalf( t2 );
+		tess.verts[ ndx + 3 ].f16TexCoords[ 0 ] = floatToHalf( s1 );
+		tess.verts[ ndx + 3 ].f16TexCoords[ 1 ] = floatToHalf( t2 );
+	}
+	else
+	{
+		Vector2Set( tess.verts[ ndx ].texCoords, s1, t1 );
+		Vector2Set( tess.verts[ ndx + 1 ].texCoords, s2, t1 );
+		Vector2Set( tess.verts[ ndx + 2 ].texCoords, s2, t2 );
+		Vector2Set( tess.verts[ ndx + 3 ].texCoords, s1, t2 );
+	}
 
 	// constant color all the way around
 	// should this be identity and let the shader specify from entity?
@@ -370,17 +391,27 @@ void Tess_AddQuadStampExt2( vec4_t quadVerts[ 4 ], const Color::Color& color, fl
 	Vector4Copy( qtangents, tess.verts[ ndx + 3 ].qtangents );
 
 	// standard square texture coordinates
-	tess.verts[ ndx ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ ndx ].texCoords[ 1 ] = floatToHalf( t1 );
+	if ( glConfig2.halfFloatVertexAvailable )
+	{
+		tess.verts[ ndx ].f16TexCoords[ 0 ] = floatToHalf( s1 );
+		tess.verts[ ndx ].f16TexCoords[ 1 ] = floatToHalf( t1 );
 
-	tess.verts[ ndx + 1 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ ndx + 1 ].texCoords[ 1 ] = floatToHalf( t1 );
+		tess.verts[ ndx + 1 ].f16TexCoords[ 0 ] = floatToHalf( s2 );
+		tess.verts[ ndx + 1 ].f16TexCoords[ 1 ] = floatToHalf( t1 );
 
-	tess.verts[ ndx + 2 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ ndx + 2 ].texCoords[ 1 ] = floatToHalf( t2 );
+		tess.verts[ ndx + 2 ].f16TexCoords[ 0 ] = floatToHalf( s2 );
+		tess.verts[ ndx + 2 ].f16TexCoords[ 1 ] = floatToHalf( t2 );
 
-	tess.verts[ ndx + 3 ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ ndx + 3 ].texCoords[ 1 ] = floatToHalf( t2 );
+		tess.verts[ ndx + 3 ].f16TexCoords[ 0 ] = floatToHalf( s1 );
+		tess.verts[ ndx + 3 ].f16TexCoords[ 1 ] = floatToHalf( t2 );
+	}
+	else
+	{
+		Vector2Set( tess.verts[ ndx ].texCoords, s1, t1 );
+		Vector2Set( tess.verts[ ndx + 1 ].texCoords, s2, t1 );
+		Vector2Set( tess.verts[ ndx + 2 ].texCoords, s2, t2 );
+		Vector2Set( tess.verts[ ndx + 3 ].texCoords, s1, t2 );
+	}
 
 	// constant color all the way around
 	// should this be identity and let the shader specify from entity?
@@ -434,16 +465,25 @@ void Tess_AddSprite( const vec3_t center, const Color::Color32Bit color, float r
 	for ( i = 0; i < 4; i++ )
 	{
 		vec4_t texCoord;
-		vec4_t orientation;
-
 		Vector4Set( texCoord, 0.5f * (i & 2), 0.5f * ( (i + 1) & 2 ),
 			    (i & 2) - 1.0f, ( (i + 1) & 2 ) - 1.0f );
 
 		VectorCopy( center, tess.verts[ ndx + i ].xyz );
 		tess.verts[ ndx + i ].color = color;
-		floatToHalf( texCoord, tess.verts[ ndx + i ].texCoords );
+
+		vec4_t orientation;
 		Vector4Set( orientation, rotation, 0.0f, 0.0f, radius );
-		floatToHalf( orientation, tess.verts[ ndx + i ].spriteOrientation );
+
+		if ( glConfig2.halfFloatVertexAvailable )
+		{
+			floatToHalf( texCoord, tess.verts[ ndx + i ].f16TexCoords );
+			floatToHalf( orientation, tess.verts[ ndx + i ].f16SpriteOrientation );
+		}
+		else
+		{
+			Vector4Copy( texCoord, tess.verts[ ndx + i ].texCoords );
+			Vector4Copy( orientation, tess.verts[ ndx + i ].spriteOrientation );
+		}
 	}
 
 	tess.numVertexes += 4;
@@ -692,8 +732,15 @@ static void Tess_SurfacePolychain( srfPoly_t *p )
 			VectorCopy(p->verts[i].xyz, tess.verts[tess.numVertexes + i].xyz);
 
 			tess.verts[tess.numVertexes + i].color = Color::Adapt(p->verts[i].modulate);
-			tess.verts[tess.numVertexes + i].texCoords[0] = floatToHalf(p->verts[i].st[0]);
-			tess.verts[tess.numVertexes + i].texCoords[1] = floatToHalf(p->verts[i].st[1]);
+
+			if ( glConfig2.halfFloatVertexAvailable )
+			{
+				floatToHalf2( p->verts[i].st, tess.verts[tess.numVertexes + i].f16TexCoords );
+			}
+			else
+			{
+				Vector2Copy( p->verts[i].st, tess.verts[tess.numVertexes + i].texCoords );
+			}
 		}
 
 		// generate fan indexes into the tess array
@@ -761,8 +808,15 @@ static void Tess_SurfacePolychain( srfPoly_t *p )
 			VectorCopy(p->verts[i].xyz, tess.verts[tess.numVertexes + i].xyz);
 			tess.verts[tess.numVertexes + i].color = Color::Adapt(p->verts[i].modulate);
 			Vector4Copy(qtangents, tess.verts[tess.numVertexes + i].qtangents);
-			tess.verts[tess.numVertexes + i].texCoords[0] = floatToHalf(p->verts[i].st[0]);
-			tess.verts[tess.numVertexes + i].texCoords[1] = floatToHalf(p->verts[i].st[1]);
+
+			if ( glConfig2.halfFloatVertexAvailable )
+			{
+				floatToHalf2( p->verts[i].st, tess.verts[tess.numVertexes + i].f16TexCoords );
+			}
+			else
+			{
+				Vector2Copy( p->verts[i].st, tess.verts[tess.numVertexes + i].texCoords );
+			}
 		}
 
 		ri.Hunk_FreeTempMemory( normals );
@@ -895,8 +949,14 @@ static void Tess_SurfaceMDV( mdvSurface_t *srf )
 			tess.verts[tess.numVertexes + j].xyz[1] = tmpVert[1];
 			tess.verts[tess.numVertexes + j].xyz[2] = tmpVert[2];
 
-			tess.verts[tess.numVertexes + j].texCoords[0] = floatToHalf(st->st[0]);
-			tess.verts[tess.numVertexes + j].texCoords[1] = floatToHalf(st->st[1]);
+			if ( glConfig2.halfFloatVertexAvailable )
+			{
+				floatToHalf2( st->st, tess.verts[tess.numVertexes + j].f16TexCoords );
+			}
+			else
+			{
+				Vector2Copy( st->st, tess.verts[tess.numVertexes + j].texCoords );
+			}
 		}
 	}
 	else
@@ -979,8 +1039,15 @@ static void Tess_SurfaceMDV( mdvSurface_t *srf )
 
 			VectorCopy(xyz[i], tess.verts[tess.numVertexes + i].xyz);
 			Vector4Copy(qtangents, tess.verts[tess.numVertexes + i].qtangents);
-			tess.verts[tess.numVertexes + i].texCoords[0] = floatToHalf(st[i].st[0]);
-			tess.verts[tess.numVertexes + i].texCoords[1] = floatToHalf(st[i].st[1]);
+
+			if ( glConfig2.halfFloatVertexAvailable )
+			{
+				floatToHalf2( st[i].st, tess.verts[tess.numVertexes + i].f16TexCoords );
+			}
+			else
+			{
+				Vector2Copy( st[i].st, tess.verts[tess.numVertexes + i].texCoords );
+			}
 		}
 
 		ri.Hunk_FreeTempMemory( normals );
@@ -1090,7 +1157,14 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 
 			VectorCopy( position, tessVertex->xyz );
 
-			Vector2Copy( surfaceVertex->texCoords, tessVertex->texCoords );
+			if ( glConfig2.halfFloatVertexAvailable )
+			{
+				Vector2Copy( surfaceVertex->f16TexCoords, tessVertex->f16TexCoords );
+			}
+			else
+			{
+				halfToFloat2( surfaceVertex->f16TexCoords, tessVertex->texCoords );
+			}
 		}
 	}
 	else
@@ -1133,7 +1207,14 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 
 			R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
 
-			Vector2Copy( surfaceVertex->texCoords, tessVertex->texCoords );
+			if ( glConfig2.halfFloatVertexAvailable )
+			{
+				Vector2Copy( surfaceVertex->f16TexCoords, tessVertex->f16TexCoords );
+			}
+			else
+			{
+				halfToFloat2( surfaceVertex->f16TexCoords, tessVertex->texCoords );
+			}
 		}
 	}
 
@@ -1250,7 +1331,8 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 	float *modelNormal = model->normals + 3 * firstVertex;
 	float *modelTangent = model->tangents + 3 * firstVertex;
 	float *modelBitangent = model->bitangents + 3 * firstVertex;
-	f16_t *modelTexcoord = model->texcoords + 2 * firstVertex;
+	// Model only supports half float for now.
+	f16_t *f16ModelTexCoords = model->f16TexCoords + 2 * firstVertex;
 	shaderVertex_t *tessVertex = tess.verts + tess.numVertexes;
 	shaderVertex_t *lastVertex = tessVertex + surf->num_vertexes;
 
@@ -1267,7 +1349,7 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 			for ( ; tessVertex < lastVertex; tessVertex++,
 				modelPosition += 3, modelNormal += 3,
 				modelTangent += 3, modelBitangent += 3,
-				modelTexcoord += 2 )
+				f16ModelTexCoords += 2 )
 			{
 				vec3_t position = {};
 
@@ -1290,7 +1372,14 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 				VectorCopy( position, tessVertex->xyz );
 
-				Vector2Copy( modelTexcoord, tessVertex->texCoords );
+				if ( glConfig2.halfFloatVertexAvailable )
+				{
+					Vector2Copy( f16ModelTexCoords, tessVertex->f16TexCoords );
+				}
+				else
+				{
+					halfToFloat2( f16ModelTexCoords, tessVertex->texCoords );
+				}
 			}
 		}
 		else
@@ -1301,7 +1390,7 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 			for ( ; tessVertex < lastVertex; tessVertex++,
 				modelPosition += 3, modelNormal += 3,
 				modelTangent += 3, modelBitangent += 3,
-				modelTexcoord += 2 )
+				f16ModelTexCoords += 2 )
 			{
 				vec3_t position = {}, tangent = {}, binormal = {}, normal = {};
 
@@ -1338,7 +1427,14 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 				R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
 
-				Vector2Copy( modelTexcoord, tessVertex->texCoords );
+				if ( glConfig2.halfFloatVertexAvailable )
+				{
+					Vector2Copy( f16ModelTexCoords, tessVertex->f16TexCoords );
+				}
+				else
+				{
+					halfToFloat2( f16ModelTexCoords, tessVertex->texCoords );
+				}
 			}
 		}
 	}
@@ -1349,13 +1445,20 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 		for ( ; tessVertex < lastVertex; tessVertex++,
 			modelPosition += 3, modelNormal += 3,
 			modelTangent += 3, modelBitangent += 3,
-			modelTexcoord += 2 )
+			f16ModelTexCoords += 2 )
 		{
 			VectorScale( modelPosition, scale, tessVertex->xyz );
 
 			R_TBNtoQtangents( modelTangent, modelBitangent, modelNormal, tessVertex->qtangents );
 
-			Vector2Copy( modelTexcoord, tessVertex->texCoords );
+			if ( glConfig2.halfFloatVertexAvailable )
+			{
+				Vector2Copy( f16ModelTexCoords, tessVertex->f16TexCoords );
+			}
+			else
+			{
+				halfToFloat2( f16ModelTexCoords, tessVertex->texCoords );
+			}
 		}
 	}
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -78,6 +78,8 @@ static Cvar::Cvar<bool> r_arb_gpu_shader5( "r_arb_gpu_shader5",
 	"Use GL_ARB_gpu_shader5 if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_half_float_pixel( "r_arb_half_float_pixel",
 	"Use GL_ARB_half_float_pixel if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_half_float_vertex( "r_arb_half_float_vertex",
+	"Use GL_ARB_half_float_vertex if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_indirect_parameters( "r_arb_indirect_parameters",
 	"Use GL_ARB_indirect_parameters if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_internalformat_query2( "r_arb_internalformat_query2",
@@ -1943,6 +1945,7 @@ static bool LoadExt( int flags, bool hasExt, const char* name, bool test = true 
 
 #define LOAD_EXTENSION_WITH_TEST(flags, ext, test) LoadExt(flags, GLEW_##ext, #ext, test)
 
+glVertexShim_t GL_vertexShim;
 glFboShim_t GL_fboShim;
 
 static void GLimp_InitExtensions()
@@ -1956,6 +1959,7 @@ static void GLimp_InitExtensions()
 	Cvar::Latch( r_arb_explicit_uniform_location );
 	Cvar::Latch( r_arb_gpu_shader5 );
 	Cvar::Latch( r_arb_half_float_pixel );
+	Cvar::Latch( r_arb_half_float_vertex );
 	Cvar::Latch( r_arb_indirect_parameters );
 	Cvar::Latch( r_arb_internalformat_query2 );
 	Cvar::Latch( r_arb_map_buffer_range );
@@ -2194,7 +2198,16 @@ static void GLimp_InitExtensions()
 
 	// VAO and VBO
 	// made required in OpenGL 3.0
-	LOAD_EXTENSION( ExtFlag_REQUIRED | ExtFlag_CORE, ARB_half_float_vertex );
+	glConfig2.halfFloatVertexAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_half_float_vertex, r_arb_half_float_vertex.Get() );
+
+	if ( glConfig2.halfFloatVertexAvailable )
+	{
+		glVertexSetHalfFloat();
+	}
+	else
+	{
+		glVertexSetFloat();
+	}
 
 	{
 		int flag = ExtFlag_CORE | ( workaround_glExtension_missingArbFbo_useExtFbo.Get() ? 0 : ExtFlag_REQUIRED );

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1737,6 +1737,10 @@ static rserr_t GLimp_StartDriverAndSetMode( int mode, bool fullscreen, bool bord
 
 	rserr_t err = GLimp_SetMode(mode, fullscreen, bordered);
 
+	const char* glRequirements =
+		"You need a graphics card with drivers supporting at least\n"
+		"OpenGL 3.2 or OpenGL 2.1 with EXT_framebuffer_object.";
+
 	switch ( err )
 	{
 		case rserr_t::RSERR_OK:
@@ -1752,21 +1756,13 @@ static rserr_t GLimp_StartDriverAndSetMode( int mode, bool fullscreen, bool bord
 			break;
 
 		case rserr_t::RSERR_MISSING_GL:
-			Sys::Error(
-				"OpenGL is not available.\n\n"
-				"You need a graphic card with drivers supporting\n"
-				"at least OpenGL 3.2 or OpenGL 2.1 with\n"
-				"ARB_half_float_vertex and EXT_framebuffer_object." );
+			Sys::Error( "OpenGL is not available.\n\n%s", glRequirements );
 
 			// Sys:Error calls OSExit() so the break and the return is unreachable.
 			break;
 
 		case rserr_t::RSERR_OLD_GL:
-			Sys::Error(
-				"OpenGL %d.%d is too old.\n\n"
-				"You need a graphic card with drivers supporting\n"
-				"at least OpenGL 3.2 or OpenGL 2.1 with\n"
-				"ARB_half_float_vertex and EXT_framebuffer_object." );
+			Sys::Error( "OpenGL %d.%d is too old.\n\n%s", glConfig2.glMajor, glConfig2.glMinor, glRequirements );
 
 			// Sys:Error calls OSExit() so the break and the return is unreachable.
 			break;


### PR DESCRIPTION
This is to address those two issues:

1. Some graphics devices don't supports `ARB_half_float_vertex` like the Intel GMA Gen3 architecture with the Mesa driver.
2. Some graphics devices don't supports `ARB_half_float_vertex` but drivers may provide an unplayable slow emulation, like the ATi r300 architecture with the Mesa driver.
   - https://github.com/DaemonEngine/Daemon/issues/1172

Those changes purposes to provide an alternative code path when `ARB_half_float_vertex` is not available or when the `r_arb_half_float_vertex` cvar is disabled on purpose to avoid a slow emulation provided by the driver.

It is the next step over preparatory work that was already merged:

- Some improvements of our type system, helping the compiler to report more type errors and then making the conversion easier with the less risk of introducing silent errors:
  https://github.com/DaemonEngine/Daemon/pull/728
- Some enablement of GL 2.1 on the said Intel graphics chip so we can know GL 2.1 is supported but catch the lack of the half float vertex extension, meaning that if we implement a workaround one day (that is the day today), we would already have everything else already in place for it:
  https://github.com/DaemonEngine/Daemon/pull/478

This branch doesn't break compatibility with the game but I implemented it over the `illwieckz/image-fistcreen/sync` branch anyway:

- https://github.com/DaemonEngine/Daemon/pull/1145

I did it that way because this other branch also helps running the game on this kind of hardware (to not upload textures too big for such hardware) and we better test this hardware over `for-0.55.0/sync` because of all compatibility-breaking changes purposed for performance that were merged there. The `illwieckz/image-fistcreen/sync` branch itself is already implemented over `for-0.55.0/sync` because of compatibility breaking.

This branch also includes the `GL_DEPTH_CLAMP` disablement when `GL_ARB_depth_clamp` to avoid spamming the console with warnings when running the game on ATi r300 graphics card, to make debugging easier:

- https://github.com/DaemonEngine/Daemon/pull/1173

~~⚠️🚧️ **This branch is in very early state!** 🚧️⚠️~~
~~⚠️🚧️ **It's even not ready to review!** 🚧️⚠️~~
~~⚠️🚧️ **This may be full of useless halffloat-to-float-to-halffloat conversions!** 🚧️⚠️~~
~~⚠️🚧️ **I even haven't tested if it doesn't break the usual code path!** 🚧️⚠️~~

~~I push this branch now because it starts to work and this is so precious I don't want the team to lose that work is something happens to me!~~

It's now ready to be reviewed, it works for me with both code paths, and is rebased on `master`.