### PR TITLE
tr_shader: always iterate grouped stages

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5647,17 +5647,13 @@ static shader_t *FinishShader()
 		}
 	}
 
-	int stage;
+	numStages = MAX_SHADER_STAGES;
+	GroupActiveStages();
 
 	// set appropriate stage information
-	for ( stage = 0; stage < MAX_SHADER_STAGES; stage++ )
+	for ( size_t stage = 0; stage < numStages; stage++ )
 	{
 		shaderStage_t *pStage = &stages[ stage ];
-
-		if ( !pStage->active )
-		{
-			break;
-		}
 
 		if ( !shader.isSky )
 		{
@@ -5863,7 +5859,7 @@ static shader_t *FinishShader()
 		}
 	}
 
-	numStages = stage;
+	GroupActiveStages();
 
 	// there are times when you will need to manually apply a sort to
 	// opaque alpha tested shaders that have later blend passes


### PR DESCRIPTION
Fixes #1185:

- https://github.com/DaemonEngine/Daemon/issues/1185

Alongside fixing #1185, this is something I wanted to do anyway, in order to move the next `for` loop after the first `GroupActiveStages` call to a dedicated function (this is a code validating shader stages and disabling invalid ones).

The bug is that we are now more agressive at disabling unsupported stages as soon as possible, and the stage validation code was stoping iterating the stages on first disabled stage found.

The material looks like this:

```
tremor/54ECD65C96E1201DEABD3DDB5B656605
{
	{
		map $lightmap
		rgbGen identity
	}
	
	// Q3Map2 custom lightstyle stage(s)
	{
		map $lightmap
		blendFunc GL_SRC_ALPHA GL_ONE
		rgbGen wave sawtooth 0 1 0 0.5 // style 1
		tcGen lightmap
		tcMod transform 1 0 0 1 0.45410 0.18457
	}

	{
		map textures/tremor/grate3.tga
		blendFunc GL_DST_COLOR GL_ZERO
		rgbGen identity
	}
}
```

Light styles are not supported on light modes ≠ 3 (light mapping), so it is expected the material is turned into this:

```
tremor/54ECD65C96E1201DEABD3DDB5B656605
{
	{
		map $lightmap
		rgbGen identity
	}

	{
		// disabled stage
	}

	{
		map textures/tremor/grate3.tga
		blendFunc GL_DST_COLOR GL_ZERO
		rgbGen identity
	}
}
```

But the loop doing an early break on the disabled stage, it turned the material into this:

```
tremor/54ECD65C96E1201DEABD3DDB5B656605
{
	{
		map $lightmap
		rgbGen identity
	}
}
```

Only painting the light with no texture blended over.