### PR TITLE
Add missing `break;` to reliefMaping_fp

### DIFF
--- a/src/engine/renderer/glsl_source/reliefMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/reliefMapping_fp.glsl
@@ -171,6 +171,7 @@ vec2 ReliefTexOffset(vec2 rayStartTexCoords, vec3 viewDir, mat3 tangentToWorldMa
 			if(currentDepth >= heightMapDepth)
 			{
 				bestDepth = currentDepth;
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
This can slightly increase performance if the shader compiler isn't optimising out the rest of the loop already.