### PR TITLE
cmake: always use pthread outside of MSVC

### DIFF
--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -304,10 +304,9 @@ else()
 	endif()
 
 	# The -pthread flag sets some preprocessor defines,
-	# it is also used to link with libpthread on Linux.
-	if (NOT APPLE)
-		try_c_cxx_flag(PTHREAD "-pthread")
-	endif()
+	# it is also used to link with libpthread.
+	try_c_cxx_flag(PTHREAD "-pthread")
+	try_linker_flag(LINKER_PTHREAD "-pthread")
 
 	if (USE_ADDRESS_SANITIZER)
 		set_cxx_flag("-fsanitize=address")


### PR DESCRIPTION
Always use pthread outside of MSVC.

After enabling it unconditionally I seen no build issue with Linux (GCC and Clang), macOS (AppleClang), FreeBSD (Clang), Mingw, PNaCl.

Also, CMake reported the flags to be supported in all cases, so we may make the flags mandatory.

It happens that the linker flag was lost in translation in #1997:

- https://github.com/DaemonEngine/Daemon/pull/1197

So I re-added it. It being missing did not bring any issue into all our builds (either on my end, either in our CI), but this is better like this I guess.