### PR TITLE
renderer: detect if hardware cannot blend RGBA16 framebuffers

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -875,7 +875,19 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 		format = GL_DEPTH_STENCIL;
 		internalFormat = GL_DEPTH24_STENCIL8;
 	}
-	else if ( image->bits & ( IF_RGBA16F | IF_RGBA32F | IF_RGBA16 | IF_TWOCOMP16F | IF_TWOCOMP32F | IF_ONECOMP16F | IF_ONECOMP32F ) )
+	else if ( image->bits & IF_RGBA16 )
+	{
+		if ( !glConfig2.textureRGBA16BlendAvailable )
+		{
+			Log::Warn("RGBA16 image '%s' cannot be blended", image->name );
+			internalFormat = GL_RGBA8;
+		}
+		else
+		{
+			internalFormat = GL_RGBA16;
+		}
+	}
+	else if ( image->bits & ( IF_RGBA16F | IF_RGBA32F | IF_TWOCOMP16F | IF_TWOCOMP32F | IF_ONECOMP16F | IF_ONECOMP32F ) )
 	{
 		if( !glConfig2.textureFloatAvailable ) {
 			Log::Warn("floating point image '%s' cannot be loaded", image->name );
@@ -898,10 +910,6 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 		{
 			internalFormat = glConfig2.textureRGAvailable ?
 			  GL_RG32F : GL_LUMINANCE_ALPHA32F_ARB;
-		}
-		else if ( image->bits & IF_RGBA16 )
-		{
-			internalFormat = GL_RGBA16;
 		}
 		else if ( image->bits & IF_ONECOMP16F )
 		{
@@ -2462,7 +2470,14 @@ static void R_CreateCurrentRenderImage()
 
 	if ( r_highPrecisionRendering.Get() )
 	{
-		imageParams.bits |= IF_RGBA16;
+		if ( !glConfig2.textureRGBA16BlendAvailable )
+		{
+			Log::Warn( "High-precision current render disabled because RGBA16 framebuffer blending is not available" );
+		}
+		else
+		{
+			imageParams.bits |= IF_RGBA16;
+		}
 	}
 
 	imageParams.filterType = filterType_t::FT_NEAREST;

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1022,6 +1022,20 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			Log::Notice("%sMissing GPU vertex skinning, models are not hardware-accelerated.", Color::ToString( Color::Red ) );
 		}
 
+		switch ( glConfig2.textureRGBA16BlendAvailable )
+		{
+			case 1:
+				Log::Notice( "%sUsing GL_RGBA16 with GL_FRAMEBUFFER_BLEND.", Color::ToString( Color::Green ) );
+				break;
+			case -1:
+				Log::Notice( "%sUsing GL_RGBA16 with GL_FRAMEBUFFER_BLEND (assumed to be available).", Color::ToString( Color::Yellow ) );
+				break;
+			default:
+			case 0:
+				Log::Notice( "%sMissing GL_RGBA16 with GL_FRAMEBUFFER_BLEND.", Color::ToString( Color::Red ) );
+				break;
+		}
+
 		if ( glConfig.smpActive )
 		{
 			Log::Notice("Using dual processor acceleration." );

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -82,8 +82,10 @@ struct glconfig2_t
 	int maxTexIndirections;
 
 	bool drawBuffersAvailable;
+	bool internalFormatQuery2Available;
 	bool textureHalfFloatAvailable;
 	bool textureFloatAvailable;
+	int textureRGBA16BlendAvailable;
 	bool textureIntegerAvailable;
 	bool textureRGAvailable;
 	bool computeShaderAvailable;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -77,6 +77,8 @@ static Cvar::Cvar<bool> r_arb_gpu_shader5( "r_arb_gpu_shader5",
 	"Use GL_ARB_gpu_shader5 if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_indirect_parameters( "r_arb_indirect_parameters",
 	"Use GL_ARB_indirect_parameters if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_internalformat_query2( "r_arb_internalformat_query2",
+	"Use GL_ARB_internalformat_query2 if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_map_buffer_range( "r_arb_map_buffer_range",
 	"Use GL_ARB_map_buffer_range if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_multi_draw_indirect( "r_arb_multi_draw_indirect",
@@ -1833,6 +1835,7 @@ static void GLimp_InitExtensions()
 	Cvar::Latch( r_arb_explicit_uniform_location );
 	Cvar::Latch( r_arb_gpu_shader5 );
 	Cvar::Latch( r_arb_indirect_parameters );
+	Cvar::Latch( r_arb_internalformat_query2 );
 	Cvar::Latch( r_arb_map_buffer_range );
 	Cvar::Latch( r_arb_multi_draw_indirect );
 	Cvar::Latch( r_arb_shader_atomic_counters );
@@ -1903,6 +1906,72 @@ static void GLimp_InitExtensions()
 
 	// made required in OpenGL 3.0
 	glConfig2.textureFloatAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_texture_float, r_ext_texture_float.Get() );
+
+	glConfig2.internalFormatQuery2Available = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_internalformat_query2, r_arb_internalformat_query2.Get() );
+
+	if ( glConfig2.internalFormatQuery2Available )
+	{
+		GLint64 param;
+		glGetInternalformati64v( GL_TEXTURE_2D, GL_RGBA16, GL_FRAMEBUFFER_BLEND, 1, &param );
+
+		if ( param == GL_FULL_SUPPORT || param == GL_TRUE )
+		{
+			/* There is a discrepancy between OpenGL specification and OpenGL reference pages.
+
+			The OpenGL 4.3 Core specification says the query should return either GL_FULL_SUPPORT,
+			GL_CAVEAT_SUPPORT, or GL_NONE:
+
+			- https://registry.khronos.org/OpenGL/specs/gl/glspec43.core.pdf#page=517
+
+			The ARB_internalformat_query2 document says the same:
+
+			- https://registry.khronos.org/OpenGL/extensions/ARB/ARB_internalformat_query2.txt
+
+			The OpenGL wiki page for glGetInternalformat says the same:
+
+			- https://www.khronos.org/opengl/wiki/GLAPI/glGetInternalformat
+
+			But the glGetInternalformat reference page says the query should return GL_TRUE
+			or GL_FALSE:
+
+			- https://registry.khronos.org/OpenGL-Refpages/gl4/html/glGetInternalformat.xhtml
+
+			The meaning of GL_CAVEAT_SUPPORT as a return of a GL_FRAMEBUFFER_BLEND query is
+			unknown. See this thread for details:
+
+			- https://github.com/KhronosGroup/OpenGL-Refpages/issues/157
+
+			Because of this discrepancy in documentation, drivers may have implemented
+			either GL_FULL_SUPPORT or GL_TRUE as a return for feature availability. */
+			glConfig2.textureRGBA16BlendAvailable = 1;
+		}
+		else if ( param == GL_CAVEAT_SUPPORT || param == GL_NONE )
+		{
+			/* Older Mesa versions were mistakenly reporting full support for every driver on
+			every hardware. A return that is not GL_FULL_SUPPORT and not GL_TRUE is the only
+			value we can trust. See those threads for details:
+
+			- https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30612
+			- https://gitlab.freedesktop.org/mesa/mesa/-/issues/11669#note_2521403
+
+			GL_FALSE has same value as GL_NONE. */
+			glConfig2.textureRGBA16BlendAvailable = 0;
+		}
+	}
+	else
+	{
+		/* Assume this is an old driver without the query extension but the RGBA16 blending is
+		available, as the feature is much older than the extension to check for it, the feature
+		is very likely supported. */
+		glConfig2.textureRGBA16BlendAvailable = -1;
+	}
+
+	/* Workaround for drivers not implementing the feature query or wrongly reporting the feature
+	to be supported, for various reasons. */
+	if ( glConfig2.textureRGBA16BlendAvailable != 0 && glConfig.hardwareType == glHardwareType_t::GLHW_R300 )
+	{
+		glConfig2.textureRGBA16BlendAvailable = 0;
+	}
 
 	// made required in OpenGL 3.0
 	glConfig2.gpuShader4Available = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, EXT_gpu_shader4, r_ext_gpu_shader4.Get() );


### PR DESCRIPTION
Use `GL_ARB_internalformat_query` to check if the hardware cannot blend `GL_RGBA16` framebuffers.

Hardware like ATI R300 support RGBA16 framebuffers but can't blend them. The check should detect them.

Unfortunately the Mesa r300 driver has a bug and wrongly reports such blending to be possible despite the hardware not supporting it, but since we already detect R300 hardware we can also workaround that so a workaround was also implemented.

A fix is on the way on Mesa side.

See this thread for details:

- https://gitlab.freedesktop.org/mesa/mesa/-/issues/11669

See also this is work-in-progress merge-request on Mesa side:

- https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/30612

The extension to check for the feature availability is much more recent than the feature itself:

- https://registry.khronos.org/OpenGL/extensions/ARB/ARB_internalformat_query.txt

So if it is not possible to check for the feature availability, the engine assumes the feature is available.

The purpose is to not use the feature if the driver explicitly says the feature is not supported or if we know the feature is not supported. In case the assumption is wrong and `r_highPrecisionRendering` is enabled, the symptom is translucent textures being rendered opaque, as seen in #1232:

- https://github.com/DaemonEngine/Daemon/issues/1232

Fixes #1232.