### PR TITLE
Runtime VBO layout: make half float usage optional

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4572,8 +4572,8 @@ void DebugDrawVertex(const vec3_t pos, unsigned int color, const vec2_t uv) {
 	tess.verts[ tess.numVertexes ].xyz[ 2 ] = pos[ 2 ];
 	tess.verts[ tess.numVertexes ].color = colors;
 	if( uv ) {
-		tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( uv[ 0 ] );
-		tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( uv[ 1 ] );
+		tess.verts[ tess.numVertexes ].texCoords[ 0 ] = uv[ 0 ];
+		tess.verts[ tess.numVertexes ].texCoords[ 1 ] = uv[ 1 ];
 	}
 	tess.indexes[ tess.numIndexes ] = tess.numVertexes;
 	tess.numVertexes++;
@@ -4962,32 +4962,32 @@ const RenderCommand *StretchPicCommand::ExecuteSelf( ) const
 	tess.verts[ numVerts ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 0 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts ].texCoords[ 1 ] = floatToHalf( t1 );
+	tess.verts[ numVerts ].texCoords[ 0 ] = s1;
+	tess.verts[ numVerts ].texCoords[ 1 ] = t1;
 
 	tess.verts[ numVerts + 1 ].xyz[ 0 ] = x + w;
 	tess.verts[ numVerts + 1 ].xyz[ 1 ] = y;
 	tess.verts[ numVerts + 1 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 1 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts + 1 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 1 ].texCoords[ 1 ] = floatToHalf( t1 );
+	tess.verts[ numVerts + 1 ].texCoords[ 0 ] = s2;
+	tess.verts[ numVerts + 1 ].texCoords[ 1 ] = t1;
 
 	tess.verts[ numVerts + 2 ].xyz[ 0 ] = x + w;
 	tess.verts[ numVerts + 2 ].xyz[ 1 ] = y + h;
 	tess.verts[ numVerts + 2 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 2 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts + 2 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 2 ].texCoords[ 1 ] = floatToHalf( t2 );
+	tess.verts[ numVerts + 2 ].texCoords[ 0 ] = s2;
+	tess.verts[ numVerts + 2 ].texCoords[ 1 ] = t2;
 
 	tess.verts[ numVerts + 3 ].xyz[ 0 ] = x;
 	tess.verts[ numVerts + 3 ].xyz[ 1 ] = y + h;
 	tess.verts[ numVerts + 3 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 3 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts + 3 ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts + 3 ].texCoords[ 1 ] = floatToHalf( t2 );
+	tess.verts[ numVerts + 3 ].texCoords[ 0 ] = s1;
+	tess.verts[ numVerts + 3 ].texCoords[ 1 ] = t2;
 
 	return this + 1;
 }
@@ -5041,8 +5041,8 @@ const RenderCommand *Poly2dCommand::ExecuteSelf( ) const
 		tess.verts[ tess.numVertexes ].xyz[ 1 ] = verts[ i ].xyz[ 1 ];
 		tess.verts[ tess.numVertexes ].xyz[ 2 ] = 0.0f;
 
-		tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( verts[ i ].st[ 0 ] );
-		tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( verts[ i ].st[ 1 ] );
+		tess.verts[ tess.numVertexes ].texCoords[ 0 ] = verts[ i ].st[ 0 ];
+		tess.verts[ tess.numVertexes ].texCoords[ 1 ] = verts[ i ].st[ 1 ];
 
 		tess.verts[ tess.numVertexes ].color = Color::Adapt( verts[ i ].modulate );
 		tess.numVertexes++;
@@ -5098,8 +5098,8 @@ const RenderCommand *Poly2dIndexedCommand::ExecuteSelf( ) const
 		tess.verts[ tess.numVertexes ].xyz[ 1 ] = verts[ i ].xyz[ 1 ] + translation[ 1 ];
 		tess.verts[ tess.numVertexes ].xyz[ 2 ] = 0.0f;
 
-		tess.verts[ tess.numVertexes ].texCoords[ 0 ] = floatToHalf( verts[ i ].st[ 0 ] );
-		tess.verts[ tess.numVertexes ].texCoords[ 1 ] = floatToHalf( verts[ i ].st[ 1 ] );
+		tess.verts[ tess.numVertexes ].texCoords[ 0 ] = verts[ i ].st[ 0 ];
+		tess.verts[ tess.numVertexes ].texCoords[ 1 ] = verts[ i ].st[ 1 ];
 
 		tess.verts[ tess.numVertexes ].color = Color::Adapt( verts[ i ].modulate );
 		tess.numVertexes++;
@@ -5201,32 +5201,32 @@ const RenderCommand *RotatedPicCommand::ExecuteSelf( ) const
 	tess.verts[ numVerts ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 0 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts ].texCoords[ 1 ] = floatToHalf( t1 );
+	tess.verts[ numVerts ].texCoords[ 0 ] = s1;
+	tess.verts[ numVerts ].texCoords[ 1 ] = t1;
 
 	tess.verts[ numVerts + 1 ].xyz[ 0 ] = mx + cw - sh;
 	tess.verts[ numVerts + 1 ].xyz[ 1 ] = my - sw - ch;
 	tess.verts[ numVerts + 1 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 1 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts + 1 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 1 ].texCoords[ 1 ] = floatToHalf( t1 );
+	tess.verts[ numVerts + 1 ].texCoords[ 0 ] = s2;
+	tess.verts[ numVerts + 1 ].texCoords[ 1 ] = t1;
 
 	tess.verts[ numVerts + 2 ].xyz[ 0 ] = mx + cw + sh;
 	tess.verts[ numVerts + 2 ].xyz[ 1 ] = my - sw + ch;
 	tess.verts[ numVerts + 2 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 2 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts + 2 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 2 ].texCoords[ 1 ] = floatToHalf( t2 );
+	tess.verts[ numVerts + 2 ].texCoords[ 0 ] = s2;
+	tess.verts[ numVerts + 2 ].texCoords[ 1 ] = t2;
 
 	tess.verts[ numVerts + 3 ].xyz[ 0 ] = mx - cw + sh;
 	tess.verts[ numVerts + 3 ].xyz[ 1 ] = my + sw + ch;
 	tess.verts[ numVerts + 3 ].xyz[ 2 ] = 0.0f;
 	tess.verts[ numVerts + 3 ].color = backEnd.color2D;
 
-	tess.verts[ numVerts + 3 ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts + 3 ].texCoords[ 1 ] = floatToHalf( t2 );
+	tess.verts[ numVerts + 3 ].texCoords[ 0 ] = s1;
+	tess.verts[ numVerts + 3 ].texCoords[ 1 ] = t2;
 
 	return this + 1;
 }
@@ -5285,29 +5285,29 @@ const RenderCommand *GradientPicCommand::ExecuteSelf( ) const
 	tess.verts[ numVerts ].xyz[ 1 ] = y;
 	tess.verts[ numVerts ].xyz[ 2 ] = 0.0f;
 
-	tess.verts[ numVerts ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts ].texCoords[ 1 ] = floatToHalf( t1 );
+	tess.verts[ numVerts ].texCoords[ 0 ] = s1;
+	tess.verts[ numVerts ].texCoords[ 1 ] = t1;
 
 	tess.verts[ numVerts + 1 ].xyz[ 0 ] = x + w;
 	tess.verts[ numVerts + 1 ].xyz[ 1 ] = y;
 	tess.verts[ numVerts + 1 ].xyz[ 2 ] = 0.0f;
 
-	tess.verts[ numVerts + 1 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 1 ].texCoords[ 1 ] = floatToHalf( t1 );
+	tess.verts[ numVerts + 1 ].texCoords[ 0 ] = s2;
+	tess.verts[ numVerts + 1 ].texCoords[ 1 ] = t1;
 
 	tess.verts[ numVerts + 2 ].xyz[ 0 ] = x + w;
 	tess.verts[ numVerts + 2 ].xyz[ 1 ] = y + h;
 	tess.verts[ numVerts + 2 ].xyz[ 2 ] = 0.0f;
 
-	tess.verts[ numVerts + 2 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ numVerts + 2 ].texCoords[ 1 ] = floatToHalf( t2 );
+	tess.verts[ numVerts + 2 ].texCoords[ 0 ] = s2;
+	tess.verts[ numVerts + 2 ].texCoords[ 1 ] = t2;
 
 	tess.verts[ numVerts + 3 ].xyz[ 0 ] = x;
 	tess.verts[ numVerts + 3 ].xyz[ 1 ] = y + h;
 	tess.verts[ numVerts + 3 ].xyz[ 2 ] = 0.0f;
 
-	tess.verts[ numVerts + 3 ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ numVerts + 3 ].texCoords[ 1 ] = floatToHalf( t2 );
+	tess.verts[ numVerts + 3 ].texCoords[ 0 ] = s1;
+	tess.verts[ numVerts + 3 ].texCoords[ 1 ] = t2;
 
 	return this + 1;
 }

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -905,27 +905,21 @@ static void FinishSkybox() {
 	surface->numVerts = 8;
 	surface->numIndexes = 36;
 	surface->firstIndex = 0;
-	vec3_t v0 = { min[0], min[1], min[2] };
-	vec3_t v1 = { min[0], max[1], min[2] };
-	vec3_t v2 = { max[0], max[1], min[2] };
-	vec3_t v3 = { max[0], min[1], min[2] };
-	vec3_t v4 = { min[0], min[1], max[2] };
-	vec3_t v5 = { min[0], max[1], max[2] };
-	vec3_t v6 = { max[0], max[1], max[2] };
-	vec3_t v7 = { max[0], min[1], max[2] };
 
-	shaderVertex_t verts[8];
-	VectorCopy( v0, verts[0].xyz );
-	VectorCopy( v1, verts[1].xyz );
-	VectorCopy( v2, verts[2].xyz );
-	VectorCopy( v3, verts[3].xyz );
-	VectorCopy( v4, verts[4].xyz );
-	VectorCopy( v5, verts[5].xyz );
-	VectorCopy( v6, verts[6].xyz );
-	VectorCopy( v7, verts[7].xyz );
-	surface->vbo = R_CreateStaticVBO2( va( "skybox_VBO %i", 0 ), surface->numVerts, verts,
-		ATTR_POSITION
-	);
+	vec3_t verts[ 8 ] {
+		{ min[0], min[1], min[2] },
+		{ min[0], max[1], min[2] },
+		{ max[0], max[1], min[2] },
+		{ max[0], min[1], min[2] },
+		{ min[0], min[1], max[2] },
+		{ min[0], max[1], max[2] },
+		{ max[0], max[1], max[2] },
+		{ max[0], min[1], max[2] },
+	};
+	vertexAttributeSpec_t attr[] = {
+		{ ATTR_INDEX_POSITION, GL_FLOAT, GL_FLOAT, verts, 3, sizeof( vec3_t ), 0 },
+	};
+	surface->vbo = R_CreateStaticVBO( "skybox_VBO", std::begin( attr ), std::end( attr ), surface->numVerts );
 
 	glIndex_t indexes[36] = { 0, 2, 1,  0, 3, 2,   // Bottom
 							  7, 5, 6,  7, 4, 5,   // Top
@@ -934,7 +928,7 @@ static void FinishSkybox() {
 							  2, 7, 6,  2, 3, 7,   // Right
 							  3, 4, 7,  3, 0, 4 }; // Back
 
-	surface->ibo = R_CreateStaticIBO( va( "skybox_IBO %i", 0 ), indexes, surface->numIndexes );
+	surface->ibo = R_CreateStaticIBO( "skybox_IBO", indexes, surface->numIndexes );
 	skybox->surface = ( surfaceType_t* ) surface;
 
 	tr.skybox = skybox;

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -2823,30 +2823,6 @@ void R_MovePatchSurfacesToHunk()
 	}
 }
 
-static void CopyVert( const srfVert_t *in, srfVert_t *out )
-{
-	int j;
-
-	for ( j = 0; j < 3; j++ )
-	{
-		out->xyz[ j ] = in->xyz[ j ];
-		out->normal[ j ] = in->normal[ j ];
-	}
-
-	for ( j = 0; j < 2; j++ )
-	{
-		out->st[ j ] = in->st[ j ];
-		out->lightmap[ j ] = in->lightmap[ j ];
-	}
-
-	out->lightColor = in->lightColor;
-
-	for ( j = 0; j < 4; j++ )
-	{
-		out->qtangent[ j ] = in->qtangent[ j ];
-	}
-}
-
 /*
 =================
 R_CreateClusters
@@ -2944,12 +2920,10 @@ static void R_CreateWorldVBO()
 	int       i, j, k;
 
 	int       numVerts;
-	srfVert_t *verts;
 	shaderVertex_t *vboVerts;
 	glIndex_t      *vboIdxs;
 
 	int           numTriangles;
-	srfTriangle_t *triangles;
 
 	int            numSurfaces;
 	bspSurface_t  *surface;
@@ -3126,13 +3100,6 @@ static void R_CreateWorldVBO()
 
 	Log::Debug("...calculating world VBO ( %i verts %i tris )", numVerts, numTriangles );
 
-	// create arrays
-	s_worldData.numVerts = numVerts;
-	s_worldData.verts = verts = (srfVert_t*) ri.Hunk_Alloc( numVerts * sizeof( srfVert_t ), ha_pref::h_low );
-
-	s_worldData.numTriangles = numTriangles;
-	s_worldData.triangles = triangles = (srfTriangle_t*) ri.Hunk_Alloc( numTriangles * sizeof( srfTriangle_t ), ha_pref::h_low );
-
 	vboVerts = (shaderVertex_t *)ri.Hunk_AllocateTempMemory( numVerts * sizeof( shaderVertex_t ) );
 	vboIdxs = (glIndex_t *)ri.Hunk_AllocateTempMemory( 3 * numTriangles * sizeof( glIndex_t ) );
 
@@ -3154,32 +3121,8 @@ static void R_CreateWorldVBO()
 			srfSurfaceFace_t *srf = ( srfSurfaceFace_t * ) surface->data;
 
 			srf->firstTriangle = numTriangles;
-			srf->firstVert = numVerts;
-
-			if ( srf->numTriangles )
-			{
-				srfTriangle_t *tri;
-
-				for ( i = 0, tri = srf->triangles; i < srf->numTriangles; i++, tri++ )
-				{
-					for ( j = 0; j < 3; j++ )
-					{
-						triangles[ numTriangles + i ].indexes[ j ] = srf->firstVert + tri->indexes[ j ];
-					}
-				}
-
-				numTriangles += srf->numTriangles;
-			}
-
-			if ( srf->numVerts )
-			{
-				for ( i = 0; i < srf->numVerts; i++ )
-				{
-					CopyVert( &srf->verts[ i ], &verts[ srf->firstVert + i ] );
-				}
-
-				numVerts += srf->numVerts;
-			}
+			numTriangles += srf->numTriangles;
+			numVerts += srf->numVerts;
 
 			rb_surfaceTable[Util::ordinal(surfaceType_t::SF_FACE)](srf );
 		}
@@ -3188,32 +3131,8 @@ static void R_CreateWorldVBO()
 			srfGridMesh_t *srf = ( srfGridMesh_t * ) surface->data;
 
 			srf->firstTriangle = numTriangles;
-			srf->firstVert = numVerts;
-
-			if ( srf->numTriangles )
-			{
-				srfTriangle_t *tri;
-
-				for ( i = 0, tri = srf->triangles; i < srf->numTriangles; i++, tri++ )
-				{
-					for ( j = 0; j < 3; j++ )
-					{
-						triangles[ numTriangles + i ].indexes[ j ] = srf->firstVert + tri->indexes[ j ];
-					}
-				}
-
-				numTriangles += srf->numTriangles;
-			}
-
-			if ( srf->numVerts )
-			{
-				for ( i = 0; i < srf->numVerts; i++ )
-				{
-					CopyVert( &srf->verts[ i ], &verts[ srf->firstVert + i ] );
-				}
-
-				numVerts += srf->numVerts;
-			}
+			numTriangles += srf->numTriangles;
+			numVerts += srf->numVerts;
 
 			rb_surfaceTable[Util::ordinal(surfaceType_t::SF_GRID)](srf );
 		}
@@ -3222,32 +3141,8 @@ static void R_CreateWorldVBO()
 			srfTriangles_t *srf = ( srfTriangles_t * ) surface->data;
 
 			srf->firstTriangle = numTriangles;
-			srf->firstVert = numVerts;
-
-			if ( srf->numTriangles )
-			{
-				srfTriangle_t *tri;
-
-				for ( i = 0, tri = srf->triangles; i < srf->numTriangles; i++, tri++ )
-				{
-					for ( j = 0; j < 3; j++ )
-					{
-						triangles[ numTriangles + i ].indexes[ j ] = srf->firstVert + tri->indexes[ j ];
-					}
-				}
-
-				numTriangles += srf->numTriangles;
-			}
-
-			if ( srf->numVerts )
-			{
-				for ( i = 0; i < srf->numVerts; i++ )
-				{
-					CopyVert( &srf->verts[ i ], &verts[ srf->firstVert + i ] );
-				}
-
-				numVerts += srf->numVerts;
-			}
+			numTriangles += srf->numTriangles;
+			numVerts += srf->numVerts;
 
 			rb_surfaceTable[Util::ordinal(surfaceType_t::SF_TRIANGLES)](srf );
 		}

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2070,8 +2070,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		vec4_t      binormal;
 		vec4_t      normal;
 
-		f16vec2_t texCoords;
-		char _pad[ 4 ];
+		vec2_t texCoords;
 		uint32_t    firstWeight;
 		uint32_t    numWeights;
 
@@ -2204,7 +2203,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		float           *normals;
 		float           *tangents;
 		float           *bitangents;
-		f16_t           *texcoords;
+		float           *texcoords;
 		byte            *blendIndexes;
 		byte            *blendWeights;
 		byte            *colors;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -660,8 +660,8 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 
 	enum class vboLayout_t
 	{
+		VBO_LAYOUT_CUSTOM,
 		VBO_LAYOUT_VERTEX_ANIMATION,
-		VBO_LAYOUT_SKELETAL,
 		VBO_LAYOUT_STATIC,
 		VBO_LAYOUT_XYST
 	};
@@ -672,11 +672,25 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		i16vec4_t *qtangent;
 		u8vec4_t *color;
 		union { f16vec2_t *st; vec2_t *stf; };
-		int    (*boneIndexes)[ 4 ];
-		vec4_t *boneWeights;
 
 		int	numFrames;
 		int     numVerts;
+	};
+
+	enum
+	{
+		ATTR_OPTION_NORMALIZE = BIT( 0 ),
+	};
+
+	struct vertexAttributeSpec_t
+	{
+		int attrIndex;
+		GLenum componentInputType;
+		GLenum componentStorageType;
+		const void *begin;
+		uint32_t numComponents;
+		uint32_t stride;
+		int attrOptions;
 	};
 
 	struct VBO_t
@@ -690,7 +704,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		uint32_t vertexesNum;
 		uint32_t framesNum; // number of frames for vertex animation
 
-		vboAttributeLayout_t attribs[ ATTR_INDEX_MAX ]; // info for buffer manipulation
+		std::array<vboAttributeLayout_t, ATTR_INDEX_MAX> attribs; // info for buffer manipulation
 
 		vboLayout_t layout;
 		uint32_t attribBits; // Which attributes it has. Mostly for detecting errors
@@ -3477,6 +3491,9 @@ inline bool checkGLErrors()
 
 	============================================================
 	*/
+	VBO_t *R_CreateStaticVBO(
+		Str::StringRef name, const vertexAttributeSpec_t *attrBegin, const vertexAttributeSpec_t *attrEnd,
+		uint32_t numVerts );
 	VBO_t *R_CreateStaticVBO( const char *name, vboData_t data, vboLayout_t layout );
 	VBO_t *R_CreateStaticVBO2( const char *name, int numVertexes, shaderVertex_t *verts, uint32_t stateBits );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -663,7 +663,6 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		VBO_LAYOUT_VERTEX_ANIMATION,
 		VBO_LAYOUT_SKELETAL,
 		VBO_LAYOUT_STATIC,
-		VBO_LAYOUT_POSITION,
 		VBO_LAYOUT_XYST
 	};
 
@@ -2577,8 +2576,6 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		FBO_t *sunShadowMapFBO[ MAX_SHADOWMAPS ];
 
 		// vertex buffer objects
-		VBO_t *unitCubeVBO;
-		IBO_t *unitCubeIBO;
 		VBO_t *lighttileVBO;
 
 		// internal shaders

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -661,7 +661,6 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	enum class vboLayout_t
 	{
 		VBO_LAYOUT_CUSTOM,
-		VBO_LAYOUT_VERTEX_ANIMATION,
 		VBO_LAYOUT_STATIC,
 		VBO_LAYOUT_XYST
 	};
@@ -669,17 +668,15 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	struct vboData_t
 	{
 		vec3_t *xyz;
-		i16vec4_t *qtangent;
-		u8vec4_t *color;
-		union { f16vec2_t *st; vec2_t *stf; };
+		vec2_t *stf;
 
-		int	numFrames;
 		int     numVerts;
 	};
 
 	enum
 	{
 		ATTR_OPTION_NORMALIZE = BIT( 0 ),
+		ATTR_OPTION_HAS_FRAMES = BIT( 1 ),
 	};
 
 	struct vertexAttributeSpec_t
@@ -3493,7 +3490,7 @@ inline bool checkGLErrors()
 	*/
 	VBO_t *R_CreateStaticVBO(
 		Str::StringRef name, const vertexAttributeSpec_t *attrBegin, const vertexAttributeSpec_t *attrEnd,
-		uint32_t numVerts );
+		uint32_t numVerts, uint32_t numFrames = 0 );
 	VBO_t *R_CreateStaticVBO( const char *name, vboData_t data, vboLayout_t layout );
 	VBO_t *R_CreateStaticVBO2( const char *name, int numVertexes, shaderVertex_t *verts, uint32_t stateBits );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -662,15 +662,6 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	{
 		VBO_LAYOUT_CUSTOM,
 		VBO_LAYOUT_STATIC,
-		VBO_LAYOUT_XYST
-	};
-
-	struct vboData_t
-	{
-		vec3_t *xyz;
-		vec2_t *stf;
-
-		int     numVerts;
 	};
 
 	enum
@@ -3491,7 +3482,6 @@ inline bool checkGLErrors()
 	VBO_t *R_CreateStaticVBO(
 		Str::StringRef name, const vertexAttributeSpec_t *attrBegin, const vertexAttributeSpec_t *attrEnd,
 		uint32_t numVerts, uint32_t numFrames = 0 );
-	VBO_t *R_CreateStaticVBO( const char *name, vboData_t data, vboLayout_t layout );
 	VBO_t *R_CreateStaticVBO2( const char *name, int numVertexes, shaderVertex_t *verts, uint32_t stateBits );
 
 	IBO_t *R_CreateStaticIBO( const char *name, glIndex_t *indexes, int numIndexes );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3179,7 +3179,9 @@ inline bool checkGLErrors()
 		vec3_t    xyz;
 		Color::Color32Bit color;
 		i16vec4_t qtangents;
-		f16vec4_t texCoords;
+
+		// the lightmap coords (index 2-3) may be used in some weird cases like an autosprite map surface
+		vec4_t texCoords;
 	};
 
 #ifdef GL_ARB_sync

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1727,8 +1727,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		int           numVerts;
 		srfVert_t     *verts;
 
-		// BSP VBO offsets
-		int firstVert;
+		// BSP VBO offset
 		int firstTriangle;
 
 		// static render data
@@ -1747,8 +1746,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		int           numVerts;
 		srfVert_t     *verts;
 
-		// BSP VBO offsets
-		int firstVert;
+		// BSP VBO offset
 		int firstTriangle;
 
 		// static render data
@@ -1766,8 +1764,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		int           numVerts;
 		srfVert_t     *verts;
 
-		// BSP VBO offsets
-		int firstVert;
+		// BSP VBO offset
 		int firstTriangle;
 
 		// static render data
@@ -1923,13 +1920,8 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		int           numSkyNodes;
 		bspNode_t     **skyNodes; // ydnar: don't walk the entire bsp when rendering sky
 
-		int           numVerts;
-		srfVert_t     *verts;
 		VBO_t         *vbo;
 		IBO_t         *ibo;
-
-		int           numTriangles;
-		srfTriangle_t *triangles;
 
 		int                numSurfaces;
 		bspSurface_t       *surfaces;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -607,7 +607,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	enum
 	{
 		ATTR_INDEX_POSITION = 0,
-		ATTR_INDEX_TEXCOORD,
+		ATTR_INDEX_TEXCOORD, // TODO split into 2-element texcoords and 4-element tex + lm coords
 		ATTR_INDEX_QTANGENT,
 		ATTR_INDEX_COLOR,
 
@@ -1685,8 +1685,11 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	struct srfVert_t
 	{
 		vec3_t xyz;
+
+		// HACK: st and lightmap must be adjacent for R_CreateWorldVBO
 		vec2_t st;
 		vec2_t lightmap;
+
 		vec3_t normal;
 		i16vec4_t qtangent;
 		Color::Color32Bit lightColor;
@@ -1730,7 +1733,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		srfVert_t     *verts;
 
 		// BSP VBO offset
-		int firstTriangle;
+		int firstIndex;
 
 		// static render data
 		VBO_t *vbo; // points to bsp model VBO
@@ -1749,7 +1752,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		srfVert_t     *verts;
 
 		// BSP VBO offset
-		int firstTriangle;
+		int firstIndex;
 
 		// static render data
 		VBO_t *vbo; // points to bsp model VBO
@@ -1767,7 +1770,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		srfVert_t     *verts;
 
 		// BSP VBO offset
-		int firstTriangle;
+		int firstIndex;
 
 		// static render data
 		VBO_t *vbo; // points to bsp model VBO
@@ -3243,9 +3246,6 @@ inline bool checkGLErrors()
 		// enabled when an MD3 VBO is used
 		bool    vboVertexAnimation;
 
-		// during BSP load
-		bool    buildingVBO;
-
 		// This can be thought of a "flush" function for the vertex buffer.
 		// Which function depends on backend mode and also the shader.
 		void ( *stageIteratorFunc )();
@@ -3482,7 +3482,6 @@ inline bool checkGLErrors()
 	VBO_t *R_CreateStaticVBO(
 		Str::StringRef name, const vertexAttributeSpec_t *attrBegin, const vertexAttributeSpec_t *attrEnd,
 		uint32_t numVerts, uint32_t numFrames = 0 );
-	VBO_t *R_CreateStaticVBO2( const char *name, int numVertexes, shaderVertex_t *verts, uint32_t stateBits );
 
 	IBO_t *R_CreateStaticIBO( const char *name, glIndex_t *indexes, int numIndexes );
 	IBO_t *R_CreateStaticIBO2( const char *name, int numTriangles, glIndex_t *indexes );

--- a/src/engine/renderer/tr_model_iqm.cpp
+++ b/src/engine/renderer/tr_model_iqm.cpp
@@ -481,7 +481,7 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 	size += header->num_vertexes * 3 * sizeof(float);	// normals
 	size += header->num_vertexes * 3 * sizeof(float);	// tangents
 	size += header->num_vertexes * 3 * sizeof(float);	// bitangents
-	size += header->num_vertexes * 2 * sizeof(f16_t);	// texcoords
+	size += header->num_vertexes * 2 * sizeof(float);	// texcoords
 	size += header->num_vertexes * 4 * sizeof(byte);	// blendIndexes
 	size += header->num_vertexes * 4 * sizeof(byte);	// blendWeights
 	size += header->num_vertexes * 4 * sizeof(byte);	// colors
@@ -541,7 +541,7 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 	IQModel->bitangents = (float *)ptr;
 	ptr = IQModel->bitangents + 3 * header->num_vertexes;
 
-	IQModel->texcoords = (f16_t *)ptr;
+	IQModel->texcoords = (float *)ptr;
 	ptr = IQModel->texcoords + 2 * header->num_vertexes;
 
 	IQModel->blendIndexes = (byte *)ptr;
@@ -725,7 +725,7 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 			break;
 		case IQM_TEXCOORD:
 			for( int j = 0; j < n; j++ ) {
-				IQModel->texcoords[ j ] = floatToHalf( ((float *)IQMPtr( header, vertexarray->offset ))[ j ] );
+				IQModel->texcoords[ j ] = ((float *)IQMPtr( header, vertexarray->offset ))[ j ];
 			}
 			break;
 		case IQM_BLENDINDEXES:
@@ -793,7 +793,7 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 			{ ATTR_INDEX_BONE_FACTORS, GL_UNSIGNED_SHORT, GL_UNSIGNED_SHORT, boneFactorBuf, 4, sizeof( u16vec4_t ), 0 },
 			{ ATTR_INDEX_POSITION, GL_FLOAT, GL_SHORT, IQModel->positions, 3, sizeof( float[ 3 ] ), ATTR_OPTION_NORMALIZE },
 			{ ATTR_INDEX_QTANGENT, GL_SHORT, GL_SHORT, qtangentbuf, 4, sizeof( i16vec4_t ), ATTR_OPTION_NORMALIZE, },
-			{ ATTR_INDEX_TEXCOORD, GL_HALF_FLOAT, GL_HALF_FLOAT, IQModel->texcoords, 2, sizeof( f16_t[ 2 ] ), 0 },
+			{ ATTR_INDEX_TEXCOORD, GL_FLOAT, GL_HALF_FLOAT, IQModel->texcoords, 2, sizeof( float[ 2 ] ), 0 },
 			{ ATTR_INDEX_COLOR, GL_UNSIGNED_BYTE, GL_UNSIGNED_BYTE, IQModel->colors, 4, sizeof( u8vec4_t ), ATTR_OPTION_NORMALIZE },
 		};
 

--- a/src/engine/renderer/tr_model_md3.cpp
+++ b/src/engine/renderer/tr_model_md3.cpp
@@ -254,27 +254,12 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 		for ( i = 0, surf = mdvModel->surfaces; i < mdvModel->numSurfaces; i++, surf++ )
 		{
 			//allocate temp memory for vertex data
-			vboData_t data{};
-			data.xyz = ( vec3_t * ) ri.Hunk_AllocateTempMemory( sizeof( *data.xyz ) * mdvModel->numFrames * surf->numVerts );
-			data.qtangent = ( i16vec4_t * ) ri.Hunk_AllocateTempMemory( sizeof( i16vec4_t ) * mdvModel->numFrames * surf->numVerts );
-			data.numFrames = mdvModel->numFrames;
-			data.st = ( f16vec2_t * ) ri.Hunk_AllocateTempMemory( sizeof( f16vec2_t ) * surf->numVerts );
-			data.numVerts = surf->numVerts;
+			vec3_t *scaledPosition = (vec3_t *)ri.Hunk_AllocateTempMemory( sizeof( vec3_t ) * mdvModel->numFrames * surf->numVerts );
+			i16vec4_t *qtangents = (i16vec4_t *)ri.Hunk_AllocateTempMemory( sizeof( i16vec4_t ) * mdvModel->numFrames * surf->numVerts );
 
-			// feed vertex XYZ
-			for ( f = 0; f < mdvModel->numFrames; f++ )
+			for ( int r = 0; r < surf->numVerts; r++ )
 			{
-				for ( j = 0; j < surf->numVerts; j++ )
-				{
-					VectorCopy( surf->verts[ f * surf->numVerts + j ].xyz, data.xyz[ f * surf->numVerts + j ] );
-				}
-			}
-
-			// feed vertex texcoords
-			for ( j = 0; j < surf->numVerts; j++ )
-			{
-				data.st[ j ][ 0 ] = floatToHalf( surf->st[ j ].st[ 0 ] );
-				data.st[ j ][ 1 ] = floatToHalf( surf->st[ j ].st[ 1 ] );
+				VectorScale( surf->verts[ r ].xyz, 1.0f / 512.0f, scaledPosition[ r ] );
 			}
 
 			// calc and feed tangent spaces
@@ -323,9 +308,10 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 					{
 						VectorNormalize( tangents[ j ] );
 						VectorNormalize( binormals[ j ] );
-						R_TBNtoQtangents( tangents[ j ], binormals[ j ],
-								  surf->normals[ f * surf->numVerts + j ].normal,
-								  data.qtangent[ f * surf->numVerts + j ] );
+						R_TBNtoQtangents(
+							tangents[ j ], binormals[ j ],
+							surf->normals[ f * surf->numVerts + j ].normal,
+							qtangents[ f * surf->numVerts + j ] );
 					}
 				}
 
@@ -344,16 +330,28 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 			vboSurf->numIndexes = surf->numTriangles * 3;
 			vboSurf->numVerts = surf->numVerts;
 
-			std::string name = Str::Format( "%s '%s'", modName , surf->name );
-			vboSurf->vbo = R_CreateStaticVBO( ( "MD3 surface VBO " + name ).c_str(), data, vboLayout_t::VBO_LAYOUT_VERTEX_ANIMATION );
+			// MD3 does not have color, but shaders always require the color vertex attribute, so we have
+			// to provide this 0 color.
+			const byte dummyColor[ 4 ]{};
 
-			// MD3 does not have color, but shaders always request it and the "vertex animation"
-			// vertex layout includes a color field, which is zeroed by default.
-			vboSurf->vbo->attribBits |= ATTR_COLOR;
+			vertexAttributeSpec_t attributes[] {
+				{ ATTR_INDEX_TEXCOORD, GL_FLOAT, GL_HALF_FLOAT, surf->st, 2, sizeof(mdvSt_t), 0 },
+				{ ATTR_INDEX_COLOR, GL_UNSIGNED_BYTE, GL_UNSIGNED_BYTE, dummyColor, 4, 0, ATTR_OPTION_NORMALIZE },
+				{ ATTR_INDEX_QTANGENT, GL_SHORT, GL_SHORT, qtangents, 4, sizeof(i16vec4_t), ATTR_OPTION_NORMALIZE | ATTR_OPTION_HAS_FRAMES },
+				{ ATTR_INDEX_POSITION, GL_FLOAT, GL_SHORT, scaledPosition, 3, sizeof(vec3_t), ATTR_OPTION_NORMALIZE | ATTR_OPTION_HAS_FRAMES },
+			};
+			std::string name = Str::Format( "%s '%s'", modName , surf->name );
+			vboSurf->vbo = R_CreateStaticVBO( "MD3 surface VBO " + name,
+			                                  std::begin( attributes ), std::end( attributes ),
+			                                  surf->numVerts, mdvModel->numFrames );
+
+			// HACK: the shader binding system needs duplicate definitions of some vertex attributes
+			vboSurf->vbo->attribBits |= ATTR_POSITION2 | ATTR_QTANGENT2;
+			vboSurf->vbo->attribs[ ATTR_INDEX_POSITION2 ] = vboSurf->vbo->attribs[ ATTR_INDEX_POSITION ];
+			vboSurf->vbo->attribs[ ATTR_INDEX_QTANGENT2 ] = vboSurf->vbo->attribs[ ATTR_INDEX_QTANGENT ];
 			
-			ri.Hunk_FreeTempMemory( data.st );
-			ri.Hunk_FreeTempMemory( data.qtangent );
-			ri.Hunk_FreeTempMemory( data.xyz );
+			ri.Hunk_FreeTempMemory( qtangents );
+			ri.Hunk_FreeTempMemory( scaledPosition );
 
 			indexes = (glIndex_t *)ri.Hunk_AllocateTempMemory( 3 * surf->numTriangles * sizeof( glIndex_t ) );
 			for ( f = j = 0; j < surf->numTriangles; j++ ) {

--- a/src/engine/renderer/tr_model_md5.cpp
+++ b/src/engine/renderer/tr_model_md5.cpp
@@ -380,7 +380,7 @@ bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 			{
 				token = COM_ParseExt2( &buf_p, false );
 				texCoords[ j ][ k ] = atof( token );
-				v->texCoords[ k ] = floatToHalf( texCoords[ j ][ k ] );
+				v->texCoords[ k ] = texCoords[ j ][ k ];
 			}
 
 			// skip )

--- a/src/engine/renderer/tr_model_skel.cpp
+++ b/src/engine/renderer/tr_model_skel.cpp
@@ -182,7 +182,7 @@ srfVBOMD5Mesh_t *R_GenerateMD5VBOSurface(
 		{ ATTR_INDEX_BONE_FACTORS, GL_UNSIGNED_SHORT, GL_UNSIGNED_SHORT, boneFactors, 4, sizeof(u16vec4_t), 0 },
 		{ ATTR_INDEX_POSITION, GL_FLOAT, GL_SHORT, &surf->verts[ 0 ].position, 3, sizeof(md5Vertex_t), ATTR_OPTION_NORMALIZE },
 		{ ATTR_INDEX_QTANGENT, GL_SHORT, GL_SHORT, qtangents, 4, sizeof(i16vec4_t), ATTR_OPTION_NORMALIZE },
-		{ ATTR_INDEX_TEXCOORD, GL_HALF_FLOAT, GL_HALF_FLOAT, &surf->verts[ 0 ].texCoords, 2, sizeof(md5Vertex_t), 0 },
+		{ ATTR_INDEX_TEXCOORD, GL_FLOAT, GL_HALF_FLOAT, &surf->verts[ 0 ].texCoords, 2, sizeof(md5Vertex_t), 0 },
 		{ ATTR_INDEX_COLOR, GL_UNSIGNED_BYTE, GL_UNSIGNED_BYTE, dummyColor, 4, 0, ATTR_OPTION_NORMALIZE },
 	};
 

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -128,6 +128,7 @@ struct glconfig2_t
 	bool mapBufferRangeAvailable;
 	bool syncAvailable;
 	bool depthClampAvailable;
+	bool halfFloatVertexAvailable;
 
 	bool realtimeLighting;
 	bool shadowMapping;

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -93,12 +93,6 @@ void Tess_CheckOverflow( int verts, int indexes )
 		Tess_CheckVBOAndIBO( tess.vbo, tess.ibo );
 	}
 
-	if ( tess.buildingVBO )
-	{
-		// During loading, tess.verts is assumed to have been allocated with exactly the right size.
-		return;
-	}
-
 	if ( tess.numVertexes + verts < SHADER_MAX_VERTEXES && tess.numIndexes + indexes < SHADER_MAX_INDEXES )
 	{
 		return;
@@ -754,7 +748,7 @@ static void Tess_SurfaceFace( srfSurfaceFace_t *srf )
 {
 	GLimp_LogComment( "--- Tess_SurfaceFace ---\n" );
 
-	if ( !r_vboFaces->integer || !Tess_SurfaceVBO( srf->vbo, srf->ibo, srf->numTriangles * 3, srf->firstTriangle * 3 ) )
+	if ( !r_vboFaces->integer || !Tess_SurfaceVBO( srf->vbo, srf->ibo, srf->numTriangles * 3, srf->firstIndex ) )
 	{
 		Tess_SurfaceVertsAndTris( srf->verts, srf->triangles, srf->numVerts, srf->numTriangles );
 	}
@@ -769,7 +763,7 @@ static void Tess_SurfaceGrid( srfGridMesh_t *srf )
 {
 	GLimp_LogComment( "--- Tess_SurfaceGrid ---\n" );
 
-	if ( !r_vboCurves->integer || !Tess_SurfaceVBO( srf->vbo, srf->ibo, srf->numTriangles * 3, srf->firstTriangle * 3 ) )
+	if ( !r_vboCurves->integer || !Tess_SurfaceVBO( srf->vbo, srf->ibo, srf->numTriangles * 3, srf->firstIndex ) )
 	{
 		Tess_SurfaceVertsAndTris( srf->verts, srf->triangles, srf->numVerts, srf->numTriangles );
 	}
@@ -784,7 +778,7 @@ static void Tess_SurfaceTriangles( srfTriangles_t *srf )
 {
 	GLimp_LogComment( "--- Tess_SurfaceTriangles ---\n" );
 
-	if ( !r_vboTriangles->integer || !Tess_SurfaceVBO( srf->vbo, srf->ibo, srf->numTriangles * 3, srf->firstTriangle * 3 ) )
+	if ( !r_vboTriangles->integer || !Tess_SurfaceVBO( srf->vbo, srf->ibo, srf->numTriangles * 3, srf->firstIndex ) )
 	{
 		Tess_SurfaceVertsAndTris( srf->verts, srf->triangles, srf->numVerts, srf->numTriangles );
 	}

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -153,11 +153,11 @@ static void Tess_SurfaceVertsAndTris( const srfVert_t *verts, const srfTriangle_
 		VectorCopy( vert->xyz, tess.verts[ tess.numVertexes + i ].xyz );
 		Vector4Copy( vert->qtangent, tess.verts[ tess.numVertexes + i ].qtangents );
 
-		tess.verts[ tess.numVertexes + i ].texCoords[ 0 ] = floatToHalf( vert->st[ 0 ] );
-		tess.verts[ tess.numVertexes + i ].texCoords[ 1 ] = floatToHalf( vert->st[ 1 ] );
+		tess.verts[ tess.numVertexes + i ].texCoords[ 0 ] = vert->st[ 0 ];
+		tess.verts[ tess.numVertexes + i ].texCoords[ 1 ] = vert->st[ 1 ];
 
-		tess.verts[ tess.numVertexes + i ].texCoords[ 2 ] = floatToHalf( vert->lightmap[ 0 ] );
-		tess.verts[ tess.numVertexes + i ].texCoords[ 3 ] = floatToHalf( vert->lightmap[ 1 ] );
+		tess.verts[ tess.numVertexes + i ].texCoords[ 2 ] = vert->lightmap[ 0 ];
+		tess.verts[ tess.numVertexes + i ].texCoords[ 3 ] = vert->lightmap[ 1 ];
 
 		tess.verts[ tess.numVertexes + i ].color = vert->lightColor;
 	}
@@ -274,17 +274,17 @@ void Tess_AddQuadStampExt( vec3_t origin, vec3_t left, vec3_t up, const Color::C
 	Vector4Copy( qtangents, tess.verts[ ndx + 3 ].qtangents );
 
 	// standard square texture coordinates
-	tess.verts[ ndx ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ ndx ].texCoords[ 1 ] = floatToHalf( t1 );
+	tess.verts[ ndx ].texCoords[ 0 ] = s1;
+	tess.verts[ ndx ].texCoords[ 1 ] = t1;
 
-	tess.verts[ ndx + 1 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ ndx + 1 ].texCoords[ 1 ] = floatToHalf( t1 );
+	tess.verts[ ndx + 1 ].texCoords[ 0 ] = s2;
+	tess.verts[ ndx + 1 ].texCoords[ 1 ] = t1;
 
-	tess.verts[ ndx + 2 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ ndx + 2 ].texCoords[ 1 ] = floatToHalf( t2 );
+	tess.verts[ ndx + 2 ].texCoords[ 0 ] = s2;
+	tess.verts[ ndx + 2 ].texCoords[ 1 ] = t2;
 
-	tess.verts[ ndx + 3 ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ ndx + 3 ].texCoords[ 1 ] = floatToHalf( t2 );
+	tess.verts[ ndx + 3 ].texCoords[ 0 ] = s1;
+	tess.verts[ ndx + 3 ].texCoords[ 1 ] = t2;
 
 	// constant color all the way around
 	// should this be identity and let the shader specify from entity?
@@ -364,17 +364,17 @@ void Tess_AddQuadStampExt2( vec4_t quadVerts[ 4 ], const Color::Color& color, fl
 	Vector4Copy( qtangents, tess.verts[ ndx + 3 ].qtangents );
 
 	// standard square texture coordinates
-	tess.verts[ ndx ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ ndx ].texCoords[ 1 ] = floatToHalf( t1 );
+	tess.verts[ ndx ].texCoords[ 0 ] = s1;
+	tess.verts[ ndx ].texCoords[ 1 ] = t1;
 
-	tess.verts[ ndx + 1 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ ndx + 1 ].texCoords[ 1 ] = floatToHalf( t1 );
+	tess.verts[ ndx + 1 ].texCoords[ 0 ] = s2;
+	tess.verts[ ndx + 1 ].texCoords[ 1 ] = t1;
 
-	tess.verts[ ndx + 2 ].texCoords[ 0 ] = floatToHalf( s2 );
-	tess.verts[ ndx + 2 ].texCoords[ 1 ] = floatToHalf( t2 );
+	tess.verts[ ndx + 2 ].texCoords[ 0 ] = s2;
+	tess.verts[ ndx + 2 ].texCoords[ 1 ] = t2;
 
-	tess.verts[ ndx + 3 ].texCoords[ 0 ] = floatToHalf( s1 );
-	tess.verts[ ndx + 3 ].texCoords[ 1 ] = floatToHalf( t2 );
+	tess.verts[ ndx + 3 ].texCoords[ 0 ] = s1;
+	tess.verts[ ndx + 3 ].texCoords[ 1 ] = t2;
 
 	// constant color all the way around
 	// should this be identity and let the shader specify from entity?
@@ -657,8 +657,8 @@ static void Tess_SurfacePolychain( srfPoly_t *p )
 			VectorCopy(p->verts[i].xyz, tess.verts[tess.numVertexes + i].xyz);
 
 			tess.verts[tess.numVertexes + i].color = Color::Adapt(p->verts[i].modulate);
-			tess.verts[tess.numVertexes + i].texCoords[0] = floatToHalf(p->verts[i].st[0]);
-			tess.verts[tess.numVertexes + i].texCoords[1] = floatToHalf(p->verts[i].st[1]);
+			tess.verts[tess.numVertexes + i].texCoords[0] = p->verts[i].st[0];
+			tess.verts[tess.numVertexes + i].texCoords[1] = p->verts[i].st[1];
 		}
 
 		// generate fan indexes into the tess array
@@ -726,8 +726,8 @@ static void Tess_SurfacePolychain( srfPoly_t *p )
 			VectorCopy(p->verts[i].xyz, tess.verts[tess.numVertexes + i].xyz);
 			tess.verts[tess.numVertexes + i].color = Color::Adapt(p->verts[i].modulate);
 			Vector4Copy(qtangents, tess.verts[tess.numVertexes + i].qtangents);
-			tess.verts[tess.numVertexes + i].texCoords[0] = floatToHalf(p->verts[i].st[0]);
-			tess.verts[tess.numVertexes + i].texCoords[1] = floatToHalf(p->verts[i].st[1]);
+			tess.verts[tess.numVertexes + i].texCoords[0] = p->verts[i].st[0];
+			tess.verts[tess.numVertexes + i].texCoords[1] = p->verts[i].st[1];
 		}
 
 		ri.Hunk_FreeTempMemory( normals );
@@ -860,8 +860,8 @@ static void Tess_SurfaceMDV( mdvSurface_t *srf )
 			tess.verts[tess.numVertexes + j].xyz[1] = tmpVert[1];
 			tess.verts[tess.numVertexes + j].xyz[2] = tmpVert[2];
 
-			tess.verts[tess.numVertexes + j].texCoords[0] = floatToHalf(st->st[0]);
-			tess.verts[tess.numVertexes + j].texCoords[1] = floatToHalf(st->st[1]);
+			tess.verts[tess.numVertexes + j].texCoords[0] = st->st[0];
+			tess.verts[tess.numVertexes + j].texCoords[1] = st->st[1];
 		}
 	}
 	else
@@ -944,8 +944,8 @@ static void Tess_SurfaceMDV( mdvSurface_t *srf )
 
 			VectorCopy(xyz[i], tess.verts[tess.numVertexes + i].xyz);
 			Vector4Copy(qtangents, tess.verts[tess.numVertexes + i].qtangents);
-			tess.verts[tess.numVertexes + i].texCoords[0] = floatToHalf(st[i].st[0]);
-			tess.verts[tess.numVertexes + i].texCoords[1] = floatToHalf(st[i].st[1]);
+			tess.verts[tess.numVertexes + i].texCoords[0] = st[i].st[0];
+			tess.verts[tess.numVertexes + i].texCoords[1] = st[i].st[1];
 		}
 
 		ri.Hunk_FreeTempMemory( normals );
@@ -1055,7 +1055,9 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 
 			VectorCopy( position, tessVertex->xyz );
 
-			Vector2Copy( surfaceVertex->texCoords, tessVertex->texCoords );
+			// FIXME: don't store data as half float?
+			tessVertex->texCoords[ 0 ] = halfToFloat( surfaceVertex->texCoords[ 0 ] );
+			tessVertex->texCoords[ 1 ] = halfToFloat( surfaceVertex->texCoords[ 1 ] );
 		}
 	}
 	else
@@ -1098,7 +1100,8 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 
 			R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
 
-			Vector2Copy( surfaceVertex->texCoords, tessVertex->texCoords );
+			tessVertex->texCoords[ 0 ] = halfToFloat( surfaceVertex->texCoords[ 0 ] );
+			tessVertex->texCoords[ 1 ] = halfToFloat( surfaceVertex->texCoords[ 1 ] );
 		}
 	}
 
@@ -1255,7 +1258,9 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 				VectorCopy( position, tessVertex->xyz );
 
-				Vector2Copy( modelTexcoord, tessVertex->texCoords );
+				// FIXME: don't store data as half floats?
+				tessVertex->texCoords[ 0 ] = halfToFloat( modelTexcoord[ 0 ] );
+				tessVertex->texCoords[ 1 ] = halfToFloat( modelTexcoord[ 1 ] );
 			}
 		}
 		else
@@ -1303,7 +1308,8 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 				R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
 
-				Vector2Copy( modelTexcoord, tessVertex->texCoords );
+				tessVertex->texCoords[ 0 ] = halfToFloat( modelTexcoord[ 0 ] );
+				tessVertex->texCoords[ 1 ] = halfToFloat( modelTexcoord[ 1 ] );
 			}
 		}
 	}
@@ -1320,7 +1326,8 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 			R_TBNtoQtangents( modelTangent, modelBitangent, modelNormal, tessVertex->qtangents );
 
-			Vector2Copy( modelTexcoord, tessVertex->texCoords );
+			tessVertex->texCoords[ 0 ] = halfToFloat( modelTexcoord[ 0 ] );
+			tessVertex->texCoords[ 1 ] = halfToFloat( modelTexcoord[ 1 ] );
 		}
 	}
 

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1055,9 +1055,7 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 
 			VectorCopy( position, tessVertex->xyz );
 
-			// FIXME: don't store data as half float?
-			tessVertex->texCoords[ 0 ] = halfToFloat( surfaceVertex->texCoords[ 0 ] );
-			tessVertex->texCoords[ 1 ] = halfToFloat( surfaceVertex->texCoords[ 1 ] );
+			Vector2Copy( surfaceVertex->texCoords, tessVertex->texCoords );
 		}
 	}
 	else
@@ -1100,8 +1098,7 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 
 			R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
 
-			tessVertex->texCoords[ 0 ] = halfToFloat( surfaceVertex->texCoords[ 0 ] );
-			tessVertex->texCoords[ 1 ] = halfToFloat( surfaceVertex->texCoords[ 1 ] );
+			Vector2Copy( surfaceVertex->texCoords, tessVertex->texCoords );
 		}
 	}
 
@@ -1218,7 +1215,7 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 	float *modelNormal = model->normals + 3 * firstVertex;
 	float *modelTangent = model->tangents + 3 * firstVertex;
 	float *modelBitangent = model->bitangents + 3 * firstVertex;
-	f16_t *modelTexcoord = model->texcoords + 2 * firstVertex;
+	float *modelTexcoord = model->texcoords + 2 * firstVertex;
 	shaderVertex_t *tessVertex = tess.verts + tess.numVertexes;
 	shaderVertex_t *lastVertex = tessVertex + surf->num_vertexes;
 
@@ -1258,9 +1255,7 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 				VectorCopy( position, tessVertex->xyz );
 
-				// FIXME: don't store data as half floats?
-				tessVertex->texCoords[ 0 ] = halfToFloat( modelTexcoord[ 0 ] );
-				tessVertex->texCoords[ 1 ] = halfToFloat( modelTexcoord[ 1 ] );
+				Vector2Copy( modelTexcoord, tessVertex->texCoords );
 			}
 		}
 		else
@@ -1308,8 +1303,7 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 				R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
 
-				tessVertex->texCoords[ 0 ] = halfToFloat( modelTexcoord[ 0 ] );
-				tessVertex->texCoords[ 1 ] = halfToFloat( modelTexcoord[ 1 ] );
+				Vector2Copy( modelTexcoord, tessVertex->texCoords );
 			}
 		}
 	}
@@ -1326,8 +1320,7 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 
 			R_TBNtoQtangents( modelTangent, modelBitangent, modelNormal, tessVertex->qtangents );
 
-			tessVertex->texCoords[ 0 ] = halfToFloat( modelTexcoord[ 0 ] );
-			tessVertex->texCoords[ 1 ] = halfToFloat( modelTexcoord[ 1 ] );
+			Vector2Copy( modelTexcoord, tessVertex->texCoords );
 		}
 	}
 

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -51,7 +51,7 @@ static void R_SetAttributeLayoutsStatic( VBO_t *vbo )
 	vbo->attribs[ ATTR_INDEX_QTANGENT ].frameOffset   = 0;
 
 	vbo->attribs[ ATTR_INDEX_TEXCOORD ].numComponents = 4;
-	vbo->attribs[ ATTR_INDEX_TEXCOORD ].componentType = GL_HALF_FLOAT;
+	vbo->attribs[ ATTR_INDEX_TEXCOORD ].componentType = GL_FLOAT;
 	vbo->attribs[ ATTR_INDEX_TEXCOORD ].normalize     = GL_FALSE;
 	vbo->attribs[ ATTR_INDEX_TEXCOORD ].ofs           = offsetof( shaderVertex_t, texCoords );
 	vbo->attribs[ ATTR_INDEX_TEXCOORD ].stride        = sizeShaderVertex;

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -697,23 +697,28 @@ static void R_InitGenericVBOs() {
 	surface->numVerts = 4;
 	surface->numIndexes = 6;
 	surface->firstIndex = 0;
-	vec3_t v0 = { min[0], min[1], min[2] };
-	vec3_t v1 = { min[0], max[1], min[2] };
-	vec3_t v2 = { max[0], max[1], min[2] };
-	vec3_t v3 = { max[0], min[1], min[2] };
 
-	shaderVertex_t verts[4];
-	VectorCopy( v0, verts[0].xyz );
-	VectorCopy( v1, verts[1].xyz );
-	VectorCopy( v2, verts[2].xyz );
-	VectorCopy( v3, verts[3].xyz );
-	
+	vec3_t verts[ 4 ] = {
+		{ min[0], min[1], min[2] },
+		{ min[0], max[1], min[2] },
+		{ max[0], max[1], min[2] },
+		{ max[0], min[1], min[2] },
+	};
+
+	vec2_t texCoords[ 4 ];
 	for ( int i = 0; i < 4; i++ ) {
-		verts[i].color = Color::White;
-		verts[i].texCoords[0] = floatToHalf( i < 2 ? 0.0f : 1.0f );
-		verts[i].texCoords[1] = floatToHalf( i > 0 && i < 3 ? 1.0f : 0.0f );
+		texCoords[ i ][ 0 ] = i < 2 ? 0.0f : 1.0f;
+		texCoords[ i ][ 1 ] = i > 0 && i < 3 ? 1.0f : 0.0f;
 	}
-	surface->vbo = R_CreateStaticVBO2( "generic_VBO", surface->numVerts, verts, ATTR_POSITION | ATTR_TEXCOORD | ATTR_COLOR );
+
+	Color::Color32Bit color = Color::White;
+
+	vertexAttributeSpec_t attrs[] = {
+		{ ATTR_INDEX_POSITION, GL_FLOAT, GL_FLOAT, verts, 3, sizeof( vec3_t ), 0 },
+		{ ATTR_INDEX_COLOR, GL_UNSIGNED_BYTE, GL_UNSIGNED_BYTE, color.ToArray(), 4, 0, ATTR_OPTION_NORMALIZE },
+		{ ATTR_INDEX_TEXCOORD, GL_FLOAT, GL_HALF_FLOAT, texCoords, 2, sizeof( vec2_t ), 0 },
+	};
+	surface->vbo = R_CreateStaticVBO( "generic_VBO", std::begin( attrs ), std::end( attrs ), surface->numVerts );
 
 	glIndex_t indexes[6] = { 0, 2, 1,  0, 3, 2 }; // Front
 

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -396,59 +396,6 @@ VBO_t *R_CreateStaticVBO(
 
 /*
 ============
-R_CreateVBO2
-============
-*/
-VBO_t *R_CreateStaticVBO2( const char *name, int numVertexes, shaderVertex_t *verts, unsigned int stateBits )
-{
-	VBO_t  *vbo;
-
-	if ( !numVertexes )
-	{
-		return nullptr;
-	}
-
-	// make sure the render thread is stopped
-	R_SyncRenderThread();
-
-	vbo = ( VBO_t * ) ri.Hunk_Alloc( sizeof( *vbo ), ha_pref::h_low );
-	*vbo = {};
-
-	tr.vbos.push_back( vbo );
-
-	Q_strncpyz( vbo->name, name, sizeof( vbo->name ) );
-
-	vbo->layout = vboLayout_t::VBO_LAYOUT_STATIC;
-	vbo->framesNum = 0;
-	vbo->vertexesNum = numVertexes;
-	vbo->attribBits = stateBits;
-	vbo->usage = GL_STATIC_DRAW;
-
-	R_SetVBOAttributeLayouts( vbo );
-	
-	glGenBuffers( 1, &vbo->vertexesVBO );
-	R_BindVBO( vbo );
-
-#ifdef GL_ARB_buffer_storage
-	if( glConfig2.bufferStorageAvailable ) {
-		glBufferStorage( GL_ARRAY_BUFFER, vbo->vertexesSize,
-				 verts, 0 );
-	} else
-#endif
-	{
-		glBufferData( GL_ARRAY_BUFFER, vbo->vertexesSize,
-			      verts, vbo->usage );
-	}
-
-	R_BindNullVBO();
-	GL_CheckErrors();
-
-	return vbo;
-}
-
-
-/*
-============
 R_CreateIBO
 ============
 */

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2212,8 +2212,6 @@ static void GLimp_InitExtensions()
 
 	// VAO and VBO
 	// made required in OpenGL 3.0
-	LOAD_EXTENSION( ExtFlag_REQUIRED | ExtFlag_CORE, ARB_half_float_vertex );
-	// WIP: engine is not yet usable without this
 	glConfig2.halfFloatVertexAvailable = LOAD_EXTENSION_WITH_TEST(
 		ExtFlag_CORE, ARB_half_float_vertex, r_arb_half_float_vertex.Get() );
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -80,6 +80,8 @@ static Cvar::Cvar<bool> r_arb_gpu_shader5( "r_arb_gpu_shader5",
 	"Use GL_ARB_gpu_shader5 if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_half_float_pixel( "r_arb_half_float_pixel",
 	"Use GL_ARB_half_float_pixel if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_half_float_vertex( "r_arb_half_float_vertex",
+	"Use GL_ARB_half_float_vertex if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_indirect_parameters( "r_arb_indirect_parameters",
 	"Use GL_ARB_indirect_parameters if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_internalformat_query2( "r_arb_internalformat_query2",
@@ -1972,6 +1974,7 @@ static void GLimp_InitExtensions()
 	Cvar::Latch( r_arb_framebuffer_object );
 	Cvar::Latch( r_arb_gpu_shader5 );
 	Cvar::Latch( r_arb_half_float_pixel );
+	Cvar::Latch( r_arb_half_float_vertex );
 	Cvar::Latch( r_arb_indirect_parameters );
 	Cvar::Latch( r_arb_internalformat_query2 );
 	Cvar::Latch( r_arb_map_buffer_range );
@@ -2210,6 +2213,9 @@ static void GLimp_InitExtensions()
 	// VAO and VBO
 	// made required in OpenGL 3.0
 	LOAD_EXTENSION( ExtFlag_REQUIRED | ExtFlag_CORE, ARB_half_float_vertex );
+	// WIP: engine is not yet usable without this
+	glConfig2.halfFloatVertexAvailable = LOAD_EXTENSION_WITH_TEST(
+		ExtFlag_CORE, ARB_half_float_vertex, r_arb_half_float_vertex.Get() );
 
 	if ( !workaround_glExtension_missingArbFbo_useExtFbo.Get() )
 	{


### PR DESCRIPTION
Choose vertex attribute layouts at runtime. For attributes designated as wanting half float, use half float if GL_ARB_half_float_vertex is available or full-sized float otherwise,  #1179 explains the situation in detail.

TODO: grab the commit adding a *workaround* for the cards that support the half float vertex extension, but with poor quality of implementation.

The first 4 commits are from #1341.