### PR TITLE
renderer: port GL extension cvars to new style format

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -110,19 +110,6 @@ void GL_TextureMode( const char *string )
 	gl_filter_min = modes[ i ].minimize;
 	gl_filter_max = modes[ i ].maximize;
 
-	// bound texture anisotropy
-	if ( glConfig2.textureAnisotropyAvailable )
-	{
-		if ( r_ext_texture_filter_anisotropic->value > glConfig2.maxTextureAnisotropy )
-		{
-			Cvar_Set( "r_ext_texture_filter_anisotropic", va( "%f", glConfig2.maxTextureAnisotropy ) );
-		}
-		else if ( r_ext_texture_filter_anisotropic->value < 1.0f )
-		{
-			Cvar_Set( "r_ext_texture_filter_anisotropic", "1.0" );
-		}
-	}
-
 	// change all the existing mipmap texture objects
 	for ( image_t *image : tr.images )
 	{
@@ -137,7 +124,7 @@ void GL_TextureMode( const char *string )
 			// set texture anisotropy
 			if ( glConfig2.textureAnisotropyAvailable )
 			{
-				glTexParameterf( image->type, GL_TEXTURE_MAX_ANISOTROPY_EXT, r_ext_texture_filter_anisotropic->value );
+				glTexParameterf( image->type, GL_TEXTURE_MAX_ANISOTROPY_EXT, glConfig2.textureAnisotropy );
 			}
 		}
 	}
@@ -1122,7 +1109,7 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 			// set texture anisotropy
 			if ( glConfig2.textureAnisotropyAvailable )
 			{
-				glTexParameterf( image->type, GL_TEXTURE_MAX_ANISOTROPY_EXT, r_ext_texture_filter_anisotropic->value );
+				glTexParameterf( image->type, GL_TEXTURE_MAX_ANISOTROPY_EXT, glConfig2.textureAnisotropy );
 			}
 
 			glTexParameterf( image->type, GL_TEXTURE_MIN_FILTER, gl_filter_min );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -87,23 +87,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_noMarksOnTrisurfs;
 	cvar_t      *r_lazyShaders;
 
-	cvar_t      *r_ext_occlusion_query;
-	cvar_t      *r_ext_draw_buffers;
-	cvar_t      *r_ext_half_float_pixel;
-	cvar_t      *r_ext_texture_float;
-	cvar_t      *r_ext_texture_integer;
-	cvar_t      *r_ext_texture_rg;
-	cvar_t      *r_ext_texture_filter_anisotropic;
-	cvar_t      *r_ext_gpu_shader4;
-	cvar_t      *r_arb_buffer_storage;
-	cvar_t      *r_arb_map_buffer_range;
-	cvar_t      *r_arb_sync;
-	cvar_t      *r_arb_uniform_buffer_object;
-	cvar_t      *r_arb_texture_gather;
-	cvar_t      *r_arb_gpu_shader5;
-	Cvar::Cvar<bool> r_arb_depth_clamp("r_arb_depth_clamp", "Use GL_ARB_depth_clamp if available", Cvar::NONE, true);
-	cvar_t      *r_arb_compute_shader;
-
 	cvar_t      *r_checkGLErrors;
 	cvar_t      *r_logFile;
 
@@ -1076,23 +1059,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_glExtendedValidation = Cvar_Get( "r_glExtendedValidation", "0", CVAR_LATCH );
 
 		// latched and archived variables
-		r_ext_occlusion_query = Cvar_Get( "r_ext_occlusion_query", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_ext_draw_buffers = Cvar_Get( "r_ext_draw_buffers", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_ext_half_float_pixel = Cvar_Get( "r_ext_half_float_pixel", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_ext_texture_float = Cvar_Get( "r_ext_texture_float", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_ext_texture_integer = Cvar_Get( "r_ext_texture_integer", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_ext_texture_rg = Cvar_Get( "r_ext_texture_rg", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_ext_texture_filter_anisotropic = Cvar_Get( "r_ext_texture_filter_anisotropic", "4",  CVAR_LATCH | CVAR_ARCHIVE );
-		r_ext_gpu_shader4 = Cvar_Get( "r_ext_gpu_shader4", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_arb_buffer_storage = Cvar_Get( "r_arb_buffer_storage", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_arb_map_buffer_range = Cvar_Get( "r_arb_map_buffer_range", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_arb_sync = Cvar_Get( "r_arb_sync", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_arb_uniform_buffer_object = Cvar_Get( "r_arb_uniform_buffer_object", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_arb_texture_gather = Cvar_Get( "r_arb_texture_gather", "1", CVAR_CHEAT | CVAR_LATCH );
-		r_arb_gpu_shader5 = Cvar_Get( "r_arb_gpu_shader5", "1", CVAR_CHEAT | CVAR_LATCH );
-		Cvar::Latch(r_arb_depth_clamp);
-		r_arb_compute_shader = Cvar_Get( "r_arb_compute_shader", "1", CVAR_CHEAT | CVAR_LATCH );
-
 		r_picMip = Cvar_Get( "r_picMip", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_imageMaxDimension = Cvar_Get( "r_imageMaxDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_ignoreMaterialMinDimension = Cvar_Get( "r_ignoreMaterialMinDimension", "0",  CVAR_LATCH | CVAR_ARCHIVE );
@@ -1470,11 +1436,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		R_InitAnimations();
 
 		R_InitFreeType();
-
-		if ( glConfig2.textureAnisotropyAvailable )
-		{
-			AssertCvarRange( r_ext_texture_filter_anisotropic, 0, glConfig2.maxTextureAnisotropy, false );
-		}
 
 		R_InitVisTests();
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2883,23 +2883,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_mode; // video mode
 	extern cvar_t *r_gamma;
 
-	extern cvar_t *r_ext_occlusion_query; // these control use of specific extensions
-	extern cvar_t *r_ext_draw_buffers;
-	extern cvar_t *r_ext_half_float_pixel;
-	extern cvar_t *r_ext_texture_float;
-	extern cvar_t *r_ext_texture_integer;
-	extern cvar_t *r_ext_texture_rg;
-	extern cvar_t *r_ext_texture_filter_anisotropic;
-	extern cvar_t *r_ext_gpu_shader4;
-	extern cvar_t *r_arb_buffer_storage;
-	extern cvar_t *r_arb_map_buffer_range;
-	extern cvar_t *r_arb_sync;
-	extern cvar_t *r_arb_uniform_buffer_object;
-	extern cvar_t *r_arb_texture_gather;
-	extern cvar_t *r_arb_gpu_shader5;
-	extern Cvar::Cvar<bool> r_arb_depth_clamp;
-	extern cvar_t *r_arb_compute_shader;
-
 	extern cvar_t *r_nobind; // turns off binding to appropriate textures
 	extern cvar_t *r_singleShader; // make most world faces use default shader
 	extern cvar_t *r_picMip; // controls picmip values

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -91,6 +91,7 @@ struct glconfig2_t
 	int      maxDrawBuffers;
 
 	float    maxTextureAnisotropy;
+	float textureAnisotropy;
 	bool textureAnisotropyAvailable;
 
 	int      maxRenderbufferSize;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -53,6 +53,42 @@ static Cvar::Cvar<std::string> r_glForceHardware(
 static Cvar::Cvar<std::string> r_availableModes(
 	"r_availableModes", "list of available resolutions", Cvar::ROM, "");
 
+// OpenGL extension cvars.
+static Cvar::Cvar<bool> r_arb_buffer_storage( "r_arb_buffer_storage",
+	"Use GL_ARB_buffer_storage if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_compute_shader( "r_arb_compute_shader",
+	"Use GL_ARB_compute_shader if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_debug_output( "r_arb_debug_output",
+	"Use GL_ARB_debug_output if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_depth_clamp( "r_arb_depth_clamp",
+	"Use GL_ARB_depth_clamp if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_gpu_shader5( "r_arb_gpu_shader5",
+	"Use GL_ARB_gpu_shader5 if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_map_buffer_range( "r_arb_map_buffer_range",
+	"Use GL_ARB_map_buffer_range if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_sync( "r_arb_sync",
+	"Use GL_ARB_sync if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_texture_gather( "r_arb_texture_gather",
+	"Use GL_ARB_texture_gather if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_uniform_buffer_object( "r_arb_uniform_buffer_object",
+	"Use GL_ARB_uniform_buffer_object if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_ext_draw_buffers( "r_ext_draw_buffers",
+	"Use GL_EXT_draw_buffers if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_ext_gpu_shader4( "r_ext_gpu_shader4",
+	"Use GL_EXT_gpu_shader4 if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_ext_half_float_pixel( "r_ext_half_float_pixel",
+	"Use GL_EXT_half_float_pixel if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_ext_occlusion_query( "r_ext_occlusion_query",
+	"Use GL_EXT_occlusion_query if available", Cvar::NONE, true );
+static Cvar::Range<Cvar::Cvar<float>> r_ext_texture_filter_anisotropic( "r_ext_texture_filter_anisotropic",
+	"Use GL_EXT_texture_filter_anisotropic if available: anisotropy value", Cvar::NONE, 4.0f, 0.0f, 16.0f );
+static Cvar::Cvar<bool> r_ext_texture_float( "r_ext_texture_float",
+	"Use GL_EXT_texture_float if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_ext_texture_integer( "r_ext_texture_integer",
+	"Use GL_EXT_texture_integer if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_ext_texture_rg( "r_ext_texture_rg",
+	"Use GL_EXT_texture_rg if available", Cvar::NONE, true );
+
 SDL_Window *window = nullptr;
 static SDL_GLContext glContext = nullptr;
 
@@ -1746,10 +1782,29 @@ static void GLimp_InitExtensions()
 {
 	logger.Notice("Initializing OpenGL extensions" );
 
+	Cvar::Latch( r_arb_buffer_storage );
+	Cvar::Latch( r_arb_compute_shader );
+	Cvar::Latch( r_arb_debug_output );
+	Cvar::Latch( r_arb_depth_clamp );
+	Cvar::Latch( r_arb_gpu_shader5 );
+	Cvar::Latch( r_arb_map_buffer_range );
+	Cvar::Latch( r_arb_sync );
+	Cvar::Latch( r_arb_texture_gather );
+	Cvar::Latch( r_arb_uniform_buffer_object );
+	Cvar::Latch( r_ext_draw_buffers );
+	Cvar::Latch( r_ext_gpu_shader4 );
+	Cvar::Latch( r_ext_half_float_pixel );
+	Cvar::Latch( r_ext_occlusion_query );
+	Cvar::Latch( r_ext_texture_filter_anisotropic );
+	Cvar::Latch( r_ext_texture_float );
+	Cvar::Latch( r_ext_texture_integer );
+	Cvar::Latch( r_ext_texture_rg );
+
 	glConfig2.glEnabledExtensionsString = std::string();
 	glConfig2.glMissingExtensionsString = std::string();
 
-	if ( LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_debug_output, r_glDebugProfile->value ) )
+	if ( LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_debug_output,
+		r_arb_debug_output.Get() && r_glDebugProfile->value ) )
 	{
 		glDebugMessageCallbackARB( (GLDEBUGPROCARB)GLimp_DebugCallback, nullptr );
 		glEnable( GL_DEBUG_OUTPUT_SYNCHRONOUS_ARB );
@@ -1780,24 +1835,24 @@ static void GLimp_InitExtensions()
 	glGetIntegerv( GL_MAX_CUBE_MAP_TEXTURE_SIZE_ARB, &glConfig2.maxCubeMapTextureSize );
 
 	// made required in OpenGL 3.0
-	glConfig2.textureHalfFloatAvailable =  LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_half_float_pixel, r_ext_half_float_pixel->value );
+	glConfig2.textureHalfFloatAvailable =  LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_half_float_pixel, r_ext_half_float_pixel.Get() );
 
 	// made required in OpenGL 3.0
-	glConfig2.textureFloatAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_texture_float, r_ext_texture_float->value );
+	glConfig2.textureFloatAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_texture_float, r_ext_texture_float.Get() );
 
 	// made required in OpenGL 3.0
-	glConfig2.gpuShader4Available = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, EXT_gpu_shader4, r_ext_gpu_shader4->value );
+	glConfig2.gpuShader4Available = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, EXT_gpu_shader4, r_ext_gpu_shader4.Get() );
 
 	// made required in OpenGL 4.0
-	glConfig2.gpuShader5Available = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_gpu_shader5, r_arb_gpu_shader5->value );
+	glConfig2.gpuShader5Available = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_gpu_shader5, r_arb_gpu_shader5.Get() );
 
 	// made required in OpenGL 3.0
 	// GL_EXT_texture_integer can be used in shaders only if GL_EXT_gpu_shader4 is also available
-	glConfig2.textureIntegerAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, EXT_texture_integer, r_ext_texture_integer->value )
+	glConfig2.textureIntegerAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, EXT_texture_integer, r_ext_texture_integer.Get() )
 	  && glConfig2.gpuShader4Available;
 
 	// made required in OpenGL 3.0
-	glConfig2.textureRGAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_texture_rg, r_ext_texture_rg->value );
+	glConfig2.textureRGAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_texture_rg, r_ext_texture_rg.Get() );
 
 	{
 		/* GT218-based GPU with Nvidia 340.108 driver advertising
@@ -1828,7 +1883,7 @@ static void GLimp_InitExtensions()
 		}
 
 		// made required in OpenGL 4.0
-		glConfig2.textureGatherAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_texture_gather, r_arb_texture_gather->value && !foundNvidia340 );
+		glConfig2.textureGatherAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_texture_gather, r_arb_texture_gather.Get() && !foundNvidia340 );
 	}
 
 	{
@@ -1864,10 +1919,14 @@ static void GLimp_InitExtensions()
 
 	// Texture - others
 	glConfig2.textureAnisotropyAvailable = false;
-	if ( LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, EXT_texture_filter_anisotropic, r_ext_texture_filter_anisotropic->value ) )
+	glConfig2.textureAnisotropy = 0.0f;
+	if ( LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, EXT_texture_filter_anisotropic, r_ext_texture_filter_anisotropic.Get() > 0 ) )
 	{
 		glGetFloatv( GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT, &glConfig2.maxTextureAnisotropy );
 		glConfig2.textureAnisotropyAvailable = true;
+
+		// Bound texture anisotropy.
+		glConfig2.textureAnisotropy = std::max( std::min( r_ext_texture_filter_anisotropic.Get(), glConfig2.maxTextureAnisotropy ), 1.0f );
 	}
 
 	// VAO and VBO
@@ -1906,7 +1965,7 @@ static void GLimp_InitExtensions()
 	// made required in OpenGL 1.5
 	glConfig2.occlusionQueryAvailable = false;
 	glConfig2.occlusionQueryBits = 0;
-	if ( r_ext_occlusion_query->integer != 0 )
+	if ( r_ext_occlusion_query.Get() )
 	{
 		glConfig2.occlusionQueryAvailable = true;
 		glGetQueryiv( GL_SAMPLES_PASSED, GL_QUERY_COUNTER_BITS, &glConfig2.occlusionQueryBits );
@@ -1914,7 +1973,7 @@ static void GLimp_InitExtensions()
 
 	// made required in OpenGL 2.0
 	glConfig2.drawBuffersAvailable = false;
-	if ( r_ext_draw_buffers->integer != 0 )
+	if ( r_ext_draw_buffers.Get() )
 	{
 		glGetIntegerv( GL_MAX_DRAW_BUFFERS, &glConfig2.maxDrawBuffers );
 		glConfig2.drawBuffersAvailable = true;
@@ -1935,22 +1994,22 @@ static void GLimp_InitExtensions()
 	}
 
 	glConfig2.bufferStorageAvailable = false;
-	glConfig2.bufferStorageAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_buffer_storage, r_arb_buffer_storage->integer > 0 );
+	glConfig2.bufferStorageAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_buffer_storage, r_arb_buffer_storage.Get() );
 
 	// made required since OpenGL 3.1
-	glConfig2.uniformBufferObjectAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_uniform_buffer_object, r_arb_uniform_buffer_object->value );
+	glConfig2.uniformBufferObjectAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_uniform_buffer_object, r_arb_uniform_buffer_object.Get() );
 
 	// made required in OpenGL 3.0
-	glConfig2.mapBufferRangeAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_map_buffer_range, r_arb_map_buffer_range->value );
+	glConfig2.mapBufferRangeAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_map_buffer_range, r_arb_map_buffer_range.Get() );
 
 	// made required in OpenGL 3.2
-	glConfig2.syncAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_sync, r_arb_sync->value );
+	glConfig2.syncAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_sync, r_arb_sync.Get() );
 
 	// made required in OpenGL 3.2
 	glConfig2.depthClampAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_depth_clamp, r_arb_depth_clamp.Get() );
 
 	// made required in OpenGL 4.3
-	glConfig2.computeShaderAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_compute_shader, r_arb_compute_shader->value );
+	glConfig2.computeShaderAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_compute_shader, r_arb_compute_shader.Get() );
 
 	GL_CheckErrors();
 }


### PR DESCRIPTION
Port GL extension cvars to new style format.

@slipher I have no idea is the `Cvar::Unlatch` implementation is correct.