### PR TITLE
Only do RB_RenderPostDepthLightTile() for the main view

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4791,7 +4791,9 @@ static void RB_RenderView( bool depthPass )
 	if( depthPass ) {
 		RB_RenderDrawSurfaces( shaderSort_t::SS_DEPTH, shaderSort_t::SS_DEPTH, DRAWSURFACES_ALL );
 		RB_RunVisTests();
-		RB_RenderPostDepthLightTile();
+		if ( !backEnd.viewParms.isMainView ) {
+			RB_RenderPostDepthLightTile();
+		}
 		return;
 	}
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1520,6 +1520,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		vec3_t         pvsOrigin; // may be different than or.origin for portals
 
 		int            portalLevel; // number of portals this view is through
+		bool isMainView = false;
 		int            mirrorLevel;
 		bool           isMirror; // the portal is a mirror, invert the face culling
 

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -625,6 +625,8 @@ void RE_RenderScene( const refdef_t *fd )
 	VectorCopy( fd->vieworg, parms.pvsOrigin );
 	Vector4Copy( fd->gradingWeights, parms.gradingWeights );
 
+	parms.isMainView = true;
+
 	R_AddClearBufferCmd();
 	R_AddSetupLightsCmd();
 


### PR DESCRIPTION
This will ensure that only the main view computes dynamic lights. Fixes dynamic light disappearing near portals.

This does mean that dynamic lights won't render in portals, but that was already the case anyway, and fixing that would require more complex changes, which would be unlikely to be noticeable.