### PR TITLE
renderer: our usage of GLEW doesn't require GLU

### DIFF
--- a/src/engine/renderer/TextureManager.cpp
+++ b/src/engine/renderer/TextureManager.cpp
@@ -33,7 +33,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 // TextureManager.cpp
 
-#include "TextureManager.h"
 #include "tr_local.h"
 
 Texture::Texture() {

--- a/src/engine/renderer/TextureManager.h
+++ b/src/engine/renderer/TextureManager.h
@@ -36,9 +36,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef TEXTURE_MANAGER_H
 #define TEXTURE_MANAGER_H
 
-#include <vector>
-#include "GL/glew.h"
-
 class Texture {
 	public:
 	GLuint textureHandle = 0;

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -24,7 +24,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "tr_local.h"
 #include "gl_shader.h"
-#include "TextureManager.h"
 #include "Material.h"
 #if defined( REFBONE_NAMES )
 	#include <client/client.h>

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -24,6 +24,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef TR_LOCAL_H
 #define TR_LOCAL_H
 
+#define GLEW_NO_GLU
+#include <GL/glew.h>
+
 #include "common/FileSystem.h"
 #include "qcommon/q_shared.h"
 #include "qcommon/qfiles.h"
@@ -32,9 +35,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "tr_public.h"
 #include "iqm.h"
 #include "TextureManager.h"
-
-#define GLEW_NO_GLU
-#include <GL/glew.h>
 
 #define DYN_BUFFER_SIZE ( 4 * 1024 * 1024 )
 #define DYN_BUFFER_SEGMENTS 4


### PR DESCRIPTION
This `glew.h` include without the `GLEW_NO_GLU` define broke the docker-based release script:

```
In file included from /Unvanquished/daemon/src/engine/renderer/TextureManager.h:40,
                 from /Unvanquished/daemon/src/engine/renderer/tr_local.h:34,
                 from /Unvanquished/daemon/src/engine/renderer/gl_shader.h:26,
                 from /Unvanquished/daemon/src/engine/renderer/gl_shader.cpp:25:
/Unvanquished/daemon/external_deps/linux-amd64-default_10/include/GL/glew.h:1219:14: fatal error: GL/glu.h: No such file or directory
 #    include <GL/glu.h>
              ^~~~~~~~~~
compilation terminated.
```