### PR TITLE
tr_shader: transmit `RSF_FITSCREEN` and `RSF_NOMIP` flag from gamecode to shaders

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6335,6 +6335,16 @@ shader_t       *R_FindShader( const char *name, shaderType_t type, int flags )
 		shader.autoSpriteMode = 1;
 	}
 
+	if ( flags & RSF_NOMIP )
+	{
+		shader.noPicMip = true;
+	}
+
+	if ( flags & RSF_FITSCREEN )
+	{
+		shader.fitScreen = true;
+	}
+
 	// attempt to define shader from an explicit parameter file
 	shaderText = FindShaderInShaderText( strippedName );
 
@@ -6380,13 +6390,11 @@ shader_t       *R_FindShader( const char *name, shaderType_t type, int flags )
 	if ( flags & RSF_NOMIP )
 	{
 		bits |= IF_NOPICMIP;
-		shader.noPicMip = true;
 	}
 
 	if ( flags & RSF_FITSCREEN )
 	{
 		bits |= IF_FITSCREEN;
-		shader.fitScreen = true;
 	}
 
 	if ( flags & RSF_NOLIGHTSCALE )


### PR DESCRIPTION
When the game code requests the engine to load a texture and sets the `RSF_FITSCREEN` or the `RSF_NOMIP` flag, it was only used on images without shaders.