### PR TITLE
Fix fog image

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2224,7 +2224,7 @@ float R_FogFactor( float s, float t )
 		return 0;
 	}
 
-	if ( t < 31.0f / 320.0f )
+	if ( t < 31.0f / 32.0f )
 	{
 		s *= ( t - 1.0f / 32.0f ) / ( 30.0f / 32.0f );
 	}


### PR DESCRIPTION
Fixes a regression introduced in 7e7cb4f43e4fabdf54b7b3830e01ee362665fe3f.
Fixes #1258.

Before:
![unvanquished_2024-09-20_191811_000](https://github.com/user-attachments/assets/39492892-0a96-443a-9cff-472393c0ee95)
After:
![unvanquished_2024-09-20_191653_000](https://github.com/user-attachments/assets/3fec337e-8fff-41c7-88ec-3b9c9e12d4d4)
Reference (0.51.2):
![unvanquished_2024-09-20_192031_000](https://github.com/user-attachments/assets/a1b01ef4-60d7-4d8e-897e-a9e0ba4a84b4)