### PR TITLE
Add sv_novis to disable server PVS checks

### DIFF
--- a/src/engine/server/sv_snapshot.cpp
+++ b/src/engine/server/sv_snapshot.cpp
@@ -57,6 +57,8 @@ A server packet will look something like:
 =============================================================================
 */
 
+static Cvar::Cvar<bool> sv_novis("sv_novis", "skip PVS check when transmitting entities", 0, false);
+
 /*
 =============
 SV_EmitPacketEntities
@@ -452,6 +454,12 @@ static void SV_AddEntitiesVisibleFromPoint( vec3_t origin, clientSnapshot_t *fra
 		// don't double add an entity through portals
 		if ( svEnt->snapshotCounter == sv.snapshotCounter )
 		{
+			continue;
+		}
+
+		if ( sv_novis.Get() )
+		{
+			SV_AddEntToSnapshot( playerEnt, svEnt, ent, eNums );
 			continue;
 		}
 


### PR DESCRIPTION
Disables PVS checking when transmitting entities to clients.

sv_novis was documented at
https://wiki.unvanquished.net/wiki/Testing/Maps, but it turns out such a cvar has never existed. I wanted to use it, so I made it real.