### PR TITLE
Fix post-deph lighttile

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4801,8 +4801,9 @@ static void RB_RenderView( bool depthPass )
 	if( depthPass ) {
 		RB_RenderDrawSurfaces( shaderSort_t::SS_DEPTH, shaderSort_t::SS_DEPTH, DRAWSURFACES_ALL );
 		RB_RunVisTests();
-		if ( !backEnd.viewParms.isMainView ) {
+		if ( !backEnd.postDepthLightTileRendered && !backEnd.viewParms.hasNestedViews ) {
 			RB_RenderPostDepthLightTile();
+			backEnd.postDepthLightTileRendered = true;
 		}
 		return;
 	}
@@ -5517,6 +5518,7 @@ const RenderCommand *ClearBufferCommand::ExecuteSelf( ) const
 
 	backEnd.refdef = refdef;
 	backEnd.viewParms = viewParms;
+	backEnd.postDepthLightTileRendered = false;
 
 	GL_CheckErrors();
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1520,7 +1520,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		vec3_t         pvsOrigin; // may be different than or.origin for portals
 
 		int            portalLevel; // number of portals this view is through
-		bool isMainView = false;
+		bool hasNestedViews = false;
 		int            mirrorLevel;
 		bool           isMirror; // the portal is a mirror, invert the face culling
 
@@ -2550,6 +2550,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		trRefEntity_t     *currentEntity;
 		trRefLight_t      *currentLight; // only used when lighting interactions
 		bool          skyRenderedThisView; // flag for drawing sun
+		bool postDepthLightTileRendered = false;
 
 		bool          projection2D; // if true, drawstretchpic doesn't need to change modes
 		Color::Color32Bit color2D;

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1884,6 +1884,8 @@ static bool R_MirrorViewBySurface(drawSurf_t *drawSurf)
 	// save old viewParms so we can return to it after the mirror view
 	viewParms_t oldParms = tr.viewParms;
 
+	oldParms.hasNestedViews = true;
+
 	newParms.portalLevel++;
 
 	// convert screen rectangle to scissor test

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -625,8 +625,6 @@ void RE_RenderScene( const refdef_t *fd )
 	VectorCopy( fd->vieworg, parms.pvsOrigin );
 	Vector4Copy( fd->gradingWeights, parms.gradingWeights );
 
-	parms.isMainView = true;
-
 	R_AddClearBufferCmd();
 	R_AddSetupLightsCmd();
 


### PR DESCRIPTION
Do `RenderPostDepthTile()` once after depth pre-pass of the first view that doesn't have any nested views. Fixes the issue in #1212.