### PR TITLE
tr_init: set default r_reliefDepthScale to 0.02 like DarkPlaces

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1213,7 +1213,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_normalMapping = Cvar_Get( "r_normalMapping", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_highQualityNormalMapping = Cvar_Get( "r_highQualityNormalMapping", "0",  CVAR_LATCH );
 		r_liquidMapping = Cvar_Get( "r_liquidMapping", "0", CVAR_LATCH | CVAR_ARCHIVE );
-		r_reliefDepthScale = Cvar_Get( "r_reliefDepthScale", "0.03", CVAR_CHEAT );
+		r_reliefDepthScale = Cvar_Get( "r_reliefDepthScale", "0.02", CVAR_CHEAT );
 		r_reliefMapping = Cvar_Get( "r_reliefMapping", "0", CVAR_LATCH | CVAR_ARCHIVE );
 		r_glowMapping = Cvar_Get( "r_glowMapping", "1", CVAR_LATCH );
 		r_reflectionMapping = Cvar_Get( "r_reflectionMapping", "0", CVAR_LATCH | CVAR_ARCHIVE );


### PR DESCRIPTION
Most of our heightmaps come from Xonotic which are supposed to use DarkPlaces 0.02 default relief depth scale. It's easier for use to align with that default than to convert any height map with import from Xonotic. Our heightmaps are actually wrong without this.

I haven't seen any relief mapping code after a quick search in ioq3, so we're not breaking any usage but we may actually be defining the standard instead. If we are in position to set the standard for idtech3 games, better align with friendly projects like Xonotic/DarkPlaces.