### PR TITLE
renderer: detect OpenGL hardware and driver vendor

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -87,6 +87,8 @@ if (DAEMON_PARENT_SCOPE_DIR)
 endif()
 
 set(RENDERERLIST
+    ${ENGINE_DIR}/renderer/DetectGLVendors.cpp
+    ${ENGINE_DIR}/renderer/DetectGLVendors.h
     ${ENGINE_DIR}/renderer/gl_shader.cpp
     ${ENGINE_DIR}/renderer/gl_shader.h
     ${ENGINE_DIR}/renderer/iqm.h

--- a/src/engine/renderer/DetectGLVendors.cpp
+++ b/src/engine/renderer/DetectGLVendors.cpp
@@ -1,0 +1,278 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+
+#include "DetectGLVendors.h"
+
+std::string GetGLHardwareVendorName( glHardwareVendor_t hardwareVendor )
+{
+	static const std::string hardwareVendorNames[] = {
+		"Unknown",
+		"Software rasterizer",
+		"API Translator",
+		"Arm",
+		"AMD/ATI",
+		"Broadcom",
+		"Intel",
+		"Nvidia",
+		"OutOfRange",
+	};
+
+	int index = Util::ordinal( hardwareVendor );
+	static constexpr size_t lastNameIndex = ARRAY_LEN( hardwareVendorNames ) - 1;
+	static constexpr int lastEnumIndex = Util::ordinal( glHardwareVendor_t::NUM_HARDWARE_VENDORS );
+
+	static_assert( lastNameIndex == lastEnumIndex, "glHardwareVendor_t and hardwareVendorNames count mismatch" );
+	ASSERT_GE( index, 0 );
+	ASSERT_LT( index, lastEnumIndex );
+
+	index = ( index < 0 || index > lastEnumIndex ) ? lastNameIndex : index;
+
+	return hardwareVendorNames[ index ];
+}
+
+std::string GetGLDriverVendorName( glDriverVendor_t driverVendor )
+{
+	static const std::string driverVendorNames[] = {
+		"Unknown",
+		"AMD/ATI",
+		"Intel",
+		"Mesa",
+		"Nvidia",
+		"OutOfRange",
+	};
+
+	int index = Util::ordinal( driverVendor );
+	static constexpr size_t lastNameIndex = ARRAY_LEN( driverVendorNames ) - 1;
+	static constexpr int lastEnumIndex = Util::ordinal( glDriverVendor_t::NUM_DRIVER_VENDORS );
+
+	static_assert( lastNameIndex == lastEnumIndex, "glDriverVendor_t and driverVendorNames count mismatch" );
+	ASSERT_GE( index, 0 );
+	ASSERT_LT( index, lastEnumIndex );
+
+	index = ( index < 0 || index > lastEnumIndex ) ? lastNameIndex : index;
+
+	return driverVendorNames[ index ];
+}
+
+void DetectGLVendors(
+	const std::string& vendorString,
+	const std::string& versionString,
+	const std::string& rendererString,
+	glHardwareVendor_t& hardwareVendor,
+	glDriverVendor_t& driverVendor )
+{
+	hardwareVendor = glHardwareVendor_t::UNKNOWN;
+	driverVendor = glDriverVendor_t::UNKNOWN;
+
+	// Those vendor strings are assumed to be unambiguous about both driver and hardware vendors.
+	static const std::unordered_map<std::string, std::pair<glDriverVendor_t, glHardwareVendor_t>>
+		vendorDriverHardware =
+	{
+		// Mesa AMD/ATI.
+		{ "AMD", { glDriverVendor_t::MESA, glHardwareVendor_t::ATI } },
+		{ "AMD inc.", { glDriverVendor_t::MESA, glHardwareVendor_t::ATI } },
+		{ "X.Org R300 Project", { glDriverVendor_t::MESA, glHardwareVendor_t::ATI } },
+		// Proprietary ATI or AMD drivers on all systems like Linux, Windows, and macOS: OGLP, Catalyst…
+		{ "ATI Technologies Inc.", { glDriverVendor_t::ATI, glHardwareVendor_t::ATI } },
+		// Proprietary Intel driver on macOS.
+		{ "Intel Inc.", { glDriverVendor_t::INTEL, glHardwareVendor_t::INTEL } },
+		// Mesa Intel.
+		{ "Intel Open Source Technology Center", { glDriverVendor_t::MESA, glHardwareVendor_t::INTEL } },
+		{ "Tungsten Graphics, Inc", { glDriverVendor_t::MESA, glHardwareVendor_t::INTEL } },
+		// Mesa V3D and VC4 (Raspberry Pi).
+		{ "Broadcom", { glDriverVendor_t::MESA, glHardwareVendor_t::BROADCOM } },
+		// Mesa Panfrost, newer Panfrost uses "Mesa" instead.
+		{ "Panfrost", { glDriverVendor_t::MESA, glHardwareVendor_t::ARM } },
+		// Mesa Nvidia for supported OpenGL 2+ hardware.
+		{ "nouveau", { glDriverVendor_t::MESA, glHardwareVendor_t::NVIDIA } },
+		// Proprietary Nvidia drivers on all systems like Linux, Windows, and macOS.
+		{ "NVIDIA Corporation", { glDriverVendor_t::NVIDIA, glHardwareVendor_t::NVIDIA } },
+		// Mesa Amber also provides "Nouveau", but this is for unsupported pre-OpenGL 2 Nvidia.
+	};
+
+	auto it = vendorDriverHardware.find( vendorString );
+	if ( it != vendorDriverHardware.end() )
+	{
+		driverVendor = it->second.first;	
+		hardwareVendor = it->second.second;	
+		return;
+	}
+
+	// This vendor string is used by at least two different Intel drivers.
+	if ( vendorString == "Intel Corporation" )
+	{
+		if ( Str::IsPrefix( "SWR ", rendererString ) )
+		{
+			/* It is part of Mesa Amber, but was merged in Mesa lately after being an internal
+			Intel product for years. It doesn't share much things with Mesa, and we better
+			not assume it behaves the same as Mesa, it may even behave like Intel.
+			We keep driverVendor as glDriverVendor_t::UNKNOWN on purpose. */
+			hardwareVendor = glHardwareVendor_t::SOFTWARE;
+			return;
+		}
+		else
+		{
+			driverVendor = glDriverVendor_t::MESA;
+			hardwareVendor = glHardwareVendor_t::INTEL;
+			return;
+		}
+	}
+
+	// This vendor string is used by at least two different Microsoft drivers.
+	if ( vendorString == "Microsoft Corporation" )
+	{
+		/* The GL_VENDOR string can also be "Microsoft Corporation" with GL_RENDERER
+		set to "GDI Generic" which is not Mesa and isn't supported (OpenGL 1.1). */
+		if ( Str::IsPrefix( "DRD12 ", rendererString ) )
+		{
+			driverVendor = glDriverVendor_t::MESA;
+			// OpenGL over Direct3D12 translation.
+			hardwareVendor = glHardwareVendor_t::TRANSLATION;
+			return;
+		}
+	}
+
+	/* Those substrings at the beginning of a renderer string are assumed to be unambiguous about
+	both driver and hardware. */
+	static const std::pair<std::string, glHardwareVendor_t> rendererMesaStartStringHardware[] = {
+		// "Mesa DRI R200" exists for ATI but isn't supported.
+		{ "Mesa DRI nv", glHardwareVendor_t::NVIDIA },
+		{ "Mesa DRI Intel(R)", glHardwareVendor_t::INTEL },
+	};
+
+	for ( auto& p : rendererMesaStartStringHardware )
+	{
+		if ( Str::IsPrefix( p.first, rendererString ) )
+		{
+			driverVendor = glDriverVendor_t::MESA;
+			hardwareVendor = p.second;
+			return;
+		}
+	}
+	
+	// Those vendor strings are assumed to be unambiguous about being from Mesa drivers.
+	static const std::string mesaVendors[] = {
+		// Mesa.
+		"Mesa",
+		"Mesa Project",
+		"Mesa/X.org",
+		"X.Org",
+		// Zink.
+		"Collabora Ltd",
+		// virgl.
+		"Red Hat",
+		// llvmpipe, softpipe, SVGA3D.
+		"VMware, Inc.",
+	};
+
+	for ( auto& s : mesaVendors )
+	{
+		if ( vendorString == s )
+		{
+			driverVendor = glDriverVendor_t::MESA;
+			break;
+		}
+	}
+
+	/* This substring in a version string is assumed to be unambiguous about being from Mesa
+	drivers. Mesa GL_VENDOR and GL_RENDERER strings are very fluid, but it is believed that
+	GL_VERSION always contains the " Mesa " substring and that substring always means Mesa. */
+	if ( driverVendor == glDriverVendor_t::UNKNOWN && versionString.find( " Mesa " ) != std::string::npos )
+	{
+		driverVendor = glDriverVendor_t::MESA;
+	}
+
+	if ( driverVendor == glDriverVendor_t::MESA )
+	{
+		// This vendor string for a Mesa driver is assumed to be unambiguous about the hardware.
+		if ( vendorString == "Intel" )
+		{
+			hardwareVendor = glHardwareVendor_t::INTEL;
+			return;
+		}
+
+		/* Those substrings at the beginning of a renderer string are assumed to be unambiguous about
+		the hardware or underlying technology. */
+		static const std::pair<std::string, glHardwareVendor_t> rendererStartStringHardware[] = {
+			{ "ATI ", glHardwareVendor_t::ATI },
+			{ "AMD ", glHardwareVendor_t::ATI },
+			{ "i915 ", glHardwareVendor_t::INTEL },
+			{ "NV", glHardwareVendor_t::NVIDIA },
+			{ "Mali-", glHardwareVendor_t::ARM },
+			// OpenGL over Vulkan translation.
+			{ "zink ", glHardwareVendor_t::TRANSLATION },
+			// Virtualization.
+			{ "virgl", glHardwareVendor_t::TRANSLATION },
+		};
+
+		for ( auto& p : rendererStartStringHardware )
+		{
+			if ( Str::IsPrefix( p.first, rendererString ) )
+			{
+				hardwareVendor = p.second;
+				return;
+			}
+		}
+
+		/* Those substrings within a renderer string are assumed to be unambiguous about
+		the underlying technology. */
+		static const std::pair<std::string, glHardwareVendor_t> rendererSubStringHardware[] = {
+			{ "Panfrost", glHardwareVendor_t::ARM },
+			// Software rendering.
+			{ "llvmpipe", glHardwareVendor_t::SOFTWARE },
+			{ "softpipe", glHardwareVendor_t::SOFTWARE },
+			// Virtualization.
+			{ "SVGA3D", glHardwareVendor_t::TRANSLATION },
+		};
+
+		for ( auto& p : rendererSubStringHardware )
+		{
+			if ( rendererString.find( p.first ) != std::string::npos )
+			{
+				hardwareVendor = p.second;
+				return;
+			}
+		}
+	}
+
+	/* As both proprietary Intel driver on Windows and Mesa may report "Intel",
+	we rely on the fact Mesa is already detected to know it is the proprietary
+	Windows driver if not Mesa. */
+	if ( vendorString == "Intel" )
+	{
+		driverVendor = glDriverVendor_t::INTEL;
+		hardwareVendor = glHardwareVendor_t::INTEL;
+		return;
+	}
+}

--- a/src/engine/renderer/DetectGLVendors.h
+++ b/src/engine/renderer/DetectGLVendors.h
@@ -1,0 +1,82 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+
+// DetectGLVendors.h
+
+#ifndef DETECT_OPENGL_VENDORS_H
+#define DETECT_OPENGL_VENDORS_H
+
+#include "common/Assert.h"
+#include "common/Common.h"
+#include "qcommon/q_shared.h"
+
+enum class glHardwareVendor_t
+{
+	UNKNOWN,
+	// Assumed to be slow (running on CPU).
+	SOFTWARE,
+	/* Assumed to be fast (running on GPU through a translation, like an OpenGL over Vulkan
+	driver, or an OpenGL virtualization driver sending commands to an hypervisor. */
+	TRANSLATION,
+	// Assumed to be fast (running on GPU directly).
+	ARM,
+	ATI,
+	BROADCOM,
+	INTEL,
+	NVIDIA,
+	NUM_HARDWARE_VENDORS,
+};
+
+enum class glDriverVendor_t
+{
+	UNKNOWN,
+	ATI,
+	INTEL,
+	MESA,
+	NVIDIA,
+	NUM_DRIVER_VENDORS,
+};
+
+std::string GetGLHardwareVendorName( glHardwareVendor_t hardwareVendor );
+
+std::string GetGLDriverVendorName( glDriverVendor_t driverVendor );
+
+void DetectGLVendors(
+	const std::string& vendorString,
+	const std::string& versionString,
+	const std::string& rendererString,
+	glHardwareVendor_t& hardwareVendor,
+	glDriverVendor_t& driverVendor );
+
+#endif // DETECT_OPENGL_VENDORS_H

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 // tr_init.c -- functions that are not called every frame
 #include "tr_local.h"
 #include "framework/CvarSystem.h"
+#include "DetectGLVendors.h"
 #include "Material.h"
 
 	glconfig_t  glConfig;
@@ -883,6 +884,14 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			"windowed",
 			"fullscreen"
 		};
+
+		Log::Notice( "%sOpenGL hardware vendor: %s",
+			Color::ToString( Util::ordinal(glConfig2.hardwareVendor) ? Color::Green : Color::Yellow ),
+			GetGLHardwareVendorName( glConfig2.hardwareVendor ) );
+
+		Log::Notice( "%sOpenGL driver vendor: %s",
+			Color::ToString( Util::ordinal(glConfig2.driverVendor) ? Color::Green : Color::Yellow ),
+			GetGLDriverVendorName( glConfig2.driverVendor ) );
 
 		Log::Notice("GL_VENDOR: %s", glConfig.vendor_string );
 		Log::Notice("GL_RENDERER: %s", glConfig.renderer_string );

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -37,6 +37,7 @@ Maryland 20850 USA.
 #define __TR_PUBLIC_H
 
 #include "tr_types.h"
+#include "DetectGLVendors.h"
 #include <string>
 
 #define REF_API_VERSION 10
@@ -58,6 +59,9 @@ struct glconfig2_t
 
 	bool glCoreProfile;
 	bool glForwardCompatibleContext;
+
+	glDriverVendor_t driverVendor;
+	glHardwareVendor_t hardwareVendor;
 
 	std::string glExtensionsString;
 	std::string glEnabledExtensionsString;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -28,6 +28,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #endif
 
 #include "renderer/tr_local.h"
+#include "renderer/DetectGLVendors.h"
 
 #pragma warning(push)
 #pragma warning(disable : 4125) // "decimal digit terminates octal escape sequence"
@@ -2013,7 +2014,8 @@ static void GLimp_InitExtensions()
 		lighting so it is likely this feature would be disabled to
 		get acceptable framerate on this hardware anyway, making the
 		need for such extension and the related shader code useless. */
-		bool foundNvidia340 = ( Q_stristr( glConfig.vendor_string, "NVIDIA Corporation" ) && Q_stristr( glConfig.version_string, "NVIDIA 340." ) );
+		bool foundNvidia340 = ( glConfig2.driverVendor == glDriverVendor_t::NVIDIA
+			&& Q_stristr( glConfig.version_string, "NVIDIA 340." ) );
 
 		if ( foundNvidia340 )
 		{
@@ -2026,7 +2028,7 @@ static void GLimp_InitExtensions()
 	}
 
 	{
-		bool foundIntel = Q_stristr( glConfig.vendor_string, "Intel" );
+		bool foundIntel = glConfig2.hardwareVendor == glHardwareVendor_t::INTEL;
 
 		if ( foundIntel
 			&& LOAD_EXTENSION( ExtFlag_NONE, ARB_provoking_vertex ) )
@@ -2152,6 +2154,7 @@ static void GLimp_InitExtensions()
 
 	// Some of the mesa 24.x driver versions have a bug in their shader compiler related to bindless textures,
 	// which results in either glitches or the shader compiler crashing (when material system is enabled)
+	if ( glConfig2.driverVendor == glDriverVendor_t::MESA )
 	{
 		bool foundMesa241 = false;
 		std::string mesaVersion = "";
@@ -2349,6 +2352,16 @@ success:
 	}
 
 	Q_strncpyz( glConfig.version_string, ( char * ) glGetString( GL_VERSION ), sizeof( glConfig.version_string ) );
+
+	DetectGLVendors(
+		glConfig.vendor_string,
+		glConfig.version_string,
+		glConfig.renderer_string,
+		glConfig2.hardwareVendor,
+		glConfig2.driverVendor );
+
+	Log::Debug( "Detected OpenGL hardware vendor: %s", GetGLHardwareVendorName( glConfig2.hardwareVendor ) );
+	Log::Debug( "Detected OpenGL driver vendor: %s", GetGLDriverVendorName( glConfig2.driverVendor ) );
 
 	glConfig2.glExtensionsString = std::string();
 


### PR DESCRIPTION
Detect OpenGL hardware and driver vendor.

Start to reuse this information.

I wanted to do that for a long time, thought about it some days ago yet again, and @VReaperV is facing the same need for #1241:

- https://github.com/DaemonEngine/Daemon/pull/1241

It may reused for more stuff in the future, especially in #1224:

- https://github.com/DaemonEngine/Daemon/pull/1224

We may also implement specific workarounds for when the OpenGL driver is a software rasterizer (not rare when virtualizing), for example our own CPU model animation code may be faster than Mesa emulating the features. That's why I make a difference between slow emulation (`SOFTWARE`) and fast one (`TRANSLATION`).

I used this as a reference:

- https://opengl.gpuinfo.org/displaycapability.php?name=GL_VENDOR

I may add more in the future, but this is a good start.