### PR TITLE
tr_shader: use dummy stage renderer if stage cannot be rendered, fix crash with stahl map

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5475,8 +5475,13 @@ static void SetStagesRenderers()
 				};
 				break;
 			default:
-				Log::Warn( "Missing renderer for stage type %d", Util::ordinal(stage->type) );
-				ASSERT_UNREACHABLE();
+				Log::Warn( "Missing renderer for stage type %d in shader %s, stage %d",
+					Util::ordinal(stage->type), shader.name, s );
+				stageRendererOptions = {
+					&Render_NOP,
+					&UpdateSurfaceDataNOP, &BindShaderNOP, &ProcessMaterialNOP,
+					false, false,
+				};
 				break;
 		}
 


### PR DESCRIPTION
The stahl map have those materials:

```
textures/stahl/sfx_05_blue
{
	qer_editorimage textures/stahl/sfx_05b_blue
	cull none
	surfaceparm nodlight
	surfaceparm nolightmap
	surfaceparm nonsolid
	surfaceparm trans
	qer_trans 0.75
	{
		map textures/stahl/sfx_05b_blue
		blendFunc add
	}
	glowmap textures/stahl/sfx_05b_blue
}

textures/stahl/sfx_05_red
{
	qer_editorimage textures/stahl/sfx_05b_red
	cull none
	surfaceparm nodlight
	surfaceparm nolightmap
	surfaceparm nonsolid
	surfaceparm trans
	qer_trans 0.75
	{
		map textures/stahl/sfx_05b_red
		blendFunc add
	}
	glowmap textures/stahl/sfx_05b_red
}
```

You see they both use a legacy doom3-like glow map stage after a legacy quake3-like color map.

For some unknown reasons we fail to collapse the glow map with the color map.

Collapsing this glow map with the color map may be a bug to fix or a feature request to implement, but in all cases, we should not crash on badly crafted data.

Even if in the future we manage to properly collapse the glow map with the color map, one nasty individual may distribute this kind of purposedly wrong material to crash player's engine:

```
textures/broken/broken1
{
	glowmap textures/stahl/sfx_05b_red
}

textures/broken/broken2
{
	{
		map textures/stahl/sfx_05b_red
		blendFunc add
	}
	glowmap textures/stahl/sfx_05b_red
	glowmap textures/stahl/sfx_05b_red
	glowmap textures/stahl/sfx_05b_red
	glowmap textures/stahl/sfx_05b_red
}
```

So we better tell the renderer to actually process the stage with a dummy renderer than going to smash some stack.