### PR TITLE
renderer: make r_dynamicLight only enable the related renderer, not a kind of light

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -392,11 +392,11 @@ void UpdateSurfaceDataLightMapping( uint32_t* materials, Material& material, dra
 	// TODO: Update this when this is extended to MDV support
 	gl_lightMappingShaderMaterial->SetUniform_VertexInterpolation( false );
 
-	if ( glConfig2.dynamicLight ) {
+	if ( glConfig2.realtimeLighting ) {
 		gl_lightMappingShaderMaterial->SetUniformBlock_Lights( tr.dlightUBO );
 
 		// bind u_LightTiles
-		if ( r_dynamicLightRenderer.Get() == Util::ordinal( dynamicLightRenderer_t::TILED ) ) {
+		if ( r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) ) {
 			gl_lightMappingShaderMaterial->SetUniform_LightTilesIntBindless(
 				GL_BindToTMU( BIND_LIGHTTILES, tr.lighttileRenderImage )
 			);
@@ -1734,8 +1734,8 @@ void MaterialSystem::AddStageTextures( drawSurf_t* drawSurf, shaderStage_t* pSta
 	material->AddTexture( lightmap->texture );
 	material->AddTexture( deluxemap->texture );
 
-	if ( glConfig2.dynamicLight ) {
-		if ( r_dynamicLightRenderer.Get() == Util::ordinal( dynamicLightRenderer_t::TILED ) ) {
+	if ( glConfig2.realtimeLighting ) {
+		if ( r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) ) {
 			material->AddTexture( tr.lighttileRenderImage->texture );
 		}
 	}

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -678,10 +678,10 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_highPrecisionRendering", 1 );
 	}
 
-	if ( glConfig2.dynamicLight )
+	if ( glConfig2.realtimeLighting )
 	{
-		AddDefine( str, "r_dynamicLight", 1 );
-		AddDefine( str, "r_dynamicLightRenderer", r_dynamicLightRenderer.Get() );
+		AddDefine( str, "r_realtimeLighting", 1 );
+		AddDefine( str, "r_realtimeLightingRenderer", r_realtimeLightingRenderer.Get() );
 	}
 
 	if ( r_precomputedLighting->integer )

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -37,7 +37,7 @@ uniform samplerCube u_EnvironmentMap1;
 uniform float u_EnvironmentInterpolation;
 #endif // USE_REFLECTIVE_SPECULAR
 
-#if defined(r_dynamicLight) && r_dynamicLightRenderer == 1
+#if defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1
 #if defined(HAVE_ARB_uniform_buffer_object)
 struct light {
   vec4  center_radius;
@@ -62,7 +62,7 @@ const struct GetLightOffsets {
 #endif // HAVE_ARB_uniform_buffer_object
 
 uniform int u_numLights;
-#endif // r_dynamicLight && r_dynamicLightRenderer == 1
+#endif // defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1
 
 // lighting helper functions
 
@@ -75,7 +75,7 @@ void ReadLightGrid(in vec4 texel, out vec3 ambientColor, out vec3 lightColor) {
 }
 #endif
 
-#if defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING) || (defined(r_dynamicLight) && r_dynamicLightRenderer == 1)
+#if defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING) || (defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1)
 uniform vec2 u_SpecularExponent;
 
 #if defined(USE_REFLECTIVE_SPECULAR)
@@ -156,7 +156,7 @@ void computeDeluxeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightCol
 #endif // r_specularMapping
 #endif // !USE_PHYSICAL_MAPPING
 }
-#endif // defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING) || (defined(r_dynamicLight) && r_dynamicLightRenderer == 1)
+#endif // defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING) || (defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1)
 
 #if !defined(USE_DELUXE_MAPPING) && !defined(USE_GRID_DELUXE_MAPPING)
 void computeLight(in vec3 lightColor, vec4 diffuseColor, inout vec4 color) {
@@ -164,7 +164,7 @@ void computeLight(in vec3 lightColor, vec4 diffuseColor, inout vec4 color) {
 }
 #endif // !defined(USE_DELUXE_MAPPING) && !defined(USE_GRID_DELUXE_MAPPING)
 
-#if defined(r_dynamicLight) && r_dynamicLightRenderer == 1
+#if defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1
 #if defined(HAVE_EXT_texture_integer) && defined(r_highPrecisionRendering)
 const int lightsPerLayer = 16;
 uniform usampler3D u_LightTilesInt;
@@ -288,4 +288,4 @@ void computeDynamicLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4
   }
 #endif
 }
-#endif // r_dynamicLight && r_dynamicLightRenderer == 1
+#endif // defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -185,7 +185,7 @@ void main()
 	#endif
 
 	// Blend dynamic lights.
-	#if defined(r_dynamicLight) && r_dynamicLightRenderer == 1
+	#if defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1
 		#if defined(USE_REFLECTIVE_SPECULAR)
 			computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color, u_LightTilesInt,
 								 u_EnvironmentMap0, u_EnvironmentMap1);

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -2824,12 +2824,12 @@ void RB_RunVisTests( )
 
 void RB_RenderPostDepthLightTile()
 {
-	if ( !glConfig2.dynamicLight )
+	if ( !glConfig2.realtimeLighting )
 	{
 		return;
 	}
 
-	if ( r_dynamicLightRenderer.Get() != Util::ordinal( dynamicLightRenderer_t::TILED ) )
+	if ( r_realtimeLightingRenderer.Get() != Util::ordinal( realtimeLightingRenderer_t::TILED ) )
 	{
 		/* Do not run lightTile code when the tiled renderer is not used.
 
@@ -5444,7 +5444,7 @@ RB_SetupLights
 */
 const RenderCommand *SetupLightsCommand::ExecuteSelf( ) const
 {
-	if ( !glConfig2.dynamicLight )
+	if ( !glConfig2.realtimeLighting )
 	{
 		return this + 1;
 	}

--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -436,8 +436,8 @@ void R_InitFBOs()
 	R_AttachFBOTexturePackedDepthStencil( tr.currentDepthImage->texnum );
 	R_CheckFBO( tr.mainFBO[1] );
 
-	if ( glConfig2.dynamicLight
-		&&  r_dynamicLightRenderer.Get() == Util::ordinal( dynamicLightRenderer_t::TILED ) )
+	if ( glConfig2.realtimeLighting
+		&& r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) )
 	{
 		/* It's only required to create frame buffers only used by the
 		tiled dynamic lighting renderer when this feature is enabled. */

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2487,7 +2487,7 @@ static void R_CreateDepthRenderImage()
 {
 	ASSERT( glConfig2.textureFloatAvailable );
 
-	if ( !glConfig2.dynamicLight )
+	if ( !glConfig2.realtimeLighting )
 	{
 		return;
 	}
@@ -2507,7 +2507,7 @@ static void R_CreateDepthRenderImage()
 		tr.dlightImage = R_CreateImage("_dlightImage", nullptr, w, h, 4, imageParams );
 	}
 
-	if ( r_dynamicLightRenderer.Get() != Util::ordinal( dynamicLightRenderer_t::TILED ) )
+	if ( r_realtimeLightingRenderer.Get() != Util::ordinal( realtimeLightingRenderer_t::TILED ) )
 	{
 		/* Do not create lightTile images when the tiled renderer is not used.
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -73,14 +73,15 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_lightScissors;
 	cvar_t      *r_noLightVisCull;
 	cvar_t      *r_noInteractionSort;
-	Cvar::Range<Cvar::Cvar<int>> r_dynamicLightRenderer( "r_dynamicLightRenderer",
-		"renderer for dynamic lights: 0: legacy, 1: tiled", Cvar::NONE,
-		Util::ordinal(dynamicLightRenderer_t::TILED),
-		Util::ordinal(dynamicLightRenderer_t::LEGACY),
-		Util::ordinal(dynamicLightRenderer_t::TILED) );
-	Cvar::Cvar<bool> r_dynamicLight( "r_dynamicLight", "enable dynamic lights", Cvar::NONE, true );
-	Cvar::Cvar<bool> r_staticLight( "r_staticLight", "enable static lights", Cvar::NONE, true );
-	cvar_t      *r_dynamicLightCastShadows;
+	Cvar::Range<Cvar::Cvar<int>> r_realtimeLightingRenderer( "r_realtimeLightingRenderer",
+		"renderer for real time lights: 0: legacy, 1: tiled", Cvar::NONE,
+		Util::ordinal(realtimeLightingRenderer_t::TILED),
+		Util::ordinal(realtimeLightingRenderer_t::LEGACY),
+		Util::ordinal(realtimeLightingRenderer_t::TILED) );
+	Cvar::Cvar<bool> r_realtimeLighting( "r_realtimeLighting", "enable realtime light rendering", Cvar::NONE, true );
+	Cvar::Cvar<bool> r_dynamicLight( "r_dynamicLight", "enable dynamic lights (if realtime lighting is enabled)", Cvar::NONE, true );
+	Cvar::Cvar<bool> r_staticLight( "r_staticLight", "enable BSP entity lights (if realtime lighting is enabled)", Cvar::NONE, true );
+	cvar_t      *r_realtimeLightingCastShadows;
 	cvar_t      *r_precomputedLighting;
 	Cvar::Cvar<int> r_mapOverBrightBits("r_mapOverBrightBits", "default map light color shift", Cvar::NONE, 2);
 	Cvar::Cvar<bool> r_forceLegacyOverBrightClamping("r_forceLegacyOverBrightClamping", "clamp over bright of legacy maps (enable multiplied color clamping and normalization)", Cvar::NONE, false);
@@ -1075,7 +1076,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_customwidth = Cvar_Get( "r_customwidth", "1600", CVAR_LATCH | CVAR_ARCHIVE );
 		r_customheight = Cvar_Get( "r_customheight", "1024", CVAR_LATCH | CVAR_ARCHIVE );
 		r_subdivisions = Cvar_Get( "r_subdivisions", "4", CVAR_LATCH );
-		r_dynamicLightCastShadows = Cvar_Get( "r_dynamicLightCastShadows", "1", 0 );
+		r_realtimeLightingCastShadows = Cvar_Get( "r_realtimeLightingCastShadows", "1", 0 );
 		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_CHEAT | CVAR_LATCH );
 		Cvar::Latch( r_mapOverBrightBits );
 		Cvar::Latch( r_forceLegacyOverBrightClamping );
@@ -1162,7 +1163,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_noLightVisCull = Cvar_Get( "r_noLightVisCull", "0", CVAR_CHEAT );
 		r_noInteractionSort = Cvar_Get( "r_noInteractionSort", "0", CVAR_CHEAT );
 
-		Cvar::Latch( r_dynamicLightRenderer );
+		Cvar::Latch( r_realtimeLightingRenderer );
+		Cvar::Latch( r_realtimeLighting );
 		Cvar::Latch( r_dynamicLight );
 		Cvar::Latch( r_staticLight );
 		Cvar::Latch( r_materialSystem );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -294,7 +294,7 @@ static inline void glFboSetExt()
 enum class lightMode_t { FULLBRIGHT, VERTEX, GRID, MAP };
 enum class deluxeMode_t { NONE, GRID, MAP };
 
-enum class dynamicLightRenderer_t { LEGACY, TILED };
+enum class realtimeLightingRenderer_t { LEGACY, TILED };
 
 	enum class renderSpeeds_t
 	{
@@ -2834,10 +2834,11 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_lightScale;
 
 	extern Cvar::Cvar<bool> r_fastsky; // Controls whether sky should be cleared or drawn.
-	extern Cvar::Range<Cvar::Cvar<int>> r_dynamicLightRenderer;
+	extern Cvar::Range<Cvar::Cvar<int>> r_realtimeLightingRenderer;
+	extern Cvar::Cvar<bool> r_realtimeLighting;
 	extern Cvar::Cvar<bool> r_dynamicLight;
 	extern Cvar::Cvar<bool> r_staticLight;
-	extern cvar_t *r_dynamicLightCastShadows;
+	extern cvar_t *r_realtimeLightingCastShadows;
 	extern cvar_t *r_precomputedLighting;
 	extern Cvar::Cvar<int> r_mapOverBrightBits;
 	extern Cvar::Cvar<bool> r_forceLegacyOverBrightClamping;

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -2420,7 +2420,7 @@ void R_AddLightInteractions()
 	bspNode_t    *leaf;
 	link_t       *l;
 
-	dynamicLightRenderer_t dynamicLightRenderer = dynamicLightRenderer_t( r_dynamicLightRenderer.Get() );
+	realtimeLightingRenderer_t realtimeLightingRenderer = realtimeLightingRenderer_t( r_realtimeLightingRenderer.Get() );
 
 	tr.refdef.numShaderLights = 0;
 
@@ -2440,7 +2440,7 @@ void R_AddLightInteractions()
 				continue;
 			}
 
-			if ( dynamicLightRenderer == dynamicLightRenderer_t::TILED )
+			if ( realtimeLightingRenderer == realtimeLightingRenderer_t::TILED )
 			{
 				tr.refdef.numShaderLights++;
 				tr.pc.c_slights++;
@@ -2464,7 +2464,7 @@ void R_AddLightInteractions()
 				light->cull = cullResult_t::CULL_OUT;
 				continue;
 			}
-			else if ( dynamicLightRenderer == dynamicLightRenderer_t::TILED )
+			else if ( realtimeLightingRenderer == realtimeLightingRenderer_t::TILED )
 			{
 				tr.refdef.numShaderLights++;
 				tr.pc.c_dlights++;
@@ -2665,7 +2665,7 @@ void R_AddLightBoundsToVisBounds()
 				continue;
 			}
 
-			if( r_dynamicLightRenderer.Get() == Util::ordinal( dynamicLightRenderer_t::TILED ) )
+			if( r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) )
 			{
 				continue;
 			}

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -116,6 +116,7 @@ struct glconfig2_t
 	bool syncAvailable;
 	bool depthClampAvailable;
 
+	bool realtimeLighting;
 	bool dynamicLight;
 	bool staticLight;
 	bool shadowMapping;

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -321,7 +321,7 @@ void RE_AddRefLightToScene( const refLight_t *l )
 		light->l.scale = r_lightScale->value;
 	}
 
-	if ( !r_dynamicLightCastShadows->integer && !light->l.inverseShadows )
+	if ( !r_realtimeLightingCastShadows->integer && !light->l.inverseShadows )
 	{
 		light->l.noShadows = true;
 	}
@@ -336,6 +336,11 @@ static void R_AddWorldLightsToScene()
 {
 	int          i;
 	trRefLight_t *light;
+
+	if ( !glConfig2.staticLight )
+	{
+		return;
+	}
 
 	if ( !tr.registered )
 	{
@@ -378,6 +383,11 @@ void RE_AddDynamicLightToSceneET( const vec3_t org, float radius, float intensit
 {
 	trRefLight_t *light;
 
+	if ( !glConfig2.dynamicLight )
+	{
+		return;
+	}
+
 	if ( !tr.registered )
 	{
 		return;
@@ -418,14 +428,14 @@ void RE_AddDynamicLightToSceneET( const vec3_t org, float radius, float intensit
 	light->l.color[ 1 ] = g;
 	light->l.color[ 2 ] = b;
 
-	if ( r_dynamicLightRenderer.Get() == Util::ordinal( dynamicLightRenderer_t::TILED ) )
+	if ( r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) )
 	{
 		// Cancel overBright on dynamic lights.
 		VectorScale( light->l.color, tr.mapInverseLightFactor, light->l.color );
 	}
 
 	light->l.inverseShadows = (flags & REF_INVERSE_DLIGHT) != 0;
-	light->l.noShadows = !r_dynamicLightCastShadows->integer && !light->l.inverseShadows;
+	light->l.noShadows = !r_realtimeLightingCastShadows->integer && !light->l.inverseShadows;
 
 	if( flags & REF_RESTRICT_DLIGHT ) {
 		light->restrictInteractionFirst = r_numEntities - r_firstSceneEntity;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5202,7 +5202,7 @@ static void FinishStages()
 
 			case stageType_t::ST_ATTENUATIONMAP_XY:
 			case stageType_t::ST_ATTENUATIONMAP_Z:
-				stage->active = ( glConfig2.dynamicLight && r_dynamicLightRenderer.Get() == Util::ordinal( dynamicLightRenderer_t::LEGACY ) );
+				stage->active = ( glConfig2.realtimeLighting && r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::LEGACY ) );
 				break;
 
 			default:

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -925,12 +925,12 @@ static void R_InitUnitCubeVBO()
 
 static void R_InitTileVBO()
 {
-	if ( !glConfig2.dynamicLight )
+	if ( !glConfig2.realtimeLighting )
 	{
 		return;
 	}
 
-	if ( r_dynamicLightRenderer.Get() != Util::ordinal( dynamicLightRenderer_t::TILED ) )
+	if ( r_realtimeLightingRenderer.Get() != Util::ordinal( realtimeLightingRenderer_t::TILED ) )
 	{
 		/* This computation is part of the tiled dynamic lighting renderer,
 		it's better to not run it and save CPU cycles when such effects
@@ -977,7 +977,7 @@ const int indexCapacity = DYN_BUFFER_SIZE / sizeof( glIndex_t );
 
 static void R_InitLightUBO()
 {
-	if ( !glConfig2.dynamicLight )
+	if ( !glConfig2.realtimeLighting )
 	{
 		return;
 	}


### PR DESCRIPTION
renderer: make `r_dynamicLight` only enable a kind of light and `r_realtimeLighting` enable the renderer

With that change,

- `r_realtimeLighting` enables the rendering of dynamic lights
- `r_realtimeLightingRenderer` selects the dynamic light renderer
- `r_dynamicLight` enables the non-static kind of dynamic lights (weapons, particles…)
- `r_staticLight` enables the static kind of dynamic lights (static map lights)

---

_Original post (obsolete):_

Make r_dynamicLight only enable the related renderer, not a kind of light.

With that change,

- r_dynamicLight enables the dynamic light renderer
- r_animatedLight enables the “animated” kind of dynamic lights (weapons, particles…)
- r_staticLight enables the “static” kind of dynamic lights (static map lights)

The animated/static light naming scheme is inspired from the misc_anim_model and misc_model map entities (the later being described as “static” in documentation).

The purpose of that PR is that by disabling r_dynamicLight, the dynamic light renderer is effectively disabled and related GLSL code is not compiled.

Previously, disabling r_dynamicLight but keeping r_staticLight enable was still compiling the GLSL related code, depite no one map uses the feature yet.

The idea is that we would always keep r_animatedLight and r_staticLight enabled, but only enable/disable r_dynamicLight in presets.

This makes possible to not have to add entries for r_staticLight in presets or in game options.

Basically, r_animatedLight and r_staticLight becomes debugging cvars, while r_dynamicLight is kept as a feature cvar.

In the glConfig2 struct,

- dynamicLight is enabled if the engine should run the dynamic light renderer and then allocate related images and compile the related GLSL code. It is enabled if r_dynamicLight cvar enabled and either r_animatedLight or r_staticLight is enabled.
- animatedLight is enabled if the engine should process animated lights. It is enabled if r_dynamicLight and r_animatedLight is enabled.
- staticLight is enabled if the engine should process static lights. It is enabled if r_dynamicLight and r_staticLight is enabled.