### PR TITLE
Suppress a warning with -connect when no argument are provided

### DIFF
--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -456,7 +456,7 @@ static void ParseCmdline(int argc, char** argv, cmdlineArgs_t& cmdlineArgs)
 		// Any arguments after the URI are discarded.
 		if (Str::IsIEqual("-connect", argv[i])) {
 			if (argc < i + 2) {
-				Log::Warn("Missing command line parameter for -connect");
+				Log::Notice("Ignoring -connect parameter as no server was provided");
 				break;
 			}
 


### PR DESCRIPTION
Some context: the flatpack uses a patch to suppress the warning, this commit upstreams the patch.

Slipher seems to be ok with this patch: https://github.com/Unvanquished/updater/issues/95#issuecomment-2223449484.

This patch is currently [added manually in the flatpack](https://github.com/flathub/net.unvanquished.Unvanquished/blob/0217843/0001-Suppress-a-warning.patch), and can be dropped after this is merged.