### PR TITLE
Fix skybox debug draw

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2501,8 +2501,7 @@ GLShader_skybox::GLShader_skybox( GLShaderManager *manager ) :
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this ),
-	GLDeformStage( this )
+	u_InverseLightFactor( this )
 {
 }
 
@@ -2523,8 +2522,7 @@ GLShader_skyboxMaterial::GLShader_skyboxMaterial( GLShaderManager* manager ) :
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this ),
-	GLDeformStage( this ) {
+	u_InverseLightFactor( this ) {
 }
 
 void GLShader_skyboxMaterial::SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) {

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -4315,8 +4315,7 @@ class GLShader_skybox :
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor,
-	public GLDeformStage
+	public u_InverseLightFactor
 {
 public:
 	GLShader_skybox( GLShaderManager *manager );
@@ -4334,8 +4333,7 @@ class GLShader_skyboxMaterial :
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor,
-	public GLDeformStage {
+	public u_InverseLightFactor {
 	public:
 	GLShader_skyboxMaterial( GLShaderManager* manager );
 	void SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) override;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -3053,7 +3053,10 @@ void Tess_End()
 			// draw debugging stuff
 			if ( r_showTris->integer || r_showBatches->integer || ( r_showLightBatches->integer && ( tess.stageIteratorFunc == Tess_StageIteratorLighting ) ) )
 			{
-				DrawTris();
+				// Skybox triangle rendering is done in Tess_StageIteratorSky()
+				if ( tess.stageIteratorFunc != Tess_StageIteratorSky ) {
+					DrawTris();
+				}
 			}
 		}
 	}

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -126,6 +126,23 @@ void Tess_StageIteratorSky()
 		Tess_DrawElements();
 	}
 
+	if ( r_showTris->integer ) {
+		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHFUNC_ALWAYS );
+
+		// bind u_ColorMap
+		gl_skyboxShader->SetUniform_ColorMapCubeBindless(
+			GL_BindToTMU( 0, tr.whiteCubeImage )
+		);
+
+		// Only render the outer skybox outline at this stage
+		gl_skyboxShader->SetUniform_UseCloudMap( false );
+
+		// u_AlphaThreshold
+		gl_skyboxShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
+
+		Tess_DrawElements();
+	}
+
 	// Only render clouds at these stages
 	gl_skyboxShader->SetUniform_UseCloudMap( true );
 	gl_skyboxShader->SetUniform_CloudHeight( tess.surfaceShader->sky.cloudHeight );


### PR DESCRIPTION
Skybox is rendered with a mesh that has only position, so it can't be used with generic shader. Fixes the log spam and correctly shows where the skybox tris are.

Also remove GLDeformStage from skybox.