### PR TITLE
Fix moving portal surfaces, cleanup portal code a bit

### DIFF
--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1281,9 +1281,6 @@ static bool R_GetPortalOrientations( drawSurf_t *drawSurf, orientation_t *surfac
 		// against the portalSurface entities
 		R_LocalNormalToWorld( originalPlane.normal, plane.normal );
 		plane.dist = originalPlane.dist + DotProduct( plane.normal, tr.orientation.origin );
-
-		// translate the original plane
-		originalPlane.dist = originalPlane.dist + DotProduct( originalPlane.normal, tr.orientation.origin );
 	}
 	else
 	{
@@ -1320,6 +1317,10 @@ static bool R_GetPortalOrientations( drawSurf_t *drawSurf, orientation_t *surfac
 			currentPortal = e;
 		}
 	}
+	if( drawSurf->entity != &tr.worldEntity ) {
+		VectorAdd( portalCenter, drawSurf->entity->e.origin, portalCenter );
+	}
+
 	if( currentPortal ) {
 		// project the origin onto the surface plane to get
 		// an origin point we can rotate around

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1366,11 +1366,17 @@ static bool R_GetPortalOrientations( drawSurf_t *drawSurf, orientation_t *surfac
 			}
 		}
 
+		/* The calculation of the new axes and origin works by first calculating the transforms from world->portal camera
+		and portal surface->world, then transforming the current orientation and origin:
+		first from portal surface->world, then world->portal camera */
+
+		// World->portal camera
 		vec3_t axisAngles;
 		AxisToAngles( e->e.axis, axisAngles );
 		quat_t worldToCameraQuat;
 		QuatFromAngles( worldToCameraQuat, axisAngles[0], axisAngles[1], axisAngles[2] );
 
+		// Portal surface->world
 		axis_t drawSurfAxis;
 		VectorCopy( plane.normal, drawSurfAxis[0] );
 		VectorInverse( drawSurfAxis[0] );
@@ -1386,8 +1392,8 @@ static bool R_GetPortalOrientations( drawSurf_t *drawSurf, orientation_t *surfac
 		QuatFromAngles( surfToWorldQuatYaw, 0.0, -axisAngles[1], 0.0 );
 		QuatFromAngles( surfToWorldQuatRoll, 0.0, 0.0, -axisAngles[2] );
 
+		// Axis transform
 		vec3_t currentAxis;
-
 		VectorCopy( tr.viewParms.orientation.axis[0], currentAxis );
 		// QuatTransformVector rotates on a local plane so transform in the worlds XY plane first
 		float currentAxisZ = currentAxis[2];
@@ -1412,6 +1418,7 @@ static bool R_GetPortalOrientations( drawSurf_t *drawSurf, orientation_t *surfac
 
 		CrossProduct( outAxis[0], outAxis[1], outAxis[2] );
 
+		// Origin transform
 		vec3_t newOrigin;
 		VectorSubtract( portalCenter, tr.viewParms.orientation.origin, newOrigin );
 		currentAxisZ = newOrigin[2];
@@ -1441,7 +1448,7 @@ static bool R_GetPortalOrientations( drawSurf_t *drawSurf, orientation_t *surfac
 	// portal entity the server won't have communicated a proper entity set
 	// in the snapshot
 
-	// unfortunately, with local movement prediction it is easily possible
+	// Unfortunately, with local movement prediction it is easily possible
 	// to see a surface before the server has communicated the matching
 	// portal surface entity, so we don't want to print anything here...
 

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1393,38 +1393,36 @@ static bool R_GetPortalOrientations( drawSurf_t *drawSurf, orientation_t *surfac
 		QuatFromAngles( surfToWorldQuatRoll, 0.0, 0.0, -axisAngles[2] );
 
 		// Axis transform
-		vec3_t currentAxis;
-		VectorCopy( tr.viewParms.orientation.axis[0], currentAxis );
-		// QuatTransformVector rotates on a local plane so transform in the worlds XY plane first
-		float currentAxisZ = currentAxis[2];
-		currentAxis[2] = 0.0;
-		QuatTransformVector( surfToWorldQuatYaw, tr.viewParms.orientation.axis[0], currentAxis );
-		currentAxis[2] = currentAxisZ;
-		// Have to keep rotation separate for each axis in a local to world transform to get the correct result
-		QuatTransformVector( surfToWorldQuatPitch, currentAxis, currentAxis );
-		QuatTransformVector( surfToWorldQuatRoll, currentAxis, currentAxis );
-		QuatTransformVector( worldToCameraQuat, currentAxis, currentAxis );
-		VectorCopy( currentAxis, outAxis[0] );
+		/* We have to transform both of the first 2 axes to always get correct rotation,
+		but we can get the last one with a cross product */
+		for ( int i = 0; i < 2; i++ ) {
+			vec3_t currentAxis;
+			VectorCopy( tr.viewParms.orientation.axis[i], currentAxis );
 
-		VectorCopy( tr.viewParms.orientation.axis[1], currentAxis );
-		currentAxisZ = currentAxis[2];
-		currentAxis[2] = 0.0;
-		QuatTransformVector( surfToWorldQuatYaw, tr.viewParms.orientation.axis[1], currentAxis );
-		currentAxis[2] = currentAxisZ;
-		QuatTransformVector( surfToWorldQuatPitch, currentAxis, currentAxis );
-		QuatTransformVector( surfToWorldQuatRoll, currentAxis, currentAxis );
-		QuatTransformVector( worldToCameraQuat, currentAxis, currentAxis );
-		VectorCopy( currentAxis, outAxis[1] );
+			// QuatTransformVector rotates on a local plane so transform in the worlds XY plane first
+			float currentAxisZ = currentAxis[2];
+			currentAxis[2] = 0.0;
+			QuatTransformVector( surfToWorldQuatYaw, tr.viewParms.orientation.axis[i], currentAxis );
+			currentAxis[2] = currentAxisZ;
+
+			// Have to keep rotation separate for each axis in a local to world transform to get the correct result
+			QuatTransformVector( surfToWorldQuatPitch, currentAxis, currentAxis );
+			QuatTransformVector( surfToWorldQuatRoll, currentAxis, currentAxis );
+			QuatTransformVector( worldToCameraQuat, currentAxis, currentAxis );
+			VectorCopy( currentAxis, outAxis[i] );
+		}
 
 		CrossProduct( outAxis[0], outAxis[1], outAxis[2] );
 
 		// Origin transform
 		vec3_t newOrigin;
 		VectorSubtract( portalCenter, tr.viewParms.orientation.origin, newOrigin );
-		currentAxisZ = newOrigin[2];
+
+		float currentAxisZ = newOrigin[2];
 		newOrigin[2] = 0.0;
 		QuatTransformVector( surfToWorldQuatYaw, newOrigin, newOrigin );
 		newOrigin[2] = currentAxisZ;
+
 		QuatTransformVector( surfToWorldQuatPitch, newOrigin, newOrigin );
 		QuatTransformVector( surfToWorldQuatRoll, newOrigin, newOrigin );
 		QuatTransformVector( worldToCameraQuat, newOrigin, newOrigin );

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1760,7 +1760,10 @@ bool PortalOffScreenOrOutOfRange( const drawSurf_t *drawSurf, screenRect_t& surf
 		float  len;
 		vec3_t qnormal;
 
-		VectorSubtract( tess.verts[ tess.indexes[ i ] ].xyz, tr.orientation.viewOrigin, normal );
+		VectorSubtract( tess.verts[ tess.indexes[ i ] ].xyz, tr.viewParms.pvsOrigin, normal );
+		if ( tr.currentEntity != &tr.worldEntity ) {
+			VectorAdd( normal, tr.currentEntity->e.origin, normal );
+		}
 
 		len = VectorLengthSquared( normal );  // lose the sqrt
 

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1946,7 +1946,6 @@ bool R_MirrorViewBySurface(drawSurf_t *drawSurf)
 	newParms.portalLevel++;
 
 	// convert screen rectangle to scissor test
-	// OPTIMIZE: could do better with stencil test in renderer backend
 	newParms.scissorX = surfRect.coords[0];
 	newParms.scissorY = surfRect.coords[1];
 	newParms.scissorWidth = surfRect.coords[2] - surfRect.coords[0] + 1;


### PR DESCRIPTION
This bug was revealed by the map https://users.unvanquished.net/~kai/map-test-portals-moving_0.1.dpk.

Current behaviour on `for-0.55.0`:
![unvanquished_2024-09-01_144844_000](https://github.com/user-attachments/assets/93946c80-a019-433e-b57c-e6b8d50cb498)
![unvanquished_2024-09-01_144848_000](https://github.com/user-attachments/assets/87ef63b5-7dfc-4010-b767-308b74c0484e)
![unvanquished_2024-09-01_144851_000](https://github.com/user-attachments/assets/9d8074a1-262b-4f0a-a209-873f7df11465)

With this pr:
![unvanquished_2024-09-01_053636_000](https://github.com/user-attachments/assets/1443e7ad-e9e3-4e48-8fc6-3ff30915cb9f)
![unvanquished_2024-09-01_053642_000](https://github.com/user-attachments/assets/ce75bbbc-bf3e-4f05-a4e9-71ee328c2ec6)
![unvanquished_2024-09-01_053649_000](https://github.com/user-attachments/assets/0c31cd9e-c64e-4edd-abd1-bb3af24832ff)

I've also cleaned up both `PortalOffScreenOrOutOfRange()` and `R_GetPortalOrientations()` a bit, and added some comments for the rotation code.