### PR TITLE
Material debug improvements

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -2136,9 +2136,14 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 
 	if ( r_showTris->integer
 		&& ( material.stateBits & GLS_DEPTHMASK_TRUE ) == 0
-		&& material.shaderBinder == &BindShaderLightMapping )
+		&& ( material.shaderBinder == &BindShaderLightMapping || material.shaderBinder == &BindShaderGeneric3D ) )
 	{
-		gl_lightMappingShaderMaterial->SetUniform_ShowTris( 1 );
+		if ( material.shaderBinder == &BindShaderLightMapping ) {
+			gl_lightMappingShaderMaterial->SetUniform_ShowTris( 1 );
+		} else if ( material.shaderBinder == &BindShaderGeneric3D ) {
+			gl_genericShaderMaterial->SetUniform_ShowTris( 1 );
+		}
+
 		GL_State( GLS_DEPTHTEST_DISABLE );
 		glMultiDrawElementsIndirectCountARB( GL_LINES, GL_UNSIGNED_INT,
 			BUFFER_OFFSET( material.surfaceCommandBatchOffset * SURFACE_COMMANDS_PER_BATCH * sizeof( GLIndirectBuffer::GLIndirectCommand )
@@ -2147,7 +2152,12 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 			material.globalID * sizeof( uint32_t )
 			+ ( MAX_COMMAND_COUNTERS * ( MAX_VIEWS * currentFrame + viewID ) ) * sizeof( uint32_t ),
 			material.drawCommands.size(), 0 );
-		gl_lightMappingShaderMaterial->SetUniform_ShowTris( 0 );
+
+		if ( material.shaderBinder == &BindShaderLightMapping ) {
+			gl_lightMappingShaderMaterial->SetUniform_ShowTris( 0 );
+		} else if ( material.shaderBinder == &BindShaderGeneric3D ) {
+			gl_genericShaderMaterial->SetUniform_ShowTris( 0 );
+		}
 	}
 
 	culledCommandsBuffer.UnBindBuffer( GL_DRAW_INDIRECT_BUFFER );

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -317,13 +317,17 @@ class MaterialSystem {
 	void UpdateFrameData();
 };
 
-extern GLSSBO materialsSSBO;
+extern GLSSBO materialsSSBO; // Global
+
 extern GLSSBO surfaceDescriptorsSSBO; // Global
 extern GLSSBO surfaceCommandsSSBO; // Per viewframe, GPU updated
 extern GLBuffer culledCommandsBuffer; // Per viewframe
 extern GLUBO surfaceBatchesUBO; // Global
 extern GLBuffer atomicCommandCountersBuffer; // Per viewframe
 extern GLSSBO portalSurfacesSSBO; // Per viewframe
+
+extern GLSSBO debugSSBO; // Global
+
 extern MaterialSystem materialSystem;
 
 void UpdateSurfaceDataNONE( uint32_t*, Material&, drawSurf_t*, const uint32_t );

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -112,6 +112,8 @@ struct Material {
 
 	cullType_t cullType;
 
+	uint32_t sort;
+
 	bool usePolygonOffset = false;
 
 	VBO_t* vbo;
@@ -136,6 +138,13 @@ struct Material {
 			textures.emplace_back( texture );
 		}
 	}
+};
+
+enum class MaterialDebugMode {
+	NONE,
+	DEPTH,
+	OPAQUE,
+	OPAQUE_TRANSPARENT
 };
 
 struct PortalSurface {

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2078,6 +2078,7 @@ GLShader_genericMaterial::GLShader_genericMaterial( GLShaderManager* manager ) :
 	// u_Bones( this ),
 	u_VertexInterpolation( this ),
 	u_DepthScale( this ),
+	u_ShowTris( this ),
 	u_MaterialColour( this ),
 	GLDeformStage( this ),
 	// GLCompileMacro_USE_VERTEX_SKINNING( this ),

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -725,6 +725,11 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_showCubeProbes", 1 );
 	}
 
+	if ( r_materialDebug.Get() )
+	{
+		AddDefine( str, "r_materialDebug", 1 );
+	}
+
 	if ( glConfig2.vboVertexSkinningAvailable )
 	{
 		AddDefine( str, "r_vertexSkinning", 1 );

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -715,6 +715,10 @@ static std::string GenEngineConstants() {
 	{
 		AddDefine( str, "r_showVertexColors", 1 );
 	}
+	else if ( r_showGlobalMaterials.Get() != 0 )
+	{
+		AddDefine( str, "r_showGlobalMaterials", r_showGlobalMaterials.Get() );
+	}
 
 	if( r_showCubeProbes.Get() )
 	{
@@ -2074,6 +2078,7 @@ GLShader_genericMaterial::GLShader_genericMaterial( GLShaderManager* manager ) :
 	// u_Bones( this ),
 	u_VertexInterpolation( this ),
 	u_DepthScale( this ),
+	u_MaterialColour( this ),
 	GLDeformStage( this ),
 	// GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
@@ -2193,6 +2198,7 @@ GLShader_lightMappingMaterial::GLShader_lightMappingMaterial( GLShaderManager* m
 	u_numLights( this ),
 	u_Lights( this ),
 	u_ShowTris( this ),
+	u_MaterialColour( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_BSP_SURFACE( this ),
 	// GLCompileMacro_USE_VERTEX_SKINNING( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3279,7 +3279,7 @@ class u_TotalDrawSurfs :
 	GLUniform1ui {
 	public:
 	u_TotalDrawSurfs( GLShader* shader ) :
-		GLUniform1ui( shader, "u_TotalDrawSurfs" ) {
+		GLUniform1ui( shader, "u_TotalDrawSurfs", true ) {
 	}
 
 	void SetUniform_TotalDrawSurfs( const uint totalDrawSurfs ) {
@@ -3356,6 +3356,18 @@ class u_SurfaceCommandsOffset :
 
 	void SetUniform_SurfaceCommandsOffset( const uint surfaceCommandsOffset ) {
 		this->SetValue( surfaceCommandsOffset );
+	}
+};
+
+class u_MaterialColour :
+	GLUniform3f {
+	public:
+	u_MaterialColour( GLShader* shader ) :
+		GLUniform3f( shader, "u_MaterialColour", true ) {
+	}
+
+	void SetUniform_MaterialColour( const vec3_t materialColour ) {
+		this->SetValue( materialColour );
 	}
 };
 
@@ -3971,6 +3983,7 @@ class GLShader_genericMaterial :
 	// public u_Bones,
 	public u_VertexInterpolation,
 	public u_DepthScale,
+	public u_MaterialColour,
 	public GLDeformStage,
 	// public GLCompileMacro_USE_VERTEX_SKINNING,
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
@@ -4069,6 +4082,7 @@ class GLShader_lightMappingMaterial :
 	public u_numLights,
 	public u_Lights,
 	public u_ShowTris,
+	public u_MaterialColour,
 	public GLDeformStage,
 	public GLCompileMacro_USE_BSP_SURFACE,
 	// public GLCompileMacro_USE_VERTEX_SKINNING,

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3983,6 +3983,7 @@ class GLShader_genericMaterial :
 	// public u_Bones,
 	public u_VertexInterpolation,
 	public u_DepthScale,
+	public u_ShowTris,
 	public u_MaterialColour,
 	public GLDeformStage,
 	// public GLCompileMacro_USE_VERTEX_SKINNING,

--- a/src/engine/renderer/glsl_source/cull_cp.glsl
+++ b/src/engine/renderer/glsl_source/cull_cp.glsl
@@ -53,6 +53,15 @@ layout(std430, binding = 5) restrict buffer portalSurfacesSSBO {
 	PortalSurface portalSurfaces[];
 };
 
+#if defined( r_materialDebug )
+	#define DEBUG_INVOCATION_SIZE 5
+	#define DEBUG_ID( id ) ( id * DEBUG_INVOCATION_SIZE )
+
+	layout(std430, binding = 10) writeonly restrict buffer debugSSBO {
+		uvec4 debug[];
+	};
+#endif
+
 uniform uint u_Frame;
 uniform uint u_ViewID;
 uniform uint u_TotalDrawSurfs;
@@ -160,6 +169,10 @@ void ProcessSurfaceCommands( const in SurfaceDescriptor surface, const in bool e
 		}
 		// Subtract 1 because of no-command
 		surfaceCommands[commandID + u_SurfaceCommandsOffset - 1].enabled = enabled;
+		
+		#if defined( r_materialDebug )
+			debug[DEBUG_ID( GLOBAL_INVOCATION_ID ) + 1][i] = commandID;
+		#endif
 	}
 }
 
@@ -186,4 +199,8 @@ void main() {
 	bool culled = CullSurface( surface.boundingSphere );
 
 	ProcessSurfaceCommands( surface, !culled );
+	
+	#if defined( r_materialDebug )
+		debug[DEBUG_ID( globalInvocationID )].x = culled ? 1 : 0;
+	#endif
 }

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -32,6 +32,7 @@ uniform float u_InverseLightFactor;
 #endif
 
 #if defined(USE_MATERIAL_SYSTEM)
+	uniform bool u_ShowTris;
 	uniform vec3 u_MaterialColour;
 #endif
 
@@ -48,6 +49,13 @@ DECLARE_OUTPUT(vec4)
 void	main()
 {
 	#insert material_fp
+
+	#if defined(USE_MATERIAL_SYSTEM)
+		if( u_ShowTris ) {
+			outputColor = vec4( 0.0, 0.0, 1.0, 1.0 );
+			return;
+		}
+	#endif
 
 	vec4 color = texture2D(u_ColorMap, var_TexCoords);
 

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -31,6 +31,10 @@ uniform float		u_AlphaThreshold;
 uniform float u_InverseLightFactor;
 #endif
 
+#if defined(USE_MATERIAL_SYSTEM)
+	uniform vec3 u_MaterialColour;
+#endif
+
 IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec4		var_Color;
 
@@ -74,5 +78,11 @@ void	main()
 // Debugging.
 #if defined(r_showVertexColors) && !defined(GENERIC_2D)
 	outputColor = vec4(0.0, 0.0, 0.0, 0.0);
+#elif defined(USE_MATERIAL_SYSTEM) && defined(r_showGlobalMaterials)
+	outputColor.rgb = u_MaterialColour;
+
+	#if !defined(GENERIC_2D) && !defined(USE_DEPTH_FADE)
+		outputColor.rgb *= u_InverseLightFactor;
+	#endif
 #endif
 }

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -57,7 +57,10 @@ uniform sampler3D u_LightGrid2;
 	uniform vec3 u_LightGridScale;
 #endif
 
-uniform bool u_ShowTris;
+#if defined(USE_MATERIAL_SYSTEM)
+	uniform bool u_ShowTris;
+	uniform vec3 u_MaterialColour;
+#endif
 
 DECLARE_OUTPUT(vec4)
 
@@ -65,10 +68,12 @@ void main()
 {
 	#insert material_fp
 
-	if( u_ShowTris ) {
-		outputColor = vec4( 0.0, 0.0, 1.0, 1.0 );
-		return;
-	}
+	#if defined(USE_MATERIAL_SYSTEM)
+		if( u_ShowTris ) {
+			outputColor = vec4( 0.0, 0.0, 1.0, 1.0 );
+			return;
+		}
+	#endif
 
 	// Compute view direction in world space.
 	vec3 viewDir = normalize(u_ViewOrigin - var_Position);
@@ -258,5 +263,14 @@ void main()
 		#else
 			outputColor.rgb = vec3(0.0, 0.0, 0.0);
 		#endif
+	#elif defined(USE_MATERIAL_SYSTEM) && defined(r_showGlobalMaterials)
+		outputColor.rgb = u_MaterialColour + lightColor.rgb * u_MaterialColour;
+
+		/* HACK: use sign to know if there is a light or not, and
+		then if it will receive overbright multiplication or not. */
+		if ( u_InverseLightFactor < 0 )
+		{
+			outputColor *= - u_InverseLightFactor;
+		}
 	#endif
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -238,6 +238,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<int> r_showCubeProbeFace( "r_showCubeProbeFace", "Render from the perspective of a selected static reflection "
 		"cubemap face, -1 to disable", Cvar::NONE, -1 );
 	cvar_t      *r_showBspNodes;
+	Cvar::Range<Cvar::Cvar<int>> r_showGlobalMaterials( "r_showGlobalMaterials", "Show material system materials: 0: off, 1: depth, "
+		"2: opaque, 3: opaque + transparent", Cvar::NONE,
+		Util::ordinal( MaterialDebugMode::NONE ),
+		Util::ordinal( MaterialDebugMode::NONE ),
+		Util::ordinal( MaterialDebugMode::OPAQUE_TRANSPARENT ) );
 	cvar_t      *r_showParallelShadowSplits;
 
 	cvar_t      *r_vboFaces;
@@ -1347,6 +1352,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_showMaterialMaps = Cvar_Get( "r_showMaterialMaps", "0", CVAR_CHEAT | CVAR_LATCH );
 		Cvar::Latch( r_showReflectionMaps );
 		r_showBspNodes = Cvar_Get( "r_showBspNodes", "0", CVAR_CHEAT );
+		Cvar::Latch( r_showGlobalMaterials );
 		r_showParallelShadowSplits = Cvar_Get( "r_showParallelShadowSplits", "0", CVAR_CHEAT | CVAR_LATCH );
 
 		// make sure all the commands added here are also removed in R_Shutdown

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -243,6 +243,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 		Util::ordinal( MaterialDebugMode::NONE ),
 		Util::ordinal( MaterialDebugMode::NONE ),
 		Util::ordinal( MaterialDebugMode::OPAQUE_TRANSPARENT ) );
+	Cvar::Cvar<bool> r_materialDebug( "r_materialDebug", "Enable material debug SSBO", Cvar::NONE, false );
 	cvar_t      *r_showParallelShadowSplits;
 
 	cvar_t      *r_vboFaces;
@@ -1353,6 +1354,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		Cvar::Latch( r_showReflectionMaps );
 		r_showBspNodes = Cvar_Get( "r_showBspNodes", "0", CVAR_CHEAT );
 		Cvar::Latch( r_showGlobalMaterials );
+		Cvar::Latch( r_materialDebug );
 		r_showParallelShadowSplits = Cvar_Get( "r_showParallelShadowSplits", "0", CVAR_CHEAT | CVAR_LATCH );
 
 		// make sure all the commands added here are also removed in R_Shutdown

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2968,6 +2968,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	extern Cvar::Cvar<bool> r_showCubeProbes;
 	extern Cvar::Cvar<int> r_showCubeProbeFace;
 	extern cvar_t *r_showBspNodes;
+	extern Cvar::Range<Cvar::Cvar<int>> r_showGlobalMaterials;
 	extern cvar_t *r_showParallelShadowSplits;
 
 	extern cvar_t *r_vboFaces;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2969,6 +2969,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	extern Cvar::Cvar<int> r_showCubeProbeFace;
 	extern cvar_t *r_showBspNodes;
 	extern Cvar::Range<Cvar::Cvar<int>> r_showGlobalMaterials;
+	extern Cvar::Cvar<bool> r_materialDebug;
 	extern cvar_t *r_showParallelShadowSplits;
 
 	extern cvar_t *r_vboFaces;

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -991,12 +991,18 @@ static void R_InitLightUBO()
 static void R_InitMaterialBuffers() {
 	if( glConfig2.materialSystemAvailable ) {
 		materialsSSBO.GenBuffer();
+
 		surfaceDescriptorsSSBO.GenBuffer();
 		surfaceCommandsSSBO.GenBuffer();
 		culledCommandsBuffer.GenBuffer();
 		surfaceBatchesUBO.GenBuffer();
 		atomicCommandCountersBuffer.GenBuffer();
+		
 		portalSurfacesSSBO.GenBuffer();
+
+		if ( r_materialDebug.Get() ) {
+			debugSSBO.GenBuffer();
+		}
 	}
 }
 
@@ -1119,12 +1125,18 @@ void R_ShutdownVBOs()
 
 	if ( glConfig2.materialSystemAvailable ) {
 		materialsSSBO.DelBuffer();
+
 		surfaceDescriptorsSSBO.DelBuffer();
 		surfaceCommandsSSBO.DelBuffer();
 		culledCommandsBuffer.DelBuffer();
 		surfaceBatchesUBO.DelBuffer();
 		atomicCommandCountersBuffer.DelBuffer();
+
 		portalSurfacesSSBO.DelBuffer();
+
+		if ( r_materialDebug.Get() ) {
+			debugSSBO.DelBuffer();
+		}
 	}
 
 	tess.verts = tess.vertsBuffer = nullptr;


### PR DESCRIPTION
Add an `r_showGlobalMaterials` cvar that allows visualising material system materials by color-coding surfaces, in 3 different modes: depth, opaque, opaque + transparent.

Add `r_showTris` to `gl_genericShaderMaterial`.

Add `r_materialDebug` cvar to allow to quickly add debug output to shaders. This is intended for use with compute shaders and Nsight Graphics (due to formatting interface).