### PR TITLE
Fix material system missing surfaces bug

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1574,6 +1574,7 @@ void MaterialSystem::GenerateWorldMaterials() {
 
 	R_SyncRenderThread();
 
+	++tr.viewCountNoReset;
 	R_AddWorldSurfaces();
 
 	Log::Notice( "World bounds: min: %f %f %f max: %f %f %f", tr.viewParms.visBounds[0][0], tr.viewParms.visBounds[0][1],

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1999,9 +1999,6 @@ void MaterialSystem::EndFrame() {
 	if ( nextFrame >= MAX_FRAMES ) {
 		nextFrame = 0;
 	}
-
-	currentView = 0;
-	return;
 }
 
 void MaterialSystem::GeneratePortalBoundingSpheres() {

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -203,8 +203,6 @@ class MaterialSystem {
 	bool generatingWorldCommandBuffer = false;
 	vec3_t worldViewBounds[2] = {};
 
-	uint32_t currentView = 0;
-
 	uint8_t maxStages = 0;
 	uint32_t descriptorSize;
 

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4755,7 +4755,6 @@ static void RB_RenderView( bool depthPass )
 	{
 		RB_Hyperspace();
 
-		materialSystem.currentView++;
 		return;
 	}
 	else
@@ -4865,8 +4864,6 @@ static void RB_RenderView( bool depthPass )
 
 		backEnd.pc.c_portals++;
 	}
-
-	materialSystem.currentView++;
 
 	backEnd.pc.c_views++;
 }

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2581,7 +2581,7 @@ enum class dynamicLightRenderer_t { LEGACY, TILED };
 		int      frameCount; // incremented every frame
 		int      sceneCount; // incremented every scene
 		int      viewCount; // incremented every view (twice a scene if portaled)
-		int      viewCountNoReset;
+		int      viewCountNoReset; // incremented when doing something that visits surfaces and sets their viewCount
 		int      lightCount; // incremented every time a dlight traverses the world
 		// and every R_MarkFragments call
 

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -2028,8 +2028,12 @@ void R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, i
 			materialSystem.skyShaders.emplace_back( shader );
 		}
 
-		if ( shader->isPortal && std::find( materialSystem.portalSurfacesTmp.begin(), materialSystem.portalSurfacesTmp.end(), drawSurf ) 
-							  == materialSystem.portalSurfacesTmp.end() ) {
+		if ( shader->isPortal )
+		{
+			// R_AddWorldSurfaces guarantees not to add surfaces more than once
+			ASSERT_EQ(
+				std::find( materialSystem.portalSurfacesTmp.begin(), materialSystem.portalSurfacesTmp.end(), drawSurf ),
+				materialSystem.portalSurfacesTmp.end() );
 			materialSystem.portalSurfacesTmp.emplace_back( drawSurf );
 		}
 		return;


### PR DESCRIPTION
Fixes bug (1) described on https://github.com/DaemonEngine/Daemon/issues/1259: in many maps some of the surfaces are at times absent from the material system's buffer of world surfaces.

Plus a couple of small cleanup commits.