### PR TITLE
Some improvements to r_glDebugProfile/r_glDebugMode

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -37,8 +37,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_glMajorVersion;
 	cvar_t      *r_glMinorVersion;
 	cvar_t      *r_glProfile;
-	cvar_t      *r_glDebugProfile;
-	cvar_t      *r_glDebugMode;
+	Cvar::Cvar<bool> r_glDebugProfile( "r_glDebugProfile", "Enable GL debug message callback", Cvar::NONE, false );
+	Cvar::Range<Cvar::Cvar<int>> r_glDebugMode( "r_glDebugMode",
+		"GL debug message callback mode: 0: none, 1: error, 2: deprecated, 3: undefined, 4: portability, 5: performance,"
+		"6: other, 7: all", Cvar::NONE,
+		Util::ordinal( glDebugModes_t::GLDEBUG_NONE ),
+		Util::ordinal( glDebugModes_t::GLDEBUG_NONE ),
+		Util::ordinal( glDebugModes_t::GLDEBUG_ALL ) );
 	cvar_t      *r_glAllowSoftware;
 	cvar_t      *r_glExtendedValidation;
 
@@ -1055,8 +1060,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_glMajorVersion = Cvar_Get( "r_glMajorVersion", "", CVAR_LATCH );
 		r_glMinorVersion = Cvar_Get( "r_glMinorVersion", "", CVAR_LATCH );
 		r_glProfile = Cvar_Get( "r_glProfile", "", CVAR_LATCH );
-		r_glDebugProfile = Cvar_Get( "r_glDebugProfile", "", CVAR_LATCH );
-		r_glDebugMode = Cvar_Get( "r_glDebugMode", "0", CVAR_CHEAT );
+		Cvar::Latch( r_glDebugProfile );
 		r_glAllowSoftware = Cvar_Get( "r_glAllowSoftware", "0", CVAR_LATCH );
 		r_glExtendedValidation = Cvar_Get( "r_glExtendedValidation", "0", CVAR_LATCH );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2848,8 +2848,8 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_glMajorVersion; // override GL version autodetect (for testing)
 	extern cvar_t *r_glMinorVersion;
 	extern cvar_t *r_glProfile;
-	extern cvar_t *r_glDebugProfile;
-	extern cvar_t *r_glDebugMode;
+	extern Cvar::Cvar<bool> r_glDebugProfile;
+	extern Cvar::Range<Cvar::Cvar<int>> r_glDebugMode;
 	extern cvar_t *r_glAllowSoftware;
 	extern cvar_t *r_glExtendedValidation;
 


### PR DESCRIPTION
Use the core extension, which is more widely supported, switch the cvars to new-style. Also removed the cheat flag as it made no sense there.