### PR TITLE
color: Add the ability to selectively preserve colors

### DIFF
--- a/src/common/Color.h
+++ b/src/common/Color.h
@@ -344,6 +344,9 @@ namespace Constants {
 enum {
 	ESCAPE = '^',
 	NULL_COLOR = '*',
+	// Magic chars to preserve colors between DECOLOR_OFF and DECOLOR_ON when calling StripColors.
+	DECOLOR_OFF = '\16',
+	DECOLOR_ON  = '\17',
 }; // enum
 } // namespace Constants
 
@@ -371,6 +374,7 @@ public:
 		CHARACTER,     // A character
 		ESCAPE,        // Color escape
 		COLOR,         // Color code
+		CONTROL,       // Control character (basically controlling decolor behavior.)
 	};
 
 	/*

--- a/src/common/ColorTest.cpp
+++ b/src/common/ColorTest.cpp
@@ -42,6 +42,11 @@ TEST(StripColorTest, ReturningString)
 
    std::string onlyColors = "^xF1A^1^0^O^9^a^;^*^xeE2^#123Aa5^#3903ff";
    EXPECT_EQ("", StripColors(onlyColors));
+
+    // Decolor
+    std::string decolor = Str::Format("%c^1wtf^#aabbccbad%c^1a^2c^^^3c", Constants::DECOLOR_ON, Constants::DECOLOR_OFF);
+    EXPECT_EQ("wtfbad^1a^2c^^3c", StripColors(decolor));
+
 }
 
 TEST(StripColorTest, ToBuffer)
@@ -57,8 +62,13 @@ TEST(StripColorTest, ToBuffer)
     char justright[7];
     StripColors("dretc^#123456h", justright, sizeof(justright));
     EXPECT_EQ("dretch", std::string(justright));
+
+    // Decolor
+    char decolorjustright[9];
+    StripColors(Str::Format("%c^1dretc%c^#123456h", Constants::DECOLOR_OFF, Constants::DECOLOR_ON).c_str(), decolorjustright, sizeof(decolorjustright));
+    EXPECT_EQ("^1dretch", std::string(decolorjustright));
+
 }
 
 } // namespace
 } // namespace Color
-


### PR DESCRIPTION
This adds back the "DECOLOR" functionality that was removed as part of https://github.com/Unvanquished/Unvanquished/commit/d61c9d2237ddf2df04799f33e91f9477a3bc79d3. No motivation was given for the removal, and the DECOLOR functionality is important for external tools that parse game logs to display player colors leading to a richer experience.