### PR TITLE
tr_bsp: do not load deluxe maps if deluxe mapping was disabled because of hardware being incompatible

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -4406,7 +4406,7 @@ void R_LoadEntities( lump_t *l, std::string &externalEntities )
 		{
 			Log::Debug("map features directional light mapping" );
 			// This will be disabled if the engine fails to load the lightmaps.
-			tr.worldDeluxeMapping = r_deluxeMapping->integer != 0;
+			tr.worldDeluxeMapping = glConfig2.deluxeMapping;
 			continue;
 		}
 
@@ -4431,7 +4431,7 @@ void R_LoadEntities( lump_t *l, std::string &externalEntities )
 			{
 				Log::Debug("map features directional light mapping" );
 				// This will be disabled if the engine fails to load the lightmaps.
-				tr.worldDeluxeMapping = r_deluxeMapping->integer != 0;
+				tr.worldDeluxeMapping = glConfig2.deluxeMapping;
 			}
 
 			continue;
@@ -7049,7 +7049,7 @@ void RE_LoadWorldMap( const char *name )
 			}
 		}
 
-		if ( r_deluxeMapping->integer )
+		if ( glConfig2.deluxeMapping )
 		{
 			// Enable deluxe mapping emulation if light direction grid is there.
 			if ( tr.lightGrid2Image )


### PR DESCRIPTION
Do not load deluxe maps if deluxe mapping was disabled because of hardware being incompatible.

Fixup for #1229:

- https://github.com/DaemonEngine/Daemon/pull/1229

The engine now knows how to disable deluxe mapping when the r_deluxeMapping cvar is enabled while the hardware is known to not be able to support the feature.

The renderer always loaded the deluxe maps when that cvar was enabled and told the renderer the feature was available, meaning it would select the deluxe mapping shader while it has never been built if the hardware doesn't support the feature.
