### PR TITLE
Reimport a mismerged fix

### DIFF
--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1841,6 +1841,16 @@ bool R_MirrorViewBySurface(drawSurf_t *drawSurf)
 	newParms.scissorWidth = surfRect.coords[2] - surfRect.coords[0] + 1;
 	newParms.scissorHeight = surfRect.coords[3] - surfRect.coords[1] + 1;
 
+	// Scissor width/height must not be negative, so flip the coordinates if needed
+	if ( newParms.scissorWidth < 0 ) {
+		newParms.scissorX += newParms.scissorWidth;
+		newParms.scissorWidth *= -1;
+	}
+	if ( newParms.scissorHeight < 0 ) {
+		newParms.scissorY += newParms.scissorHeight;
+		newParms.scissorHeight *= -1;
+	}
+
 	// restrict view frustum to screen rect of surface
 	R_SetupPortalFrustum(oldParms, camera, newParms);
 


### PR DESCRIPTION
It looks like merge commit 2ea20a9f29ac4f0b886d001accadc8eadad19a47 was wrong and left this change aside.

Hopefully fixes #1297:

- https://github.com/DaemonEngine/Daemon/issues/1297

----

Fix portal scissor test

Width and height in glScissor() must not be negative, so if surfRect has lower x2 or y2 than x1 or y1, then flip the scissor parameters.