### PR TITLE
Fix generic quad verts being added to other surfaces

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -714,6 +714,12 @@ void GL_VertexAttribPointers( uint32_t attribBits )
 				frame = glState.vertexAttribsOldFrame;
 			}
 
+			if ( !( glState.currentVBO->attribBits & bit ) )
+			{
+				Log::Warn( "GL_VertexAttribPointers: %s does not have %s",
+				           glState.currentVBO->name, attributeNames[ i ] );
+			}
+
 			glVertexAttribPointer( i, layout->numComponents, layout->componentType, layout->normalize, layout->stride, BUFFER_OFFSET( layout->ofs + ( frame * layout->frameOffset + base ) ) );
 			glState.vertexAttribPointersSet |= bit;
 		}

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1879,11 +1879,7 @@ static void RB_SetupLightForLighting( trRefLight_t *light )
 						x = 205 * frustumIndex;
 						y = 70;
 
-						Tess_InstantQuad( x, y, w, h );
-
-						gl_debugShadowMapShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
-						
-						Tess_DrawElements();
+						Tess_InstantQuad( *gl_debugShadowMapShader, x, y, w, h );
 
 						{
 							int    j;
@@ -2063,11 +2059,7 @@ static void RB_BlurShadowMap( const trRefLight_t *light, int i )
 	gl_blurXShader->SetUniform_DeformMagnitude( 1 );
 	gl_blurXShader->SetUniform_TexScale( texScale );
 
-	Tess_InstantQuad( 0, 0, fbos[ index ]->width, fbos[ index ]->height );
-
-	gl_blurXShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
-
-	Tess_DrawElements();
+	Tess_InstantQuad( *gl_blurXShader, 0, 0, fbos[ index ]->width, fbos[ index ]->height );
 
 	R_AttachFBOTexture2D( images[ index ]->type, images[ index ]->texnum, 0 );
 
@@ -2079,11 +2071,7 @@ static void RB_BlurShadowMap( const trRefLight_t *light, int i )
 	gl_blurYShader->SetUniform_DeformMagnitude( 1 );
 	gl_blurYShader->SetUniform_TexScale( texScale );
 
-	Tess_InstantQuad( 0, 0, fbos[index]->width, fbos[index]->height );
-
-	gl_blurYShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
-
-	Tess_DrawElements();
+	Tess_InstantQuad( *gl_blurYShader, 0, 0, fbos[index]->width, fbos[index]->height );
 
 	GL_PopMatrix();
 }
@@ -2873,12 +2861,9 @@ void RB_RenderPostDepthLightTile()
 		backEnd.viewParms.viewportY + backEnd.viewParms.viewportHeight, -99999, 99999 );
 	GL_LoadProjectionMatrix( ortho );
 
-	Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
-					  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
-
-	gl_depthtile1Shader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
-
-	Tess_DrawElements();
+	Tess_InstantQuad( *gl_depthtile1Shader,
+	                  backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+	                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 
 	// 2nd step
 	R_BindFBO( tr.depthtile2FBO );
@@ -2891,12 +2876,9 @@ void RB_RenderPostDepthLightTile()
 
 	GL_BindToTMU( 0, tr.depthtile1RenderImage );
 
-	gl_depthtile2Shader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
-
-	Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
-					  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
-
-	Tess_DrawElements();
+	Tess_InstantQuad( *gl_depthtile2Shader,
+	                  backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+	                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 
 	GL_PopMatrix();
 
@@ -3035,12 +3017,9 @@ void RB_RenderGlobalFog()
 	GL_LoadProjectionMatrix( ortho );
 
 	// draw viewport
-	Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
-					  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
-
-	gl_fogGlobalShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
-
-	Tess_DrawElements();
+	Tess_InstantQuad( *gl_fogGlobalShader,
+	                  backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+	                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 
 	// go back to 3D
 	GL_PopMatrix();
@@ -3094,12 +3073,9 @@ void RB_RenderBloom()
 		glClear( GL_COLOR_BUFFER_BIT );
 
 		// draw viewport
-		Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
-						  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
-
-		gl_contrastShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
-
-		Tess_DrawElements();
+		Tess_InstantQuad( *gl_contrastShader,
+		                  backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+		                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 
 		// render bloom in multiple passes
 		GL_BindToTMU( 0, tr.contrastRenderFBOImage );
@@ -3124,27 +3100,26 @@ void RB_RenderBloom()
 				MatrixOrthogonalProjection( ortho, 0, tr.bloomRenderFBO[ 0 ]->width, 0, tr.bloomRenderFBO[ 0 ]->height, -99999, 99999 );
 				GL_LoadProjectionMatrix( ortho );
 
-				Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
-								  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
-
 				if ( i == 0 )
 				{
 					gl_blurXShader->BindProgram( 0 );
 
 					gl_blurXShader->SetUniform_DeformMagnitude( r_bloomBlur->value );
-					gl_blurXShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 					gl_blurXShader->SetUniform_TexScale( texScale );
+					Tess_InstantQuad( *gl_blurXShader,
+					                  backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+					                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 				}
 				else
 				{
 					gl_blurYShader->BindProgram( 0 );
 
 					gl_blurYShader->SetUniform_DeformMagnitude( r_bloomBlur->value );
-					gl_blurYShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 					gl_blurYShader->SetUniform_TexScale( texScale );
+					Tess_InstantQuad( *gl_blurYShader,
+					                  backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+					                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 				}
-
-				Tess_DrawElements();
 
 				GL_BindToTMU( 0, tr.bloomRenderFBOImage[ flip ] );
 
@@ -3159,14 +3134,11 @@ void RB_RenderBloom()
 		GL_State( GLS_DEPTHTEST_DISABLE | GLS_SRCBLEND_ONE | GLS_DSTBLEND_ONE );
 		glVertexAttrib4fv( ATTR_INDEX_COLOR, Color::White.ToArray() );
 
-		Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
-						  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
-
 		GL_BindToTMU( 0, tr.blackImage );
 
-		gl_screenShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
-
-		Tess_DrawElements();
+		Tess_InstantQuad( *gl_screenShader,
+		                  backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+		                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 	}
 
 	// go back to 3D
@@ -3208,12 +3180,9 @@ void RB_RenderMotionBlur()
 	GL_LoadProjectionMatrix( ortho );
 
 	// draw quad
-	Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
-					  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
-
-	gl_motionblurShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
-
-	Tess_DrawElements();
+	Tess_InstantQuad( *gl_motionblurShader,
+	                   backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+	                   backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 
 	GL_PopMatrix();
 
@@ -3264,12 +3233,9 @@ void RB_RenderSSAO()
 	GL_LoadProjectionMatrix( ortho );
 
 	// draw quad
-	Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
-					  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
-
-	gl_ssaoShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
-
-	Tess_DrawElements();
+	Tess_InstantQuad( *gl_ssaoShader,
+	                  backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+	                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 
 	GL_PopMatrix();
 
@@ -3311,12 +3277,9 @@ void RB_FXAA()
 		backEnd.viewParms.viewportY + backEnd.viewParms.viewportHeight, -99999, 99999 );
 	GL_LoadProjectionMatrix( ortho );
 
-	Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
-					  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
-
-	gl_fxaaShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
-
-	Tess_DrawElements();
+	Tess_InstantQuad( *gl_fxaaShader,
+	                  backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+	                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 
 	GL_PopMatrix();
 
@@ -3363,12 +3326,9 @@ void RB_CameraPostFX()
 	GL_BindToTMU( 3, tr.colorGradeImage );
 
 	// draw viewport
-	Tess_InstantQuad( backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
-					  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
-
-	gl_cameraEffectsShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
-
-	Tess_DrawElements();
+	Tess_InstantQuad( *gl_cameraEffectsShader,
+	                  backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
+	                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 
 	// go back to 3D
 	GL_PopMatrix();
@@ -4007,11 +3967,8 @@ static void RB_RenderDebugUtils()
 		{
 			gl_genericShader->SetUniform_Color( Color::White );
 
-			Tess_InstantQuad( ia->scissorX, ia->scissorY, ia->scissorWidth - 1.0f, ia->scissorHeight - 1.0f );
-
-			gl_genericShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
-
-			Tess_DrawElements();
+			Tess_InstantQuad( *gl_genericShader,
+			                  ia->scissorX, ia->scissorY, ia->scissorWidth - 1.0f, ia->scissorHeight - 1.0f );
 
 			if ( !ia->next )
 			{
@@ -4315,11 +4272,7 @@ static void RB_RenderDebugUtils()
 				Vector4Set( quadVerts[ 2 ], x + w, y + h, 0, 1 );
 				Vector4Set( quadVerts[ 3 ], x, y + h, 0, 1 );
 
-				Tess_InstantQuad( x, y, w, h );
-
-				gl_genericShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
-
-				Tess_DrawElements();
+				Tess_InstantQuad( *gl_genericShader, x, y, w, h );
 
 				{
 					int    j;
@@ -5830,11 +5783,7 @@ void RB_ShowImages()
 		// bind u_ColorMap
 		GL_Bind( image );
 
-		Tess_InstantQuad( x, y, w, h );
-
-		gl_genericShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
-
-		Tess_DrawElements();
+		Tess_InstantQuad( *gl_genericShader, x, y, w, h );
 	}
 
 	GL_PopMatrix();

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3443,7 +3443,9 @@ inline bool checkGLErrors()
 	void Tess_AddCube( const vec3_t position, const vec3_t minSize, const vec3_t maxSize, const Color::Color& color );
 	void Tess_AddCubeWithNormals( const vec3_t position, const vec3_t minSize, const vec3_t maxSize, const Color::Color& color );
 
-	void Tess_InstantQuad( const float x, const float y, const float width, const float height );
+	class u_ModelViewProjectionMatrix;
+	void Tess_InstantQuad( u_ModelViewProjectionMatrix &shader, float x, float y, float width, float height );
+
 	void Tess_MapVBOs( bool forceCPU );
 	void Tess_UpdateVBOs();
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -697,14 +697,6 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	  ATTR_QTANGENT2      = BIT( ATTR_INDEX_QTANGENT2 ),
 
 	  ATTR_INTERP_BITS = ATTR_POSITION2 | ATTR_QTANGENT2,
-
-	  ATTR_BITS = ATTR_POSITION |
-	              ATTR_TEXCOORD |
-	              ATTR_QTANGENT |
-	              ATTR_COLOR // |
-
-	              //ATTR_BONE_INDEXES |
-	              //ATTR_BONE_WEIGHTS
 	};
 
 	struct vboAttributeLayout_t
@@ -754,7 +746,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		vboAttributeLayout_t attribs[ ATTR_INDEX_MAX ]; // info for buffer manipulation
 
 		vboLayout_t layout;
-		uint32_t attribBits;
+		uint32_t attribBits; // Which attributes it has. Mostly for detecting errors
 		GLenum      usage;
 	};
 

--- a/src/engine/renderer/tr_model_md3.cpp
+++ b/src/engine/renderer/tr_model_md3.cpp
@@ -345,6 +345,10 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 			vboSurf->numVerts = surf->numVerts;
 
 			vboSurf->vbo = R_CreateStaticVBO( va( "staticMD3Mesh_VBO '%s'", surf->name ), data, vboLayout_t::VBO_LAYOUT_VERTEX_ANIMATION );
+
+			// MD3 does not have color, but shaders always request it and the "vertex animation"
+			// vertex layout includes a color field, which is zeroed by default.
+			vboSurf->vbo->attribBits |= ATTR_COLOR;
 			
 			ri.Hunk_FreeTempMemory( data.st );
 			ri.Hunk_FreeTempMemory( data.qtangent );

--- a/src/engine/renderer/tr_model_skel.cpp
+++ b/src/engine/renderer/tr_model_skel.cpp
@@ -182,6 +182,10 @@ void R_AddSurfaceToVBOSurfacesList(
 
 	vboSurf->ibo = R_CreateStaticIBO( va( "staticMD5Mesh_IBO %i", ( int )vboSurfaces.size() ), indexes, indexesNum );
 
+	// MD5 does not have color, but shaders always request it and the skeletal animation
+	// vertex layout includes a color field, which is zeroed by default.
+	vboSurf->vbo->attribBits |= ATTR_COLOR;
+
 	ri.Hunk_FreeTempMemory( indexes );
 	ri.Hunk_FreeTempMemory( data.st );
 	ri.Hunk_FreeTempMemory( data.boneWeights );

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -584,7 +584,7 @@ void Tess_AddCubeWithNormals( const vec3_t position, const vec3_t minSize, const
 Tess_InstantQuad
 ==============
 */
-void Tess_InstantQuad( const float x, const float y, const float width, const float height )
+void Tess_InstantQuad( u_ModelViewProjectionMatrix &shader, const float x, const float y, const float width, const float height )
 {
 	GLimp_LogComment( "--- Tess_InstantQuad ---\n" );
 
@@ -592,6 +592,8 @@ void Tess_InstantQuad( const float x, const float y, const float width, const fl
 	tess.numVertexes = 0;
 	tess.numIndexes = 0;
 	tess.attribsSet = 0;
+	tess.vboVertexSkinning = false;
+	tess.vboVertexAnimation = false;
 
 	matrix_t modelViewMatrix;
 	MatrixCopy( matrixIdentity, modelViewMatrix );
@@ -600,12 +602,21 @@ void Tess_InstantQuad( const float x, const float y, const float width, const fl
 	modelViewMatrix[0] = width;
 	modelViewMatrix[5] = height;
 	GL_LoadModelViewMatrix( modelViewMatrix );
+	shader.SetUniform_ModelViewProjectionMatrix(
+		glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 
 	rb_surfaceTable[Util::ordinal( *( tr.genericQuad->surface ) )]( tr.genericQuad->surface );
 	tess.attribsSet = ATTR_POSITION | ATTR_TEXCOORD | ATTR_COLOR;
 	GL_VertexAttribsState( tess.attribsSet );
 
+	Tess_DrawElements();
+
 	GL_CheckErrors();
+
+	tess.multiDrawPrimitives = 0;
+	tess.numVertexes = 0;
+	tess.numIndexes = 0;
+	tess.attribsSet = 0;
 }
 
 /*

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -1036,7 +1036,9 @@ R_InitVBOs
 */
 void R_InitVBOs()
 {
-	uint32_t attribs = ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT | ATTR_COLOR;
+	// ATTR_QTANGENT and ATTR_ORIENTATION are mutually exclusive, but we don't know in advance
+	// which attributes will be used as this buffer is used for many purposes.
+	uint32_t attribs = ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT | ATTR_ORIENTATION | ATTR_COLOR;
 
 	Log::Debug("------- R_InitVBOs -------" );
 


### PR DESCRIPTION
Fixes #1196.

Also adds a check to detect requesting vertex attributes which are not provided by a VBO.