### PR TITLE
Revert "Only do RB_RenderPostDepthLightTile() for the main view"

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4801,9 +4801,7 @@ static void RB_RenderView( bool depthPass )
 	if( depthPass ) {
 		RB_RenderDrawSurfaces( shaderSort_t::SS_DEPTH, shaderSort_t::SS_DEPTH, DRAWSURFACES_ALL );
 		RB_RunVisTests();
-		if ( !backEnd.viewParms.isMainView ) {
-			RB_RenderPostDepthLightTile();
-		}
+		RB_RenderPostDepthLightTile();
 		return;
 	}
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1520,7 +1520,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		vec3_t         pvsOrigin; // may be different than or.origin for portals
 
 		int            portalLevel; // number of portals this view is through
-		bool isMainView = false;
 		int            mirrorLevel;
 		bool           isMirror; // the portal is a mirror, invert the face culling
 

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -625,8 +625,6 @@ void RE_RenderScene( const refdef_t *fd )
 	VectorCopy( fd->vieworg, parms.pvsOrigin );
 	Vector4Copy( fd->gradingWeights, parms.gradingWeights );
 
-	parms.isMainView = true;
-
 	R_AddClearBufferCmd();
 	R_AddSetupLightsCmd();
 


### PR DESCRIPTION
This reverts commit c3d538d0990dd45b5a5b688ea7c3b38d1b515cce.

It breaks dynamic lighting. The light tile rectangles are visible.

![unvanquished_2024-06-30_152600_000](https://github.com/DaemonEngine/Daemon/assets/7809431/b3e911fd-b83d-4fbd-bd6e-dda2b751a5b1)
