### PR TITLE
Use shader subgroup operations if available

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -474,7 +474,20 @@ static std::string GenComputeVersionDeclaration() {
 		{ glConfig2.explicitUniformLocationAvailable, 430, "ARB_explicit_uniform_location" },
 		{ glConfig2.shaderImageLoadStoreAvailable, 420, "ARB_shader_image_load_store" },
 		{ glConfig2.shaderAtomicCountersAvailable, 420, "ARB_shader_atomic_counters" },
+		/* ARB_shader_atomic_counter_ops set to -1,
+		because we might get a 4.6 GL context, where the core functions have different names */
+		{ glConfig2.shaderAtomicCounterOpsAvailable, -1, "ARB_shader_atomic_counter_ops" },
 		{ glConfig2.bindlessTexturesAvailable, -1, "ARB_bindless_texture" },
+		/* Even though these are part of the GL_KHR_shader_subgroup extension, we need to enable the individual extensions
+		for each feature
+		GL_KHR_shader_subgroup itself can't be used in the shader */
+		{ glConfig2.shaderSubgroupBasicAvailable, -1, "KHR_shader_subgroup_basic" },
+		{ glConfig2.shaderSubgroupVoteAvailable, -1, "KHR_shader_subgroup_vote" },
+		{ glConfig2.shaderSubgroupArithmeticAvailable, -1, "KHR_shader_subgroup_arithmetic" },
+		{ glConfig2.shaderSubgroupBallotAvailable, -1, "KHR_shader_subgroup_ballot" },
+		{ glConfig2.shaderSubgroupShuffleAvailable, -1, "KHR_shader_subgroup_shuffle" },
+		{ glConfig2.shaderSubgroupShuffleRelativeAvailable, -1, "KHR_shader_subgroup_shuffle_relative" },
+		{ glConfig2.shaderSubgroupQuadAvailable, -1, "KHR_shader_subgroup_quad" },
 	};
 
 	for ( const auto& extension : extensions ) {

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -98,6 +98,16 @@ struct glconfig2_t
 	bool explicitUniformLocationAvailable;
 	bool shaderImageLoadStoreAvailable;
 	bool shaderAtomicCountersAvailable;
+	bool shaderAtomicCounterOpsAvailable;
+	bool shaderSubgroupAvailable;
+	bool shaderSubgroupBasicAvailable;
+	bool shaderSubgroupVoteAvailable;
+	bool shaderSubgroupArithmeticAvailable;
+	bool shaderSubgroupBallotAvailable;
+	bool shaderSubgroupShuffleAvailable;
+	bool shaderSubgroupShuffleRelativeAvailable;
+	bool shaderSubgroupClusteredAvailable;
+	bool shaderSubgroupQuadAvailable;
 	bool materialSystemAvailable;
 	bool gpuShader4Available;
 	bool gpuShader5Available;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2211,7 +2211,7 @@ static void GLimp_InitExtensions()
 	// made required in OpenGL 4.6
 	glConfig2.shaderAtomicCounterOpsAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_shader_atomic_counter_ops, r_arb_shader_atomic_counter_ops.Get() );
 
-	// not required by any OpenGL version
+	// made required in OpenGL 4.6
 	glConfig2.indirectParametersAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_indirect_parameters, r_arb_indirect_parameters.Get() );
 
 	glConfig2.materialSystemAvailable = glConfig2.shaderDrawParametersAvailable && glConfig2.SSBOAvailable


### PR DESCRIPTION
Builds on #1284.

Replace per-lane atomic increment with a subgroup scan + one atomic add per subgroup, if they're available. This slightly increases performance.