### PR TITLE
Fix videoMap regression

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -90,14 +90,14 @@ GLuint64 BindAnimatedImage( int unit, textureBundle_t *bundle )
 	{
 		if ( bundle->videoMapHandle >= 0 && CIN_RunCinematic( bundle->videoMapHandle ) )
 		{
+			GL_SelectTexture( unit );
 			CIN_UploadCinematic( bundle->videoMapHandle );
+			return tr.cinematicImage[ bundle->videoMapHandle ]->texture->bindlessTextureHandle;
 		}
 		else
 		{
 			return GL_BindToTMU( unit, tr.defaultImage );
 		}
-
-		return tr.cinematicImage[bundle->videoMapHandle]->texture->bindlessTextureHandle;
 	}
 
 	if ( bundle->numImages <= 1 )

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4994,8 +4994,6 @@ RENDER BACK END THREAD FUNCTIONS
 
 void RE_UploadCinematic( int cols, int rows, const byte *data, int client, bool dirty )
 {
-	R_SyncRenderThread();
-
 	GL_Bind( tr.cinematicImage[ client ] );
 
 	// if the scratchImage isn't in the format we want, specify it as a new texture

--- a/src/engine/renderer/tr_cmds.cpp
+++ b/src/engine/renderer/tr_cmds.cpp
@@ -201,6 +201,8 @@ OpenGL calls until R_IssueRenderCommands is called.
 */
 void R_SyncRenderThread()
 {
+	ASSERT( Sys::OnMainThread() ); // only call this from the frontend
+
 	if ( !tr.registered )
 	{
 		return;


### PR DESCRIPTION
Make the in-game videos show up again. Regression in f960177aba3c68e17e8ebfc865e8e8682268667a related to bindless texture changes.

Videos still don't work if bindless textures are enabled.