### PR TITLE
Switch most vertex/fragment libs to use #insert instead

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2177,20 +2177,6 @@ GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 {
 }
 
-void GLShader_lightMapping::BuildShaderVertexLibNames( std::string& vertexInlines )
-{
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation vertexSprite ";
-}
-
-void GLShader_lightMapping::BuildShaderFragmentLibNames( std::string& fragmentInlines )
-{
-	fragmentInlines += "computeLight reliefMapping";
-}
-
-void GLShader_lightMapping::BuildShaderCompileMacros( std::string& /*compileMacros*/ )
-{
-}
-
 void GLShader_lightMapping::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_DiffuseMap" ), BIND_DIFFUSEMAP );
@@ -2259,17 +2245,6 @@ GLShader_lightMappingMaterial::GLShader_lightMappingMaterial( GLShaderManager* m
 	GLCompileMacro_USE_PHYSICAL_MAPPING( this ) {
 }
 
-void GLShader_lightMappingMaterial::BuildShaderVertexLibNames( std::string& vertexInlines ) {
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation vertexSprite ";
-}
-
-void GLShader_lightMappingMaterial::BuildShaderFragmentLibNames( std::string& fragmentInlines ) {
-	fragmentInlines += "computeLight reliefMapping";
-}
-
-void GLShader_lightMappingMaterial::BuildShaderCompileMacros( std::string& /*compileMacros*/ ) {
-}
-
 void GLShader_lightMappingMaterial::SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_DiffuseMap" ), BIND_DIFFUSEMAP );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_NormalMap" ), BIND_NORMALMAP );
@@ -2327,20 +2302,6 @@ GLShader_forwardLighting_omniXYZ::GLShader_forwardLighting_omniXYZ( GLShaderMana
 {
 }
 
-void GLShader_forwardLighting_omniXYZ::BuildShaderVertexLibNames( std::string& vertexInlines )
-{
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation ";
-}
-
-void GLShader_forwardLighting_omniXYZ::BuildShaderFragmentLibNames( std::string& fragmentInlines )
-{
-	fragmentInlines += "computeLight reliefMapping";
-}
-
-void GLShader_forwardLighting_omniXYZ::BuildShaderCompileMacros( std::string& /*compileMacros*/ )
-{
-}
-
 void GLShader_forwardLighting_omniXYZ::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_DiffuseMap" ), 0 );
@@ -2394,16 +2355,6 @@ GLShader_forwardLighting_projXYZ::GLShader_forwardLighting_projXYZ( GLShaderMana
 	GLCompileMacro_USE_RELIEF_MAPPING( this ),
 	GLCompileMacro_USE_SHADOWING( this )
 {
-}
-
-void GLShader_forwardLighting_projXYZ::BuildShaderVertexLibNames( std::string& vertexInlines )
-{
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation ";
-}
-
-void GLShader_forwardLighting_projXYZ::BuildShaderFragmentLibNames( std::string& fragmentInlines )
-{
-	fragmentInlines += "computeLight reliefMapping";
 }
 
 void GLShader_forwardLighting_projXYZ::BuildShaderCompileMacros( std::string& compileMacros )
@@ -2473,16 +2424,6 @@ GLShader_forwardLighting_directionalSun::GLShader_forwardLighting_directionalSun
 {
 }
 
-void GLShader_forwardLighting_directionalSun::BuildShaderVertexLibNames( std::string& vertexInlines )
-{
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation ";
-}
-
-void GLShader_forwardLighting_directionalSun::BuildShaderFragmentLibNames( std::string& fragmentInlines )
-{
-	fragmentInlines += "computeLight reliefMapping";
-}
-
 void GLShader_forwardLighting_directionalSun::BuildShaderCompileMacros( std::string& compileMacros )
 {
 	compileMacros += "LIGHT_DIRECTIONAL ";
@@ -2528,11 +2469,6 @@ GLShader_shadowFill::GLShader_shadowFill( GLShaderManager *manager ) :
 {
 }
 
-void GLShader_shadowFill::BuildShaderVertexLibNames( std::string& vertexInlines )
-{
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation ";
-}
-
 void GLShader_shadowFill::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
@@ -2557,20 +2493,6 @@ GLShader_reflection::GLShader_reflection( GLShaderManager *manager ):
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
 	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_RELIEF_MAPPING( this )
-{
-}
-
-void GLShader_reflection::BuildShaderVertexLibNames( std::string& vertexInlines )
-{
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation ";
-}
-
-void GLShader_reflection::BuildShaderFragmentLibNames( std::string& fragmentInlines )
-{
-	fragmentInlines += "reliefMapping";
-}
-
-void GLShader_reflection::BuildShaderCompileMacros( std::string& )
 {
 }
 
@@ -2600,17 +2522,6 @@ GLShader_reflectionMaterial::GLShader_reflectionMaterial( GLShaderManager* manag
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
 	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_RELIEF_MAPPING( this ) {
-}
-
-void GLShader_reflectionMaterial::BuildShaderVertexLibNames( std::string& vertexInlines ) {
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation ";
-}
-
-void GLShader_reflectionMaterial::BuildShaderFragmentLibNames( std::string& fragmentInlines ) {
-	fragmentInlines += "reliefMapping";
-}
-
-void GLShader_reflectionMaterial::BuildShaderCompileMacros( std::string& ) {
 }
 
 void GLShader_reflectionMaterial::SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) {
@@ -2679,11 +2590,6 @@ GLShader_fogQuake3::GLShader_fogQuake3( GLShaderManager *manager ) :
 {
 }
 
-void GLShader_fogQuake3::BuildShaderVertexLibNames( std::string& vertexInlines )
-{
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation ";
-}
-
 void GLShader_fogQuake3::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
@@ -2704,10 +2610,6 @@ GLShader_fogQuake3Material::GLShader_fogQuake3Material( GLShaderManager* manager
 	GLDeformStage( this ),
 	// GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ) {
-}
-
-void GLShader_fogQuake3Material::BuildShaderVertexLibNames( std::string& vertexInlines ) {
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation ";
 }
 
 void GLShader_fogQuake3Material::SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) {
@@ -2760,16 +2662,6 @@ GLShader_heatHaze::GLShader_heatHaze( GLShaderManager *manager ) :
 {
 }
 
-void GLShader_heatHaze::BuildShaderVertexLibNames( std::string& vertexInlines )
-{
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation vertexSprite ";
-}
-
-void GLShader_heatHaze::BuildShaderFragmentLibNames( std::string& fragmentInlines )
-{
-	fragmentInlines += "reliefMapping";
-}
-
 void GLShader_heatHaze::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_NormalMap" ), 0 );
@@ -2799,14 +2691,6 @@ GLShader_heatHazeMaterial::GLShader_heatHazeMaterial( GLShaderManager* manager )
 	// GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
 	GLCompileMacro_USE_VERTEX_SPRITE( this ) {
-}
-
-void GLShader_heatHazeMaterial::BuildShaderVertexLibNames( std::string& vertexInlines ) {
-	vertexInlines += "vertexSimple vertexSkinning vertexAnimation vertexSprite ";
-}
-
-void GLShader_heatHazeMaterial::BuildShaderFragmentLibNames( std::string& fragmentInlines ) {
-	fragmentInlines += "reliefMapping";
 }
 
 void GLShader_heatHazeMaterial::SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) {
@@ -2954,11 +2838,6 @@ GLShader_liquid::GLShader_liquid( GLShaderManager *manager ) :
 {
 }
 
-void GLShader_liquid::BuildShaderFragmentLibNames( std::string& fragmentInlines )
-{
-	fragmentInlines += "computeLight reliefMapping";
-}
-
 void GLShader_liquid::SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_CurrentMap" ), 0 );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_PortalMap" ), 1 );
@@ -2998,10 +2877,6 @@ GLShader_liquidMaterial::GLShader_liquidMaterial( GLShaderManager* manager ) :
 	u_LightGridScale( this ),
 	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_RELIEF_MAPPING( this ) {
-}
-
-void GLShader_liquidMaterial::BuildShaderFragmentLibNames( std::string& fragmentInlines ) {
-	fragmentInlines += "computeLight reliefMapping";
 }
 
 void GLShader_liquidMaterial::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -4050,9 +4050,6 @@ class GLShader_lightMapping :
 {
 public:
 	GLShader_lightMapping( GLShaderManager *manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
-	void BuildShaderCompileMacros( std::string& compileMacros ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
 
@@ -4103,9 +4100,6 @@ class GLShader_lightMappingMaterial :
 	public GLCompileMacro_USE_PHYSICAL_MAPPING {
 	public:
 	GLShader_lightMappingMaterial( GLShaderManager* manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
-	void BuildShaderCompileMacros( std::string& compileMacros ) override;
 	void SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) override;
 };
 
@@ -4150,9 +4144,6 @@ class GLShader_forwardLighting_omniXYZ :
 {
 public:
 	GLShader_forwardLighting_omniXYZ( GLShaderManager *manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
-	void BuildShaderCompileMacros( std::string& compileMacros ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
 
@@ -4198,8 +4189,6 @@ class GLShader_forwardLighting_projXYZ :
 {
 public:
 	GLShader_forwardLighting_projXYZ( GLShaderManager *manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
 	void BuildShaderCompileMacros( std::string& compileMacros ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
@@ -4253,8 +4242,6 @@ class GLShader_forwardLighting_directionalSun :
 {
 public:
 	GLShader_forwardLighting_directionalSun( GLShaderManager *manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
 	void BuildShaderCompileMacros( std::string& compileMacros ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
@@ -4279,7 +4266,6 @@ class GLShader_shadowFill :
 {
 public:
 	GLShader_shadowFill( GLShaderManager *manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
 
@@ -4305,9 +4291,6 @@ class GLShader_reflection :
 {
 public:
 	GLShader_reflection( GLShaderManager *manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
-	void BuildShaderCompileMacros( std::string& compileMacros ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
 
@@ -4332,9 +4315,6 @@ class GLShader_reflectionMaterial :
 	public GLCompileMacro_USE_RELIEF_MAPPING {
 	public:
 	GLShader_reflectionMaterial( GLShaderManager* manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
-	void BuildShaderCompileMacros( std::string& compileMacros ) override;
 	void SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) override;
 };
 
@@ -4393,7 +4373,6 @@ class GLShader_fogQuake3 :
 {
 public:
 	GLShader_fogQuake3( GLShaderManager *manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
 
@@ -4414,7 +4393,6 @@ class GLShader_fogQuake3Material :
 	public GLCompileMacro_USE_VERTEX_ANIMATION {
 	public:
 	GLShader_fogQuake3Material( GLShaderManager* manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
 	void SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) override;
 };
 
@@ -4461,8 +4439,6 @@ class GLShader_heatHaze :
 {
 public:
 	GLShader_heatHaze( GLShaderManager *manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
 
@@ -4490,8 +4466,6 @@ class GLShader_heatHazeMaterial :
 	public GLCompileMacro_USE_VERTEX_SPRITE {
 	public:
 	GLShader_heatHazeMaterial( GLShaderManager* manager );
-	void BuildShaderVertexLibNames( std::string& vertexInlines ) override;
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
 	void SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) override;
 };
 
@@ -4618,7 +4592,6 @@ class GLShader_liquid :
 {
 public:
 	GLShader_liquid( GLShaderManager *manager );
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
 
@@ -4653,7 +4626,6 @@ class GLShader_liquidMaterial :
 	public GLCompileMacro_USE_RELIEF_MAPPING {
 	public:
 	GLShader_liquidMaterial( GLShaderManager* manager );
-	void BuildShaderFragmentLibNames( std::string& fragmentInlines ) override;
 	void SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) override;
 };
 

--- a/src/engine/renderer/glsl_source/fogQuake3_vp.glsl
+++ b/src/engine/renderer/glsl_source/fogQuake3_vp.glsl
@@ -22,6 +22,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* fogQuake3_vp.glsl */
 
+#insert vertexSimple_vp
+#insert vertexSkinning_vp
+#insert vertexAnimation_vp
+
 uniform vec3		u_ViewOrigin;
 
 uniform float		u_Time;

--- a/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
@@ -22,6 +22,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* forwardLighting_fp.glsl */
 
+#insert computeLight_fp
+#insert reliefMapping_fp
+
 /* swizzle one- and two-component textures to RG */
 #if defined(HAVE_ARB_texture_rg)
 #  define SWIZ1 r

--- a/src/engine/renderer/glsl_source/forwardLighting_vp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_vp.glsl
@@ -22,6 +22,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* forwardLighting_vp.glsl */
 
+#insert vertexSimple_vp
+#insert vertexSkinning_vp
+#insert vertexAnimation_vp
+
 uniform mat4		u_TextureMatrix;
 uniform mat4		u_LightAttenuationMatrix;
 uniform mat4		u_ModelMatrix;

--- a/src/engine/renderer/glsl_source/fxaa_fp.glsl
+++ b/src/engine/renderer/glsl_source/fxaa_fp.glsl
@@ -35,6 +35,9 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 
 // The FXAA parameters are put directly in fxaa3_11_fp.glsl
 // because we cannot #include in the middle of a shader
+// ^This is no longer true, but I'm not touching that mess
+
+#insert fxaa3_11_fp
 
 uniform sampler2D	u_ColorMap;
 

--- a/src/engine/renderer/glsl_source/heatHaze_fp.glsl
+++ b/src/engine/renderer/glsl_source/heatHaze_fp.glsl
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* heatHaze_fp.glsl */
 
+#insert reliefMapping_fp
+
 #define HEATHAZE_GLSL
 
 uniform sampler2D	u_CurrentMap;

--- a/src/engine/renderer/glsl_source/heatHaze_vp.glsl
+++ b/src/engine/renderer/glsl_source/heatHaze_vp.glsl
@@ -22,6 +22,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* heatHaze_vp.glsl */
 
+#insert vertexSimple_vp
+#insert vertexSkinning_vp
+#insert vertexAnimation_vp
+#insert vertexSprite_vp
+
 uniform float		u_Time;
 
 uniform mat4		u_TextureMatrix;

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -22,6 +22,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* lightMapping_fp.glsl */
 
+#insert computeLight_fp
+#insert reliefMapping_fp
+
 #define LIGHTMAPPING_GLSL
 
 uniform sampler2D	u_DiffuseMap;

--- a/src/engine/renderer/glsl_source/lightMapping_vp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_vp.glsl
@@ -22,6 +22,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* lightMapping_vp.glsl */
 
+#insert vertexSimple_vp
+#insert vertexSkinning_vp
+#insert vertexAnimation_vp
+#insert vertexSprite_vp
+
 #if !defined(USE_BSP_SURFACE)
 	#define USE_MODEL_SURFACE
 #endif

--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -22,6 +22,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* liquid_fp.glsl */
 
+#insert computeLight_fp
+#insert reliefMapping_fp
+
 #define LIQUID_GLSL
 
 uniform sampler2D	u_CurrentMap;

--- a/src/engine/renderer/glsl_source/reflection_CB_fp.glsl
+++ b/src/engine/renderer/glsl_source/reflection_CB_fp.glsl
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* reflection_CB_fp.glsl */
 
+#insert reliefMapping_fp
+
 #define REFLECTION_CB_GLSL
 
 uniform samplerCube	u_ColorMap;

--- a/src/engine/renderer/glsl_source/reflection_CB_vp.glsl
+++ b/src/engine/renderer/glsl_source/reflection_CB_vp.glsl
@@ -22,6 +22,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* reflection_CB_vp.glsl */
 
+#insert vertexSimple_vp
+#insert vertexSkinning_vp
+#insert vertexAnimation_vp
+
 uniform mat4		u_TextureMatrix;
 uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;

--- a/src/engine/renderer/glsl_source/shadowFill_vp.glsl
+++ b/src/engine/renderer/glsl_source/shadowFill_vp.glsl
@@ -22,6 +22,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* shadowFill_vp.glsl */
 
+#insert vertexSimple_vp
+#insert vertexSkinning_vp
+#insert vertexAnimation_vp
+
 uniform vec4		u_Color;
 
 uniform mat4		u_TextureMatrix;


### PR DESCRIPTION
Switch ones that can be easily changed. Other shaders might require some extra effort to switch, before vertex/fragment libs can be removed completely.

This is part of a change to move all shaders to use #insert instead of vertex/fragment libs, since that would allow to simplify code and because #insert is a more powerful tool.