### PR TITLE
Deduplicate Material renderer function selection

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -206,7 +206,14 @@ static image_t* GetDeluxeMap( drawSurf_t* drawSurf ) {
 // UpdateSurface*() functions will actually write the uniform values to the SSBO
 // Mirrors parts of the Render_*() functions in tr_shade.cpp
 
-static void UpdateSurfaceDataGeneric( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
+void UpdateSurfaceDataNONE( uint32_t*, Material&, drawSurf_t*, const uint32_t ) {
+	ASSERT_UNREACHABLE();
+}
+
+void UpdateSurfaceDataNOP( uint32_t*, Material&, drawSurf_t*, const uint32_t ) {
+}
+
+void UpdateSurfaceDataGeneric3D( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
 	shader_t* shader = drawSurf->shader;
 	shaderStage_t* pStage = &shader->stages[stage];
 
@@ -273,7 +280,7 @@ static void UpdateSurfaceDataGeneric( uint32_t* materials, Material& material, d
 	gl_genericShaderMaterial->WriteUniformsToBuffer( materials );
 }
 
-static void UpdateSurfaceDataLightMapping( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
+void UpdateSurfaceDataLightMapping( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
 	shader_t* shader = drawSurf->shader;
 	shaderStage_t* pStage = &shader->stages[stage];
 
@@ -584,7 +591,7 @@ static void UpdateSurfaceDataLightMapping( uint32_t* materials, Material& materi
 	gl_lightMappingShaderMaterial->WriteUniformsToBuffer( materials );
 }
 
-static void UpdateSurfaceDataReflection( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
+void UpdateSurfaceDataReflection( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
 	shader_t* shader = drawSurf->shader;
 	shaderStage_t* pStage = &shader->stages[stage];
 
@@ -637,7 +644,7 @@ static void UpdateSurfaceDataReflection( uint32_t* materials, Material& material
 	gl_reflectionShaderMaterial->WriteUniformsToBuffer( materials );
 }
 
-static void UpdateSurfaceDataSkybox( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
+void UpdateSurfaceDataSkybox( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
 	shader_t* shader = drawSurf->shader;
 	shaderStage_t* pStage = &shader->stages[stage];
 
@@ -666,7 +673,7 @@ static void UpdateSurfaceDataSkybox( uint32_t* materials, Material& material, dr
 	gl_skyboxShaderMaterial->WriteUniformsToBuffer( materials );
 }
 
-static void UpdateSurfaceDataScreen( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
+void UpdateSurfaceDataScreen( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
 	shader_t* shader = drawSurf->shader;
 	shaderStage_t* pStage = &shader->stages[stage];
 
@@ -687,7 +694,7 @@ static void UpdateSurfaceDataScreen( uint32_t* materials, Material& material, dr
 	gl_screenShaderMaterial->WriteUniformsToBuffer( materials );
 }
 
-static void UpdateSurfaceDataHeatHaze( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
+void UpdateSurfaceDataHeatHaze( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
 	shader_t* shader = drawSurf->shader;
 	shaderStage_t* pStage = &shader->stages[stage];
 
@@ -724,7 +731,7 @@ static void UpdateSurfaceDataHeatHaze( uint32_t* materials, Material& material, 
 	gl_heatHazeShaderMaterial->WriteUniformsToBuffer( materials );
 }
 
-static void UpdateSurfaceDataLiquid( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
+void UpdateSurfaceDataLiquid( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
 	shader_t* shader = drawSurf->shader;
 	shaderStage_t* pStage = &shader->stages[stage];
 
@@ -913,49 +920,7 @@ void MaterialSystem::GenerateWorldMaterialsBuffer() {
 
 					AddStageTextures( drawSurf, pStage, &material );
 
-					switch ( pStage->type ) {
-						case stageType_t::ST_COLORMAP:
-							// generic2D
-							UpdateSurfaceDataGeneric( materialsData, material, drawSurf, stage );
-							break;
-						case stageType_t::ST_STYLELIGHTMAP:
-						case stageType_t::ST_STYLECOLORMAP:
-							UpdateSurfaceDataGeneric( materialsData, material, drawSurf, stage );
-							break;
-						case stageType_t::ST_LIGHTMAP:
-						case stageType_t::ST_DIFFUSEMAP:
-						case stageType_t::ST_COLLAPSE_COLORMAP:
-						case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
-							UpdateSurfaceDataLightMapping( materialsData, material, drawSurf, stage );
-							break;
-						case stageType_t::ST_REFLECTIONMAP:
-						case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
-							UpdateSurfaceDataReflection( materialsData, material, drawSurf, stage );
-							break;
-						case stageType_t::ST_REFRACTIONMAP:
-						case stageType_t::ST_DISPERSIONMAP:
-							// Not implemented yet
-							break;
-						case stageType_t::ST_SKYBOXMAP:
-							UpdateSurfaceDataSkybox( materialsData, material, drawSurf, stage );
-							break;
-						case stageType_t::ST_SCREENMAP:
-							UpdateSurfaceDataScreen( materialsData, material, drawSurf, stage );
-							break;
-						case stageType_t::ST_PORTALMAP:
-							// This is supposedly used for alphagen portal and portal surfaces should never get here
-							ASSERT_UNREACHABLE();
-							break;
-						case stageType_t::ST_HEATHAZEMAP:
-							UpdateSurfaceDataHeatHaze( materialsData, material, drawSurf, stage );
-							break;
-						case stageType_t::ST_LIQUIDMAP:
-							UpdateSurfaceDataLiquid( materialsData, material, drawSurf, stage );
-							break;
-
-						default:
-							break;
-					}
+					pStage->surfaceDataUpdater( materialsData, material, drawSurf, stage );
 
 					tess.currentDrawSurf = drawSurf;
 
@@ -1791,49 +1756,7 @@ void MaterialSystem::UpdateDynamicSurfaces() {
 		for ( shaderStage_t* pStage = drawSurf.shader->stages; pStage < drawSurf.shader->lastStage; pStage++ ) {
 			Material& material = materialPacks[drawSurf.materialPackIDs[stage]].materials[drawSurf.materialIDs[stage]];
 
-			switch ( pStage->type ) {
-				case stageType_t::ST_COLORMAP:
-					// generic2D also uses this, but it's for ui only, so skip that for now
-					UpdateSurfaceDataGeneric( materialsData, material, &drawSurf, stage );
-					break;
-				case stageType_t::ST_STYLELIGHTMAP:
-				case stageType_t::ST_STYLECOLORMAP:
-					UpdateSurfaceDataGeneric( materialsData, material, &drawSurf, stage );
-					break;
-				case stageType_t::ST_LIGHTMAP:
-				case stageType_t::ST_DIFFUSEMAP:
-				case stageType_t::ST_COLLAPSE_COLORMAP:
-				case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
-					UpdateSurfaceDataLightMapping( materialsData, material, &drawSurf, stage );
-					break;
-				case stageType_t::ST_REFLECTIONMAP:
-				case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
-					UpdateSurfaceDataReflection( materialsData, material, &drawSurf, stage );
-					break;
-				case stageType_t::ST_REFRACTIONMAP:
-				case stageType_t::ST_DISPERSIONMAP:
-					// Not implemented yet
-					break;
-				case stageType_t::ST_SKYBOXMAP:
-					UpdateSurfaceDataSkybox( materialsData, material, &drawSurf, stage );
-					break;
-				case stageType_t::ST_SCREENMAP:
-					UpdateSurfaceDataScreen( materialsData, material, &drawSurf, stage );
-					break;
-				case stageType_t::ST_PORTALMAP:
-					// This is supposedly used for alphagen portal and portal surfaces should never get here
-					ASSERT_UNREACHABLE();
-					break;
-				case stageType_t::ST_HEATHAZEMAP:
-					UpdateSurfaceDataHeatHaze( materialsData, material, &drawSurf, stage );
-					break;
-				case stageType_t::ST_LIQUIDMAP:
-					UpdateSurfaceDataLiquid( materialsData, material, &drawSurf, stage );
-					break;
-
-				default:
-					break;
-			}
+			pStage->surfaceDataUpdater( materialsData, material, &drawSurf, stage );
 
 			stage++;
 		}

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1202,70 +1202,117 @@ void MaterialSystem::GenerateDepthImages( const int width, const int height, ima
 }
 
 static void BindShaderGeneric( Material* material ) {
+	// Select shader permutation.
 	gl_genericShaderMaterial->SetVertexAnimation( material->vertexAnimation );
-
 	gl_genericShaderMaterial->SetTCGenEnvironment( material->tcGenEnvironment );
 	gl_genericShaderMaterial->SetTCGenLightmap( material->tcGen_Lightmap );
-
 	gl_genericShaderMaterial->SetDepthFade( material->hasDepthFade );
 	gl_genericShaderMaterial->SetVertexSprite( material->vertexSprite );
 
+	// Bind shader.
 	gl_genericShaderMaterial->BindProgram( material->deformIndex );
+
+	// Set shader uniforms.
+	if ( material->tcGenEnvironment || material->vertexSprite ) {
+		gl_genericShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
+		gl_genericShaderMaterial->SetUniform_ViewUp( backEnd.orientation.axis[2] );
+	}
+
+	gl_genericShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_genericShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 }
 
 static void BindShaderLightMapping( Material* material ) {
+	// Select shader permutation.
 	gl_lightMappingShaderMaterial->SetVertexAnimation( material->vertexAnimation );
 	gl_lightMappingShaderMaterial->SetBspSurface( material->bspSurface );
-
 	gl_lightMappingShaderMaterial->SetDeluxeMapping( material->enableDeluxeMapping );
-
 	gl_lightMappingShaderMaterial->SetGridLighting( material->enableGridLighting );
-
 	gl_lightMappingShaderMaterial->SetGridDeluxeMapping( material->enableGridDeluxeMapping );
-
 	gl_lightMappingShaderMaterial->SetHeightMapInNormalMap( material->hasHeightMapInNormalMap );
-
 	gl_lightMappingShaderMaterial->SetReliefMapping( material->enableReliefMapping );
-
 	gl_lightMappingShaderMaterial->SetReflectiveSpecular( material->enableNormalMapping && tr.cubeHashTable != nullptr );
-
 	gl_lightMappingShaderMaterial->SetPhysicalShading( material->enablePhysicalMapping );
 
+	// Bind shader.
 	gl_lightMappingShaderMaterial->BindProgram( material->deformIndex );
+
+	// Set shader uniforms.
+	if ( tr.world ) {
+		gl_lightMappingShaderMaterial->SetUniform_LightGridOrigin( tr.world->lightGridGLOrigin );
+		gl_lightMappingShaderMaterial->SetUniform_LightGridScale( tr.world->lightGridGLScale );
+	}
+	// FIXME: else
+
+	gl_lightMappingShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
+	gl_lightMappingShaderMaterial->SetUniform_numLights( backEnd.refdef.numLights );
+	gl_lightMappingShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_lightMappingShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 }
 
 static void BindShaderReflection( Material* material ) {
+	// Select shader permutation.
 	gl_reflectionShaderMaterial->SetHeightMapInNormalMap( material->hasHeightMapInNormalMap );
-
 	gl_reflectionShaderMaterial->SetReliefMapping( material->enableReliefMapping );
-
 	gl_reflectionShaderMaterial->SetVertexAnimation( material->vertexAnimation );
 
+	// Bind shader.
 	gl_reflectionShaderMaterial->BindProgram( material->deformIndex );
+
+	// Set shader uniforms.
+	gl_reflectionShaderMaterial->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );
+	gl_reflectionShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_reflectionShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 }
 
 static void BindShaderSkybox( Material* material ) {
+	// Bind shader.
 	gl_skyboxShaderMaterial->BindProgram( material->deformIndex );
+
+	// Set shader uniforms.
+	gl_skyboxShaderMaterial->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );
+	gl_skyboxShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_skyboxShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 }
 
 static void BindShaderScreen( Material* material ) {
+	// Bind shader.
 	gl_screenShaderMaterial->BindProgram( material->deformIndex );
+
+	// Set shader uniforms.
+	gl_screenShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 }
 
 static void BindShaderHeatHaze( Material* material ) {
+	// Select shader permutation.
 	gl_heatHazeShaderMaterial->SetVertexAnimation( material->vertexAnimation );
-
 	gl_heatHazeShaderMaterial->SetVertexSprite( material->vertexSprite );
 
+	// Bind shader.
 	gl_heatHazeShaderMaterial->BindProgram( material->deformIndex );
+
+	// Set shader uniforms.
+	if ( material->vertexSprite ) {
+		gl_heatHazeShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
+		gl_heatHazeShaderMaterial->SetUniform_ViewUp( backEnd.orientation.axis[2] );
+	}
+
+	gl_heatHazeShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_heatHazeShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 }
 
 static void BindShaderLiquid( Material* material ) {
+	// Select shader permutation.
 	gl_liquidShaderMaterial->SetHeightMapInNormalMap( material->hasHeightMapInNormalMap );
-
 	gl_liquidShaderMaterial->SetReliefMapping( material->enableReliefMapping );
 
+	// Bind shader.
 	gl_liquidShaderMaterial->BindProgram( material->deformIndex );
+
+	// Set shader uniforms.
+	gl_liquidShaderMaterial->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );
+	gl_liquidShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_liquidShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 }
 
 void ProcessMaterialNONE( Material*, shaderStage_t*, drawSurf_t* ) {
@@ -2230,43 +2277,19 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 		case stageType_t::ST_STYLELIGHTMAP:
 		case stageType_t::ST_STYLECOLORMAP:
 			BindShaderGeneric( &material );
-
-			if ( material.tcGenEnvironment || material.vertexSprite ) {
-				gl_genericShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
-				gl_genericShaderMaterial->SetUniform_ViewUp( backEnd.orientation.axis[2] );
-			}
-
-			gl_genericShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
-			gl_genericShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 			break;
 		case stageType_t::ST_LIGHTMAP:
 		case stageType_t::ST_DIFFUSEMAP:
 		case stageType_t::ST_COLLAPSE_COLORMAP:
 		case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
 			BindShaderLightMapping( &material );
-			if ( tr.world ) {
-				gl_lightMappingShaderMaterial->SetUniform_LightGridOrigin( tr.world->lightGridGLOrigin );
-				gl_lightMappingShaderMaterial->SetUniform_LightGridScale( tr.world->lightGridGLScale );
-			}
-			// FIXME: else
-
-			gl_lightMappingShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
-			gl_lightMappingShaderMaterial->SetUniform_numLights( backEnd.refdef.numLights );
-			gl_lightMappingShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
-			gl_lightMappingShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 			break;
 		case stageType_t::ST_LIQUIDMAP:
 			BindShaderLiquid( &material );
-			gl_liquidShaderMaterial->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );
-			gl_liquidShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
-			gl_liquidShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 			break;
 		case stageType_t::ST_REFLECTIONMAP:
 		case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
 			BindShaderReflection( &material );
-			gl_reflectionShaderMaterial->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );
-			gl_reflectionShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
-			gl_reflectionShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 			break;
 		case stageType_t::ST_REFRACTIONMAP:
 		case stageType_t::ST_DISPERSIONMAP:
@@ -2274,13 +2297,9 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 			break;
 		case stageType_t::ST_SKYBOXMAP:
 			BindShaderSkybox( &material );
-			gl_skyboxShaderMaterial->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );
-			gl_skyboxShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
-			gl_skyboxShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 			break;
 		case stageType_t::ST_SCREENMAP:
 			BindShaderScreen( &material );
-			gl_screenShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 			break;
 		case stageType_t::ST_PORTALMAP:
 			// This is supposedly used for alphagen portal and portal surfaces should never get here
@@ -2289,14 +2308,6 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 		case stageType_t::ST_HEATHAZEMAP:
 			// FIXME: This requires 2 draws per surface stage rather than 1
 			BindShaderHeatHaze( &material );
-
-			if ( material.vertexSprite ) {
-				gl_heatHazeShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
-				gl_heatHazeShaderMaterial->SetUniform_ViewUp( backEnd.orientation.axis[2] );
-			}
-
-			gl_heatHazeShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
-			gl_heatHazeShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 			break;
 		default:
 			break;

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -81,7 +81,6 @@ struct Material {
 	uint32_t syncMaterial = 0; // Must not be drawn before the material with this id
 
 	uint32_t stateBits = 0;
-	stageType_t stageType;
 	stageShaderBinder_t shaderBinder;
 	GLuint program = 0;
 	GLShader* shader;

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -311,4 +311,14 @@ extern GLBuffer atomicCommandCountersBuffer; // Per viewframe
 extern GLSSBO portalSurfacesSSBO; // Per viewframe
 extern MaterialSystem materialSystem;
 
+void ProcessMaterialNONE( Material*, shaderStage_t*, drawSurf_t* );
+void ProcessMaterialNOP( Material*, shaderStage_t*, drawSurf_t* );
+void ProcessMaterialGeneric3D( Material* material, shaderStage_t* pStage, drawSurf_t* drawSurf );
+void ProcessMaterialLightMapping( Material* material, shaderStage_t* pStage, drawSurf_t* drawSurf );
+void ProcessMaterialReflection( Material* material, shaderStage_t* pStage, drawSurf_t* /* drawSurf */ );
+void ProcessMaterialSkybox( Material* material, shaderStage_t* pStage, drawSurf_t* /* drawSurf */ );
+void ProcessMaterialScreen( Material* material, shaderStage_t* pStage, drawSurf_t* /* drawSurf */ );
+void ProcessMaterialHeatHaze( Material* material, shaderStage_t* pStage, drawSurf_t* drawSurf );
+void ProcessMaterialLiquid( Material* material, shaderStage_t* pStage, drawSurf_t* /* drawSurf */ );
+
 #endif // MATERIAL_H

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -82,6 +82,7 @@ struct Material {
 
 	uint32_t stateBits = 0;
 	stageType_t stageType;
+	stageShaderBinder_t shaderBinder;
 	GLuint program = 0;
 	GLShader* shader;
 
@@ -310,6 +311,16 @@ extern GLUBO surfaceBatchesUBO; // Global
 extern GLBuffer atomicCommandCountersBuffer; // Per viewframe
 extern GLSSBO portalSurfacesSSBO; // Per viewframe
 extern MaterialSystem materialSystem;
+
+void BindShaderNONE( Material* );
+void BindShaderNOP( Material* );
+void BindShaderGeneric3D( Material* material );
+void BindShaderLightMapping( Material* material );
+void BindShaderReflection( Material* material );
+void BindShaderSkybox( Material* material );
+void BindShaderScreen( Material* material );
+void BindShaderHeatHaze( Material* material );
+void BindShaderLiquid( Material* material );
 
 void ProcessMaterialNONE( Material*, shaderStage_t*, drawSurf_t* );
 void ProcessMaterialNOP( Material*, shaderStage_t*, drawSurf_t* );

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -312,6 +312,16 @@ extern GLBuffer atomicCommandCountersBuffer; // Per viewframe
 extern GLSSBO portalSurfacesSSBO; // Per viewframe
 extern MaterialSystem materialSystem;
 
+void UpdateSurfaceDataNONE( uint32_t*, Material&, drawSurf_t*, const uint32_t );
+void UpdateSurfaceDataNOP( uint32_t*, Material&, drawSurf_t*, const uint32_t );
+void UpdateSurfaceDataGeneric3D( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
+void UpdateSurfaceDataLightMapping( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
+void UpdateSurfaceDataReflection( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
+void UpdateSurfaceDataSkybox( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
+void UpdateSurfaceDataScreen( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
+void UpdateSurfaceDataHeatHaze( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
+void UpdateSurfaceDataLiquid( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
+
 void BindShaderNONE( Material* );
 void BindShaderNOP( Material* );
 void BindShaderGeneric3D( Material* material );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1096,6 +1096,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	struct drawSurf_t;
 
 	using stageRenderer_t = void(*)(shaderStage_t *);
+	using stageSurfaceDataUpdater_t = void(*)(uint32_t*, Material&, drawSurf_t*, const uint32_t);
 	using stageShaderBinder_t = void(*)(Material*);
 	using stageMaterialProcessor_t = void(*)(Material*, shaderStage_t*, drawSurf_t*);
 
@@ -1111,7 +1112,11 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 
 		bool shaderHasNoLight;
 
+		// Core renderer (code path for when only OpenGL Core is available, or compatible OpenGL 2).
 		stageRenderer_t colorRenderer;
+
+		// Material renderer (code path for advanced OpenGL techniques like bindless textures).
+		stageSurfaceDataUpdater_t surfaceDataUpdater;
 		stageShaderBinder_t shaderBinder;
 		stageMaterialProcessor_t materialProcessor;
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1092,8 +1092,11 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	};
 
 	struct shaderStage_t;
+	struct Material;
+	struct drawSurf_t;
 
 	using stageRenderer_t = void(*)(shaderStage_t *);
+	using stageMaterialProcessor_t = void(*)(Material*, shaderStage_t*, drawSurf_t*);
 
 	struct shaderStage_t
 	{
@@ -1108,6 +1111,8 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		bool shaderHasNoLight;
 
 		stageRenderer_t colorRenderer;
+		stageMaterialProcessor_t materialProcessor;
+
 		bool doShadowFill;
 		bool doForwardLighting;
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1096,6 +1096,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 	struct drawSurf_t;
 
 	using stageRenderer_t = void(*)(shaderStage_t *);
+	using stageShaderBinder_t = void(*)(Material*);
 	using stageMaterialProcessor_t = void(*)(Material*, shaderStage_t*, drawSurf_t*);
 
 	struct shaderStage_t
@@ -1111,6 +1112,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		bool shaderHasNoLight;
 
 		stageRenderer_t colorRenderer;
+		stageShaderBinder_t shaderBinder;
 		stageMaterialProcessor_t materialProcessor;
 
 		bool doShadowFill;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5346,6 +5346,7 @@ static void SetStagesRenderers()
 {
 	struct stageRendererOptions_t {
 		stageRenderer_t colorRenderer;
+		stageShaderBinder_t shaderBinder;
 		stageMaterialProcessor_t materialProcessor;
 		bool doShadowFill;
 		bool doForwardLighting;
@@ -5355,7 +5356,11 @@ static void SetStagesRenderers()
 	{
 		shaderStage_t *stage = &stages[ s ];
 
-		stageRendererOptions_t stageRendererOptions = { &Render_NONE, &ProcessMaterialNONE, false, false };
+		stageRendererOptions_t stageRendererOptions = {
+			&Render_NONE,
+			&BindShaderNONE, &ProcessMaterialNONE,
+			false, false,
+		};
 
 		bool opaqueOrLess = shader.sort <= Util::ordinal(shaderSort_t::SS_OPAQUE);
 
@@ -5364,46 +5369,90 @@ static void SetStagesRenderers()
 			case stageType_t::ST_COLORMAP:
 				/* Comment from the Material code:
 				generic2D also uses this, but it's for UI only, so skip that for now. */
-				stageRendererOptions = { &Render_generic, &ProcessMaterialGeneric3D, opaqueOrLess, false };
+				stageRendererOptions = {
+					&Render_generic,
+					&BindShaderGeneric3D, &ProcessMaterialGeneric3D,
+					opaqueOrLess, false,
+				};
 				break;
 			case stageType_t::ST_STYLELIGHTMAP:
 			case stageType_t::ST_STYLECOLORMAP:
-				stageRendererOptions = { &Render_generic3D, &ProcessMaterialGeneric3D, true, false };
+				stageRendererOptions = {
+					&Render_generic3D,
+					&BindShaderGeneric3D, &ProcessMaterialGeneric3D,
+					true, false,
+				};
 				break;
 			case stageType_t::ST_LIGHTMAP:
 			case stageType_t::ST_DIFFUSEMAP:
 			case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
-				stageRendererOptions = { &Render_lightMapping, &ProcessMaterialLightMapping, true, true };
+				stageRendererOptions = {
+					&Render_lightMapping,
+					&BindShaderLightMapping, &ProcessMaterialLightMapping,
+					true, true,
+				};
 				break;
 			case stageType_t::ST_COLLAPSE_COLORMAP:
-				stageRendererOptions = { &Render_lightMapping, &ProcessMaterialLightMapping, true, false };
+				stageRendererOptions = {
+					&Render_lightMapping,
+					&BindShaderLightMapping, &ProcessMaterialLightMapping,
+					true, false,
+				};
 				break;
 			case stageType_t::ST_REFLECTIONMAP:
 			case stageType_t::ST_COLLAPSE_REFLECTIONMAP:
-				stageRendererOptions = { &Render_reflection_CB, &ProcessMaterialReflection, false, false };
+				stageRendererOptions = {
+					&Render_reflection_CB,
+					&BindShaderReflection, &ProcessMaterialReflection,
+					false, false,
+				};
 				break;
 			case stageType_t::ST_SKYBOXMAP:
-				stageRendererOptions = { &Render_skybox, &ProcessMaterialSkybox, false, false };
+				stageRendererOptions = {
+					&Render_skybox,
+					&BindShaderSkybox, &ProcessMaterialSkybox,
+					false, false,
+				};
 				break;
 			case stageType_t::ST_SCREENMAP:
-				stageRendererOptions = { &Render_screen, &ProcessMaterialScreen, false, false };
+				stageRendererOptions = {
+					&Render_screen,
+					&BindShaderScreen, &ProcessMaterialScreen,
+					false, false,
+				};
 				break;
 			case stageType_t::ST_PORTALMAP:
 				/* Comment from the Material code:
 				This is supposedly used for alphagen portal and portal surfaces should never get here. */
-				stageRendererOptions = { &Render_portal, &ProcessMaterialNONE, false, false };
+				stageRendererOptions = {
+					&Render_portal,
+					&BindShaderNONE, &ProcessMaterialNONE,
+					false, false,
+				};
 				break;
 			case stageType_t::ST_HEATHAZEMAP:
 				/* Comment from the Material code:
 				FIXME: This requires 2 draws per surface stage rather than 1. */
-				stageRendererOptions = { &Render_heatHaze, &ProcessMaterialHeatHaze, false, false };
+				stageRendererOptions = {
+					&Render_heatHaze,
+					&BindShaderHeatHaze, &ProcessMaterialHeatHaze,
+					false, false,
+				};
 				break;
 			case stageType_t::ST_LIQUIDMAP:
-				stageRendererOptions = { &Render_liquid, &ProcessMaterialLiquid, false, false };
+				stageRendererOptions = {
+					&Render_liquid,
+					&BindShaderLiquid, &ProcessMaterialLiquid,
+					false, false,
+				};
 				break;
 			case stageType_t::ST_ATTENUATIONMAP_XY:
 			case stageType_t::ST_ATTENUATIONMAP_Z:
-				stageRendererOptions = { &Render_NOP, &ProcessMaterialNOP, false, true };
+				stageRendererOptions = {
+					&Render_NOP,
+					&BindShaderNOP, &ProcessMaterialNOP,
+					false, true,
+				};
 				break;
 			default:
 				Log::Warn( "Missing renderer for stage type %d", Util::ordinal(stage->type) );
@@ -5412,6 +5461,7 @@ static void SetStagesRenderers()
 		}
 
 		stage->colorRenderer = stageRendererOptions.colorRenderer;
+		stage->shaderBinder = stageRendererOptions.shaderBinder;
 		stage->materialProcessor = stageRendererOptions.materialProcessor;
 		stage->doShadowFill = stageRendererOptions.doShadowFill;
 		stage->doForwardLighting = stageRendererOptions.doForwardLighting;


### PR DESCRIPTION
That part of the Material code seems to be stable enough to start mutualizing some logic with the non-Material code.

The various `ProcessMaterial*`, `BindShader*` and `UpdateSurfaceData*` functions are selected at the same time the `Render_*` functions are, at q3shader parsing time.

This deduplicates many `switch` boilerplate and reduce risks to introduce discrepancies in the future when modifying some parts of the code and forgetting to report the same change everywhere else.