### PR TITLE
Material system: Implement GPU occlusion culling

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -149,6 +149,7 @@ set(GLSLSOURCELIST
     ${ENGINE_DIR}/renderer/glsl_source/material_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/cull_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/clearSurfaces_cp.glsl
+    ${ENGINE_DIR}/renderer/glsl_source/depthReduction_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/processSurfaces_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/skybox_vp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/ssao_fp.glsl

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1473,6 +1473,10 @@ class GLSSBO : public GLBuffer {
 		GLBuffer::BindBuffer( GL_SHADER_STORAGE_BUFFER );
 	}
 
+	void UnBindBuffer() {
+		GLBuffer::UnBindBuffer( GL_SHADER_STORAGE_BUFFER );
+	}
+
 	void BufferStorage( const GLsizeiptr areaSize, const GLsizeiptr areaCount, const void* data ) {
 		GLBuffer::BufferStorage( GL_SHADER_STORAGE_BUFFER, areaSize, areaCount, data );
 	}
@@ -1483,6 +1487,10 @@ class GLSSBO : public GLBuffer {
 
 	void FlushCurrentArea() {
 		GLBuffer::FlushCurrentArea( GL_SHADER_STORAGE_BUFFER );
+	}
+
+	void FlushAll() {
+		GLBuffer::FlushAll( GL_SHADER_STORAGE_BUFFER );
 	}
 
 	uint32_t* MapBufferRange( const GLsizeiptr count ) {
@@ -1529,6 +1537,10 @@ class GLUBO : public GLBuffer {
 		GLBuffer::FlushCurrentArea( GL_UNIFORM_BUFFER );
 	}
 
+	void FlushAll() {
+		GLBuffer::FlushAll( GL_UNIFORM_BUFFER );
+	}
+
 	uint32_t* MapBufferRange( const GLsizeiptr count ) {
 		return GLBuffer::MapBufferRange( GL_UNIFORM_BUFFER, count );
 	}
@@ -1571,6 +1583,10 @@ class GLAtomicCounterBuffer : public GLBuffer {
 
 	void FlushCurrentArea() {
 		GLBuffer::FlushCurrentArea( GL_ATOMIC_COUNTER_BUFFER );
+	}
+
+	void FlushAll() {
+		GLBuffer::FlushAll( GL_ATOMIC_COUNTER_BUFFER );
 	}
 
 	uint32_t* MapBufferRange( const GLsizeiptr count ) {
@@ -3178,6 +3194,90 @@ class u_ViewID :
 	}
 };
 
+class u_FirstPortalGroup :
+	GLUniform1ui {
+	public:
+	u_FirstPortalGroup( GLShader* shader ) :
+		GLUniform1ui( shader, "u_FirstPortalGroup" ) {
+	}
+
+	void SetUniform_FirstPortalGroup( const uint firstPortalGroup ) {
+		this->SetValue( firstPortalGroup );
+	}
+};
+
+class u_TotalPortals :
+	GLUniform1ui {
+	public:
+	u_TotalPortals( GLShader* shader ) :
+		GLUniform1ui( shader, "u_TotalPortals" ) {
+	}
+
+	void SetUniform_TotalPortals( const uint totalPortals ) {
+		this->SetValue( totalPortals );
+	}
+};
+
+class u_ViewWidth :
+	GLUniform1ui {
+	public:
+	u_ViewWidth( GLShader* shader ) :
+		GLUniform1ui( shader, "u_ViewWidth" ) {
+	}
+
+	void SetUniform_ViewWidth( const uint viewWidth ) {
+		this->SetValue( viewWidth );
+	}
+};
+
+class u_ViewHeight :
+	GLUniform1ui {
+	public:
+	u_ViewHeight( GLShader* shader ) :
+		GLUniform1ui( shader, "u_ViewHeight" ) {
+	}
+
+	void SetUniform_ViewHeight( const uint viewHeight ) {
+		this->SetValue( viewHeight );
+	}
+};
+
+class u_InitialDepthLevel :
+	GLUniform1Bool {
+	public:
+	u_InitialDepthLevel( GLShader* shader ) :
+		GLUniform1Bool( shader, "u_InitialDepthLevel" ) {
+	}
+
+	void SetUniform_InitialDepthLevel( const int initialDepthLevel ) {
+		this->SetValue( initialDepthLevel );
+	}
+};
+
+class u_P00 :
+	GLUniform1f {
+	public:
+	u_P00( GLShader* shader ) :
+		GLUniform1f( shader, "u_P00" ) {
+	}
+
+	void SetUniform_P00( const float P00 ) {
+		this->SetValue( P00 );
+	}
+};
+
+class u_P11 :
+	GLUniform1f {
+	public:
+	u_P11( GLShader* shader ) :
+		GLUniform1f( shader, "u_P11" ) {
+	}
+
+	void SetUniform_P11( const float P11 ) {
+		this->SetValue( P11 );
+	}
+};
+
 class u_TotalDrawSurfs :
 	GLUniform1ui {
 	public:
@@ -3187,6 +3287,54 @@ class u_TotalDrawSurfs :
 
 	void SetUniform_TotalDrawSurfs( const uint totalDrawSurfs ) {
 		this->SetValue( totalDrawSurfs );
+	}
+};
+
+class u_UseFrustumCulling :
+	GLUniform1Bool {
+	public:
+	u_UseFrustumCulling( GLShader* shader ) :
+		GLUniform1Bool( shader, "u_UseFrustumCulling" ) {
+	}
+
+	void SetUniform_UseFrustumCulling( const int useFrustumCulling ) {
+		this->SetValue( useFrustumCulling );
+	}
+};
+
+class u_UseOcclusionCulling :
+	GLUniform1Bool {
+	public:
+	u_UseOcclusionCulling( GLShader* shader ) :
+		GLUniform1Bool( shader, "u_UseOcclusionCulling" ) {
+	}
+
+	void SetUniform_UseOcclusionCulling( const int useOcclusionCulling ) {
+		this->SetValue( useOcclusionCulling );
+	}
+};
+
+class u_ShowTris :
+	GLUniform1Bool {
+	public:
+	u_ShowTris( GLShader* shader ) :
+		GLUniform1Bool( shader, "u_ShowTris" ) {
+	}
+
+	void SetUniform_ShowTris( const int showTris ) {
+		this->SetValue( showTris );
+	}
+};
+
+class u_CameraPosition :
+	GLUniform3f {
+	public:
+	u_CameraPosition( GLShader* shader ) :
+		GLUniform3f( shader, "u_CameraPosition" ) {
+	}
+
+	void SetUniform_CameraPosition( const vec3_t cameraPosition ) {
+		this->SetValue( cameraPosition );
 	}
 };
 
@@ -3941,6 +4089,7 @@ class GLShader_lightMappingMaterial :
 	public u_LightGridScale,
 	public u_numLights,
 	public u_Lights,
+	public u_ShowTris,
 	public GLDeformStage,
 	public GLCompileMacro_USE_BSP_SURFACE,
 	// public GLCompileMacro_USE_VERTEX_SKINNING,
@@ -4581,11 +4730,33 @@ public:
 
 class GLShader_cull :
 	public GLShader,
+	public u_Frame,
+	public u_ViewID,
 	public u_TotalDrawSurfs,
 	public u_SurfaceCommandsOffset,
-	public u_Frustum {
+	public u_Frustum,
+	public u_UseFrustumCulling,
+	public u_UseOcclusionCulling,
+	public u_CameraPosition,
+	public u_ModelViewMatrix,
+	public u_FirstPortalGroup,
+	public u_TotalPortals,
+	public u_ViewWidth,
+	public u_ViewHeight,
+	public u_P00,
+	public u_P11 {
 	public:
 	GLShader_cull( GLShaderManager* manager );
+};
+
+class GLShader_depthReduction :
+	public GLShader,
+	public u_ViewWidth,
+	public u_ViewHeight,
+	public u_InitialDepthLevel {
+	public:
+	GLShader_depthReduction( GLShaderManager* manager );
+	void SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) override;
 };
 
 class GLShader_clearSurfaces :
@@ -4614,6 +4785,7 @@ extern GLShader_generic2D                       *gl_generic2DShader;
 extern GLShader_generic                         *gl_genericShader;
 extern GLShader_genericMaterial                 *gl_genericShaderMaterial;
 extern GLShader_cull                            *gl_cullShader;
+extern GLShader_depthReduction                  *gl_depthReductionShader;
 extern GLShader_clearSurfaces                   *gl_clearSurfacesShader;
 extern GLShader_processSurfaces                 *gl_processSurfacesShader;
 extern GLShader_lightMapping                    *gl_lightMappingShader;

--- a/src/engine/renderer/glsl_source/cull_cp.glsl
+++ b/src/engine/renderer/glsl_source/cull_cp.glsl
@@ -9,14 +9,14 @@ This file is part of the Daemon BSD Source Code (Daemon Source Code).
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the Daemon developers nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -37,14 +37,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Keep this to 64 because we don't want extra shared mem etc. to be allocated, and to minimize wasted lanes
 layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
+layout(binding = 0) uniform sampler2D depthImage;
+
 struct BoundingSphere {
-    vec3 center;
-    float radius;
+	vec3 center;
+	float radius;
 };
 
 struct SurfaceDescriptor {
-    BoundingSphere boundingSphere;
-    uint surfaceCommandIDs[MAX_SURFACE_COMMANDS];
+	BoundingSphere boundingSphere;
+	uint surfaceCommandIDs[MAX_SURFACE_COMMANDS];
 };
 
 struct GLIndirectCommand {
@@ -56,59 +58,164 @@ struct GLIndirectCommand {
 };
 
 struct SurfaceCommand {
-    bool enabled;
-    GLIndirectCommand drawCommand;
+	bool enabled;
+	GLIndirectCommand drawCommand;
 };
 
 layout(std430, binding = 1) readonly restrict buffer surfaceDescriptorsSSBO {
-    SurfaceDescriptor surfaces[];
+	SurfaceDescriptor surfaces[];
 };
 
 layout(std430, binding = 2) writeonly restrict buffer surfaceCommandsSSBO {
-    SurfaceCommand surfaceCommands[];
+	SurfaceCommand surfaceCommands[];
 };
 
-struct Plane {
-    vec3 normal;
-    float distance;
+struct PortalSurface {
+	BoundingSphere boundingSphere;
+
+	uint drawSurfID;
+	float distance;
+	vec2 padding;
 };
 
+layout(std430, binding = 5) restrict buffer portalSurfacesSSBO {
+	PortalSurface portalSurfaces[];
+};
+
+uniform uint u_Frame;
+uniform uint u_ViewID;
 uniform uint u_TotalDrawSurfs;
 uniform uint u_SurfaceCommandsOffset;
 uniform vec4 u_Frustum[6]; // xyz - normal, w - distance
+uniform bool u_UseFrustumCulling;
+uniform bool u_UseOcclusionCulling;
+uniform vec3 u_CameraPosition;
+uniform uint u_FirstPortalGroup;
+uniform uint u_TotalPortals;
+uniform mat4 u_ModelViewMatrix;
+uniform uint u_ViewWidth;
+uniform uint u_ViewHeight;
+uniform float u_P00;
+uniform float u_P11;
+
+// Based on https://zeux.io/2023/01/12/approximate-projected-bounds/
+bool ProjectSphere( in vec3 center, in float radius, in float zNear, in float P00, in float P11, inout vec4 boundingBox ) {
+	if ( -center.z - radius < zNear ) {
+		return false;
+	}
+
+	vec3 cr = center * radius;
+	float czr2 = center.z * center.z - radius * radius;
+
+	float vx = sqrt( center.x * center.x + czr2 );
+	float minx = center.x * center.x + czr2 >= 0.0 ? ( vx * center.x - cr.z ) / ( vx * center.z + cr.x ) : -1.0;
+	float maxx = center.x * center.x + czr2 >= 0.0 ? ( vx * center.x + cr.z ) / ( vx * center.z - cr.x ) : 1.0;
+
+	float vy = sqrt( center.y * center.y + czr2 );
+	float miny = center.y * center.y + czr2 >= 0.0 ? ( vy * center.y - cr.z ) / ( vy * center.z + cr.y ) : -1.0;
+	float maxy = center.y * center.y + czr2 >= 0.0 ? ( vy * center.y + cr.z ) / ( vy * center.z - cr.y ) : 1.0;
+
+	boundingBox = vec4( minx * P00, miny * P11, maxx * P00, maxy * P11 );
+	boundingBox = boundingBox.xwzy * vec4( 0.5f, -0.5f, 0.5f, -0.5f ) + vec4( 0.5, 0.5, 0.5, 0.5 ); // clip space -> uv space
+
+	return true;
+}
 
 bool CullSurface( in BoundingSphere boundingSphere ) {
-    // Skip far plane because we always make it encompass the whole map in the current direction
-    // This might need to be changed later for shadowmaps since lights could have some far plane set
-    for( int i = 0; i < 5; i++ ) {
-        const float distance = dot( u_Frustum[i].xyz, boundingSphere.center ) - u_Frustum[i].w;
+	bool culled = false;
 
-        if( distance < -boundingSphere.radius ) {
-            return true;
-        }
-    }
-    return false;
+	// Frustum culling
+	// Skip far plane because we always make it encompass the whole map in the current direction
+	// This might need to be changed later for shadowmaps since lights could have some far plane set
+	if( u_UseFrustumCulling ) {
+		for( int i = 0; i < 5; i++ ) {
+			const float distance = dot( u_Frustum[i].xyz, boundingSphere.center ) - u_Frustum[i].w;
+
+			if( distance < -boundingSphere.radius ) {
+				culled = true;
+				break;
+			}
+		}
+	}
+	
+	// Occlusion culling for surfaces that passed frustum culling
+	vec4 boundingBox = vec4( -1.0, 1.0, -1.0, 1.0 );
+	const vec3 viewSpaceCenter = vec3( u_ModelViewMatrix * vec4( boundingSphere.center, 1.0 ) );
+	
+	// Only do occlusion culling on the main view because portals use stencil buffer,
+	// so doing depth reduction there would be complicated
+
+	// ProjectSphere() gives us the screen-space AABB of the surface, based on its bounding sphere
+	if( u_UseOcclusionCulling && u_ViewID == 0 && !culled
+		&& ProjectSphere( viewSpaceCenter, boundingSphere.radius, r_zNear, u_P00, u_P11, boundingBox ) ) {
+		boundingBox.xz = vec2( min( 1 - boundingBox.x, 1 - boundingBox.z ), max( 1 - boundingBox.x, 1 - boundingBox.z ) );
+		const float width = clamp( ( boundingBox.z - boundingBox.x ) * float( u_ViewWidth ), 0.0, float( u_ViewWidth ) );
+		const float height = clamp( ( boundingBox.w - boundingBox.y ) * float( u_ViewHeight ), 0.0, float( u_ViewHeight ) );
+
+		// Sample the depth-reduction image at the mip-level where the surface covers 4 pixels
+		const int level = int( floor( log2( max( width, height ) ) ) );
+
+		// Coords for the 4 pixels covered by the AABB, adjusted for partially off-screen surfaces as needed
+		vec2 surfaceCoords = vec2( u_ViewWidth >> level, u_ViewHeight >> level );
+		surfaceCoords *= ( boundingBox.xy + boundingBox.zw ) * 0.5;
+		const ivec2 surfaceCoordsFloor = ivec2( clamp( surfaceCoords.x, 0.0, float( u_ViewWidth >> level ) ), clamp( surfaceCoords.y, 0.0, float( u_ViewHeight >> level ) ) );
+		ivec4 depthCoords = ivec4( surfaceCoordsFloor.xy,
+								   surfaceCoordsFloor.x + ( surfaceCoords.x - surfaceCoordsFloor.x >= 0.5 ? 1 : -1 ),
+								   surfaceCoordsFloor.y + ( surfaceCoords.y - surfaceCoordsFloor.y >= 0.5 ? 1 : -1 ) );
+		depthCoords.x = clamp( depthCoords.x, 0, int( ( u_ViewWidth >> level ) - 1 ) );
+		depthCoords.y = clamp( depthCoords.y, 0, int( ( u_ViewHeight >> level ) - 1 ) );
+		depthCoords.z = clamp( depthCoords.z, 0, int( ( u_ViewWidth >> level ) - 1 ) );
+		depthCoords.w = clamp( depthCoords.w, 0, int( ( u_ViewHeight >> level ) - 1 ) );
+
+		vec4 depthValues;
+		depthValues.x = texelFetch( depthImage, depthCoords.xy, level ).r;
+		depthValues.y = texelFetch( depthImage, depthCoords.zy, level ).r;
+		depthValues.z = texelFetch( depthImage, depthCoords.xw, level ).r;
+		depthValues.w = texelFetch( depthImage, depthCoords.zw, level ).r;
+
+		const float surfaceDepth = max( max( max( depthValues.x, depthValues.y ), depthValues.z ), depthValues.w );
+
+		culled = ( 1 + r_zNear / ( viewSpaceCenter.z + boundingSphere.radius ) ) > surfaceDepth;
+	}
+
+	return culled;
 }
 
 void ProcessSurfaceCommands( const in SurfaceDescriptor surface, const in bool enabled ) {
-    for( uint i = 0; i < MAX_SURFACE_COMMANDS; i++ ) {
-        const uint commandID = surface.surfaceCommandIDs[i];
-        if( commandID == 0 ) { // Reserved for no-command
-            return;
-        }
-        surfaceCommands[commandID + u_SurfaceCommandsOffset].enabled = enabled;
-    }
+	for( uint i = 0; i < MAX_SURFACE_COMMANDS; i++ ) {
+		const uint commandID = surface.surfaceCommandIDs[i];
+		if( commandID == 0 ) { // Reserved for no-command
+			return;
+		}
+		surfaceCommands[commandID + u_SurfaceCommandsOffset].enabled = enabled;
+	}
 }
 
 void main() {
-    const uint globalInvocationID = gl_GlobalInvocationID.z * gl_NumWorkGroups.x * gl_WorkGroupSize.x * gl_NumWorkGroups.y * gl_WorkGroupSize.y
-                             + gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x
-                             + gl_GlobalInvocationID.x;
-    if( globalInvocationID >= u_TotalDrawSurfs ) {
-        return;
-    }
-    SurfaceDescriptor surface = surfaces[globalInvocationID];
-    bool culled = CullSurface( surface.boundingSphere );
+	const uint globalGroupID = gl_WorkGroupID.z * gl_NumWorkGroups.x * gl_NumWorkGroups.y
+							 + gl_WorkGroupID.y * gl_NumWorkGroups.x
+							 + gl_WorkGroupID.x;
+	const uint globalInvocationID = gl_GlobalInvocationID.z * gl_NumWorkGroups.x * gl_WorkGroupSize.x * gl_NumWorkGroups.y * gl_WorkGroupSize.y
+								  + gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x
+								  + gl_GlobalInvocationID.x;
 
-    ProcessSurfaceCommands( surface, !culled );
+	// Portals
+	const uint portalID = globalInvocationID - u_FirstPortalGroup * 64;
+	if( globalGroupID >= u_FirstPortalGroup && ( portalID < u_TotalPortals ) ) {
+		const uint portalSurfaceID = portalID + ( u_Frame * MAX_VIEWS + u_ViewID ) * u_TotalPortals;
+		PortalSurface surface = portalSurfaces[portalSurfaceID];
+		bool culled = CullSurface( surface.boundingSphere );
+
+		portalSurfaces[portalSurfaceID].distance = !culled ? distance( u_CameraPosition, surface.boundingSphere.center ) : -1.0;
+		return;
+	}
+
+	// Regular surfaces
+	if( globalInvocationID >= u_TotalDrawSurfs ) {
+		return;
+	}
+	SurfaceDescriptor surface = surfaces[globalInvocationID];
+	bool culled = CullSurface( surface.boundingSphere );
+
+	ProcessSurfaceCommands( surface, !culled );
 }

--- a/src/engine/renderer/glsl_source/depthReduction_cp.glsl
+++ b/src/engine/renderer/glsl_source/depthReduction_cp.glsl
@@ -1,0 +1,89 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Daemon developers nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+
+/* depthReduction_cp.glsl */
+
+// Keep this to 8x8 because we don't want extra shared mem etc. to be allocated, and to minimize wasted lanes
+layout (local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(binding = 0) uniform sampler2D depthTextureInitial;
+layout(r32f, binding = 1) uniform readonly image2D depthImageIn;
+layout(r32f, binding = 2) uniform writeonly image2D depthImageOut;
+
+uniform uint u_ViewWidth;
+uniform uint u_ViewHeight;
+uniform bool u_InitialDepthLevel;
+
+void main() {
+    const uint globalInvocationID = gl_GlobalInvocationID.z * gl_NumWorkGroups.x * gl_WorkGroupSize.x * gl_NumWorkGroups.y * gl_WorkGroupSize.y
+                             + gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x
+                             + gl_GlobalInvocationID.x;
+
+    const ivec2 position = ivec2( gl_GlobalInvocationID.xy );
+    if( position.x >= u_ViewWidth || position.y >= u_ViewHeight ) {
+        return;
+    };
+
+    // Depth buffer uses a packed D24S8 format, so we have to copy it over to an r32f image first
+    if( u_InitialDepthLevel ) {
+        vec4 depthOut = texelFetch( depthTextureInitial, position, 0 );
+        imageStore( depthImageOut, position, depthOut );
+    } else {
+        float depth[4];
+        
+        for( int x = 0; x < 2; x++ ) {
+            for( int y = 0; y < 2; y++ ) {
+                depth[y * 2 + x] = imageLoad( depthImageIn, position * 2 + ivec2( x, y ) ).r;
+            }
+        }
+
+        float depthOut = max( depth[0], depth[1] );
+        depthOut = max( depthOut, depth[2] );
+        depthOut = max( depthOut, depth[3] );
+
+        // Mipmaps round the dimensions down for each level, so we might need to sample up to 5 extra texels along the edges
+        if( ( u_ViewWidth & 1 ) == 1 ) {
+            depthOut = max( depthOut, imageLoad( depthImageIn, position * 2 + ivec2( 2, 0 ) ).r );
+            depthOut = max( depthOut, imageLoad( depthImageIn, position * 2 + ivec2( 2, 1 ) ).r );
+        }
+        if( ( u_ViewHeight & 1 ) == 1 ) {
+            depthOut = max( depthOut, imageLoad( depthImageIn, position * 2 + ivec2( 0, 2 ) ).r );
+            depthOut = max( depthOut, imageLoad( depthImageIn, position * 2 + ivec2( 1, 2 ) ).r );
+        }
+        if( ( u_ViewWidth & 1 ) == 1 && ( u_ViewHeight & 1 ) == 1 ) {
+            depthOut = max( depthOut, imageLoad( depthImageIn, position * 2 + ivec2( 2, 2 ) ).r );
+        }
+        imageStore( depthImageOut, position, vec4( depthOut, 0.0, 0.0, 0.0 ) );
+    }
+}

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -54,11 +54,18 @@ uniform sampler3D u_LightGrid2;
 	uniform vec3 u_LightGridScale;
 #endif
 
+uniform bool u_ShowTris;
+
 DECLARE_OUTPUT(vec4)
 
 void main()
 {
 	#insert material_fp
+
+	if( u_ShowTris ) {
+		outputColor = vec4( 0.0, 0.0, 1.0, 1.0 );
+		return;
+	}
 
 	// Compute view direction in world space.
 	vec3 viewDir = normalize(u_ViewOrigin - var_Position);

--- a/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
+++ b/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
@@ -9,14 +9,14 @@ This file is part of the Daemon BSD Source Code (Daemon Source Code).
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of the Daemon developers nor the
-      names of its contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
 ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
@@ -46,24 +46,24 @@ struct GLIndirectCommand {
 };
 
 struct SurfaceCommand {
-    bool enabled;
-    GLIndirectCommand drawCommand;
+	bool enabled;
+	GLIndirectCommand drawCommand;
 };
 
 struct SurfaceCommandBatch {
-    uvec2 materialIDs[2];
+	uvec2 materialIDs[2];
 };
 
 layout(std430, binding = 2) readonly restrict buffer surfaceCommandsSSBO {
-    SurfaceCommand surfaceCommands[];
+	SurfaceCommand surfaceCommands[];
 };
 
 layout(std430, binding = 3) writeonly restrict buffer culledCommandsSSBO {
-    GLIndirectCommand culledCommands[];
+	GLIndirectCommand culledCommands[];
 };
 
 layout(std140, binding = 0) uniform ub_SurfaceBatches {
-    SurfaceCommandBatch surfaceBatches[MAX_SURFACE_COMMAND_BATCHES];
+	SurfaceCommandBatch surfaceBatches[MAX_SURFACE_COMMAND_BATCHES];
 };
 
 layout (binding = 4) uniform atomic_uint atomicCommandCounters[MAX_COMMAND_COUNTERS * MAX_VIEWS * MAX_FRAMES];
@@ -74,27 +74,27 @@ uniform uint u_SurfaceCommandsOffset;
 uniform uint u_CulledCommandsOffset;
 
 void AddDrawCommand( in uint commandID, in uvec2 materialID ) {
-    SurfaceCommand command = surfaceCommands[commandID + u_SurfaceCommandsOffset];
-    if( command.enabled ) {
-        // materialID.x is the global ID of the material
-        // materialID.y is the offset for the memory allocated to the material's culled commands
-        const uint atomicCmdID = atomicCounterIncrement( atomicCommandCounters[materialID.x
-                                                         + MAX_COMMAND_COUNTERS * ( MAX_VIEWS * u_Frame + u_ViewID )] );
-        culledCommands[atomicCmdID + materialID.y * MAX_COMMAND_COUNTERS + u_CulledCommandsOffset] = command.drawCommand;
-    }
+	SurfaceCommand command = surfaceCommands[commandID + u_SurfaceCommandsOffset];
+	if( command.enabled ) {
+		// materialID.x is the global ID of the material
+		// materialID.y is the offset for the memory allocated to the material's culled commands
+		const uint atomicCmdID = atomicCounterIncrement( atomicCommandCounters[materialID.x
+		                                                 + MAX_COMMAND_COUNTERS * ( MAX_VIEWS * u_Frame + u_ViewID )] );
+		culledCommands[atomicCmdID + materialID.y * MAX_COMMAND_COUNTERS + u_CulledCommandsOffset] = command.drawCommand;
+	}
 }
 
 void main() {
-    const uint globalGroupID = gl_WorkGroupID.z * gl_NumWorkGroups.x * gl_NumWorkGroups.y
-                             + gl_WorkGroupID.y * gl_NumWorkGroups.x
-                             + gl_WorkGroupID.x;
-    const uint globalInvocationID = gl_GlobalInvocationID.z * gl_NumWorkGroups.x * gl_WorkGroupSize.x
-                             * gl_NumWorkGroups.y * gl_WorkGroupSize.y
-                             + gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x
-                             + gl_GlobalInvocationID.x
-                             + 1; // Add 1 because the first surface command is always reserved as a fake command
-    // Each surfaceBatch encompasses 64 surfaceCommands with the same material, padded to 64 as necessary
-    const uvec2 materialID = surfaceBatches[globalGroupID / 2].materialIDs[globalGroupID % 2];
+	const uint globalGroupID = gl_WorkGroupID.z * gl_NumWorkGroups.x * gl_NumWorkGroups.y
+	                         + gl_WorkGroupID.y * gl_NumWorkGroups.x
+	                         + gl_WorkGroupID.x;
+	const uint globalInvocationID = gl_GlobalInvocationID.z * gl_NumWorkGroups.x * gl_WorkGroupSize.x
+	                              * gl_NumWorkGroups.y * gl_WorkGroupSize.y
+	                              + gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x
+	                              + gl_GlobalInvocationID.x
+	                              + 1; // Add 1 because the first surface command is always reserved as a fake command
+	// Each surfaceBatch encompasses 64 surfaceCommands with the same material, padded to 64 as necessary
+	const uvec2 materialID = surfaceBatches[globalGroupID / 2].materialIDs[globalGroupID % 2];
 
-    AddDrawCommand( globalInvocationID, materialID );
+	AddDrawCommand( globalInvocationID, materialID );
 }

--- a/src/engine/renderer/shaders.cpp
+++ b/src/engine/renderer/shaders.cpp
@@ -61,6 +61,7 @@
 #include "material_vp.glsl.h"
 #include "material_fp.glsl.h"
 #include "cull_cp.glsl.h"
+#include "depthReduction_cp.glsl.h"
 #include "processSurfaces_cp.glsl.h"
 #include "clearSurfaces_cp.glsl.h"
 
@@ -76,6 +77,7 @@ std::unordered_map<std::string, std::string> shadermap({
 	{ "glsl/contrast_vp.glsl", std::string(reinterpret_cast<const char*>(contrast_vp_glsl), sizeof(contrast_vp_glsl)) },
 	{ "glsl/clearSurfaces_cp.glsl", std::string( reinterpret_cast< const char* >( clearSurfaces_cp_glsl ), sizeof( clearSurfaces_cp_glsl ) ) },
 	{ "glsl/cull_cp.glsl", std::string( reinterpret_cast< const char* >( cull_cp_glsl ), sizeof( cull_cp_glsl ) ) },
+	{ "glsl/depthReduction_cp.glsl", std::string( reinterpret_cast< const char* >( depthReduction_cp_glsl ), sizeof( depthReduction_cp_glsl ) ) },
 	{ "glsl/debugShadowMap_fp.glsl", std::string(reinterpret_cast<const char*>(debugShadowMap_fp_glsl), sizeof(debugShadowMap_fp_glsl)) },
 	{ "glsl/debugShadowMap_vp.glsl", std::string(reinterpret_cast<const char*>(debugShadowMap_vp_glsl), sizeof(debugShadowMap_vp_glsl)) },
 	{ "glsl/deformVertexes_vp.glsl", std::string(reinterpret_cast<const char*>(deformVertexes_vp_glsl), sizeof(deformVertexes_vp_glsl)) },

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4962,6 +4962,13 @@ This is done so various debugging facilities will work properly
 */
 static void RB_RenderPostProcess()
 {
+	if ( glConfig2.materialSystemAvailable ) {
+		// Dispatch the cull compute shaders for queued once we're done with post-processing
+		// We'll only use the results from those shaders in the next frame so we don't block the pipeline
+		materialSystem.CullSurfaces();
+		materialSystem.EndFrame();
+	}
+
 	RB_FXAA();
 
 	// render chromatric aberration
@@ -4982,13 +4989,6 @@ static void RB_RenderPostProcess()
 		{
 			tr.refdef.pixelTarget[(i * 4) + 3] = 255;  //set the alpha pure white
 		}
-	}
-	
-	if( glConfig2.materialSystemAvailable ) {
-		// Dispatch the cull compute shaders for queued views once we're done with post-processing
-		// We'll only use the results from those shaders in the next frame so we don't block the pipeline
-		materialSystem.CullSurfaces();
-		materialSystem.EndFrame();
 	}
 
 	GL_CheckErrors();

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "InternalImage.h"
 #include "tr_local.h"
 #include <iomanip>
+#include "Material.h"
 
 int                  gl_filter_min = GL_LINEAR_MIPMAP_NEAREST;
 int                  gl_filter_max = GL_LINEAR;
@@ -2476,6 +2477,10 @@ static void R_CreateCurrentRenderImage()
 	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
 
 	tr.currentDepthImage = R_CreateImage( "_currentDepth", nullptr, width, height, 1, imageParams );
+
+	if ( glConfig2.materialSystemAvailable ) {
+		materialSystem.GenerateDepthImages( width, height, imageParams );
+	}
 }
 
 static void R_CreateDepthRenderImage()

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -81,6 +81,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<bool> r_forceLegacyOverBrightClamping("r_forceLegacyOverBrightClamping", "clamp over bright of legacy maps (enable multiplied color clamping and normalization)", Cvar::NONE, false);
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	Cvar::Cvar<bool> r_materialSystem( "r_materialSystem", "Use Material System", Cvar::NONE, false );
+	Cvar::Cvar<bool> r_gpuFrustumCulling( "r_gpuFrustumCulling", "Use frustum culling on the GPU for the Material System", Cvar::NONE, true );
+	Cvar::Cvar<bool> r_gpuOcclusionCulling( "r_gpuOcclusionCulling", "Use occlusion culling on the GPU for the Material System", Cvar::NONE, true );
 	cvar_t      *r_lightStyles;
 	cvar_t      *r_exportTextures;
 	cvar_t      *r_heatHaze;
@@ -1161,6 +1163,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		Cvar::Latch( r_dynamicLight );
 		Cvar::Latch( r_staticLight );
 		Cvar::Latch( r_materialSystem );
+		Cvar::Latch( r_gpuFrustumCulling );
+		Cvar::Latch( r_gpuOcclusionCulling );
 
 		r_drawworld = Cvar_Get( "r_drawworld", "1", CVAR_CHEAT );
 		r_portalOnly = Cvar_Get( "r_portalOnly", "0", CVAR_CHEAT );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2880,6 +2880,8 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern Cvar::Cvar<bool> r_forceLegacyOverBrightClamping;
 	extern Cvar::Range<Cvar::Cvar<int>> r_lightMode;
 	extern Cvar::Cvar<bool> r_materialSystem;
+	extern Cvar::Cvar<bool> r_gpuFrustumCulling;
+	extern Cvar::Cvar<bool> r_gpuOcclusionCulling;
 	extern cvar_t *r_lightStyles;
 	extern cvar_t *r_exportTextures;
 	extern cvar_t *r_heatHaze;
@@ -3056,6 +3058,7 @@ inline bool checkGLErrors()
 	float          R_NoiseGet4f( float x, float y, float z, float t );
 	void           R_NoiseInit();
 
+	bool           PortalOffScreenOrOutOfRange( const drawSurf_t* drawSurf, screenRect_t& surfRect );
 	bool           R_MirrorViewBySurface( drawSurf_t* drawSurf );
 	void           R_RenderView( viewParms_t *parms );
 	void           R_RenderPostProcess();

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -91,6 +91,7 @@ struct glconfig2_t
 	bool shaderDrawParametersAvailable;
 	bool SSBOAvailable;
 	bool multiDrawIndirectAvailable;
+	bool indirectParametersAvailable;
 	bool shadingLanguage420PackAvailable;
 	bool explicitUniformLocationAvailable;
 	bool shaderImageLoadStoreAvailable;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -179,9 +179,9 @@ static void GLSL_InitGPUShadersOrError()
 		gl_shaderManager.load( gl_genericShaderMaterial );
 		gl_shaderManager.load( gl_lightMappingShaderMaterial );
 
-		gl_shaderManager.load( gl_cullShader );
 		gl_shaderManager.load( gl_clearSurfacesShader );
 		gl_shaderManager.load( gl_processSurfacesShader );
+		gl_shaderManager.load( gl_depthReductionShader );
 	}
 
 	if ( glConfig2.dynamicLight )
@@ -424,6 +424,7 @@ void GLSL_ShutdownGPUShaders()
 	gl_genericShader = nullptr;
 	gl_genericShaderMaterial = nullptr;
 	gl_cullShader = nullptr;
+	gl_depthReductionShader = nullptr;
 	gl_clearSurfacesShader = nullptr;
 	gl_processSurfacesShader = nullptr;
 	gl_lightMappingShader = nullptr;

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -1008,6 +1008,7 @@ static void R_InitMaterialBuffers() {
 		culledCommandsBuffer.GenBuffer();
 		surfaceBatchesUBO.GenBuffer();
 		atomicCommandCountersBuffer.GenBuffer();
+		portalSurfacesSSBO.GenBuffer();
 	}
 }
 
@@ -1135,6 +1136,7 @@ void R_ShutdownVBOs()
 		culledCommandsBuffer.DelBuffer();
 		surfaceBatchesUBO.DelBuffer();
 		atomicCommandCountersBuffer.DelBuffer();
+		portalSurfacesSSBO.DelBuffer();
 	}
 
 	tess.verts = tess.vertsBuffer = nullptr;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -72,6 +72,8 @@ static Cvar::Cvar<bool> r_arb_explicit_uniform_location( "r_arb_explicit_uniform
 	"Use GL_ARB_explicit_uniform_location if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_gpu_shader5( "r_arb_gpu_shader5",
 	"Use GL_ARB_gpu_shader5 if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_indirect_parameters( "r_arb_indirect_parameters",
+	"Use GL_ARB_indirect_parameters if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_map_buffer_range( "r_arb_map_buffer_range",
 	"Use GL_ARB_map_buffer_range if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_multi_draw_indirect( "r_arb_multi_draw_indirect",
@@ -1809,6 +1811,7 @@ static void GLimp_InitExtensions()
 	Cvar::Latch( r_arb_depth_clamp );
 	Cvar::Latch( r_arb_explicit_uniform_location );
 	Cvar::Latch( r_arb_gpu_shader5 );
+	Cvar::Latch( r_arb_indirect_parameters );
 	Cvar::Latch( r_arb_map_buffer_range );
 	Cvar::Latch( r_arb_multi_draw_indirect );
 	Cvar::Latch( r_arb_shader_atomic_counters );
@@ -2108,16 +2111,15 @@ static void GLimp_InitExtensions()
 	// made required in OpenGL 4.2
 	glConfig2.shaderAtomicCountersAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_shader_atomic_counters, r_arb_shader_atomic_counters.Get() );
 
+	// not required by any OpenGL version
+	glConfig2.indirectParametersAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_indirect_parameters, r_arb_indirect_parameters.Get() );
+
 	glConfig2.materialSystemAvailable = glConfig2.shaderDrawParametersAvailable && glConfig2.SSBOAvailable
 									    && glConfig2.multiDrawIndirectAvailable && glConfig2.bindlessTexturesAvailable
 										&& glConfig2.computeShaderAvailable && glConfig2.shadingLanguage420PackAvailable
 										&& glConfig2.explicitUniformLocationAvailable && glConfig2.shaderImageLoadStoreAvailable
-										&& glConfig2.shaderAtomicCountersAvailable
-										&& r_smp->integer == 0 // Currently doesn't work with r_smp 1
+										&& glConfig2.shaderAtomicCountersAvailable && glConfig2.indirectParametersAvailable
 										&& r_materialSystem.Get(); // Allow disabling it without disabling any extensions
-	if ( r_materialSystem.Get() && r_smp->integer ) {
-		Log::Warn( "Material system disabled because r_smp is not 0" );
-	}
 
 	GL_CheckErrors();
 }


### PR DESCRIPTION
Implement occlusion culling in compute shaders using a Hierarchical Depth-Buffer.

The depth buffer is processed before the post-processing pass, reducing it to the next mip level until a 1x1 resolution is reached.
Then it's used to find out if a surface that passed frustum culling is behind some opaque surfaces. This is done by getting the screen-space AABB from the bounding sphere of the surface, and then comparing its depth to the depth in the appropriate level of the depth-reduction image. The level of the depth image is chosen based on how much of the screen space it's taking up.