### PR TITLE
Fix lightMapping_fp compile error

### DIFF
--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -110,9 +110,9 @@ void main()
 	#if defined(r_specularMapping) || defined(r_physicalMapping)
 		// Compute the material term.
 		vec4 material = texture2D(u_MaterialMap, texCoords);
-	#elif defined(r_dynamicLight) && r_dynamicLightRenderer == 1
+	#elif defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1
 		// The computeDynamicLights function requires this variable to exist.
-		vec4 material = { 0, 0, 0, 1 };
+		vec4 material = vec4( 0.0, 0.0, 0.0, 1.0 );
 	#endif
 
 	// Compute final color.


### PR DESCRIPTION
Use the correct cvars and initializer that is supported on earlier GLSL versions.