### PR TITLE
Material System: Make depth pre-pass surfaces into stages of the main surface

### DIFF
--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -258,6 +258,7 @@ class MaterialSystem {
 	void GenerateDepthImages( const int width, const int height, imageParams_t imageParms );
 
 	void AddStageTextures( drawSurf_t* drawSurf, shaderStage_t* pStage, Material* material );
+	void ProcessStage( drawSurf_t* drawSurf, shaderStage_t* pStage, shader_t* shader, uint32_t* packIDs, uint32_t& stage );
 	void GenerateWorldMaterials();
 	void GenerateWorldMaterialsBuffer();
 	void GenerateWorldCommandBuffer();

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -761,8 +761,8 @@ class GLUniform1ui : protected GLUniform {
 class GLUniform1Bool : protected GLUniform {
 	protected:
 	// GLSL std430 bool is always 4 bytes, which might not correspond to C++ bool
-	GLUniform1Bool( GLShader* shader, const char* name ) :
-		GLUniform( shader, name, "bool", 1, 1, false ) {
+	GLUniform1Bool( GLShader* shader, const char* name, const bool global ) :
+		GLUniform( shader, name, "bool", 1, 1, global ) {
 	}
 
 	inline void SetValue( int value ) {
@@ -3243,7 +3243,7 @@ class u_InitialDepthLevel :
 	GLUniform1Bool {
 	public:
 	u_InitialDepthLevel( GLShader* shader ) :
-		GLUniform1Bool( shader, "u_InitialDepthLevel" ) {
+		GLUniform1Bool( shader, "u_InitialDepthLevel", true ) {
 	}
 
 	void SetUniform_InitialDepthLevel( const int initialDepthLevel ) {
@@ -3291,7 +3291,7 @@ class u_UseFrustumCulling :
 	GLUniform1Bool {
 	public:
 	u_UseFrustumCulling( GLShader* shader ) :
-		GLUniform1Bool( shader, "u_UseFrustumCulling" ) {
+		GLUniform1Bool( shader, "u_UseFrustumCulling", true ) {
 	}
 
 	void SetUniform_UseFrustumCulling( const int useFrustumCulling ) {
@@ -3303,7 +3303,7 @@ class u_UseOcclusionCulling :
 	GLUniform1Bool {
 	public:
 	u_UseOcclusionCulling( GLShader* shader ) :
-		GLUniform1Bool( shader, "u_UseOcclusionCulling" ) {
+		GLUniform1Bool( shader, "u_UseOcclusionCulling", true ) {
 	}
 
 	void SetUniform_UseOcclusionCulling( const int useOcclusionCulling ) {
@@ -3315,7 +3315,7 @@ class u_ShowTris :
 	GLUniform1Bool {
 	public:
 	u_ShowTris( GLShader* shader ) :
-		GLUniform1Bool( shader, "u_ShowTris" ) {
+		GLUniform1Bool( shader, "u_ShowTris", true ) {
 	}
 
 	void SetUniform_ShowTris( const int showTris ) {
@@ -3480,7 +3480,7 @@ class u_UseCloudMap :
 	GLUniform1Bool {
 	public:
 	u_UseCloudMap( GLShader* shader ) :
-		GLUniform1Bool( shader, "u_UseCloudMap" ) {
+		GLUniform1Bool( shader, "u_UseCloudMap", true ) {
 	}
 
 	void SetUniform_UseCloudMap( const bool useCloudMap ) {

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1663,6 +1663,9 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		bool texturesDynamic[ MAX_SHADER_STAGES ];
 		uint drawCommandIDs[ MAX_SHADER_STAGES ];
 
+		drawSurf_t* depthSurface;
+		bool materialSystemSkip = false;
+
 		inline int index() const {
 			return int( ( sort & SORT_INDEX_MASK ) );
 		}

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -2037,6 +2037,8 @@ void R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, i
 
 	if ( shader->depthShader != nullptr ) {
 		R_AddDrawSurf( surface, shader->depthShader, 0, 0, bspSurface );
+		drawSurf->depthSurface = &tr.refdef.drawSurfs[index + 1];
+		drawSurf->depthSurface->materialSystemSkip = true;
 	}
 }
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5901,18 +5901,6 @@ static shader_t *FinishShader()
 	// Copy the current global shader to a newly allocated shader.
 	shader_t *ret = MakeShaderPermanent();
 
-	if ( glConfig2.materialSystemAvailable && !tr.worldLoaded ) {
-		uint8_t maxStages = 0;
-		for ( shaderStage_t* pStage = ret->stages; pStage < ret->lastStage; pStage++ ) {
-			maxStages++;
-		}
-
-		if ( maxStages % 4 != 0 ) { // Aligned to 4 components
-			maxStages = ( maxStages / 4 + 1 ) * 4;
-		}
-		materialSystem.maxStages = maxStages > materialSystem.maxStages ? maxStages : materialSystem.maxStages;
-	}
-
 	// generate depth-only shader if necessary
 	if( !shader.isSky &&
 	    numStages > 0 &&
@@ -5929,6 +5917,17 @@ static shader_t *FinishShader()
 		if ( !CheckShaderNameLength( "FinishShader", shader.name, depthShaderSuffix ) )
 		{
 			ret->depthShader = nullptr;
+
+			if ( glConfig2.materialSystemAvailable && !tr.worldLoaded ) {
+				uint8_t maxStages = 0;
+				for ( shaderStage_t* pStage = ret->stages; pStage < ret->lastStage; pStage++ ) {
+					maxStages++;
+				}
+
+				maxStages = PAD( maxStages, 4 ); // Aligned to 4 components
+				materialSystem.maxStages = std::max( maxStages, materialSystem.maxStages );
+			}
+
 			return ret;
 		}
 
@@ -5977,6 +5976,16 @@ static shader_t *FinishShader()
 		ret->stages[0].stateBits &= ~GLS_DEPTHMASK_TRUE;
 	} else {
 		ret->depthShader = nullptr;
+	}
+
+	if ( glConfig2.materialSystemAvailable && !tr.worldLoaded ) {
+		uint8_t maxStages = 0;
+		for ( shaderStage_t* pStage = ret->stages; pStage < ret->lastStage; pStage++ ) {
+			maxStages++;
+		}
+
+		maxStages = PAD( maxStages, 4 ); // Aligned to 4 components
+		materialSystem.maxStages = std::max( maxStages, materialSystem.maxStages );
 	}
 
 	// load all altShaders recursively


### PR DESCRIPTION
Builds on #1180

Avoid culling the same surface twice, which is especially important for occlusion culling since it reduces the amount of texture accesses by half. Also changed material generation a bit to make it easier to add non-world surfaces later.