### PR TITLE
cmake: empty string is not missing token (2)

### DIFF
--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -343,7 +343,7 @@ else()
         try_c_cxx_flag(WSTACK_PROTECTOR "-Wstack-protector")
         try_c_cxx_flag(FPIE "-fPIE")
         try_linker_flag(LINKER_PIE "-pie")
-        if (${FLAG_LINKER_PIE} AND MINGW)
+        if ("${FLAG_LINKER_PIE}" AND MINGW)
             # https://github.com/msys2/MINGW-packages/issues/4100
             if (ARCH STREQUAL "i686")
                 set_linker_flag("-Wl,-e,_mainCRTStartup")


### PR DESCRIPTION
When `-pie` isn't supported, `FLAG_LINKER_PIE` isn't set and this line errors out because `if(AND MINGW)` is a syntax error.

This is a fix similar to #1157:

- https://github.com/DaemonEngine/Daemon/pull/1157




