### PR TITLE
Allow disabling entity baselines (can load big layouts)

### DIFF
--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -263,12 +263,9 @@ baseline will be transmitted
 */
 void SV_CreateBaseline()
 {
-	sharedEntity_t *svent;
-	int            entnum;
-
-	for ( entnum = 1; entnum < sv.num_entities; entnum++ )
+	for ( int entnum = MAX_CLIENTS; entnum < sv.num_entities; entnum++ )
 	{
-		svent = SV_GentityNum( entnum );
+		sharedEntity_t *svent = SV_GentityNum( entnum );
 
 		if ( !svent->r.linked )
 		{

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -52,6 +52,8 @@ static Cvar::Cvar<std::string> cvar_pakname(
 	"pakname", "pak containing current map", Cvar::SERVERINFO | Cvar::ROM, "");
 static Cvar::Cvar<std::string> sv_paks(
 	"sv_paks", "currently loaded paks", Cvar::SYSTEMINFO | Cvar::ROM, "");
+static Cvar::Cvar<bool> sv_useBaseline(
+	"sv_useBaseline", "send entity baseline for non-snapshot delta compression", Cvar::NONE, true);
 
 /*
 ===============
@@ -263,6 +265,14 @@ baseline will be transmitted
 */
 void SV_CreateBaseline()
 {
+	Cvar::Latch( sv_useBaseline );
+
+	if ( !sv_useBaseline.Get() )
+	{
+		// make a baseline with no entities
+		return;
+	}
+
 	for ( int entnum = MAX_CLIENTS; entnum < sv.num_entities; entnum++ )
 	{
 		sharedEntity_t *svent = SV_GentityNum( entnum );


### PR DESCRIPTION
Entity baselines are supposed to make netcode more efficient, but it's dubious (see #1321). Let server owners disable entity baselines with `set sv_useBaseline 0` as a workaround to https://github.com/Unvanquished/Unvanquished/issues/2124. This is compatible with vanilla clients. Probably no one will notice a difference wrt bandwith efficiency.