### PR TITLE
More renderer debug logs

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -6777,7 +6777,8 @@ void R_BuildCubeMaps()
 		}
 
 		// build the cubemap
-		cubeProbe->cubemap = R_AllocImage( Str::Format( "_autoCube%d", i ).c_str(), false );
+		std::string name = Str::Format( "_autoCube%d", i );
+		cubeProbe->cubemap = R_AllocImage( name.c_str(), false );
 
 		if ( !cubeProbe->cubemap )
 		{
@@ -6795,7 +6796,7 @@ void R_BuildCubeMaps()
 
 		imageParams_t imageParams = {};
 
-		R_UploadImage( ( const byte ** ) tr.cubeTemp, 6, 1, cubeProbe->cubemap, imageParams );
+		R_UploadImage( name.c_str(), ( const byte ** ) tr.cubeTemp, 6, 1, cubeProbe->cubemap, imageParams );
 	}
 
 	r_gpuOcclusionCulling.Set( gpuOcclusionCulling );

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -792,7 +792,7 @@ level 1 has only numLayers/2 layers. There are still numLayers pointers in
 the dataArray for every mip level, the unneeded elements at the end aren't used.
 ===============
 */
-void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t *image, const imageParams_t &imageParams )
+void R_UploadImage( const char *name, const byte **dataArray, int numLayers, int numMips, image_t *image, const imageParams_t &imageParams )
 {
 	const byte *data;
 	byte       *scaledBuffer = nullptr;
@@ -1021,6 +1021,8 @@ void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t 
 			}
 		}
 	}
+
+	Log::Debug( "Uploading image %s (%d×%d, %d layers, %0#x type, %0#x format)", name, scaledWidth, scaledHeight, numLayers, image->type, internalFormat );
 
 	// 3D textures are uploaded in slices via glTexSubImage3D,
 	// so the storage has to be allocated before the loop
@@ -1348,6 +1350,8 @@ R_AllocImage
 */
 image_t        *R_AllocImage( const char *name, bool linkIntoHashTable )
 {
+	Log::Debug( "Allocating image %s", name );
+
 	image_t *image;
 	unsigned hash;
 
@@ -1405,6 +1409,8 @@ R_CreateImage
 */
 image_t *R_CreateImage( const char *name, const byte **pic, int width, int height, int numMips, const imageParams_t &imageParams )
 {
+	Log::Debug( "Creating image %s (%d×%d, %d mips)", name, width, height, numMips );
+
 	image_t *image;
 
 	image = R_AllocImage( name, true );
@@ -1424,7 +1430,7 @@ image_t *R_CreateImage( const char *name, const byte **pic, int width, int heigh
 	image->filterType = imageParams.filterType;
 	image->wrapType = imageParams.wrapType;
 
-	R_UploadImage( pic, 1, numMips, image, imageParams );
+	R_UploadImage( name, pic, 1, numMips, image, imageParams );
 
 	if( r_exportTextures->integer ) {
 		R_ExportTexture( image );
@@ -1505,7 +1511,7 @@ image_t *R_CreateCubeImage( const char *name, const byte *pic[ 6 ], int width, i
 	image->filterType = imageParams.filterType;
 	image->wrapType = imageParams.wrapType;
 
-	R_UploadImage( pic, 6, 1, image, imageParams );
+	R_UploadImage( name, pic, 6, 1, image, imageParams );
 
 	if( r_exportTextures->integer ) {
 		R_ExportTexture( image );
@@ -1552,7 +1558,7 @@ image_t *R_Create3DImage( const char *name, const byte *pic, int width, int heig
 	image->filterType = imageParams.filterType;
 	image->wrapType = imageParams.wrapType;
 
-	R_UploadImage( pics, numLayers, 1, image, imageParams );
+	R_UploadImage( name, pics, numLayers, 1, image, imageParams );
 
 	if( pics ) {
 		ri.Hunk_FreeTempMemory( pics );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3208,7 +3208,7 @@ inline bool checkGLErrors()
 	qhandle_t RE_GenerateTexture( const byte *pic, int width, int height );
 
 	image_t *R_AllocImage( const char *name, bool linkIntoHashTable );
-	void R_UploadImage( const byte **dataArray, int numLayers, int numMips, image_t *image, const imageParams_t &imageParams );
+	void R_UploadImage( const char *name, const byte **dataArray, int numLayers, int numMips, image_t *image, const imageParams_t &imageParams );
 
 	void    RE_GetTextureSize( int textureID, int *width, int *height );
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1897,7 +1897,14 @@ static bool LoadExt( int flags, bool hasExt, const char* name, bool test = true 
 	{
 		if ( test )
 		{
-			logger.WithoutSuppression().Notice( "...using GL_%s", name );
+			if ( flags & ExtFlag_REQUIRED )
+			{
+				logger.WithoutSuppression().Notice( "...using required extension GL_%s.", name );
+			}
+			else
+			{
+				logger.WithoutSuppression().Notice( "...using optional extension GL_%s.", name );
+			}
 
 			if ( glConfig2.glEnabledExtensionsString.length() != 0 )
 			{
@@ -1914,18 +1921,18 @@ static bool LoadExt( int flags, bool hasExt, const char* name, bool test = true 
 			// Required extension can't be made optional
 			ASSERT( !( flags & ExtFlag_REQUIRED ) );
 
-			logger.WithoutSuppression().Notice( "...ignoring GL_%s", name );
+			logger.WithoutSuppression().Notice( "...ignoring optional extension GL_%s.", name );
 		}
 	}
 	else
 	{
 		if ( flags & ExtFlag_REQUIRED )
 		{
-			Sys::Error( "Required extension GL_%s is missing.", name );
+			Sys::Error( "Missing required extension GL_%s.", name );
 		}
 		else
 		{
-			logger.WithoutSuppression().Notice( "...GL_%s not found.", name );
+			logger.WithoutSuppression().Notice( "...missing optional extension GL_%s.", name );
 
 			if ( glConfig2.glMissingExtensionsString.length() != 0 )
 			{


### PR DESCRIPTION
Some renderer debug logs I needed to debug things:

- sdl_glimp: tell if used extension is required or optional

When it is suspected an extension may be buggy, it is useful to know which ones are optional so one can disable them to verify the assumption.

- renderer: add more debug log about image creation

When the OpenGL driver reports errors when creating or uploading an image, it's useful to have such debug logs to know exactly which image failed, just by reading the immediate previous line. It is useful to identify which image format may be broken in an OpenGL driver.