### PR TITLE
Convert vector macros to template functions

### DIFF
--- a/src/engine/qcommon/q_math.cpp
+++ b/src/engine/qcommon/q_math.cpp
@@ -36,6 +36,9 @@
 
 #include "q_shared.h"
 
+#define DotProduct4(x, y)            (( x )[ 0 ] * ( y )[ 0 ] + ( x )[ 1 ] * ( y )[ 1 ] + ( x )[ 2 ] * ( y )[ 2 ] + ( x )[ 3 ] * ( y )[ 3 ] )
+#define VectorMultiply( a,b,c )      ( ( c )[ 0 ] = ( a )[ 0 ] * ( b )[ 0 ],( c )[ 1 ] = ( a )[ 1 ] * ( b )[ 1 ],( c )[ 2 ] = ( a )[ 2 ] * ( b )[ 2 ] )
+
 const vec3_t vec3_origin = { 0, 0, 0 };
 
 const vec3_t axisDefault[ 3 ] = { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } };

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -381,30 +381,122 @@ inline float DotProduct( const vec3_t x, const vec3_t y )
 	return x[ 0 ] * y[ 0 ] + x[ 1 ] * y[ 1 ] + x[ 2 ] * y[ 2 ];
 }
 
-#define VectorSubtract( a,b,c )      ( ( c )[ 0 ] = ( a )[ 0 ] - ( b )[ 0 ],( c )[ 1 ] = ( a )[ 1 ] - ( b )[ 1 ],( c )[ 2 ] = ( a )[ 2 ] - ( b )[ 2 ] )
-#define VectorAdd( a,b,c )           ( ( c )[ 0 ] = ( a )[ 0 ] + ( b )[ 0 ],( c )[ 1 ] = ( a )[ 1 ] + ( b )[ 1 ],( c )[ 2 ] = ( a )[ 2 ] + ( b )[ 2 ] )
-#define VectorMultiply( a,b,c )      ( ( c )[ 0 ] = ( a )[ 0 ] * ( b )[ 0 ],( c )[ 1 ] = ( a )[ 1 ] * ( b )[ 1 ],( c )[ 2 ] = ( a )[ 2 ] * ( b )[ 2 ] )
-#define VectorCopy( a,b )            ( ( b )[ 0 ] = ( a )[ 0 ],( b )[ 1 ] = ( a )[ 1 ],( b )[ 2 ] = ( a )[ 2 ] )
-#define VectorScale( v, s, o )       ( ( o )[ 0 ] = ( v )[ 0 ] * ( s ),( o )[ 1 ] = ( v )[ 1 ] * ( s ),( o )[ 2 ] = ( v )[ 2 ] * ( s ) )
+template<typename A, typename B, typename C>
+void VectorSubtract( const A &a, const B &b, C &&c )
+{
+	c[ 0 ] = a[ 0 ] - b[ 0 ];
+	c[ 1 ] = a[ 1 ] - b[ 1 ];
+	c[ 2 ] = a[ 2 ] - b[ 2 ];
+}
+
+template<typename A, typename B, typename C>
+void VectorAdd( const A &a, const B &b, C &&c )
+{
+	c[ 0 ] = a[ 0 ] + b[ 0 ];
+	c[ 1 ] = a[ 1 ] + b[ 1 ];
+	c[ 2 ] = a[ 2 ] + b[ 2 ];
+}
+
+template<typename A, typename B>
+void VectorCopy( const A &a, B &&b )
+{
+	b[ 0 ] = a[ 0 ];
+	b[ 1 ] = a[ 1 ];
+	b[ 2 ] = a[ 2 ];
+}
+
+template<typename V, typename S, typename O>
+void VectorScale( const V &v, S s, O &&o )
+{
+	o[ 0 ] = v[ 0 ] * s;
+	o[ 1 ] = v[ 1 ] * s;
+	o[ 2 ] = v[ 2 ] * s;
+}
+
 /** Stands for MultiplyAdd: adding a vector "b" scaled by "s" to "v" and writing it to "o" */
-#define VectorMA( v, s, b, o )       ( ( o )[ 0 ] = ( v )[ 0 ] + ( b )[ 0 ] * ( s ),( o )[ 1 ] = ( v )[ 1 ] + ( b )[ 1 ] * ( s ),( o )[ 2 ] = ( v )[ 2 ] + ( b )[ 2 ] * ( s ) )
+template<typename V, typename S, typename B, typename O>
+void VectorMA( const V &v, S s, const B &b, O &&o )
+{
+	o[ 0 ] = v[ 0 ] + b[ 0 ] * s;
+	o[ 1 ] = v[ 1 ] + b[ 1 ] * s;
+	o[ 2 ] = v[ 2 ] + b[ 2 ] * s;
+}
+
+template<typename A>
+void VectorClear( A &&a )
+{
+	a[ 0 ] = 0;
+	a[ 1 ] = 0;
+	a[ 2 ] = 0;
+}
+
+template<typename A, typename B>
+void VectorNegate( const A &a, B &&b )
+{
+	b[ 0 ] = -a[ 0 ];
+	b[ 1 ] = -a[ 1 ];
+	b[ 2 ] = -a[ 2 ];
+}
+
+template<typename V, typename X, typename Y, typename Z>
+void VectorSet( V &&v, X x, Y y, Z z )
+{
+	v[ 0 ] = x;
+	v[ 1 ] = y;
+	v[ 2 ] = z;
+}
+
+template<typename A, typename B>
+void Vector2Copy( const A &a, B &&b )
+{
+	b[ 0 ] = a[ 0 ];
+	b[ 1 ] = a[ 1 ];
+}
+
+template<typename V, typename X, typename Y>
+void Vector2Set( V &&v, X x, Y y )
+{
+	v[ 0 ] = x;
+	v[ 1 ] = y;
+}
+
+template<typename A, typename B, typename C>
+void Vector2Subtract( const A &a, const B &b, C &&c )
+{
+	c[ 0 ] = a[ 0 ] - b[ 0 ];
+	c[ 1 ] = a[ 1 ] - b[ 1 ];
+}
+
+template<typename V, typename X, typename Y, typename Z, typename W>
+void Vector4Set( V &&v, X x, Y y, Z z, W w )
+{
+	v[ 0 ] = x;
+	v[ 1 ] = y;
+	v[ 2 ] = z;
+	v[ 3 ] = w;
+}
+
+template<typename A, typename B>
+void Vector4Copy( const A &a, B &&b )
+{
+	b[ 0 ] = a[ 0 ];
+	b[ 1 ] = a[ 1 ];
+	b[ 2 ] = a[ 2 ];
+	b[ 3 ] = a[ 3 ];
+}
+
+// good for floats only
+template<typename V>
+void SnapVector( V &&v )
+{
+	v[ 0 ] = roundf( v[ 0 ] );
+	v[ 1 ] = roundf( v[ 1 ] );
+	v[ 2 ] = roundf( v[ 2 ] );
+}
+
 #define VectorLerpTrem( f, s, e, r ) (( r )[ 0 ] = ( s )[ 0 ] + ( f ) * (( e )[ 0 ] - ( s )[ 0 ] ), \
                                       ( r )[ 1 ] = ( s )[ 1 ] + ( f ) * (( e )[ 1 ] - ( s )[ 1 ] ), \
                                       ( r )[ 2 ] = ( s )[ 2 ] + ( f ) * (( e )[ 2 ] - ( s )[ 2 ] ))
-
-#define VectorClear( a )             ( ( a )[ 0 ] = ( a )[ 1 ] = ( a )[ 2 ] = 0 )
-#define VectorNegate( a,b )          ( ( b )[ 0 ] = -( a )[ 0 ],( b )[ 1 ] = -( a )[ 1 ],( b )[ 2 ] = -( a )[ 2 ] )
-#define VectorSet( v, x, y, z )      ( ( v )[ 0 ] = ( x ), ( v )[ 1 ] = ( y ), ( v )[ 2 ] = ( z ) )
-
-#define Vector2Set( v, x, y )        ( ( v )[ 0 ] = ( x ),( v )[ 1 ] = ( y ) )
-#define Vector2Copy( a,b )           ( ( b )[ 0 ] = ( a )[ 0 ],( b )[ 1 ] = ( a )[ 1 ] )
-#define Vector2Subtract( a,b,c )     ( ( c )[ 0 ] = ( a )[ 0 ] - ( b )[ 0 ],( c )[ 1 ] = ( a )[ 1 ] - ( b )[ 1 ] )
-
-#define Vector4Set( v, x, y, z, n )  ( ( v )[ 0 ] = ( x ),( v )[ 1 ] = ( y ),( v )[ 2 ] = ( z ),( v )[ 3 ] = ( n ) )
-#define Vector4Copy( a,b )           ( ( b )[ 0 ] = ( a )[ 0 ],( b )[ 1 ] = ( a )[ 1 ],( b )[ 2 ] = ( a )[ 2 ],( b )[ 3 ] = ( a )[ 3 ] )
-#define DotProduct4(x, y)            (( x )[ 0 ] * ( y )[ 0 ] + ( x )[ 1 ] * ( y )[ 1 ] + ( x )[ 2 ] * ( y )[ 2 ] + ( x )[ 3 ] * ( y )[ 3 ] )
-
-#define SnapVector( v )              do { ( v )[ 0 ] = ( floor( ( v )[ 0 ] + 0.5f ) ); ( v )[ 1 ] = ( floor( ( v )[ 1 ] + 0.5f ) ); ( v )[ 2 ] = ( floor( ( v )[ 2 ] + 0.5f ) ); } while ( 0 )
 
 	float    RadiusFromBounds( const vec3_t mins, const vec3_t maxs );
 	void     ZeroBounds( vec3_t mins, vec3_t maxs );

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -53,7 +53,7 @@ int trap_CM_MarkFragments( int numPoints, const vec3_t *points, const vec3_t pro
 	std::vector<std::array<float, 3>> mypoints(numPoints);
 	std::array<float, 3> myproj;
 	memcpy((float*)mypoints.data(), points, sizeof(float) * 3 * numPoints);
-	VectorCopy(projection, myproj.data());
+	VectorCopy(projection, myproj);
 
 	std::vector<std::array<float, 3>> mypointBuffer;
 	std::vector<markFragment_t> myfragmentBuffer;
@@ -275,8 +275,8 @@ bool trap_R_inPVVS( const vec3_t p1, const vec3_t p2 )
 {
 	bool res;
 	std::array<float, 3> myp1, myp2;
-	VectorCopy(p1, myp1.data());
-	VectorCopy(p2, myp2.data());
+	VectorCopy(p1, myp1);
+	VectorCopy(p2, myp2);
 	VM::SendMsg<Render::InPVVSMsg>(myp1, myp2, res);
 	return res;
 }
@@ -379,14 +379,14 @@ void trap_R_ResetMatrixTransform()
 void trap_R_AddLightToScene( const vec3_t org, float radius, float intensity, float r, float g, float b, qhandle_t hShader, int flags )
 {
 	std::array<float, 3> myorg;
-	VectorCopy(org, myorg.data());
+	VectorCopy(org, myorg);
 	cmdBuffer.SendMsg<Render::AddLightToSceneMsg>(myorg, radius, intensity, r, g, b, hShader, flags);
 }
 
 void trap_R_AddAdditiveLightToScene( const vec3_t org, float intensity, float r, float g, float b )
 {
 	std::array<float, 3> myorg;
-	VectorCopy(org, myorg.data());
+	VectorCopy(org, myorg);
 	cmdBuffer.SendMsg<Render::AddAdditiveLightToSceneMsg>(myorg, intensity, r, g, b);
 }
 
@@ -429,8 +429,8 @@ void trap_R_ModelBounds( clipHandle_t model, vec3_t mins, vec3_t maxs )
 {
 	std::array<float, 3> mymins, mymaxs;
 	VM::SendMsg<Render::ModelBoundsMsg>(model, mymins, mymaxs);
-	VectorCopy(mymins.data(), mins);
-	VectorCopy(mymaxs.data(), maxs);
+	VectorCopy(mymins, mins);
+	VectorCopy(mymaxs, maxs);
 }
 
 int trap_R_LerpTag( orientation_t *tag, const refEntity_t *refent, const char *tagName, int startIndex )
@@ -449,8 +449,8 @@ bool trap_R_inPVS( const vec3_t p1, const vec3_t p2 )
 {
 	bool res;
 	std::array<float, 3> myp1, myp2;
-	VectorCopy(p1, myp1.data());
-	VectorCopy(p2, myp2.data());
+	VectorCopy(p1, myp1);
+	VectorCopy(p2, myp2);
 	VM::SendMsg<Render::InPVSMsg>(myp1, myp2, res);
 	return res;
 }
@@ -459,11 +459,11 @@ int trap_R_LightForPoint( vec3_t point, vec3_t ambientLight, vec3_t directedLigh
 {
 	int result;
 	std::array<float, 3> mypoint, myambient, mydirected, mydir;
-	VectorCopy(point, mypoint.data());
+	VectorCopy(point, mypoint);
 	VM::SendMsg<Render::LightForPointMsg>(mypoint, myambient, mydirected, mydir, result);
-	VectorCopy(myambient.data(), ambientLight);
-	VectorCopy(mydirected.data(), directedLight);
-	VectorCopy(mydir.data(), lightDir);
+	VectorCopy(myambient, ambientLight);
+	VectorCopy(mydirected, directedLight);
+	VectorCopy(mydir, lightDir);
 	return result;
 }
 
@@ -550,7 +550,7 @@ qhandle_t trap_RegisterVisTest()
 void trap_AddVisTestToScene( qhandle_t hTest, const vec3_t pos, float depthAdjust, float area )
 {
 	std::array<float, 3> mypos;
-	VectorCopy(pos, mypos.data());
+	VectorCopy(pos, mypos);
 	cmdBuffer.SendMsg<Render::AddVisTestToSceneMsg>(hTest, mypos, depthAdjust, area);
 }
 


### PR DESCRIPTION
The point of this is to prevent the arguments from being evaluated multiple times. In the commit message I give an example of this happening in cgame.

Also it can be useful for assigning a temporary GLM vector to a vec3_t. This is one more GLM/vec3_t adaptor we need in addition to [GLM4READ and GLM4RW](https://github.com/Unvanquished/Unvanquished/pull/3021). I was motivated to make this branch upon seeing, in a GLM conversion branch, VectorCopy used to assign a function's GLM return value to a vec3_t (heretofore a bad idea as the function is called 3 times).