### PR TITLE
computeLight_fp: fix compilation when r_highPrecisionRendering is disabled

### DIFF
--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -188,10 +188,10 @@ void main()
 	// Blend dynamic lights.
 	#if defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1
 		#if defined(USE_REFLECTIVE_SPECULAR)
-			computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color, u_LightTilesInt,
+			computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color, lightTilesUniform,
 								 u_EnvironmentMap0, u_EnvironmentMap1);
 		#else // !USE_REFLECTIVE_SPECULAR
-			computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color, u_LightTilesInt);
+			computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color, lightTilesUniform);
 		#endif // !USE_REFLECTIVE_SPECULAR
 	#endif
 


### PR DESCRIPTION
Fix compilation when `r_highPrecisionRendering` is disabled.

I don't know if the fix is right, but it fixes building the `lightMapping` GLSL and I see no visual bugs.

What makes me doubt is that I replace a `sampler3D` with an `usampler3D` but I don't know the difference.

This fixes a bug introduced in f960177aba3c68e17e8ebfc865e8e8682268667a from #1105:

- https://github.com/DaemonEngine/Daemon/pull/1105