### PR TITLE
Some fixes and optimizations in the renderer

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -887,11 +887,7 @@ static bool IsUnusedPermutation( const char *compileMacros )
 	const char* token;
 	while ( *( token = COM_ParseExt2( &compileMacros, false ) ) )
 	{
-		if ( strcmp( token, "USE_NORMAL_MAPPING" ) == 0 )
-		{
-			if ( !glConfig2.normalMapping ) return true;
-		}
-		else if ( strcmp( token, "USE_DELUXE_MAPPING" ) == 0 )
+		if ( strcmp( token, "USE_DELUXE_MAPPING" ) == 0 )
 		{
 			if ( !glConfig2.deluxeMapping ) return true;
 		}

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -729,7 +729,7 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_showLightTiles", 1 );
 	}
 
-	if ( r_normalMapping->integer )
+	if ( glConfig2.normalMapping )
 	{
 		AddDefine( str, "r_normalMapping", 1 );
 	}
@@ -739,12 +739,12 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_liquidMapping", 1 );
 	}
 
-	if ( r_specularMapping->integer )
+	if ( glConfig2.specularMapping )
 	{
 		AddDefine( str, "r_specularMapping", 1 );
 	}
 
-	if ( r_physicalMapping->integer )
+	if ( glConfig2.physicalMapping )
 	{
 		AddDefine( str, "r_physicalMapping", 1 );
 	}

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -37,6 +37,7 @@ uniform samplerCube u_EnvironmentMap1;
 uniform float u_EnvironmentInterpolation;
 #endif // USE_REFLECTIVE_SPECULAR
 
+#if defined(r_dynamicLight) && r_dynamicLightRenderer == 1
 #if defined(HAVE_ARB_uniform_buffer_object)
 struct light {
   vec4  center_radius;
@@ -61,21 +62,21 @@ const struct GetLightOffsets {
 #endif // HAVE_ARB_uniform_buffer_object
 
 uniform int u_numLights;
-
-uniform vec2 u_SpecularExponent;
+#endif // r_dynamicLight && r_dynamicLightRenderer == 1
 
 // lighting helper functions
 
+#if defined(USE_GRID_LIGHTING) || defined(USE_GRID_DELUXE_MAPPING)
 void ReadLightGrid(in vec4 texel, out vec3 ambientColor, out vec3 lightColor) {
 	float ambientScale = 2.0 * texel.a;
 	float directedScale = 2.0 - ambientScale;
 	ambientColor = ambientScale * texel.rgb;
 	lightColor = directedScale * texel.rgb;
 }
+#endif
 
-void computeLight(in vec3 lightColor, vec4 diffuseColor, inout vec4 color) {
-	color.rgb += lightColor.rgb * diffuseColor.rgb;
-}
+#if defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING) || (defined(r_dynamicLight) && r_dynamicLightRenderer == 1)
+uniform vec2 u_SpecularExponent;
 
 #if defined(USE_REFLECTIVE_SPECULAR)
 void computeDeluxeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightColor,
@@ -155,7 +156,15 @@ void computeDeluxeLight( vec3 lightDir, vec3 normal, vec3 viewDir, vec3 lightCol
 #endif // r_specularMapping
 #endif // !USE_PHYSICAL_MAPPING
 }
+#endif // defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING) || (defined(r_dynamicLight) && r_dynamicLightRenderer == 1)
 
+#if !defined(USE_DELUXE_MAPPING) && !defined(USE_GRID_DELUXE_MAPPING)
+void computeLight(in vec3 lightColor, vec4 diffuseColor, inout vec4 color) {
+	color.rgb += lightColor.rgb * diffuseColor.rgb;
+}
+#endif // !defined(USE_DELUXE_MAPPING) && !defined(USE_GRID_DELUXE_MAPPING)
+
+#if defined(r_dynamicLight) && r_dynamicLightRenderer == 1
 #if defined(HAVE_EXT_texture_integer) && defined(r_highPrecisionRendering)
 const int lightsPerLayer = 16;
 uniform usampler3D u_LightTilesInt;
@@ -185,7 +194,6 @@ int nextIdx( inout idxs_t idxs ) {
 
 const int numLayers = MAX_REF_LIGHTS / 256;
 
-#if defined(r_dynamicLight) && r_dynamicLightRenderer == 1
 #if defined(USE_REFLECTIVE_SPECULAR)
 void computeDynamicLight( int idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse,
 		    vec4 material, inout vec4 color, in samplerCube u_EnvironmentMap0, in samplerCube u_EnvironmentMap1 )
@@ -280,4 +288,4 @@ void computeDynamicLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4
   }
 #endif
 }
-#endif
+#endif // r_dynamicLight && r_dynamicLightRenderer == 1

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -107,8 +107,13 @@ void main()
 		vec3 normal = NormalInWorldSpace(texCoords, tangentToWorldMatrix);
 	#endif // !r_normalMapping
 
-	// Compute the material term.
-	vec4 material = texture2D(u_MaterialMap, texCoords);
+	#if defined(r_specularMapping) || defined(r_physicalMapping)
+		// Compute the material term.
+		vec4 material = texture2D(u_MaterialMap, texCoords);
+	#elif defined(r_dynamicLight) && r_dynamicLightRenderer == 1
+		// The computeDynamicLights function requires this variable to exist.
+		vec4 material = { 0, 0, 0, 1 };
+	#endif
 
 	// Compute final color.
 	vec4 color;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -104,6 +104,12 @@ static void EnableAvailableFeatures()
 		}
 	}
 
+
+	// Disable features that require deluxe mapping to be enabled.
+	glConfig2.normalMapping = glConfig2.deluxeMapping && glConfig2.normalMapping;
+	glConfig2.specularMapping = glConfig2.deluxeMapping && glConfig2.specularMapping;
+	glConfig2.physicalMapping = glConfig2.deluxeMapping && glConfig2.physicalMapping;
+
 	glConfig2.bloom = r_bloom->integer;
 
 	/* Motion blur is enabled by cg_motionblur which is a client cvar so we have to build it in all cases,


### PR DESCRIPTION
- use `glConfig.*` instead of `r_*` when exists as the features can now be disabled when the hardware doesn't support it,
  this is a fixup for: https://github.com/DaemonEngine/Daemon/pull/1228
- more unused GLSL permutation detection,
- disable normal, specular and physical mapping when deluxe mapping is disabled,
- do not sample dummy material map when feature is disabled,
  some low-end hardware have a low amount of texture fetches, so we better avoid that if possible,
- produce smaller GLSL files, do not allocate unused structures,
- also reorganize a bit the code.