### PR TITLE
Fix heat haze shaders not rendered due to bad sorting

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5813,6 +5813,11 @@ static float DetermineShaderSort()
 
 	for ( size_t stage = 0; stage < numStages; stage++ )
 	{
+		if ( stages[ stage ].type == stageType_t::ST_HEATHAZEMAP )
+		{
+			return Util::ordinal(shaderSort_t::SS_BLEND0);
+		}
+
 		// determine sort order and fog color adjustment
 		if ( ( stages[ stage ].stateBits & ( GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS ) ) &&
 		     ( stages[ 0 ].stateBits & ( GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS ) ) )


### PR DESCRIPTION
All of the heat haze shaders in our weapon assets suffer from having a wrong sort order value (SS_OPAQUE). Only some more or less worked, due to the luck of being drawn later than most other opaque surfaces. It would seem the first properly working heat haze shader in our project was https://github.com/UnvanquishedAssets/map-plat23_src.dpkdir/pull/1: this shader received a SS_BLEND0 sort due to other stages.

Targeting 0.55 since some suddenly-visible assets probably need to be fixed. The Lucifer Cannon secondary fire impact looks stupid: the impacted surface suddenly assumes a distorted aspect, then 3 seconds later snaps back to normal.