### PR TITLE
Fix compilation with gcc 8.3

### DIFF
--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -368,7 +368,7 @@ static void SignalHandler(int sig)
 
 	Sys::Error("Forcing shutdown from signal: %s", strsignal(sig));
 }
-NORETURN static void SignalThread()
+static void SignalThread()
 {
 	// Unblock the signals we are interested in and handle them in this thread
 	sigset_t sigset;


### PR DESCRIPTION
The noreturn made std::thread(SignalHandler) not compile