### PR TITLE
Optimize material compute

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1868,13 +1868,11 @@ void MaterialSystem::AddDrawCommand( const uint32_t materialID, const uint32_t m
 	}
 
 	cmd.cmd.count = count;
-	cmd.cmd.instanceCount = 1;
 	cmd.cmd.firstIndex = firstIndex;
-	cmd.cmd.baseVertex = 0;
 	cmd.cmd.baseInstance = materialsSSBOOffset;
 	cmd.materialsSSBOOffset = materialsSSBOOffset;
 
-	materialPacks[materialPackID].materials[materialID].drawCommands.emplace_back(cmd);
+	materialPacks[materialPackID].materials[materialID].drawCommands.emplace_back( cmd );
 	lastCommandID = materialPacks[materialPackID].materials[materialID].drawCommands.size() - 1;
 	cmd.textureCount = 0;
 }

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -926,30 +926,24 @@ void MaterialSystem::GenerateWorldCommandBuffer() {
 	culledCommandsBuffer.FlushAll( GL_SHADER_STORAGE_BUFFER );
 
 	surfaceBatchesUBO.BindBuffer();
-	// Multiply by 2 because we write a uvec2, which is aligned as vec4
-	glBufferData( GL_UNIFORM_BUFFER, MAX_SURFACE_COMMAND_BATCHES * 2 * sizeof( SurfaceCommandBatch ), nullptr, GL_STATIC_DRAW );
+	glBufferData( GL_UNIFORM_BUFFER, MAX_SURFACE_COMMAND_BATCHES * sizeof( SurfaceCommandBatch ), nullptr, GL_STATIC_DRAW );
 	SurfaceCommandBatch* surfaceCommandBatches =
-		( SurfaceCommandBatch* ) surfaceBatchesUBO.MapBufferRange( MAX_SURFACE_COMMAND_BATCHES * 2 * SURFACE_COMMAND_BATCH_SIZE );
+		( SurfaceCommandBatch* ) surfaceBatchesUBO.MapBufferRange( MAX_SURFACE_COMMAND_BATCHES * SURFACE_COMMAND_BATCH_SIZE );
 
-	// memset( (void*) surfaceCommandBatches, 0, MAX_SURFACE_COMMAND_BATCHES * 2 * sizeof( SurfaceCommandBatch ) );
+	// memset( (void*) surfaceCommandBatches, 0, MAX_SURFACE_COMMAND_BATCHES * sizeof( SurfaceCommandBatch ) );
 	// Fuck off gcc
-	for ( int i = 0; i < MAX_SURFACE_COMMAND_BATCHES * 2; i++ ) {
+	for ( int i = 0; i < MAX_SURFACE_COMMAND_BATCHES; i++ ) {
 		surfaceCommandBatches[i] = {};
 	}
 
 	uint32_t id = 0;
 	uint32_t matID = 0;
-	uint32_t subID = 0;
 	for ( MaterialPack& pack : materialPacks ) {
 		for ( Material& mat : pack.materials ) {
 			for ( uint32_t i = 0; i < mat.surfaceCommandBatchCount; i++ ) {
-				surfaceCommandBatches[id * 4 + subID].materialIDs[0] = matID;
-				surfaceCommandBatches[id * 4 + subID].materialIDs[1] = mat.surfaceCommandBatchOffset;
-				subID++;
-				if ( subID == 4 ) {
-					id++;
-					subID = 0;
-				}
+				surfaceCommandBatches[id].materialIDs[0] = matID;
+				surfaceCommandBatches[id].materialIDs[1] = mat.surfaceCommandBatchOffset;
+				id++;
 			}
 			matID++;
 		}

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -159,13 +159,13 @@ extern PortalView portalStack[MAX_VIEWS];
 #define MAX_COMMAND_COUNTERS 64
 #define SURFACE_COMMANDS_PER_BATCH 64
 
-#define MAX_SURFACE_COMMAND_BATCHES 2048
+#define MAX_SURFACE_COMMAND_BATCHES 4096
 
 #define BOUNDING_SPHERE_SIZE 4
 
 #define INDIRECT_COMMAND_SIZE 5
 #define SURFACE_COMMAND_SIZE 4
-#define SURFACE_COMMAND_BATCH_SIZE 4 // Aligned to 4 components
+#define SURFACE_COMMAND_BATCH_SIZE 2
 #define PORTAL_SURFACE_SIZE 8
 
 #define MAX_FRAMES 2
@@ -201,7 +201,7 @@ struct SurfaceCommand {
 };
 
 struct SurfaceCommandBatch {
-	uint32_t materialIDs[4] { 0, 0, 0, 0 };
+	uint32_t materialIDs[2] { 0, 0 };
 };
 
 class MaterialSystem {

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -43,8 +43,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static constexpr uint32_t MAX_DRAWCOMMAND_TEXTURES = 64;
 
+/* Similar to GLIndirectBuffer::GLIndirectCommand, but we always set instanceCount to 1 and baseVertex to 0,
+ so no need to waste memory on those */
+struct IndirectCompactCommand {
+	GLuint count;
+	GLuint firstIndex;
+	GLuint baseInstance;
+};
+
 struct DrawCommand {
-	GLIndirectBuffer::GLIndirectCommand cmd;
+	IndirectCompactCommand cmd;
 	uint32_t materialsSSBOOffset = 0;
 	uint32_t textureCount = 0;
 	Texture* textures[MAX_DRAWCOMMAND_TEXTURES];
@@ -156,7 +164,7 @@ extern PortalView portalStack[MAX_VIEWS];
 #define BOUNDING_SPHERE_SIZE 4
 
 #define INDIRECT_COMMAND_SIZE 5
-#define SURFACE_COMMAND_SIZE 6
+#define SURFACE_COMMAND_SIZE 4
 #define SURFACE_COMMAND_BATCH_SIZE 4 // Aligned to 4 components
 #define PORTAL_SURFACE_SIZE 8
 
@@ -189,7 +197,7 @@ struct SurfaceDescriptor {
 
 struct SurfaceCommand {
 	uint32_t enabled; // uint because bool in GLSL is always 4 bytes
-	GLIndirectBuffer::GLIndirectCommand drawCommand;
+	IndirectCompactCommand drawCommand;
 };
 
 struct SurfaceCommandBatch {

--- a/src/engine/renderer/glsl_source/cull_cp.glsl
+++ b/src/engine/renderer/glsl_source/cull_cp.glsl
@@ -49,17 +49,15 @@ struct SurfaceDescriptor {
 	uint surfaceCommandIDs[MAX_SURFACE_COMMANDS];
 };
 
-struct GLIndirectCommand {
+struct IndirectCompactCommand {
 	uint count;
-	uint instanceCount;
 	uint firstIndex;
-	int baseVertex;
 	uint baseInstance;
 };
 
 struct SurfaceCommand {
 	bool enabled;
-	GLIndirectCommand drawCommand;
+	IndirectCompactCommand drawCommand;
 };
 
 layout(std430, binding = 1) readonly restrict buffer surfaceDescriptorsSSBO {

--- a/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
+++ b/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
@@ -45,9 +45,15 @@ struct GLIndirectCommand {
 	uint baseInstance;
 };
 
+struct IndirectCompactCommand {
+	uint count;
+	uint firstIndex;
+	uint baseInstance;
+};
+
 struct SurfaceCommand {
 	bool enabled;
-	GLIndirectCommand drawCommand;
+	IndirectCompactCommand drawCommand;
 };
 
 struct SurfaceCommandBatch {
@@ -80,7 +86,15 @@ void AddDrawCommand( in uint commandID, in uvec2 materialID ) {
 		// materialID.y is the offset for the memory allocated to the material's culled commands
 		const uint atomicCmdID = atomicCounterIncrement( atomicCommandCounters[materialID.x
 		                                                 + MAX_COMMAND_COUNTERS * ( MAX_VIEWS * u_Frame + u_ViewID )] );
-		culledCommands[atomicCmdID + materialID.y * MAX_COMMAND_COUNTERS + u_CulledCommandsOffset] = command.drawCommand;
+		
+		GLIndirectCommand indirectCommand;
+		indirectCommand.count = command.drawCommand.count;
+		indirectCommand.instanceCount = 1;
+		indirectCommand.firstIndex = command.drawCommand.firstIndex;
+		indirectCommand.baseVertex = 0;
+		indirectCommand.baseInstance = command.drawCommand.baseInstance;
+		
+		culledCommands[atomicCmdID + materialID.y * MAX_COMMAND_COUNTERS + u_CulledCommandsOffset] = indirectCommand;
 	}
 }
 

--- a/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
+++ b/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
@@ -99,8 +99,8 @@ void AddDrawCommand( in uint commandID, in uvec2 materialID ) {
 /* Allows accessing each element of a uvec4 array with a singular
 Useful to avoid wasting memory due to alignment requirements */
 
-#define UINT_ID_TO_UVEC4( array, id ) array[id / 4][id % 4]
-#define UVEC2_ID_TO_UVEC4( array, id ) id % 2 == 0 ? array[id / 2].xy : array[id / 2].zw;
+#define UINT_FROM_UVEC4_ARRAY( array, id ) array[id / 4][id % 4]
+#define UVEC2_FROM_UVEC4_ARRAY( array, id ) id % 2 == 0 ? array[id / 2].xy : array[id / 2].zw;
 
 void main() {
 	const uint globalGroupID = gl_WorkGroupID.z * gl_NumWorkGroups.x * gl_NumWorkGroups.y
@@ -112,7 +112,7 @@ void main() {
 	                              + gl_GlobalInvocationID.x
 	                              + 1; // Add 1 because the first surface command is always reserved as a fake command
 	// Each surfaceBatch encompasses 64 surfaceCommands with the same material, padded to 64 as necessary
-	const uvec2 materialID = UVEC2_ID_TO_UVEC4( surfaceBatches, globalGroupID );
+	const uvec2 materialID = UVEC2_FROM_UVEC4_ARRAY( surfaceBatches, globalGroupID );
 
 	AddDrawCommand( globalInvocationID, materialID );
 }


### PR DESCRIPTION
Since we always set `instanceCount = 1` and `baseVertex = 0`, we don't need to put those into the `surfaceCommands` buffer.
Use a macro to get the correct uvec2 part of the uvec4 array to avoid adding padding.

This slightly improves performace since there's less memory to fetch/write.