### PR TITLE
renderer: rewrite the GLSL extension enablement

### DIFF
--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -35,7 +35,7 @@ uniform samplerCube u_EnvironmentMap1;
 uniform float u_EnvironmentInterpolation;
 #endif // USE_REFLECTIVE_SPECULAR
 
-#ifdef HAVE_ARB_uniform_buffer_object
+#if defined(HAVE_ARB_uniform_buffer_object)
 struct light {
   vec4  center_radius;
   vec4  color_type;
@@ -146,7 +146,7 @@ void computeDeluxeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightCol
 #endif // !USE_PHYSICAL_MAPPING
 }
 
-#if defined(TEXTURE_INTEGER) && defined(r_highPrecisionRendering)
+#if defined(HAVE_EXT_texture_integer) && defined(r_highPrecisionRendering)
 const int lightsPerLayer = 16;
 uniform usampler3D u_LightTiles;
 #define idxs_t uvec4
@@ -158,7 +158,7 @@ int nextIdx( inout idxs_t idxs ) {
   idxs = idxs >> 2;
   return int( tmp.x + tmp.y + tmp.z + tmp.w );
 }
-#else // !TEXTURE INTEGER
+#else // !HAVE_EXT_texture_integer
 const int lightsPerLayer = 4;
 uniform sampler3D u_LightTiles;
 #define idxs_t vec4
@@ -171,7 +171,7 @@ int nextIdx( inout idxs_t idxs ) {
   tmp -= 4.0 * idxs;
   return int( dot( tmp, vec4( 64.0, 16.0, 4.0, 1.0 ) ) );
 }
-#endif // TEXTURE_INTEGER
+#endif // HAVE_EXT_texture_integer
 
 const int numLayers = MAX_REF_LIGHTS / 256;
 

--- a/src/engine/renderer/glsl_source/debugShadowMap_fp.glsl
+++ b/src/engine/renderer/glsl_source/debugShadowMap_fp.glsl
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 /* debugShadowMap_fp.glsl */
 
 /* swizzle one- and two-component textures to RG */
-#ifdef TEXTURE_RG
+#if defined(HAVE_ARB_texture_rg)
 #  define SWIZ1 r
 #  define SWIZ2 rg
 #else

--- a/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 /* forwardLighting_fp.glsl */
 
 /* swizzle one- and two-component textures to RG */
-#ifdef TEXTURE_RG
+#if defined(HAVE_ARB_texture_rg)
 #  define SWIZ1 r
 #  define SWIZ2 rg
 #else

--- a/src/engine/renderer/glsl_source/lighttile_fp.glsl
+++ b/src/engine/renderer/glsl_source/lighttile_fp.glsl
@@ -46,7 +46,7 @@ struct light {
   float angle;
 };
 
-#ifdef HAVE_ARB_uniform_buffer_object
+#if defined(HAVE_ARB_uniform_buffer_object)
 layout(std140) uniform u_Lights {
   vec4 lightvec[ MAX_REF_LIGHTS * 3 ];
 };
@@ -88,7 +88,7 @@ uniform vec3 u_zFar;
 
 const int numLayers = MAX_REF_LIGHTS / 256;
 
-#if defined(TEXTURE_INTEGER) && defined(r_highPrecisionRendering)
+#if defined(HAVE_EXT_texture_integer) && defined(r_highPrecisionRendering)
 #define idxs_t uvec4
 #define idx_initializer uvec4(3)
 DECLARE_OUTPUT(uvec4)

--- a/src/engine/renderer/glsl_source/shadowFill_fp.glsl
+++ b/src/engine/renderer/glsl_source/shadowFill_fp.glsl
@@ -33,7 +33,7 @@ IN(smooth) vec4		var_Color;
 
 DECLARE_OUTPUT(vec4)
 
-#ifdef TEXTURE_RG
+#if defined(HAVE_ARB_texture_rg)
 #  define SWIZ1 r
 #  define SWIZ2 rg
 #else

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -85,6 +85,7 @@ struct glconfig2_t
 	bool textureIntegerAvailable;
 	bool textureRGAvailable;
 	bool gpuShader4Available;
+	bool gpuShader5Available;
 	bool textureGatherAvailable;
 	int      maxDrawBuffers;
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1788,6 +1788,9 @@ static void GLimp_InitExtensions()
 	// made required in OpenGL 3.0
 	glConfig2.gpuShader4Available = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, EXT_gpu_shader4, r_ext_gpu_shader4->value );
 
+	// made required in OpenGL 4.0
+	glConfig2.gpuShader5Available = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_gpu_shader5, r_arb_gpu_shader5->value );
+
 	// made required in OpenGL 3.0
 	// GL_EXT_texture_integer can be used in shaders only if GL_EXT_gpu_shader4 is also available
 	glConfig2.textureIntegerAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, EXT_texture_integer, r_ext_texture_integer->value )


### PR DESCRIPTION
- trust `GLimp_InitExtensions` and deduplicate the code
- unify the way to tell an extension is available