### PR TITLE
q_shared: delete unused IS_NAN

### DIFF
--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -338,10 +338,6 @@ extern const vec3_t   axisDefault[ 3 ];
 extern const matrix_t matrixIdentity;
 extern const quat_t   quatIdentity;
 
-#define nanmask ( 255 << 23 )
-
-#define IS_NAN( x ) ( ( ( *(int *)&( x ) ) & nanmask ) == nanmask )
-
 #define Q_ftol(x) ((long)(x))
 
 	// Overall relative error bound (ignoring unknown powerpc case): 5 * 10^-6


### PR DESCRIPTION
Delete unused `IS_NAN`.

One should prefer using `!Math::IsFinite` instead.