### PR TITLE
Some more material cleanup

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -144,12 +144,13 @@ set(RENDERERLIST
 )
 
 set(GLSLSOURCELIST
-    ${ENGINE_DIR}/renderer/glsl_source/material_vp.glsl
-    ${ENGINE_DIR}/renderer/glsl_source/material_fp.glsl
-    ${ENGINE_DIR}/renderer/glsl_source/cull_cp.glsl
+    ${ENGINE_DIR}/renderer/glsl_source/common_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/clearSurfaces_cp.glsl
+    ${ENGINE_DIR}/renderer/glsl_source/cull_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/depthReduction_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/processSurfaces_cp.glsl
+    ${ENGINE_DIR}/renderer/glsl_source/material_vp.glsl
+    ${ENGINE_DIR}/renderer/glsl_source/material_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/skybox_vp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/ssao_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/ssao_vp.glsl

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -291,7 +291,6 @@ class MaterialSystem {
 	uint32_t totalBatchCount = 0;
 
 	uint32_t surfaceCommandsCount = 0;
-	uint32_t culledCommandsCount = 0;
 	uint32_t surfaceDescriptorsCount = 0;
 
 	std::vector<drawSurf_t> dynamicDrawSurfs;

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2972,6 +2972,5 @@ GLShader_processSurfaces::GLShader_processSurfaces( GLShaderManager* manager ) :
 	GLShader( "processSurfaces", ATTR_POSITION, manager, false, false, true ),
 	u_Frame( this ),
 	u_ViewID( this ),
-	u_SurfaceCommandsOffset( this ),
-	u_CulledCommandsOffset( this ) {
+	u_SurfaceCommandsOffset( this ) {
 }

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3359,18 +3359,6 @@ class u_SurfaceCommandsOffset :
 	}
 };
 
-class u_CulledCommandsOffset :
-	GLUniform1ui {
-	public:
-	u_CulledCommandsOffset( GLShader* shader ) :
-		GLUniform1ui( shader, "u_CulledCommandsOffset" ) {
-	}
-
-	void SetUniform_CulledCommandsOffset( const uint culledCommandsOffset ) {
-		this->SetValue( culledCommandsOffset );
-	}
-};
-
 class u_ModelMatrix :
 	GLUniformMatrix4f
 {
@@ -4735,8 +4723,7 @@ class GLShader_processSurfaces :
 	public GLShader,
 	public u_Frame,
 	public u_ViewID,
-	public u_SurfaceCommandsOffset,
-	public u_CulledCommandsOffset {
+	public u_SurfaceCommandsOffset {
 	public:
 	GLShader_processSurfaces( GLShaderManager* manager );
 };

--- a/src/engine/renderer/glsl_source/clearSurfaces_cp.glsl
+++ b/src/engine/renderer/glsl_source/clearSurfaces_cp.glsl
@@ -34,6 +34,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /* clearSurfaces_cp.glsl */
 
+#insert common_cp
+
 layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
 layout(std430, binding = 4) writeonly buffer atomicCommandCountersBuffer {
@@ -43,9 +45,7 @@ layout(std430, binding = 4) writeonly buffer atomicCommandCountersBuffer {
 uniform uint u_Frame;
 
 void main() {
-    const uint globalInvocationID = gl_GlobalInvocationID.z * gl_NumWorkGroups.x * gl_WorkGroupSize.x * gl_NumWorkGroups.y * gl_WorkGroupSize.y
-                             + gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x
-                             + gl_GlobalInvocationID.x;
+    const uint globalInvocationID = GLOBAL_INVOCATION_ID;
     if( globalInvocationID >= MAX_COMMAND_COUNTERS * MAX_VIEWS ) {
         return;
     }

--- a/src/engine/renderer/glsl_source/clearSurfaces_cp.glsl
+++ b/src/engine/renderer/glsl_source/clearSurfaces_cp.glsl
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
 layout(std430, binding = 4) writeonly buffer atomicCommandCountersBuffer {
-    uint atomicCommandCounters[MAX_COMMAND_COUNTERS * MAX_VIEWS * MAX_FRAMES];
+    uint atomicCommandCounters[MAX_COMMAND_COUNTERS * MAX_VIEWFRAMES];
 };
 
 uniform uint u_Frame;

--- a/src/engine/renderer/glsl_source/common_cp.glsl
+++ b/src/engine/renderer/glsl_source/common_cp.glsl
@@ -1,0 +1,94 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+
+/* common_cp.glsl */
+
+/* Common defines */
+
+/* Allows accessing each element of a uvec4 array with a singular ID
+Useful to avoid wasting memory due to alignment requirements
+array must be in the form of uvec4 array[] */
+
+#define UINT_FROM_UVEC4_ARRAY( array, id ) ( array[id / 4][id % 4] )
+#define UVEC2_FROM_UVEC4_ARRAY( array, id ) ( id % 2 == 0 ? array[id / 2].xy : array[id / 2].zw )
+
+// Scalar global workgroup ID
+#define GLOBAL_GROUP_ID ( gl_WorkGroupID.z * gl_NumWorkGroups.x * gl_NumWorkGroups.y\
+                        + gl_WorkGroupID.y * gl_NumWorkGroups.x\
+                        + gl_WorkGroupID.x )
+						
+// Scalar global invocation ID
+#define GLOBAL_INVOCATION_ID ( gl_GlobalInvocationID.z * gl_NumWorkGroups.x * gl_WorkGroupSize.x\
+                             * gl_NumWorkGroups.y * gl_WorkGroupSize.y\
+                             + gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x\
+                             + gl_GlobalInvocationID.x )
+
+/* Common structs */
+
+struct BoundingSphere {
+	vec3 origin;
+	float radius;
+};
+
+struct SurfaceDescriptor {
+	BoundingSphere boundingSphere;
+	uint surfaceCommandIDs[MAX_SURFACE_COMMANDS];
+};
+
+struct PortalSurface {
+	BoundingSphere boundingSphere;
+
+	uint drawSurfID;
+	float distance;
+	vec2 padding;
+};
+
+struct GLIndirectCommand {
+	uint count;
+	uint instanceCount;
+	uint firstIndex;
+	int baseVertex;
+	uint baseInstance;
+};
+
+struct IndirectCompactCommand {
+	uint count;
+	uint firstIndex;
+	uint baseInstance;
+};
+
+struct SurfaceCommand {
+	bool enabled;
+	IndirectCompactCommand drawCommand;
+};

--- a/src/engine/renderer/glsl_source/cull_cp.glsl
+++ b/src/engine/renderer/glsl_source/cull_cp.glsl
@@ -158,7 +158,8 @@ void ProcessSurfaceCommands( const in SurfaceDescriptor surface, const in bool e
 		if( commandID == 0 ) { // Reserved for no-command
 			return;
 		}
-		surfaceCommands[commandID + u_SurfaceCommandsOffset].enabled = enabled;
+		// Subtract 1 because of no-command
+		surfaceCommands[commandID + u_SurfaceCommandsOffset - 1].enabled = enabled;
 	}
 }
 

--- a/src/engine/renderer/glsl_source/depthReduction_cp.glsl
+++ b/src/engine/renderer/glsl_source/depthReduction_cp.glsl
@@ -34,6 +34,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /* depthReduction_cp.glsl */
 
+#insert common_cp
+
 // Keep this to 8x8 because we don't want extra shared mem etc. to be allocated, and to minimize wasted lanes
 layout (local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
@@ -46,9 +48,7 @@ uniform uint u_ViewHeight;
 uniform bool u_InitialDepthLevel;
 
 void main() {
-    const uint globalInvocationID = gl_GlobalInvocationID.z * gl_NumWorkGroups.x * gl_WorkGroupSize.x * gl_NumWorkGroups.y * gl_WorkGroupSize.y
-                             + gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x
-                             + gl_GlobalInvocationID.x;
+    const uint globalInvocationID = GLOBAL_INVOCATION_ID;
 
     const ivec2 position = ivec2( gl_GlobalInvocationID.xy );
     if( position.x >= u_ViewWidth || position.y >= u_ViewHeight ) {

--- a/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
+++ b/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
@@ -58,7 +58,6 @@ layout (binding = 4) uniform atomic_uint atomicCommandCounters[MAX_COMMAND_COUNT
 uniform uint u_Frame;
 uniform uint u_ViewID;
 uniform uint u_SurfaceCommandsOffset;
-uniform uint u_CulledCommandsOffset;
 
 #if defined(HAVE_KHR_shader_subgroup_basic) && defined(HAVE_KHR_shader_subgroup_arithmetic)\
 	&& defined(HAVE_KHR_shader_subgroup_ballot) && defined(HAVE_ARB_shader_atomic_counter_ops)
@@ -99,17 +98,16 @@ void AddDrawCommand( in uint commandID, in uvec2 materialID ) {
 		indirectCommand.baseInstance = command.drawCommand.baseInstance;
 		
 		#if defined(HAVE_processSurfaces_subgroup)
-			culledCommands[atomicCmdID + subgroupOffset + materialID.y * MAX_COMMAND_COUNTERS + u_CulledCommandsOffset] = indirectCommand;
+			culledCommands[atomicCmdID + subgroupOffset + materialID.y * MAX_COMMAND_COUNTERS + u_SurfaceCommandsOffset] = indirectCommand;
 		#else
-			culledCommands[atomicCmdID + materialID.y * MAX_COMMAND_COUNTERS + u_CulledCommandsOffset] = indirectCommand;
+			culledCommands[atomicCmdID + materialID.y * MAX_COMMAND_COUNTERS + u_SurfaceCommandsOffset] = indirectCommand;
 		#endif
 	}
 }
 
 void main() {
 	const uint globalGroupID = GLOBAL_GROUP_ID;
-	// Add 1 because the first surface command is always reserved as a fake command
-	const uint globalInvocationID = GLOBAL_INVOCATION_ID + 1;
+	const uint globalInvocationID = GLOBAL_INVOCATION_ID;
 
 	// Each surfaceBatch encompasses 64 surfaceCommands with the same material, padded to 64 as necessary
 	const uvec2 materialID = UVEC2_FROM_UVEC4_ARRAY( surfaceBatches, globalGroupID );

--- a/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
+++ b/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
@@ -53,7 +53,7 @@ layout(std140, binding = 0) uniform ub_SurfaceBatches {
 	SurfaceCommandBatch surfaceBatches[MAX_SURFACE_COMMAND_BATCHES];
 };
 
-layout (binding = 4) uniform atomic_uint atomicCommandCounters[MAX_COMMAND_COUNTERS * MAX_VIEWS * MAX_FRAMES];
+layout (binding = 4) uniform atomic_uint atomicCommandCounters[MAX_COMMAND_COUNTERS * MAX_VIEWFRAMES];
 
 uniform uint u_Frame;
 uniform uint u_ViewID;

--- a/src/engine/renderer/shaders.cpp
+++ b/src/engine/renderer/shaders.cpp
@@ -60,10 +60,11 @@
 #include "skybox_fp.glsl.h"
 #include "material_vp.glsl.h"
 #include "material_fp.glsl.h"
+#include "common_cp.glsl.h"
+#include "clearSurfaces_cp.glsl.h"
 #include "cull_cp.glsl.h"
 #include "depthReduction_cp.glsl.h"
 #include "processSurfaces_cp.glsl.h"
-#include "clearSurfaces_cp.glsl.h"
 
 std::unordered_map<std::string, std::string> shadermap({
 	{ "blurX_fp.glsl", std::string(reinterpret_cast<const char*>(blurX_fp_glsl), sizeof(blurX_fp_glsl)) },
@@ -75,6 +76,7 @@ std::unordered_map<std::string, std::string> shadermap({
 	{ "computeLight_fp.glsl", std::string(reinterpret_cast<const char*>(computeLight_fp_glsl), sizeof(computeLight_fp_glsl)) },
 	{ "contrast_fp.glsl", std::string(reinterpret_cast<const char*>(contrast_fp_glsl), sizeof(contrast_fp_glsl)) },
 	{ "contrast_vp.glsl", std::string(reinterpret_cast<const char*>(contrast_vp_glsl), sizeof(contrast_vp_glsl)) },
+	{ "common_cp.glsl", std::string( reinterpret_cast< const char* >( common_cp_glsl ), sizeof( common_cp_glsl ) ) },
 	{ "clearSurfaces_cp.glsl", std::string( reinterpret_cast< const char* >( clearSurfaces_cp_glsl ), sizeof( clearSurfaces_cp_glsl ) ) },
 	{ "cull_cp.glsl", std::string( reinterpret_cast< const char* >( cull_cp_glsl ), sizeof( cull_cp_glsl ) ) },
 	{ "depthReduction_cp.glsl", std::string( reinterpret_cast< const char* >( depthReduction_cp_glsl ), sizeof( depthReduction_cp_glsl ) ) },


### PR DESCRIPTION
Builds on #1285.

Add `common_cp` shader. This shader is for use with #insert in other compute shaders, and contains a few #define's and structs that are shared between shaders, as well as #define's for workgroup and invocation ID's.

Don't actually add `surfaceCommand` 0, just do `-1` when adding the command. Simplify some code a bit, remove `culledCommandsOffset`.

Replace `MAX_FRAMES * MAX_VIEWS` with `MAX_VIEWFRAMES`.