### PR TITLE
Minor fixes and improvements to ssao

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2390,6 +2390,7 @@ void GLShader_motionblur::SetShaderProgramUniforms( shaderProgram_t *shaderProgr
 GLShader_ssao::GLShader_ssao( GLShaderManager *manager ) :
 	GLShader( "ssao", ATTR_POSITION, manager ),
 	u_ModelViewProjectionMatrix( this ),
+	u_UnprojectionParams( this ),
 	u_zFar( this )
 {
 }

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2216,6 +2216,18 @@ public:
 	}
 };
 
+class u_UnprojectionParams :
+	GLUniform3f {
+	public:
+	u_UnprojectionParams( GLShader* shader ) :
+		GLUniform3f( shader, "u_UnprojectionParams" ) {
+	}
+
+	void SetUniform_UnprojectionParams( const vec3_t value ) {
+		this->SetValue( value );
+	}
+};
+
 class u_numLights :
 	GLUniform1i
 {
@@ -2716,6 +2728,7 @@ public:
 class GLShader_ssao :
 	public GLShader,
 	public u_ModelViewProjectionMatrix,
+	public u_UnprojectionParams,
 	public u_zFar
 {
 public:

--- a/src/engine/renderer/glsl_source/ssao_vp.glsl
+++ b/src/engine/renderer/glsl_source/ssao_vp.glsl
@@ -25,14 +25,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 IN vec3 attr_Position;
 
 uniform mat4 u_ModelViewProjectionMatrix;
-uniform vec3 u_zFar;
-OUT(flat) vec3 unprojectionParams;
 
 void	main()
 {
-	unprojectionParams.x = - r_zNear * u_zFar.z;
-	unprojectionParams.y = 2.0 * (u_zFar.z - r_zNear);
-	unprojectionParams.z = 2.0 * u_zFar.z - r_zNear;
-
 	gl_Position = u_ModelViewProjectionMatrix * vec4( attr_Position, 1.0f );
 }

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3197,8 +3197,6 @@ void RB_RenderMotionBlur()
 
 void RB_RenderSSAO()
 {
-	vec3_t zParams;
-
 	GLimp_LogComment( "--- RB_RenderSSAO ---\n" );
 
 	if ( !GLEW_ARB_texture_gather ) {
@@ -3216,17 +3214,25 @@ void RB_RenderSSAO()
 
 	if ( r_ssao->integer < 0 ) {
 		// clear the screen to show only SSAO
-		GL_ClearColor( 1.0f, 1.0f, 1.0f, 1.0f);
+		GL_ClearColor( tr.mapInverseLightFactor, tr.mapInverseLightFactor, tr.mapInverseLightFactor, 1.0 );
 		glClear( GL_COLOR_BUFFER_BIT );
 	}
 
 	gl_ssaoShader->BindProgram( 0 );
 
-	zParams[ 0 ] = 2.0f * tanf( DEG2RAD( backEnd.refdef.fov_x * 0.5f) ) / glConfig.vidWidth;
-	zParams[ 1 ] = 2.0f * tanf( DEG2RAD( backEnd.refdef.fov_y * 0.5f) ) / glConfig.vidHeight;
+	vec3_t zParams;
+	zParams[ 0 ] = 2.0f * tanf( DEG2RAD( backEnd.refdef.fov_x * 0.5f ) ) / glConfig.vidWidth;
+	zParams[ 1 ] = 2.0f * tanf( DEG2RAD( backEnd.refdef.fov_y * 0.5f ) ) / glConfig.vidHeight;
 	zParams[ 2 ] = backEnd.viewParms.zFar;
 
 	gl_ssaoShader->SetUniform_zFar( zParams );
+
+	vec3_t unprojectionParams;
+	unprojectionParams[ 0 ] = -r_znear->value * zParams[ 2 ];
+	unprojectionParams[ 1 ] = 2.0 * ( zParams[ 2 ] - r_znear->value );
+	unprojectionParams[ 2 ] = 2.0 * zParams[ 2 ] - r_znear->value;
+
+	gl_ssaoShader->SetUniform_UnprojectionParams( unprojectionParams );
 
 	GL_BindToTMU( 0, tr.currentDepthImage );
 


### PR DESCRIPTION
Change unprojectionParams to be a uniform, take map inverse light factor into account when setting the buffer clear colour for `r_ssao < 0`, minor formatting fixes. Removed unused variables and the preprocessor check for GLSL version > 1.20, since there's already a preceding check for `GL_ARB_texture_gather`, which requires version 1.30.