### PR TITLE
Simplify some GLSL shader loading code

### DIFF
--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -340,7 +340,7 @@ private:
 			      GLenum shaderType ) const;
 	void CompileGPUShaders( GLShader *shader, shaderProgram_t *program,
 				const std::string &compileMacros );
-	void CompileAndLinkGPUShaderProgram( GLShader *shader, shaderProgram_t *program,
+	void CompileAndLinkGPUShaderProgram( GLShader *shader, shaderProgram_t *program, shaderProgram_t* baseProgram,
 	                                     Str::StringRef compileMacros, int deformIndex );
 	std::string BuildDeformShaderText( const std::string& steps );
 	std::string BuildGPUShaderText( Str::StringRef mainShader, Str::StringRef libShaders, GLenum shaderType ) const;


### PR DESCRIPTION
Make somewhat messy code I noticed while working on #1105 and subsequent prs into something more readable.

Merge the two branches in `GLShaderManager::buildPermutation()` into one since they were doing essentially the same thing. Change some variable names to avoid confusion between shader and shader programs, fixed some formatting like whitespaces in [] and missing {} in if statements. Removed a redundant namespace in function call.

There is technically a slight difference in that compute shaders may be loaded even if `deformIndex` is > 0, but I don't think that really matters.