### PR TITLE
Report more texture size and handle case when there is no 3D texture support

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -792,7 +792,7 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_glowMapping", 1 );
 	}
 
-	if ( r_colorGrading.Get() )
+	if ( glConfig2.colorGrading )
 	{
 		AddDefine( str, "r_colorGrading", 1 );
 	}

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3364,7 +3364,7 @@ void RB_CameraPostFX()
 		GL_BindToTMU( 0, tr.currentRenderImage[backEnd.currentMainFBO] ) 
 	);
 
-	if ( r_colorGrading.Get() )
+	if ( glConfig2.colorGrading )
 	{
 		gl_cameraEffectsShader->SetUniform_ColorMap3DBindless( GL_BindToTMU( 3, tr.colorGradeImage ) );
 	}

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -3969,6 +3969,20 @@ R_LoadLightGrid
 */
 void R_LoadLightGrid( lump_t *l )
 {
+	if ( glConfig2.max3DTextureSize == 0 )
+	{
+		Log::Warn( "Grid lighting disabled because of missing 3D texture support." );
+
+		if ( glConfig2.deluxeMapping )
+		{
+			Log::Warn( "Grid deluxe mapping disabled because of missing 3D texture support." );
+		}
+
+		tr.lightGrid1Image = nullptr;
+		tr.lightGrid2Image = nullptr;
+		return;
+	}
+
 	int            i, j, k;
 	vec3_t         maxs;
 	world_t        *w;
@@ -5036,15 +5050,13 @@ void RE_LoadWorldMap( const char *name )
 	//R_BuildCubeMaps();
 
 	tr.worldLight = tr.lightMode;
+	tr.modelLight = lightMode_t::FULLBRIGHT;
 	tr.modelDeluxe = deluxeMode_t::NONE;
 	tr.mapLightFactor = 1.0f;
 	tr.mapInverseLightFactor = 1.0f;
 
-	if ( tr.worldLight == lightMode_t::FULLBRIGHT )
-	{
-		tr.modelLight = lightMode_t::FULLBRIGHT;
-	}
-	else
+	// Use fullbright lighting for everything if the world is fullbright.
+	if ( tr.worldLight != lightMode_t::FULLBRIGHT )
 	{
 		if ( tr.worldLight == lightMode_t::MAP )
 		{
@@ -5058,6 +5070,14 @@ void RE_LoadWorldMap( const char *name )
 				to match the color of the nearby lightmaps. We better not want to use
 				the grid light as a fallback as it would be close but not close enough. */
 
+				tr.worldLight = lightMode_t::VERTEX;
+			}
+		}
+		else if ( tr.worldLight == lightMode_t::GRID )
+		{
+			if ( !tr.lightGrid1Image )
+			{
+				// Use vertex light on world surface if light color grid is missing.
 				tr.worldLight = lightMode_t::VERTEX;
 			}
 		}
@@ -5086,19 +5106,10 @@ void RE_LoadWorldMap( const char *name )
 		algorithm for emulating the deluxe map from light direction grid.
 		See https://github.com/DaemonEngine/Daemon/issues/32 */
 
-		// Game model surfaces use grid lighting, they don't have vertex light colors.
-		tr.modelLight = lightMode_t::GRID;
-
-		if ( !tr.lightGrid1Image )
+		if ( tr.lightGrid1Image )
 		{
-			// Use fullbright light on game models if light color grid is missing.
-			tr.modelLight = lightMode_t::FULLBRIGHT;
-
-			if ( tr.worldLight == lightMode_t::GRID )
-			{
-				// Use vertex light on world surface if light color grid is missing.
-				tr.worldLight = lightMode_t::VERTEX;
-			}
+			// Game model surfaces use grid lighting, they don't have vertex light colors.
+			tr.modelLight = lightMode_t::GRID;
 		}
 
 		if ( glConfig2.deluxeMapping )

--- a/src/engine/renderer/tr_cmds.cpp
+++ b/src/engine/renderer/tr_cmds.cpp
@@ -408,7 +408,7 @@ void RE_SetColorGrading( int slot, qhandle_t hShader )
 	shader_t *shader = R_GetShaderByHandle( hShader );
 	image_t *image;
 
-	if ( !r_colorGrading.Get() )
+	if ( !glConfig2.colorGrading )
 	{
 		return;
 	}

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2755,7 +2755,7 @@ static void R_CreateWhiteCubeImage()
 
 static void R_CreateColorGradeImage()
 {
-	if ( !r_colorGrading.Get() )
+	if ( !glConfig2.colorGrading )
 	{
 		return;
 	}

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -306,8 +306,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 		if ( glConfig.vidWidth == 0 )
 		{
-			GLint temp;
-
 			if ( !GLimp_Init() )
 			{
 				return false;
@@ -325,19 +323,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 			strcpy( renderer_buffer, glConfig.renderer_string );
 			Q_strlwr( renderer_buffer );
-
-			// OpenGL driver constants
-			glGetIntegerv( GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &temp );
-			glConfig2.maxTextureUnits = temp;
-
-			glGetIntegerv( GL_MAX_TEXTURE_SIZE, &temp );
-			glConfig.maxTextureSize = temp;
-
-			// stubbed or broken drivers may have reported 0...
-			if ( glConfig.maxTextureSize <= 0 )
-			{
-				glConfig.maxTextureSize = 0;
-			}
 
 			// handle any OpenGL/GLSL brokenness here...
 			// nothing at present
@@ -916,7 +901,11 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		Log::Notice("GL_RENDERER: %s", glConfig.renderer_string );
 		Log::Notice("GL_VERSION: %s", glConfig.version_string );
 		Log::Debug("GL_EXTENSIONS: %s", glConfig2.glExtensionsString );
+
 		Log::Notice("GL_MAX_TEXTURE_SIZE: %d", glConfig.maxTextureSize );
+		Log::Notice("GL_MAX_3D_TEXTURE_SIZE: %d", glConfig2.max3DTextureSize );
+		Log::Notice("GL_MAX_CUBE_MAP_TEXTURE_SIZE: %d", glConfig2.maxCubeMapTextureSize );
+		Log::Notice("GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS: %d", glConfig2.maxTextureUnits );
 
 		Log::Notice("GL_SHADING_LANGUAGE_VERSION: %s", glConfig2.shadingLanguageVersionString );
 

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -135,6 +135,7 @@ struct glconfig2_t
 	bool depthClampAvailable;
 	bool halfFloatVertexAvailable;
 
+	bool colorGrading;
 	bool realtimeLighting;
 	bool shadowMapping;
 	shadowingMode_t shadowingMode;

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -70,9 +70,9 @@ struct glconfig2_t
 	std::string glEnabledExtensionsString;
 	std::string glMissingExtensionsString;
 
+	int max3DTextureSize;
+	int maxCubeMapTextureSize;
 	int maxTextureUnits;
-
-	int      maxCubeMapTextureSize;
 
 	char     shadingLanguageVersionString[ MAX_STRING_CHARS ];
 	int      shadingLanguageVersion;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -62,6 +62,17 @@ static void EnableAvailableFeatures()
 		}
 	}
 
+	glConfig2.colorGrading = r_colorGrading.Get();
+
+	if ( glConfig2.colorGrading )
+	{
+		if ( glConfig2.max3DTextureSize == 0 )
+		{
+			Log::Warn( "Color grading disabled because of missing 3D texture support." );
+			glConfig2.colorGrading = false;
+		}
+	}
+
 	glConfig2.shadowingMode = shadowingMode_t( r_shadows.Get() );
 	glConfig2.shadowMapping = glConfig2.shadowingMode >= shadowingMode_t::SHADOWING_ESM16;
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -53,6 +53,12 @@ static void EnableAvailableFeatures()
 				glConfig2.realtimeLighting = false;
 			}
 
+			if ( glConfig2.max3DTextureSize == 0 )
+			{
+				Log::Warn( "Tiled dynamic light renderer disabled because of missing 3D texture support." );
+				glConfig2.realtimeLighting = false;
+			}
+
 			// See below about ALU instructions on ATI R300 and Intel GMA 3.
 			if ( !glConfig2.glCoreProfile && glConfig2.maxAluInstructions < 128 )
 			{

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2047,8 +2047,46 @@ static void GLimp_InitExtensions()
 
 	logger.Notice("...using shading language version %i", glConfig2.shadingLanguageVersion );
 
-	// Texture formats and compression
+
+	// OpenGL driver constants.
+
+	glGetIntegerv( GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS, &glConfig2.maxTextureUnits );
+	glGetIntegerv( GL_MAX_TEXTURE_SIZE, &glConfig.maxTextureSize );
+	glGetIntegerv( GL_MAX_3D_TEXTURE_SIZE, &glConfig2.max3DTextureSize );
 	glGetIntegerv( GL_MAX_CUBE_MAP_TEXTURE_SIZE_ARB, &glConfig2.maxCubeMapTextureSize );
+
+	// Stubbed or broken drivers may report garbage.
+
+	if ( glConfig2.maxTextureUnits < 0 )
+	{
+		Log::Warn( "Bad GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS value: %d", glConfig2.maxTextureUnits );
+		glConfig2.maxTextureUnits = 0;
+	}
+
+	if ( glConfig.maxTextureSize < 0 )
+	{
+		Log::Warn( "Bad GL_MAX_TEXTURE_SIZE value: %d", glConfig.maxTextureSize );
+		glConfig.maxTextureSize = 0;
+	}
+
+	if ( glConfig2.max3DTextureSize < 0 )
+	{
+		Log::Warn( "Bad GL_MAX_3D_TEXTURE_SIZE value: %d", glConfig2.max3DTextureSize );
+		glConfig2.max3DTextureSize = 0;
+	}
+
+	if ( glConfig2.maxCubeMapTextureSize < 0 )
+	{
+		Log::Warn( "Bad GL_MAX_CUBE_MAP_TEXTURE_SIZE_ARB value: %d", glConfig2.maxCubeMapTextureSize );
+		glConfig2.maxCubeMapTextureSize = 0;
+	}
+
+	logger.Notice( "...using up to %d texture size.", glConfig.maxTextureSize );
+	logger.Notice( "...using up to %d 3D texture size.", glConfig2.max3DTextureSize );
+	logger.Notice( "...using up to %d cube map texture size.", glConfig2.maxCubeMapTextureSize );
+	logger.Notice( "...using up to %d texture units.", glConfig2.maxTextureUnits );
+
+	// Texture formats and compression.
 
 	// made required in OpenGL 3.0
 	glConfig2.textureHalfFloatAvailable =  LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_half_float_pixel, r_arb_half_float_pixel.Get() );


### PR DESCRIPTION
3D texture support is not optional in OpenGL _but_ some low-end OpenGL ES devices may lack hardware support for it and Linux systems may still implement OpenGL for them.

Mesa is likely to provide such incomplete OpenGL drivers in a “better than nothing” way, this to unlock out-of-the-box OpenGL compatibility with mainstream OpenGL software that don't use any 3D textures. This includes window managers, media players, visualisation software and some production software not using 3D textures, etc. For example I guess NetRadiant would work out of the box on such incomplete OpenGL driver. 

This can happen with some Arm boards, especially since some Arm platforms may have targeted first Android phones before being integrated in computer boards. A good example of device with no hardware support for 3D texture but Mesa providing an as-much-complete-as-possible OpenGL driver for it is the Broadcom VC4 used in some Raspberry Pi.

We have 4 usages of 3D textures:

1. optional tiled lighting renderer (not needed to render the game)
2. optional colorgrading (not needed to render the game)
3. optional grid-based deluxe mapping for models (not needed to render the game)
4. light grid

Light grid is supposedly the only way to lit models with light that matches the position of the model in the map. If 3D textures are not supported, the models will be fullbright. This can be considered a cheat if intentional (models will not be black in dark areas), so I don't plan to give the user a way to toggle this, and this is not something we should enable in a preset. This is a fallback compatibility feature, and I consider it's fine to have it because if you actually play on such low-end hardware, you have stronger handicaps to deal with (tiny screen resolution, low framerate…). Using such hardware is hard to consider an unfair advantage.

I may add a cheat cvar to test the fallback though.