### PR TITLE
renderer: cancel overbright on opaque decal

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -220,10 +220,7 @@ void UpdateSurfaceDataGeneric3D( uint32_t* materials, Material& material, drawSu
 	gl_genericShaderMaterial->SetUniform_AlphaTest( pStage->stateBits );
 
 	// u_InverseLightFactor
-	// We should cancel overbrightBits if there is no light,
-	// and it's not using blendFunc dst_color.
-	bool blendFunc_dstColor = ( pStage->stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_DST_COLOR;
-	float inverseLightFactor = ( pStage->shaderHasNoLight && !blendFunc_dstColor ) ? tr.mapInverseLightFactor : 1.0f;
+	float inverseLightFactor = pStage->cancelOverBright ? tr.mapInverseLightFactor : 1.0f;
 	gl_genericShaderMaterial->SetUniform_InverseLightFactor( inverseLightFactor );
 
 	// u_ColorModulate
@@ -319,9 +316,8 @@ void UpdateSurfaceDataLightMapping( uint32_t* materials, Material& material, dra
 	// u_InverseLightFactor
 	/* HACK: use sign to know if there is a light or not, and
 	then if it will receive overbright multiplication or not. */
-	bool blendFunc_dstColor = ( pStage->stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_DST_COLOR;
-	bool noLight = pStage->shaderHasNoLight || lightMode == lightMode_t::FULLBRIGHT;
-	float inverseLightFactor = ( noLight && !blendFunc_dstColor ) ? tr.mapInverseLightFactor : -tr.mapInverseLightFactor;
+	bool cancelOverBright = pStage->cancelOverBright || lightMode == lightMode_t::FULLBRIGHT;
+	float inverseLightFactor = cancelOverBright ? tr.mapInverseLightFactor : -tr.mapInverseLightFactor;
 	gl_lightMappingShaderMaterial->SetUniform_InverseLightFactor( inverseLightFactor );
 
 	// u_ColorModulate

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1107,7 +1107,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 
 		bool            dpMaterial;
 
-		bool shaderHasNoLight;
+		bool cancelOverBright;
 
 		// Core renderer (code path for when only OpenGL Core is available, or compatible OpenGL 2).
 		stageRenderer_t colorRenderer;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -876,10 +876,7 @@ void Render_generic3D( shaderStage_t *pStage )
 	gl_genericShader->SetUniform_AlphaTest( pStage->stateBits );
 
 	// u_InverseLightFactor
-	// We should cancel overbrightBits if there is no light,
-	// and it's not using blendFunc dst_color.
-	bool blendFunc_dstColor = ( pStage->stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_DST_COLOR;
-	float inverseLightFactor = ( pStage->shaderHasNoLight && !blendFunc_dstColor ) ? tr.mapInverseLightFactor : 1.0f;
+	float inverseLightFactor = pStage->cancelOverBright ? tr.mapInverseLightFactor : 1.0f;
 	gl_genericShader->SetUniform_InverseLightFactor( inverseLightFactor );
 
 	// u_ColorModulate
@@ -1082,9 +1079,8 @@ void Render_lightMapping( shaderStage_t *pStage )
 	// u_InverseLightFactor
 	/* HACK: use sign to know if there is a light or not, and
 	then if it will receive overbright multiplication or not. */
-	bool blendFunc_dstColor = ( pStage->stateBits & GLS_SRCBLEND_BITS ) == GLS_SRCBLEND_DST_COLOR;
-	bool noLight = pStage->shaderHasNoLight || lightMode == lightMode_t::FULLBRIGHT;
-	float inverseLightFactor = ( noLight && !blendFunc_dstColor ) ? tr.mapInverseLightFactor : - tr.mapInverseLightFactor;
+	bool cancelOverBright = pStage->cancelOverBright || lightMode == lightMode_t::FULLBRIGHT;
+	float inverseLightFactor = cancelOverBright ? tr.mapInverseLightFactor : -tr.mapInverseLightFactor;
 	gl_lightMappingShader->SetUniform_InverseLightFactor( inverseLightFactor );
 
 	// u_ColorModulate


### PR DESCRIPTION
In #1162 I made sure decals are not cancelling overbright, this was to fix impact marks being too faint:

- https://github.com/DaemonEngine/Daemon/pull/1162

In fact only blended decals should not cancel overbright, opaque decals are like any fullbright surface and should then cancel overbright.

The commit also rewrites a bit the code in a better way.

In the future I may rewrite that with a more theoretical operation (based on which blending is an addition, which one is a multiplication, etc. as it's basically a commutativity/associativity problem), but for now listing the various known use cases makes easier to know what is expected. This is good enough for now.