### PR TITLE
sys: add `workaround.*` cvars to disable workarounds

### DIFF
--- a/src/common/System.cpp
+++ b/src/common/System.cpp
@@ -72,6 +72,15 @@ Cvar::Cvar<bool> pedanticShutdown("common.pedanticShutdown", "run useless shutdo
 #endif // BUILD_ENGINE
 
 #ifdef _WIN32
+bool isRunningOnWine()
+{
+	// See https://www.winehq.org/pipermail/wine-devel/2008-September/069387.html
+	HMODULE hntdll = GetModuleHandle("ntdll.dll");
+	return hntdll && (void *)GetProcAddress(hntdll, "wine_get_version");
+}
+#endif
+
+#ifdef _WIN32
 SteadyClock::time_point SteadyClock::now() NOEXCEPT
 {
 	// Determine performance counter frequency

--- a/src/common/System.cpp
+++ b/src/common/System.cpp
@@ -80,6 +80,24 @@ bool isRunningOnWine()
 }
 #endif
 
+int SetEnv( const char* name, const char* value )
+{
+#ifdef _WIN32
+	return putenv( va( "%s=%s", name, value ) );
+#else
+	return setenv( name, value, true );
+#endif
+}
+
+int UnsetEnv( const char* name )
+{
+#ifdef _WIN32
+	return putenv( name );
+#else
+	return unsetenv( name );
+#endif
+}
+
 #ifdef _WIN32
 SteadyClock::time_point SteadyClock::now() NOEXCEPT
 {

--- a/src/common/System.h
+++ b/src/common/System.h
@@ -40,6 +40,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Low-level system functions
 namespace Sys {
 
+#ifdef _WIN32
+// https://www.winehq.org/pipermail/wine-devel/2008-September/069387.html
+bool isRunningOnWine();
+#endif
+
 // The Windows implementation of steady_clock is really bad, use our own
 #ifdef _WIN32
 class SteadyClock {

--- a/src/common/System.h
+++ b/src/common/System.h
@@ -45,6 +45,9 @@ namespace Sys {
 bool isRunningOnWine();
 #endif
 
+int SetEnv( const char* name, const char* value );
+int UnsetEnv( const char* name );
+
 // The Windows implementation of steady_clock is really bad, use our own
 #ifdef _WIN32
 class SteadyClock {

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -636,9 +636,6 @@ static void Init(int argc, char** argv)
 			}
 		}
 	}
-
-	// Enable S3TC on Mesa even if libtxc-dxtn is not available
-	setenv("force_s3tc_enable", "true", true);
 #endif
 
 	// Initialize the console

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -639,37 +639,6 @@ static void Init(int argc, char** argv)
 
 	// Enable S3TC on Mesa even if libtxc-dxtn is not available
 	setenv("force_s3tc_enable", "true", true);
-
-	/* Enable 2.1 GL on Intel GMA Gen 3 on Linux Mesa driver.
-
-	The Mesa i915 driver for GMA Gen 3 disabled GL 2.1 on such
-	hardware to force Google Chrome to use its CPU fallback
-	that was faster but we don't implement such fallback.
-	See https://gitlab.freedesktop.org/mesa/mesa/-/commit/a1891da7c865c80d95c450abfc0d2bc49db5f678
-
-	Only Mesa i915 on Linux supports GL 2.1 for GMA Gen 3,
-	so there is no similar tweak being required for Windows
-	and macOS.
-
-	Mesa i915 and macOS also supports GL 2.1 on GMA Gen 4
-	while windows drivers don't but those tweaks are not
-	required as the related features are enabled by default.
-
-	First Intel hardware range expected to have drivers
-	supporting GL 2.1 on Windows is GMA Gen 5.
-
-	Enabling those options would at least make the engine
-	properly report missing extension instead of missing
-	GL version, for example the Intel GMA 3100 G33 (Gen 3)
-	will report missing GL_ARB_half_float_vertex extension
-	instead of missing OpenGL 2.1 version.
-
-	The GMA 3150 is known to have wider OpenGL support than
-	GMA 3100, for example it has OpenGL version similar to
-	GMA 4 on Windows while being a GMA 3 so the list of
-	available GL extensions may be larger. */
-	setenv("fragment_shader", "true", true);
-	setenv("stub_occlusion_query", "true", true);
 #endif
 
 	// Initialize the console

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -130,6 +130,7 @@ static Cvar::Cvar<bool> workaround_noBindlessTexture_mesa241( "workaround.noBind
 static Cvar::Cvar<bool> workaround_noBindlessTexture_amdOglp( "workaround.noBindlessTexture.amdOglp", "Disable ARB_bindless_texture on AMD OGLP driver", Cvar::NONE, true );
 static Cvar::Cvar<bool> workaround_noHyperZ_mesaRv600( "workaround.noHyperZ.mesaRv600", "Disable Hyper-Z on Mesa driver on RV600 hardware", Cvar::NONE, true );
 static Cvar::Cvar<bool> workaround_noTextureGather_nvidia340( "workaround.noTextureGather.nvidia340", "Disable ARB_texture_gather on Nvidia 340 driver", Cvar::NONE, true );
+static Cvar::Cvar<bool> workaround_s3tc_mesa( "workaround.s3tc.mesa", "Enable S3TC on Mesa even when libtxc-dxtn is not available", Cvar::NONE, true );
 
 SDL_Window *window = nullptr;
 static SDL_GLContext glContext = nullptr;
@@ -2444,8 +2445,20 @@ bool GLimp_Init()
 	Cvar::Latch( workaround_noBindlessTexture_amdOglp );
 	Cvar::Latch( workaround_noHyperZ_mesaRv600 );
 	Cvar::Latch( workaround_noTextureGather_nvidia340 );
+	Cvar::Latch( workaround_s3tc_mesa );
 
 	ri.Cmd_AddCommand( "minimize", GLimp_Minimize );
+
+	/* Enable S3TC on Mesa even if libtxc-dxtn is not available
+	The environment variables is currently always set,
+	it should do nothing with other systems and drivers.
+
+	It should also be set on Win32 when running on Wine
+	on Linux anyway. */
+	if ( workaround_s3tc_mesa.Get() )
+	{
+		Sys::SetEnv( "force_s3tc_enable", "true" );
+	}
 
 	/* Enable 2.1 GL on Intel GMA Gen 3 on Linux Mesa driver.
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1345,10 +1345,23 @@ static void GLimp_RegisterConfiguration( const glConfiguration& highestConfigura
 		glConfig2.glMinor = GLminor;
 	}
 
-	/* FIXME: a duplicate of this is done in GLimp_Init, also storing it
-	for gfxinfo command. */
-	const char *glstring = ( char * ) glGetString( GL_RENDERER );
-	logger.Notice("OpenGL Renderer: %s", glstring );
+	// Get our config strings.
+	Q_strncpyz( glConfig.vendor_string, ( char * ) glGetString( GL_VENDOR ), sizeof( glConfig.vendor_string ) );
+	Q_strncpyz( glConfig.renderer_string, ( char * ) glGetString( GL_RENDERER ), sizeof( glConfig.renderer_string ) );
+	Q_strncpyz( glConfig.version_string, ( char * ) glGetString( GL_VERSION ), sizeof( glConfig.version_string ) );
+
+	if ( *glConfig.renderer_string )
+	{
+		int last = strlen( glConfig.renderer_string ) - 1;
+		if ( glConfig.renderer_string[ last ] == '\n' )
+		{
+			glConfig.renderer_string[ last ] = '\0';
+		}
+	}
+
+	logger.Notice("OpenGL vendor: %s", glConfig.vendor_string );
+	logger.Notice("OpenGL renderer: %s", glConfig.renderer_string );
+	logger.Notice("OpenGL version: %s", glConfig.version_string );
 }
 
 static void GLimp_DrawWindowContent()
@@ -2395,17 +2408,6 @@ bool GLimp_Init()
 success:
 	// These values force the UI to disable driver selection
 	glConfig.hardwareType = glHardwareType_t::GLHW_GENERIC;
-
-	// get our config strings
-	Q_strncpyz( glConfig.vendor_string, ( char * ) glGetString( GL_VENDOR ), sizeof( glConfig.vendor_string ) );
-	Q_strncpyz( glConfig.renderer_string, ( char * ) glGetString( GL_RENDERER ), sizeof( glConfig.renderer_string ) );
-
-	if ( *glConfig.renderer_string && glConfig.renderer_string[ strlen( glConfig.renderer_string ) - 1 ] == '\n' )
-	{
-		glConfig.renderer_string[ strlen( glConfig.renderer_string ) - 1 ] = 0;
-	}
-
-	Q_strncpyz( glConfig.version_string, ( char * ) glGetString( GL_VERSION ), sizeof( glConfig.version_string ) );
 
 	DetectGLVendors(
 		glConfig.vendor_string,

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1450,11 +1450,13 @@ static bool IsSdlVideoRestartNeeded()
 	with RV700 and RV800 cards that are also supported by the Mesa R600 driver.
 
 	The Mesa R600 driver has broken Hyper-Z wth RV600, not RV700 nor RV800. */
-	static bool r600_hyperz_modified = false;
-	static const char* r600_hyperz_bkp = nullptr;
-
 	if ( workaround_noHyperZ_mesaRv600.Get() )
 	{
+		if ( getenv( "R600_HYPERZ" ) )
+		{
+			return false;
+		}
+
 		if ( !Q_stricmp( glConfig.vendor_string, "Mesa" ) || !Q_stricmp( glConfig.vendor_string, "X.Org" ) )
 		{
 			bool foundRv600 = false;
@@ -1481,35 +1483,13 @@ static bool IsSdlVideoRestartNeeded()
 
 			if ( foundRv600 )
 			{
-				if ( !r600_hyperz_modified )
-				{
-					r600_hyperz_bkp = getenv( "R600_HYPERZ" );
-				}
-
 				logger.Warn( "...found buggy Mesa driver with %s card, Hyper-Z disabled", cardName );
 
 				Sys::SetEnv( "R600_HYPERZ", "false" );
 
-				r600_hyperz_modified = true;
-
 				return true;
 			}
 		}
-	}
-	else if ( r600_hyperz_modified )
-	{
-		if ( r600_hyperz_bkp )
-		{
-			Sys::SetEnv( "R600_HYPERZ", r600_hyperz_bkp );
-		}
-		else
-		{
-			Sys::UnsetEnv( "R600_HYPERZ" );
-		}
-
-		r600_hyperz_modified = false;
-
-		return true;
 	}
 
 	return false;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -421,8 +421,6 @@ cvar_t                     *r_centerWindow;
 cvar_t                     *r_displayIndex;
 cvar_t                     *r_sdlDriver;
 
-static bool firstSdlVideoAttempt;
-
 static void GLimp_DestroyContextIfExists();
 static void GLimp_DestroyWindowIfExists();
 
@@ -1439,13 +1437,9 @@ static void GLimp_CheckGLEW( const glConfiguration &requestedConfiguration )
 	}
 }
 
+// We should make sure every workaround returns false if restart already happened.
 static bool IsSdlVideoRestartNeeded()
 {
-	if ( !firstSdlVideoAttempt )
-	{
-		return false;
-	}
-
 	/* We call RV600 the first generation of R600 cards, to make a difference
 	with RV700 and RV800 cards that are also supported by the Mesa R600 driver.
 
@@ -2456,12 +2450,10 @@ bool GLimp_Init()
 	bool bordered = !r_noBorder.Get();
 
 	// Create the window and set up the context
-	firstSdlVideoAttempt = true;
 	rserr_t err = GLimp_StartDriverAndSetMode( mode, fullscreen, bordered );
 
 	if ( err == rserr_t::RSERR_RESTART )
 	{
-		firstSdlVideoAttempt = false;
 		Log::Warn( "...restarting SDL Video" );
 		SDL_QuitSubSystem( SDL_INIT_VIDEO );
 		err = GLimp_StartDriverAndSetMode( mode, fullscreen, bordered );

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1609,8 +1609,7 @@ static bool GLimp_StartDriverAndSetMode( int mode, bool fullscreen, bool bordere
 
 		if ( SDL_Init( SDL_INIT_VIDEO ) < 0 )
 		{
-			logger.Notice("SDL_Init( SDL_INIT_VIDEO ) failed: %s", SDL_GetError() );
-			return false;
+			Sys::Error("SDL_Init( SDL_INIT_VIDEO ) failed: %s", SDL_GetError() );
 		}
 
 		driverName = SDL_GetCurrentVideoDriver();

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -129,6 +129,7 @@ static Cvar::Cvar<bool> workaround_gl21_intelGma3( "workaround.gl21.intelGma3", 
 static Cvar::Cvar<bool> workaround_noBindlessTexture_mesa241( "workaround.noBindlessTexture.mesa241", "Disable ARB_bindless_texture on Mesa 24.1 driver", Cvar::NONE, true );
 static Cvar::Cvar<bool> workaround_noBindlessTexture_amdOglp( "workaround.noBindlessTexture.amdOglp", "Disable ARB_bindless_texture on AMD OGLP driver", Cvar::NONE, true );
 static Cvar::Cvar<bool> workaround_noHyperZ_mesaRv600( "workaround.noHyperZ.mesaRv600", "Disable Hyper-Z on Mesa driver on RV600 hardware", Cvar::NONE, true );
+static Cvar::Cvar<bool> workaround_noRgba16Blend_mesaRv300( "workaround.noRgba16Blend.mesaRv300", "Disable misdetected RGBA16 on Mesa driver on RV300 hardware", Cvar::NONE, true );
 static Cvar::Cvar<bool> workaround_noTextureGather_nvidia340( "workaround.noTextureGather.nvidia340", "Disable ARB_texture_gather on Nvidia 340 driver", Cvar::NONE, true );
 static Cvar::Cvar<bool> workaround_s3tc_mesa( "workaround.s3tc.mesa", "Enable S3TC on Mesa even when libtxc-dxtn is not available", Cvar::NONE, true );
 
@@ -2059,9 +2060,12 @@ static void GLimp_InitExtensions()
 
 	/* Workaround for drivers not implementing the feature query or wrongly reporting the feature
 	to be supported, for various reasons. */
-	if ( glConfig2.textureRGBA16BlendAvailable != 0 && glConfig.hardwareType == glHardwareType_t::GLHW_R300 )
+	if ( workaround_noRgba16Blend_mesaRv300.Get() )
 	{
-		glConfig2.textureRGBA16BlendAvailable = 0;
+		if ( glConfig2.textureRGBA16BlendAvailable != 0 && glConfig.hardwareType == glHardwareType_t::GLHW_R300 )
+		{
+			glConfig2.textureRGBA16BlendAvailable = 0;
+		}
 	}
 
 	// made required in OpenGL 3.0
@@ -2447,6 +2451,7 @@ bool GLimp_Init()
 	Cvar::Latch( workaround_noBindlessTexture_mesa241 );
 	Cvar::Latch( workaround_noBindlessTexture_amdOglp );
 	Cvar::Latch( workaround_noHyperZ_mesaRv600 );
+	Cvar::Latch( workaround_noRgba16Blend_mesaRv300 );
 	Cvar::Latch( workaround_noTextureGather_nvidia340 );
 	Cvar::Latch( workaround_s3tc_mesa );
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -749,7 +749,7 @@ static bool GLimp_CreateWindow( bool fullscreen, bool bordered, const glConfigur
 	-- http://wiki.libsdl.org/SDL_GL_SetAttribute */
 	GLimp_SetAttributes( configuration );
 
-	Uint32 flags = SDL_WINDOW_SHOWN | SDL_WINDOW_OPENGL;
+	Uint32 flags = SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL;
 
 	if ( r_allowResize->integer )
 	{
@@ -1368,8 +1368,11 @@ static void GLimp_RegisterConfiguration( const glConfiguration& highestConfigura
 	logger.Notice("OpenGL version: %s", glConfig.version_string );
 }
 
-static void GLimp_DrawWindowContent()
+static void GLimp_DrawWindow()
 {
+	// Unhide the window.
+	SDL_ShowWindow( window );
+
 	// Fill window with a dark grey (#141414) background.
 	glClearColor( 0.08f, 0.08f, 0.08f, 1.0f );
 	glClear( GL_COLOR_BUFFER_BIT );
@@ -1588,8 +1591,6 @@ static rserr_t GLimp_SetMode( const int mode, const bool fullscreen, const bool 
 		requestedConfiguration = bestValidatedConfiguration;
 	}
 
-	GLimp_DrawWindowContent();
-
 	GLimp_RegisterConfiguration( extendedValidationResult, requestedConfiguration );
 
 	if ( IsSdlVideoRestartNeeded() )
@@ -1597,6 +1598,8 @@ static rserr_t GLimp_SetMode( const int mode, const bool fullscreen, const bool 
 		GLimp_DestroyWindowIfExists();
 		return rserr_t::RSERR_RESTART;
 	}
+
+	GLimp_DrawWindow();
 
 	{
 		rserr_t err = GLimp_CheckOpenGLVersion( requestedConfiguration );


### PR DESCRIPTION
So, I'm thinking about it for years now, probably since the current implementation of the nvidia 340 workaround:

- https://github.com/DaemonEngine/Daemon/pull/370

I even discussed it there:

- https://github.com/DaemonEngine/Daemon/issues/360

The idea is to selectively disable a workaround we implement, to be able to test the code without it.

This is especially useful when bisecting a bug in some underlying tech like a driver, to make sure we actually test the feature in the way we expect it to fail if the third-party bug is still there.

For now I go with a dot-based hierarchy (there is no legacy cvar to mimic), and I currently use the `renderer.workaround.<whatIsDone>.<whenItIsRequired>` naming scheme.

For example `renderer.workaround.noTexturGather.nvidia340` disables `ARB_texture_gather` on Nvidia driver version 340, while `renderer.workaround.firstProvokingVertex.intel` makes the engine use first provoking vertex on Intel hardware supporting `ARB_provoking_vertex`.

The implementation is trivial, I'm mostly looking for comments about the idea itself, the naming scheme…