### PR TITLE
Mutualize SetLightDeluxeMode, SetLightMap, and SetDeluxeMap

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -220,9 +220,9 @@ static void UpdateSurfaceDataGeneric( uint32_t* materials, Material& material, d
 	gl_genericShaderMaterial->SetUniform_InverseLightFactor( inverseLightFactor );
 
 	// u_ColorModulate
-	colorGen_t rgbGen;
-	alphaGen_t alphaGen;
-	SetRgbaGen( pStage, &rgbGen, &alphaGen );
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
+
 	gl_genericShaderMaterial->SetUniform_ColorModulate( rgbGen, alphaGen );
 
 	Tess_ComputeColor( pStage );
@@ -284,9 +284,8 @@ static void UpdateSurfaceDataLightMapping( uint32_t* materials, Material& materi
 	image_t* deluxemap = SetDeluxeMap( drawSurf, deluxeMode );
 
 	// u_ColorModulate
-	colorGen_t rgbGen;
-	alphaGen_t alphaGen;
-	SetRgbaGen( pStage, &rgbGen, &alphaGen );
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
 
 	SetVertexLightingSettings( lightMode, rgbGen );
 

--- a/src/engine/renderer/ShadeCommon.h
+++ b/src/engine/renderer/ShadeCommon.h
@@ -197,6 +197,38 @@ template<typename Obj> image_t* SetDeluxeMap( Obj* obj, deluxeMode_t deluxeMode 
 	return tr.blackImage;
 }
 
+inline colorGen_t SetRgbGen( const shaderStage_t *pStage )
+{
+	switch ( pStage->rgbGen )
+	{
+		case colorGen_t::CGEN_VERTEX:
+		case colorGen_t::CGEN_ONE_MINUS_VERTEX:
+			return pStage->rgbGen;
+			break;
+
+		default:
+			break;
+	}
+
+	return colorGen_t::CGEN_CONST;
+}
+
+inline alphaGen_t SetAlphaGen( const shaderStage_t *pStage )
+{
+	switch ( pStage->alphaGen )
+	{
+		case alphaGen_t::AGEN_VERTEX:
+		case alphaGen_t::AGEN_ONE_MINUS_VERTEX:
+			return pStage->alphaGen;
+			break;
+
+		default:
+			break;
+	}
+
+	return alphaGen_t::AGEN_CONST;
+}
+
 inline void SetVertexLightingSettings( lightMode_t lightMode, colorGen_t& rgbGen )
 {
 	if ( lightMode == lightMode_t::VERTEX )

--- a/src/engine/renderer/ShadeCommon.h
+++ b/src/engine/renderer/ShadeCommon.h
@@ -1,0 +1,210 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+
+inline size_t GetLightMapNum( shaderCommands_t* tess )
+{
+	return tess->lightmapNum;
+}
+
+inline size_t GetLightMapNum( drawSurf_t* drawSurf )
+{
+	return drawSurf->lightmapNum();
+}
+
+template<typename Obj> bool HasLightMap( Obj* obj )
+{
+	return static_cast<size_t>( GetLightMapNum( obj ) ) < tr.lightmaps.size();
+}
+
+template<typename Obj> image_t* GetLightMap( Obj* obj )
+{
+	if ( HasLightMap( obj ) )
+	{
+		return tr.lightmaps[ GetLightMapNum( obj ) ];
+	}
+
+	return tr.whiteImage;
+}
+
+template<typename Obj> bool HasDeluxeMap( Obj* obj )
+{
+	return static_cast<size_t>( GetLightMapNum( obj ) ) < tr.deluxemaps.size();
+}
+
+template<typename Obj> image_t* GetDeluxeMap( Obj* obj )
+{
+	if ( HasDeluxeMap( obj ) )
+	{
+		return tr.deluxemaps[ GetLightMapNum( obj ) ];
+	}
+
+	return tr.blackImage;
+}
+
+inline shader_t* GetSurfaceShader( shaderCommands_t* tess )
+{
+	return tess->surfaceShader;
+}
+
+inline shader_t* GetSurfaceShader( drawSurf_t* drawSurf )
+{
+	return drawSurf->shader;
+}
+
+template<typename Obj> static bool hasExplicitelyDisabledLightMap( Obj* obj )
+{
+	return GetSurfaceShader( obj )->surfaceFlags & SURF_NOLIGHTMAP;
+}
+
+inline shaderStage_t* GetSurfaceLastStage( shaderCommands_t* tess )
+{
+	return tess->surfaceLastStage;
+}
+
+inline shaderStage_t* GetSurfaceLastStage( drawSurf_t* drawSurf )
+{
+	return drawSurf->shader->lastStage;
+}
+
+inline shaderStage_t* GetSurfaceStages( shaderCommands_t* tess )
+{
+	return tess->surfaceStages;
+}
+
+inline shaderStage_t* GetSurfaceStages( drawSurf_t* drawSurf )
+{
+	return drawSurf->shader->stages;
+}
+
+template<typename Obj> bool isExplicitelyVertexLitSurface( Obj* obj )
+{
+	shaderStage_t* lastStage = GetSurfaceLastStage( obj );
+	shaderStage_t* stages = GetSurfaceStages( obj );
+	return lastStage != stages && stages[0].rgbGen == colorGen_t::CGEN_VERTEX;
+}
+
+template<typename Obj> void SetLightDeluxeMode( Obj* obj,
+	stageType_t stageType,
+	lightMode_t& lightMode, deluxeMode_t& deluxeMode )
+{
+	lightMode = lightMode_t::FULLBRIGHT;
+	deluxeMode = deluxeMode_t::NONE;
+
+	if ( hasExplicitelyDisabledLightMap( obj ) && !isExplicitelyVertexLitSurface( obj ) )
+	{
+		// Use fullbright on “surfaceparm nolightmap” materials.
+	}
+	else if ( stageType == stageType_t::ST_COLLAPSE_COLORMAP )
+	{
+		/* Use fullbright for collapsed stages without lightmaps,
+		for example:
+
+		  {
+		    map textures/texture_d
+		    heightMap textures/texture_h
+		  }
+
+		This is doable for some complex multi-stage materials. */
+	}
+	else if ( obj->bspSurface )
+	{
+		lightMode = tr.worldLight;
+		deluxeMode = tr.worldDeluxe;
+
+		if ( lightMode == lightMode_t::MAP )
+		{
+			if ( !HasLightMap( obj ) )
+			{
+				lightMode = lightMode_t::VERTEX;
+				deluxeMode = deluxeMode_t::NONE;
+			}
+		}
+	}
+	else
+	{
+		lightMode = tr.modelLight;
+		deluxeMode = tr.modelDeluxe;
+	}
+}
+
+template<typename Obj> image_t* SetLightMap( Obj* obj, lightMode_t lightMode )
+{
+	switch ( lightMode ) {
+		case lightMode_t::VERTEX:
+			break;
+
+		case lightMode_t::GRID:
+			return tr.lightGrid1Image;
+			break;
+
+		case lightMode_t::MAP:
+			return GetLightMap( obj );
+			break;
+
+		default:
+			break;
+	}
+
+	return tr.whiteImage;
+}
+
+template<typename Obj> image_t* SetDeluxeMap( Obj* obj, deluxeMode_t deluxeMode )
+{
+	switch ( deluxeMode ) {
+		case deluxeMode_t::MAP:
+			return GetDeluxeMap( obj );
+			break;
+
+		case deluxeMode_t::GRID:
+			return tr.lightGrid2Image;
+			break;
+
+		default:
+			break;
+	}
+
+	return tr.blackImage;
+}
+
+inline void SetVertexLightingSettings( lightMode_t lightMode, colorGen_t& rgbGen )
+{
+	if ( lightMode == lightMode_t::VERTEX )
+	{
+		// Do not rewrite pStage->rgbGen.
+		rgbGen = colorGen_t::CGEN_VERTEX;
+		tess.svars.color.SetRed( 0.0f );
+		tess.svars.color.SetGreen( 0.0f );
+		tess.svars.color.SetBlue( 0.0f );
+	}
+}

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3397,7 +3397,6 @@ inline bool checkGLErrors()
 	void Tess_CheckOverflow( int verts, int indexes );
 
 	void SetNormalScale( const shaderStage_t* pStage, vec3_t normalScale );
-	void SetRgbaGen( const shaderStage_t* pStage, colorGen_t* rgbGen, alphaGen_t* alphaGen );
 	void Tess_ComputeColor( shaderStage_t *pStage );
 	void Tess_ComputeTexMatrices( shaderStage_t* pStage );
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -754,33 +754,6 @@ void SetNormalScale( const shaderStage_t *pStage, vec3_t normalScale )
 	normalScale[ 2 ] = pStage->normalScale[ 2 ] * r_normalScale->value;
 }
 
-void SetRgbaGen( const shaderStage_t *pStage, colorGen_t *rgbGen, alphaGen_t *alphaGen )
-{
-	switch ( pStage->rgbGen )
-	{
-		case colorGen_t::CGEN_VERTEX:
-		case colorGen_t::CGEN_ONE_MINUS_VERTEX:
-			*rgbGen = pStage->rgbGen;
-			break;
-
-		default:
-			*rgbGen = colorGen_t::CGEN_CONST;
-			break;
-	}
-
-	switch ( pStage->alphaGen )
-	{
-		case alphaGen_t::AGEN_VERTEX:
-		case alphaGen_t::AGEN_ONE_MINUS_VERTEX:
-			*alphaGen = pStage->alphaGen;
-			break;
-
-		default:
-			*alphaGen = alphaGen_t::AGEN_CONST;
-			break;
-	}
-}
-
 // *INDENT-ON*
 
 void Render_NONE( shaderStage_t * )
@@ -812,9 +785,9 @@ static void Render_generic2D( shaderStage_t *pStage )
 	gl_generic2DShader->SetUniform_AlphaTest( pStage->stateBits );
 
 	// u_ColorModulate
-	colorGen_t rgbGen;
-	alphaGen_t alphaGen;
-	SetRgbaGen( pStage, &rgbGen, &alphaGen );
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
+
 	gl_generic2DShader->SetUniform_ColorModulate( rgbGen, alphaGen );
 
 	// u_Color
@@ -904,9 +877,9 @@ void Render_generic3D( shaderStage_t *pStage )
 	gl_genericShader->SetUniform_InverseLightFactor( inverseLightFactor );
 
 	// u_ColorModulate
-	colorGen_t rgbGen;
-	alphaGen_t alphaGen;
-	SetRgbaGen( pStage, &rgbGen, &alphaGen );
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
+
 	gl_genericShader->SetUniform_ColorModulate( rgbGen, alphaGen );
 
 	// u_Color
@@ -992,9 +965,8 @@ void Render_lightMapping( shaderStage_t *pStage )
 	image_t *deluxemap = SetDeluxeMap( &tess, deluxeMode );
 
 	// u_ColorModulate
-	colorGen_t rgbGen;
-	alphaGen_t alphaGen;
-	SetRgbaGen( pStage, &rgbGen, &alphaGen );
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
 
 	SetVertexLightingSettings( lightMode, rgbGen );
 
@@ -1425,9 +1397,9 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *pStage,
 	// now we are ready to set the shader program uniforms
 
 	// u_ColorModulate
-	colorGen_t rgbGen;
-	alphaGen_t alphaGen;
-	SetRgbaGen( pStage, &rgbGen, &alphaGen );
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
+
 	gl_forwardLightingShader_omniXYZ->SetUniform_ColorModulate( rgbGen, alphaGen );
 
 	// u_Color
@@ -1603,9 +1575,9 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *pStage,
 	// now we are ready to set the shader program uniforms
 
 	// u_ColorModulate
-	colorGen_t rgbGen;
-	alphaGen_t alphaGen;
-	SetRgbaGen( pStage, &rgbGen, &alphaGen );
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
+
 	gl_forwardLightingShader_projXYZ->SetUniform_ColorModulate( rgbGen, alphaGen );
 
 	// u_Color
@@ -1782,9 +1754,9 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *pStage, trRef
 	// now we are ready to set the shader program uniforms
 
 	// u_ColorModulate
-	colorGen_t rgbGen;
-	alphaGen_t alphaGen;
-	SetRgbaGen( pStage, &rgbGen, &alphaGen );
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
+
 	gl_forwardLightingShader_directionalSun->SetUniform_ColorModulate( rgbGen, alphaGen );
 
 	// u_Color


### PR DESCRIPTION
Another effort to mutualize code between the non-Material renderer and the Material one.

- Mutualize `SetLightDeluxeMode`, `SetLightMap`, and `SetDeluxeMap`.
- Rewrite `SetRgbaGen` as `SetRgbGen` and `SetAlphaGen`.