### PR TITLE
renderer: query tex indirections and ALU instructions when possible

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -920,34 +920,34 @@ static bool IsUnusedPermutation( const char *compileMacros )
 	{
 		if ( strcmp( token, "USE_NORMAL_MAPPING" ) == 0 )
 		{
-			if ( r_normalMapping->integer == 0 ) return true;
+			if ( !glConfig2.normalMapping ) return true;
 		}
 		else if ( strcmp( token, "USE_DELUXE_MAPPING" ) == 0 )
 		{
-			if ( r_deluxeMapping->integer == 0 ) return true;
+			if ( !glConfig2.deluxeMapping ) return true;
 		}
 		else if ( strcmp( token, "USE_GRID_DELUXE_MAPPING" ) == 0 )
 		{
-			if ( r_deluxeMapping->integer == 0 ) return true;
+			if ( !glConfig2.deluxeMapping ) return true;
 		}
 		else if ( strcmp( token, "USE_PHYSICAL_MAPPING" ) == 0 )
 		{
-			if ( r_physicalMapping->integer == 0 ) return true;
+			if ( !glConfig2.physicalMapping ) return true;
 		}
 		else if ( strcmp( token, "USE_REFLECTIVE_SPECULAR" ) == 0 )
 		{
 			/* FIXME: add to the following test: && r_physicalMapping->integer == 0
 			when reflective specular is implemented for physical mapping too
 			see https://github.com/DaemonEngine/Daemon/issues/355 */
-			if ( r_specularMapping->integer == 0 ) return true;
+			if ( !glConfig2.specularMapping ) return true;
 		}
 		else if ( strcmp( token, "USE_RELIEF_MAPPING" ) == 0 )
 		{
-			if ( r_reliefMapping->integer == 0 ) return true;
+			if ( !glConfig2.reliefMapping ) return true;
 		}
 		else if ( strcmp( token, "USE_HEIGHTMAP_IN_NORMALMAP" ) == 0 )
 		{
-			if ( r_reliefMapping->integer == 0 && r_normalMapping->integer == 0 ) return true;
+			if ( !glConfig2.reliefMapping && !glConfig2.normalMapping ) return true;
 		}
 	}
 

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3083,9 +3083,8 @@ void RB_RenderBloom()
 
 	GLimp_LogComment( "--- RB_RenderBloom ---\n" );
 
-	if ( ( backEnd.refdef.rdflags & ( RDF_NOWORLDMODEL | RDF_NOBLOOM ) ) ||
-	     !r_bloom->integer ||
-	     backEnd.viewParms.portalLevel > 0 )
+	if ( ( backEnd.refdef.rdflags & ( RDF_NOWORLDMODEL | RDF_NOBLOOM ) )
+		|| !glConfig2.bloom || backEnd.viewParms.portalLevel > 0 )
 	{
 		return;
 	}
@@ -3212,8 +3211,8 @@ void RB_RenderMotionBlur()
 
 	GLimp_LogComment( "--- RB_RenderMotionBlur ---\n" );
 
-	if ( ( backEnd.refdef.rdflags & RDF_NOWORLDMODEL ) ||
-	     backEnd.viewParms.portalLevel > 0 )
+	if ( !glConfig2.motionBlur || ( backEnd.refdef.rdflags & RDF_NOWORLDMODEL )
+		|| backEnd.viewParms.portalLevel > 0 )
 	{
 		return;
 	}

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -889,6 +889,12 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		Log::Notice("GL_MAX_VERTEX_UNIFORM_COMPONENTS %d", glConfig2.maxVertexUniforms );
 		Log::Notice("GL_MAX_VERTEX_ATTRIBS %d", glConfig2.maxVertexAttribs );
 
+		if ( !glConfig2.glCoreProfile )
+		{
+			Log::Notice( "GL_MAX_PROGRAM_NATIVE_ALU_INSTRUCTIONS_ARB: %d", glConfig2.maxAluInstructions );
+			Log::Notice( "GL_MAX_PROGRAM_NATIVE_TEX_INDIRECTIONS_ARB: %d", glConfig2.maxTexIndirections );
+		}
+
 		if ( glConfig2.occlusionQueryAvailable )
 		{
 			Log::Notice("Occlusion query bits: %d", glConfig2.occlusionQueryBits );

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -78,6 +78,8 @@ struct glconfig2_t
 	int      maxVertexAttribs;
 	bool vboVertexSkinningAvailable;
 	int      maxVertexSkinningBones;
+	int maxAluInstructions;
+	int maxTexIndirections;
 
 	bool drawBuffersAvailable;
 	bool textureHalfFloatAvailable;
@@ -117,6 +119,13 @@ struct glconfig2_t
 	bool staticLight;
 	bool shadowMapping;
 	shadowingMode_t shadowingMode;
+	bool deluxeMapping;
+	bool normalMapping;
+	bool specularMapping;
+	bool physicalMapping;
+	bool reliefMapping;
+	bool bloom;
+	bool motionBlur;
 };
 
 //

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1418,10 +1418,10 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, stageType_t type,
 	const char *token = COM_ParseExt2( &buffer_p, false );
 
 	// NOTE: Normal map can ship height map in alpha channel.
-	if ( ( type == stageType_t::ST_NORMALMAP && !r_normalMapping->integer && !r_reliefMapping->integer )
-		|| ( type == stageType_t::ST_HEIGHTMAP && !r_reliefMapping->integer )
-		|| ( type == stageType_t::ST_SPECULARMAP && !r_specularMapping->integer )
-		|| ( type == stageType_t::ST_PHYSICALMAP && !r_physicalMapping->integer )
+	if ( ( type == stageType_t::ST_NORMALMAP && !glConfig2.normalMapping && !glConfig2.reliefMapping )
+		|| ( type == stageType_t::ST_HEIGHTMAP && !glConfig2.reliefMapping )
+		|| ( type == stageType_t::ST_SPECULARMAP && !glConfig2.specularMapping )
+		|| ( type == stageType_t::ST_PHYSICALMAP && !glConfig2.physicalMapping )
 		|| ( type == stageType_t::ST_GLOWMAP && !r_glowMapping->integer )
 		|| ( type == stageType_t::ST_REFLECTIONMAP && !r_reflectionMapping->integer ) )
 	{
@@ -5240,22 +5240,22 @@ static void FinishStages()
 		stage->hasHeightMapInNormalMap = stage->hasHeightMapInNormalMap && hasNormalMap;
 
 		// Available features.
-		stage->enableNormalMapping = r_normalMapping->integer && hasNormalMap;
-		stage->enableDeluxeMapping = r_deluxeMapping->integer && ( hasNormalMap || hasMaterialMap );
+		stage->enableNormalMapping = glConfig2.normalMapping && hasNormalMap;
+		stage->enableDeluxeMapping = glConfig2.deluxeMapping && ( hasNormalMap || hasMaterialMap );
 
-		stage->enableReliefMapping = r_reliefMapping->integer && !shader.disableReliefMapping
+		stage->enableReliefMapping = glConfig2.reliefMapping && !shader.disableReliefMapping
 			&& ( hasHeightMap || stage->hasHeightMapInNormalMap );
 
 		stage->enableGlowMapping = r_glowMapping->integer && hasGlowMap;
 
 		if ( stage->collapseType == collapseType_t::COLLAPSE_PBR )
 		{
-			stage->enablePhysicalMapping = r_physicalMapping->integer && hasMaterialMap;
+			stage->enablePhysicalMapping = glConfig2.physicalMapping && hasMaterialMap;
 			stage->enableSpecularMapping = false;
 		}
 		else
 		{
-			stage->enableSpecularMapping = r_specularMapping->integer && hasMaterialMap;
+			stage->enableSpecularMapping = glConfig2.specularMapping && hasMaterialMap;
 			stage->enablePhysicalMapping = false;
 		}
 
@@ -5284,7 +5284,7 @@ static void FinishStages()
 		{
 			// If specular mapping is enabled always use the specular mapping
 			// shader to avoid costly GLSL shader switching.
-			if ( r_specularMapping->integer )
+			if ( glConfig2.specularMapping )
 			{
 				stage->enableSpecularMapping = true;
 				stage->bundle[ TB_MATERIALMAP ].image[ 0 ] = tr.blackImage;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1846,6 +1846,17 @@ static void GLimp_InitExtensions()
 	glConfig2.maxVertexSkinningBones = Math::Clamp( ( glConfig2.maxVertexUniforms - reservedComponents ) / 16, 0, MAX_BONES );
 	glConfig2.vboVertexSkinningAvailable = r_vboVertexSkinning->integer && ( ( glConfig2.maxVertexSkinningBones >= 12 ) ? true : false );
 
+	/* On OpenGL Core profile the ARB_fragment_program extension doesn't exist and the related getter functions
+	return 0. We can assume OpenGL 3 Core hardware is featureful enough to not care about those limits. */
+	if ( !glConfig2.glCoreProfile )
+	{
+		if ( LOAD_EXTENSION( ExtFlag_REQUIRED, ARB_fragment_program ) )
+		{
+			glGetProgramivARB( GL_FRAGMENT_PROGRAM_ARB, GL_MAX_PROGRAM_NATIVE_ALU_INSTRUCTIONS_ARB, &glConfig2.maxAluInstructions );
+			glGetProgramivARB( GL_FRAGMENT_PROGRAM_ARB, GL_MAX_PROGRAM_NATIVE_TEX_INDIRECTIONS_ARB, &glConfig2.maxTexIndirections );
+		}
+	}
+
 	// GLSL
 
 	Q_strncpyz( glConfig2.shadingLanguageVersionString, ( char * ) glGetString( GL_SHADING_LANGUAGE_VERSION_ARB ),


### PR DESCRIPTION
Query some hardware limits like tex indirections and tex ALU instructions when possible.

The mechanism is only available on non-Core OpenGL profile, and hardware having low limits and requiring those checks don't support Core profile so it's fine if we don't check the limits on hardware with Core profile.

For reference an ATI R300 prints:

```
GL_MAX_PROGRAM_NATIVE_TEX_INDIRECTIONS_ARB: 16
GL_MAX_PROGRAM_NATIVE_ALU_INSTRUCTIONS_ARB: 64
```

An Intel GMA 3 prints:

```
GL_MAX_PROGRAM_NATIVE_TEX_INDIRECTIONS_ARB: 4
GL_MAX_PROGRAM_NATIVE_ALU_INSTRUCTIONS_ARB: 64
```

And an AMD RDNA3  (Radeon PRO W7600) prints (once GL 3 compatible context is forced):

```
GL_MAX_PROGRAM_NATIVE_TEX_INDIRECTIONS_ARB: 16384 
GL_MAX_PROGRAM_NATIVE_ALU_INSTRUCTIONS_ARB: 16384 
```

The idea is to automatically disable some GLSL shader we know the hardware cannot support, even if the related cvar is enabled.

This is useful for various reasons:

- The default preset is `medium` so many of those incompatible shaders are enabled. Before this patch, the game would load the main menu then quit with an error on map load, user had to restart the game, change the preset in the main menu, and load the map again. After this patch, the user can load the map, and switch to a lower preset in-game without being kicked out of the game.
- The motion blur shader cannot be disabled in engine yet as it is configured by a cgame cvar, this makes the engine unable to run on some low-end hardware on which the user would disable motion blur anyway. We can migrate the `cg_motionblur` cvar to the engine (like it was done for `cg_shadows`), but that may break client compatibility.

We may guard more GLSL shaders in the future by enabling them on low end hardware and catching the errors to know their limit requirements, but this is enough to make the engine run without error on default medium graphics preset on Intel GMA 3. Switching to a lower preset is now only a matter of performances, not something required to load a map.

Running the game on Intel GMA 3 requires:

- this branch to skip the motionblur GLSL shaders because of hardware limits,
  as there is no engine cvar to put in a preset to disable it.
- float vertex support:
  https://github.com/DaemonEngine/Daemon/pull/1179

In the future I may use that mechanism to make the engine automatically fallback the dynamic light renderer from tiled to legacy when tiled is not supported.