### PR TITLE
GLSL cleanup: make var_FadeDepth a scalar

### DIFF
--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -36,7 +36,7 @@ IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec4		var_Color;
 
 #if defined(USE_DEPTH_FADE)
-IN(smooth) vec2         var_FadeDepth;
+IN(smooth) float        var_FadeDepth;
 uniform sampler2D       u_DepthMap;
 #endif
 
@@ -65,7 +65,14 @@ void	main()
 
 #if defined(USE_DEPTH_FADE)
 	float depth = texture2D(u_DepthMap, gl_FragCoord.xy / r_FBufSize).x;
-	float fadeDepth = 0.5 * var_FadeDepth.x / var_FadeDepth.y + 0.5;
+
+	// convert z from normalized device coordinates [-1, 1]
+	// to window coordinates [0, 1]
+	float fadeDepth = 0.5 * var_FadeDepth + 0.5;
+
+	// HACK: the (distance from triangle to object behind it) / (shader's depthFade distance) ratio
+	// is calculated by using (nonlinear) depth values instead of the correct world units, so the
+	// fade curve will be different depending on the distance to the viewer and znear/zfar
 	color.a *= smoothstep(gl_FragCoord.z, fadeDepth, depth);
 #endif
 

--- a/src/engine/renderer/glsl_source/generic_vp.glsl
+++ b/src/engine/renderer/glsl_source/generic_vp.glsl
@@ -47,7 +47,7 @@ uniform mat4 u_ModelViewProjectionMatrix;
 
 #if defined(USE_DEPTH_FADE)
 	uniform float u_DepthScale;
-	OUT(smooth) vec2 var_FadeDepth;
+	OUT(smooth) float var_FadeDepth;
 #endif
 
 OUT(smooth) vec2 var_TexCoords;
@@ -91,8 +91,8 @@ void main() {
 
 	#if defined(USE_DEPTH_FADE)
 		// compute z of end of fading effect
-		vec4 fadeDepth = u_ModelViewProjectionMatrix * (position - u_DepthScale * vec4( LB.normal, 0.0 ) );
-		var_FadeDepth = fadeDepth.zw;
+		vec4 fadeDepth = u_ModelViewProjectionMatrix * ( position - u_DepthScale * vec4(LB.normal, 0.0) );
+		var_FadeDepth = fadeDepth.z / fadeDepth.w;
 	#endif
 
 	SHADER_PROFILER_SET


### PR DESCRIPTION
Divide out the w coordinate in the vertex shader instead of the fragment shader.

Also add comment about hacky depth fraction calc.