### PR TITLE
Only generate some images/FBO when they are used

### DIFF
--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -520,6 +520,7 @@ void R_InitFBOs()
 		R_CheckFBO( tr.portalRenderFBO );
 	}
 
+	if ( glConfig2.bloom )
 	{
 		width = glConfig.vidWidth * 0.25f;
 		height = glConfig.vidHeight * 0.25f;

--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -524,21 +524,6 @@ void R_InitFBOs()
 		width = glConfig.vidWidth * 0.25f;
 		height = glConfig.vidHeight * 0.25f;
 
-		tr.downScaleFBO_quarter = R_CreateFBO( "_downScale_quarter", width, height );
-		R_BindFBO( tr.downScaleFBO_quarter );
-
-		R_AttachFBOTexture2D( GL_TEXTURE_2D, tr.downScaleFBOImage_quarter->texnum, 0 );
-		R_CheckFBO( tr.downScaleFBO_quarter );
-
-		tr.downScaleFBO_64x64 = R_CreateFBO( "_downScale_64x64", 64, 64 );
-		R_BindFBO( tr.downScaleFBO_64x64 );
-
-		R_AttachFBOTexture2D( GL_TEXTURE_2D, tr.downScaleFBOImage_64x64->texnum, 0 );
-		R_CheckFBO( tr.downScaleFBO_64x64 );
-
-		width = glConfig.vidWidth * 0.25f;
-		height = glConfig.vidHeight * 0.25f;
-
 		tr.contrastRenderFBO = R_CreateFBO( "_contrastRender", width, height );
 		R_BindFBO( tr.contrastRenderFBO );
 

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2249,6 +2249,8 @@ R_CreateFogImage
 */
 static void R_CreateFogImage()
 {
+	// Fog image is always created because disabling fog is cheat.
+
 	int   x, y;
 	byte  *data, *ptr;
 	float d;

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2385,6 +2385,11 @@ static void R_CreateNoFalloffImage()
 
 static void R_CreateContrastRenderFBOImage()
 {
+	if ( !glConfig2.bloom)
+	{
+		return;
+	}
+
 	int  width, height;
 
 	width = glConfig.vidWidth * 0.25f;
@@ -2398,8 +2403,13 @@ static void R_CreateContrastRenderFBOImage()
 	tr.contrastRenderFBOImage = R_CreateImage( "_contrastRenderFBO", nullptr, width, height, 1, imageParams );
 }
 
-static void R_CreateBloomRenderFBOImage()
+static void R_CreateBloomRenderFBOImages()
 {
+	if ( !glConfig2.bloom)
+	{
+		return;
+	}
+
 	int  i;
 	int  width, height;
 
@@ -2886,7 +2896,7 @@ void R_CreateBuiltinImages()
 	R_CreateFogImage();
 	R_CreateNoFalloffImage();
 	R_CreateContrastRenderFBOImage();
-	R_CreateBloomRenderFBOImage();
+	R_CreateBloomRenderFBOImages();
 	R_CreateCurrentRenderImage();
 	R_CreateDepthRenderImage();
 	R_CreatePortalRenderImage();

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2589,26 +2589,6 @@ static void R_CreatePortalRenderImage()
 	tr.portalRenderImage = R_CreateImage( "_portalRender", nullptr, width, height, 1, imageParams );
 }
 
-// Tr3B: clean up this mess some day ...
-static void R_CreateDownScaleFBOImages()
-{
-	int  width, height;
-
-	width = glConfig.vidWidth * 0.25f;
-	height = glConfig.vidHeight * 0.25f;
-
-	imageParams_t imageParams = {};
-	imageParams.bits = IF_NOPICMIP;
-	imageParams.filterType = filterType_t::FT_NEAREST;
-	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
-
-	tr.downScaleFBOImage_quarter = R_CreateImage( "_downScaleFBOImage_quarter", nullptr, width, height, 1, imageParams );
-
-	width = height = 64;
-
-	tr.downScaleFBOImage_64x64 = R_CreateImage( "_downScaleFBOImage_64x64", nullptr, width, height, 1, imageParams );
-}
-
 // *INDENT-OFF*
 static void R_CreateShadowMapFBOImage()
 {
@@ -2954,7 +2934,6 @@ void R_CreateBuiltinImages()
 	R_CreateCurrentRenderImage();
 	R_CreateDepthRenderImage();
 	R_CreatePortalRenderImage();
-	R_CreateDownScaleFBOImages();
 	R_CreateShadowMapFBOImage();
 	R_CreateShadowCubeFBOImage();
 	R_CreateBlackCubeImage();

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2383,49 +2383,6 @@ static void R_CreateNoFalloffImage()
 	tr.noFalloffImage = R_CreateImage( "_noFalloff", ( const byte ** ) &dataPtr, 8, 8, 1, imageParams );
 }
 
-static const int ATTENUATION_XY_SIZE = 128;
-static void R_CreateAttenuationXYImage()
-{
-	int  x, y;
-	byte data[ ATTENUATION_XY_SIZE ][ ATTENUATION_XY_SIZE ][ 4 ];
-	byte *ptr = &data[0][0][0];
-	byte *dataPtr = &data[0][0][0];
-	int  b;
-
-	// make a centered inverse-square falloff blob for dynamic lighting
-	for ( y = 0; y < ATTENUATION_XY_SIZE; y++ )
-	{
-		for ( x = 0; x < ATTENUATION_XY_SIZE; x++ )
-		{
-			float d;
-
-			d = ( ATTENUATION_XY_SIZE / 2 - 0.5f - x ) * ( ATTENUATION_XY_SIZE / 2 - 0.5f - x ) +
-			    ( ATTENUATION_XY_SIZE / 2 - 0.5f - y ) * ( ATTENUATION_XY_SIZE / 2 - 0.5f - y );
-			b = 1000 / d;
-
-			if ( b > 255 )
-			{
-				b = 255;
-			}
-			else if ( b < 75 )
-			{
-				b = 0;
-			}
-
-			ptr[ 0 ] = ptr[ 1 ] = ptr[ 2 ] = b;
-			ptr[ 3 ] = 255;
-			ptr += 4;
-		}
-	}
-
-	imageParams_t imageParams = {};
-	imageParams.bits = IF_NOPICMIP;
-	imageParams.filterType = filterType_t::FT_DEFAULT;
-	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
-
-	tr.attenuationXYImage = R_CreateImage( "_attenuationXY", ( const byte ** ) &dataPtr, ATTENUATION_XY_SIZE, ATTENUATION_XY_SIZE, 1, imageParams );
-}
-
 static void R_CreateContrastRenderFBOImage()
 {
 	int  width, height;
@@ -2928,7 +2885,6 @@ void R_CreateBuiltinImages()
 	R_CreateRandomNormalsImage();
 	R_CreateFogImage();
 	R_CreateNoFalloffImage();
-	R_CreateAttenuationXYImage();
 	R_CreateContrastRenderFBOImage();
 	R_CreateBloomRenderFBOImage();
 	R_CreateCurrentRenderImage();

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2644,8 +2644,6 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		image_t    *lighttileRenderImage;
 		image_t    *portalRenderImage;
 
-		image_t    *downScaleFBOImage_quarter;
-		image_t    *downScaleFBOImage_64x64;
 		image_t *shadowMapFBOImage[ MAX_SHADOWMAPS * 2 ];
 		image_t *shadowCubeFBOImage[ MAX_SHADOWMAPS ];
 		image_t *sunShadowMapFBOImage[ MAX_SHADOWMAPS * 2 ];
@@ -2663,8 +2661,6 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		FBO_t *depthtile2FBO;
 		FBO_t *lighttileFBO;
 		FBO_t *portalRenderFBO; // holds a copy of the last currentRender that was rendered into a FBO
-		FBO_t *downScaleFBO_quarter;
-		FBO_t *downScaleFBO_64x64;
 		FBO_t *contrastRenderFBO;
 		FBO_t *bloomRenderFBO[ 2 ];
 		FBO_t *shadowMapFBO[ MAX_SHADOWMAPS ];

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2631,7 +2631,6 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		image_t    *flatImage; // use this as default normalmap
 		image_t    *randomNormalsImage;
 		image_t    *noFalloffImage;
-		image_t    *attenuationXYImage;
 		image_t    *blackCubeImage;
 		image_t    *whiteCubeImage;
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -253,7 +253,7 @@ static void GLSL_InitGPUShadersOrError()
 		}
 	}
 
-	if ( !r_noFog->integer )
+	// Fog GLSL is always loaded and built because disabling fog is cheat.
 	{
 		// Q3A volumetric fog
 		gl_shaderManager.load( gl_fogQuake3Shader );


### PR DESCRIPTION
- Delete some images/FBO that are never used.
- Only generate some images/FBO when they are used.
- Also latch `r_noFog` since the GLSL shader since shader is built conditionally after https://github.com/DaemonEngine/Daemon/pull/1228