### PR TITLE
Revert computeLight_fp refactoring (worsens light layer distribution)

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -307,7 +307,7 @@ void UpdateSurfaceDataLightMapping( uint32_t* materials, Material& material, dra
 
 		// bind u_LightTiles
 		if ( r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) ) {
-			gl_lightMappingShaderMaterial->SetUniform_LightTilesBindless(
+			gl_lightMappingShaderMaterial->SetUniform_LightTilesIntBindless(
 				GL_BindToTMU( BIND_LIGHTTILES, tr.lighttileRenderImage )
 			);
 		}

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2289,6 +2289,8 @@ GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 	u_LightGrid1( this ),
 	u_LightGrid2( this ),
 	u_LightTiles( this ),
+	u_LightTilesInt( this ),
+	u_LightsTexture( this ),
 	u_TextureMatrix( this ),
 	u_SpecularExponent( this ),
 	u_ColorModulate( this ),
@@ -2336,6 +2338,7 @@ void GLShader_lightMapping::SetShaderProgramUniforms( shaderProgram_t *shaderPro
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_EnvironmentMap0" ), BIND_ENVIRONMENTMAP0 );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_EnvironmentMap1" ), BIND_ENVIRONMENTMAP1 );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_LightTiles" ), BIND_LIGHTTILES );
+	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_LightTilesInt" ), BIND_LIGHTTILES );
 	if( !glConfig2.uniformBufferObjectAvailable ) {
 		glUniform1i( glGetUniformLocation( shaderProgram->program, "u_Lights" ), BIND_LIGHTS );
 	}
@@ -2355,7 +2358,7 @@ GLShader_lightMappingMaterial::GLShader_lightMappingMaterial( GLShaderManager* m
 	u_EnvironmentMap1( this ),
 	u_LightGrid1( this ),
 	u_LightGrid2( this ),
-	u_LightTiles( this ),
+	u_LightTilesInt( this ),
 	u_TextureMatrix( this ),
 	u_SpecularExponent( this ),
 	u_ColorModulate( this ),
@@ -3018,7 +3021,7 @@ GLShader_liquidMaterial::GLShader_liquidMaterial( GLShaderManager* manager ) :
 	u_NormalScale( this ),
 	u_FogDensity( this ),
 	u_FogColor( this ),
-	u_LightTiles( this ),
+	u_LightTilesInt( this ),
 	u_SpecularExponent( this ),
 	u_LightGridOrigin( this ),
 	u_LightGridScale( this ),
@@ -3095,6 +3098,7 @@ GLShader_lighttile::GLShader_lighttile( GLShaderManager *manager ) :
 	GLShader( "lighttile", ATTR_POSITION | ATTR_TEXCOORD, manager ),
 	u_DepthMap( this ),
 	u_Lights( this ),
+	u_LightsTexture( this ),
 	u_numLights( this ),
 	u_lightLayer( this ),
 	u_ModelMatrix( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2425,6 +2425,22 @@ class u_CloudMap :
 	}
 };
 
+class u_LightsTexture :
+	GLUniformSampler2D {
+	public:
+	u_LightsTexture( GLShader* shader ) :
+		GLUniformSampler2D( shader, "u_LightsTexture" ) {
+	}
+
+	void SetUniform_LightsTextureBindless( GLuint64 bindlessHandle ) {
+		this->SetValueBindless( bindlessHandle );
+	}
+
+	GLint GetUniformLocation_LightsTexture() {
+		return this->GetLocation();
+	}
+};
+
 class u_LightTiles :
 	GLUniformSampler3D {
 	public:
@@ -2437,6 +2453,22 @@ class u_LightTiles :
 	}
 
 	GLint GetUniformLocation_LightTiles() {
+		return this->GetLocation();
+	}
+};
+
+class u_LightTilesInt :
+	GLUniformUSampler3D {
+	public:
+	u_LightTilesInt( GLShader* shader ) :
+		GLUniformUSampler3D( shader, "u_LightTilesInt" ) {
+	}
+
+	void SetUniform_LightTilesIntBindless( GLuint64 bindlessHandle ) {
+		this->SetValueBindless( bindlessHandle );
+	}
+
+	GLint GetUniformLocation_LightTilesInt() {
 		return this->GetLocation();
 	}
 };
@@ -3991,6 +4023,8 @@ class GLShader_lightMapping :
 	public u_LightGrid1,
 	public u_LightGrid2,
 	public u_LightTiles,
+	public u_LightTilesInt,
+	public u_LightsTexture,
 	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_ColorModulate,
@@ -4040,7 +4074,7 @@ class GLShader_lightMappingMaterial :
 	public u_EnvironmentMap1,
 	public u_LightGrid1,
 	public u_LightGrid2,
-	public u_LightTiles,
+	public u_LightTilesInt,
 	public u_TextureMatrix,
 	public u_SpecularExponent,
 	public u_ColorModulate,
@@ -4595,7 +4629,7 @@ class GLShader_liquidMaterial :
 	public u_NormalScale,
 	public u_FogDensity,
 	public u_FogColor,
-	public u_LightTiles,
+	public u_LightTilesInt,
 	public u_SpecularExponent,
 	public u_LightGridOrigin,
 	public u_LightGridScale,
@@ -4655,6 +4689,7 @@ class GLShader_lighttile :
 	public GLShader,
 	public u_DepthMap,
 	public u_Lights,
+	public u_LightsTexture,
 	public u_numLights,
 	public u_lightLayer,
 	public u_ModelMatrix,

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -159,10 +159,10 @@ layout(std140) uniform u_Lights {
 uniform int u_numLights;
 
 #if defined(USE_REFLECTIVE_SPECULAR)
-void computeDynamicLight( uint idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse,
+void computeDynamicLight( int idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse,
 	vec4 material, inout vec4 color, in samplerCube u_EnvironmentMap0, in samplerCube u_EnvironmentMap1 )
 #else // !USE_REFLECTIVE_SPECULAR
-void computeDynamicLight( uint idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse,
+void computeDynamicLight( int idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse,
 	vec4 material, inout vec4 color )
 #endif // !USE_REFLECTIVE_SPECULAR
 {
@@ -211,50 +211,44 @@ const int lightsPerLayer = 16;
 
 #define idxs_t uvec4
 
-uniform usampler3D u_LightTiles;
+idxs_t fetchIdxs( in vec3 coords, in usampler3D u_LightTilesInt ) {
+	return texture3D( u_LightTilesInt, coords );
+}
 
-const uint numLayers = MAX_REF_LIGHTS / 256;
+int nextIdx( inout idxs_t idxs ) {
+	uvec4 tmp = ( idxs & uvec4( 3 ) ) * uvec4( 0x40, 0x10, 0x04, 0x01 );
+	idxs >>= 2;
+	return int( tmp.x + tmp.y + tmp.z + tmp.w );
+}
+
+uniform usampler3D u_LightTilesInt;
+
+const int numLayers = MAX_REF_LIGHTS / 256;
 const vec3 tileScale = vec3( r_tileStep, 1.0 / numLayers );
-
-idxs_t fetchIdxs( in vec3 coords, in usampler3D u_LightTiles ) {
-	return texture3D( u_LightTiles, coords );
-}
-
-// 8 bits per light ID
-uint nextIdx( in uint count, in idxs_t idxs ) {
-	return ( idxs[count / 4] >> ( 8 * ( count % 4 ) ) ) & 0xFF;
-}
 
 #if defined(USE_REFLECTIVE_SPECULAR)
 void computeDynamicLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4 material,
-	inout vec4 color, in usampler3D u_LightTiles,
+	inout vec4 color, in usampler3D u_LightTilesInt,
 	in samplerCube u_EnvironmentMap0, in samplerCube u_EnvironmentMap1 )
 #else // !USE_REFLECTIVE_SPECULAR
 void computeDynamicLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4 material,
-	inout vec4 color, in usampler3D u_LightTiles )
+	inout vec4 color, in usampler3D u_LightTilesInt )
 #endif // !USE_REFLECTIVE_SPECULAR
 {
 	vec2 tile = floor( gl_FragCoord.xy * ( 1.0 / float( TILE_SIZE ) ) ) + 0.5;
-	
-	// NOT the amount of lights that can actually be put into each layer of the lighttile texture
-	uint globalLightsPerLayer = ( u_numLights + numLayers - 1 ) / numLayers;
 
-	uint lightCount = 0;
-	for( uint layer = 0; layer < numLayers; layer++ ) {
-		idxs_t idxs = fetchIdxs( tileScale * vec3( tile, float( layer ) + 0.5 ), u_LightTiles );
+	#if defined(r_showLightTiles)
+		float numLights = 0.0;
+	#endif
 
-		uint lightOffset = layer * globalLightsPerLayer;
-		uint layerLightCount = lightOffset < u_numLights ? min( min( u_numLights - lightOffset, globalLightsPerLayer ), lightsPerLayer ) : 0;
-		for( uint i = 0; i < layerLightCount; i++ ) {
-			uint idx = nextIdx( lightCount, idxs );
+	for( int layer = 0; layer < numLayers; layer++ ) {
+		idxs_t idxs = fetchIdxs( tileScale * vec3( tile, float( layer ) + 0.5 ), u_LightTilesInt );
+		for( int i = 0; i < lightsPerLayer; i++ ) {
+			int idx = numLayers * nextIdx( idxs ) + layer;
 
-			if( idx == 0 ) {
+			if( idx >= u_numLights ) {
 				break;
 			}
-
-			/* Light IDs are stored relative to the layer
-			Subtract 1 because 0 means there's no light */
-			idx += ( layer * numLayers ) + layer - 1;
 	  
 			#if defined(USE_REFLECTIVE_SPECULAR)
 				computeDynamicLight( idx, P, normal, viewDir, diffuse, material, color, u_EnvironmentMap0, u_EnvironmentMap1 );
@@ -262,14 +256,16 @@ void computeDynamicLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4
 				computeDynamicLight( idx, P, normal, viewDir, diffuse, material, color );
 			#endif // !USE_REFLECTIVE_SPECULAR
 
-			lightCount++;
+			#if defined(r_showLightTiles)
+				numLights++;
+			#endif
 		}
 	}
 
 	#if defined(r_showLightTiles)
-		if ( lightCount > 0 ) {
-			color = vec4( float( lightCount ) / u_numLights, float( lightCount ) / u_numLights,
-				float( lightCount ) / u_numLights, 1.0 );
+		if ( numLights > 0.0 ) {
+			color = vec4( numLights / ( lightsPerLayer * numLayers ), numLights / ( lightsPerLayer * numLayers ),
+				numLights / ( lightsPerLayer * numLayers ), 1.0 );
 		}
 	#endif
 }

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -193,10 +193,10 @@ void main()
 	// Blend dynamic lights.
 	#if defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1
 		#if defined(USE_REFLECTIVE_SPECULAR)
-			computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color, u_LightTiles,
+			computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color, u_LightTilesInt,
 								 u_EnvironmentMap0, u_EnvironmentMap1);
 		#else // !USE_REFLECTIVE_SPECULAR
-			computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color, u_LightTiles);
+			computeDynamicLights(var_Position, normal, viewDir, diffuse, material, color, u_LightTilesInt);
 		#endif // !USE_REFLECTIVE_SPECULAR
 	#endif
 

--- a/src/engine/renderer/glsl_source/lighttile_fp.glsl
+++ b/src/engine/renderer/glsl_source/lighttile_fp.glsl
@@ -38,20 +38,20 @@ IN(smooth) vec2 vPosition;
 IN(smooth) vec2 vTexCoord;
 
 struct Light {
-	vec3 center;
-	float radius;
-	vec3 color;
-	float type;
-	vec3 direction;
-	float angle;
+  vec3 center;
+  float radius;
+  vec3 color;
+  float type;
+  vec3 direction;
+  float angle;
 };
 
 layout(std140) uniform u_Lights {
-	Light lights[MAX_REF_LIGHTS];
+  Light lights[MAX_REF_LIGHTS];
 };
 
-Light GetLight( in uint idx ) {
-	return lights[idx];
+Light GetLight( in int idx ) {
+  return lights[idx];
 }
 
 uniform int u_numLights;
@@ -62,32 +62,30 @@ uniform vec3 u_zFar;
 
 const int numLayers = MAX_REF_LIGHTS / 256;
 
-const int lightsPerLayer = 16;
-
 #define idxs_t uvec4
+#define idx_initializer uvec4( 3 )
 
 DECLARE_OUTPUT(uvec4)
 
-// 8 bits per light ID
-void pushIdxs( in uint idx, in uint count, inout uvec4 idxs ) {
-	idxs[count / 4] <<= 8;
-	idxs[count / 4] |= idx & 0xFF;
+void pushIdxs( in int idx, inout uvec4 idxs ) {
+  uvec4 bits = uvec4( idx >> 8, idx >> 6, idx >> 4, idx >> 2 ) & uvec4( 0x03 );
+  idxs = idxs << 2 | bits;
 }
 
 #define exportIdxs( x ) outputColor = ( x )
 
 void lightOutsidePlane( in vec4 plane, inout vec3 center, inout float radius ) {
-	float dist = dot( plane, vec4( center, 1.0 ) );
-	if( dist >= radius ) {
-		radius = 0.0; // light completely outside plane
-		return;
-	}
+  float dist = dot( plane, vec4( center, 1.0 ) );
+  if( dist >= radius ) {
+    radius = 0.0; // light completely outside plane
+    return;
+  }
 
-	if( dist >= 0.0 ) {
-		// light is outside plane, but intersects the volume
-		center -= dist * plane.xyz;
-		radius = sqrt( radius * radius - dist * dist );
-	}
+  if( dist >= 0.0 ) {
+    // light is outside plane, but intersects the volume
+    center -= dist * plane.xyz;
+    radius = sqrt( radius * radius - dist * dist );
+  }
 }
 
 vec3 ProjToView( vec2 inp ) {
@@ -95,58 +93,45 @@ vec3 ProjToView( vec2 inp ) {
 }
 
 void main() {
-	vec2 minmax = texture2D( u_DepthMap, 0.5 * vPosition + 0.5 ).xy;
+  vec2 minmax = texture2D( u_DepthMap, 0.5 * vPosition + 0.5 ).xy;
 
-	float minx = vPosition.x - r_tileStep.x;
-	float maxx = vPosition.x + r_tileStep.x;
-	float miny = vPosition.y - r_tileStep.y;
-	float maxy = vPosition.y + r_tileStep.y;
+  float minx = vPosition.x - r_tileStep.x;
+  float maxx = vPosition.x + r_tileStep.x;
+  float miny = vPosition.y - r_tileStep.y;
+  float maxy = vPosition.y + r_tileStep.y;
 
-	vec3 bottomleft = ProjToView( vec2( minx, miny ) );
-	vec3 bottomright = ProjToView( vec2( maxx, miny ) );
-	vec3 topright = ProjToView( vec2( maxx, maxy ) );
-	vec3 topleft = ProjToView( vec2( minx, maxy ) );
+  vec3 bottomleft = ProjToView( vec2( minx, miny ) );
+  vec3 bottomright = ProjToView( vec2( maxx, miny ) );
+  vec3 topright = ProjToView( vec2( maxx, maxy ) );
+  vec3 topleft = ProjToView( vec2( minx, maxy ) );
 
-	vec4 plane1 = vec4( normalize( cross( bottomleft, bottomright ) ), 0 );
-	vec4 plane2 = vec4( normalize( cross( bottomright, topright ) ), 0 );
-	vec4 plane3 = vec4( normalize( cross( topright, topleft ) ), 0 );
-	vec4 plane4 = vec4( normalize( cross( topleft, bottomleft ) ), 0 );
+  vec4 plane1 = vec4( normalize( cross( bottomleft, bottomright ) ), 0 );
+  vec4 plane2 = vec4( normalize( cross( bottomright, topright ) ), 0 );
+  vec4 plane3 = vec4( normalize( cross( topright, topleft ) ), 0 );
+  vec4 plane4 = vec4( normalize( cross( topleft, bottomleft ) ), 0 );
 
-	vec4 plane5 = vec4( 0.0, 0.0,  1.0,  minmax.y );
-	vec4 plane6 = vec4( 0.0, 0.0, -1.0, -minmax.x );
+  vec4 plane5 = vec4( 0.0, 0.0,  1.0,  minmax.y );
+  vec4 plane6 = vec4( 0.0, 0.0, -1.0, -minmax.x );
 
-	idxs_t idxs = uvec4( 0, 0, 0, 0 );
+  idxs_t idxs = idx_initializer;
 
-	uint lightCount = 0;
+  for( int i = u_lightLayer; i < u_numLights; i += numLayers ) {
+    Light l = GetLight( i );
+    vec3 center = ( u_ModelMatrix * vec4( l.center, 1.0 ) ).xyz;
+    float radius = max( 2.0 * l.radius, 2.0 * 32.0 ); // Avoid artifacts with weak light sources
 
-	/* Dynamic lights are put into 4 layers of a 3D texture. Since checking if we already added some light is infeasible,
-	only process 1 / 4 of different lights for each layer, extra lights going into the last layer. This can fail to add some lights
-	if 1 / 4 of all lights is more than the amount of lights that each layer can hold (16). To fix this, we'd need to either do this on CPU
-	or use compute shaders with atomics so we can have a variable amount of lights for each tile. */
-	for( uint i = u_lightLayer; i < u_numLights; i += 4 ) {
-		Light l = GetLight( i );
-		vec3 center = ( u_ModelMatrix * vec4( l.center, 1.0 ) ).xyz;
-		float radius = max( 2.0 * l.radius, 2.0 * 32.0 ); // Avoid artifacts with weak light sources
+    // todo: better checks for spotlights
+    lightOutsidePlane( plane1, center, radius );
+    lightOutsidePlane( plane2, center, radius );
+    lightOutsidePlane( plane3, center, radius );
+    lightOutsidePlane( plane4, center, radius );
+    lightOutsidePlane( plane5, center, radius );
+    lightOutsidePlane( plane6, center, radius );
 
-		// todo: better checks for spotlights
-		lightOutsidePlane( plane1, center, radius );
-		lightOutsidePlane( plane2, center, radius );
-		lightOutsidePlane( plane3, center, radius );
-		lightOutsidePlane( plane4, center, radius );
-		lightOutsidePlane( plane5, center, radius );
-		lightOutsidePlane( plane6, center, radius );
+    if( radius > 0.0 ) {
+      pushIdxs( i, idxs );
+    }
+  }
 
-		if( radius > 0.0 ) {
-			/* Light IDs are stored relative to the layer
-			Add 1 because 0 means there's no light */
-			pushIdxs( i + 1, lightCount, idxs );
-			lightCount++;
-
-			if( lightCount == lightsPerLayer ) {
-				break;
-			}
-		}
-	}
-
-	exportIdxs( idxs );
+  exportIdxs( idxs );
 }

--- a/src/engine/renderer/glsl_source/material_fp.glsl
+++ b/src/engine/renderer/glsl_source/material_fp.glsl
@@ -57,7 +57,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 samplerCube u_EnvironmentMap0 = samplerCube( u_EnvironmentMap0_initial );
 samplerCube u_EnvironmentMap1 = samplerCube( u_EnvironmentMap1_initial );
 #endif // !USE_REFLECTIVE_SPECULAR
-usampler3D u_LightTiles = usampler3D( u_LightTiles_initial );
+usampler3D u_LightTilesInt = usampler3D( u_LightTilesInt_initial );
 #endif // !COMPUTELIGHT_GLSL
 
 #if defined(FOGQUAKE3_GLSL)

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -2905,7 +2905,13 @@ void RB_RenderPostDepthLightTile()
 	gl_lighttileShader->SetUniform_numLights( backEnd.refdef.numLights );
 	gl_lighttileShader->SetUniform_zFar( projToViewParams );
 
-	gl_lighttileShader->SetUniformBlock_Lights( tr.dlightUBO );
+	if( glConfig2.uniformBufferObjectAvailable ) {
+		gl_lighttileShader->SetUniformBlock_Lights( tr.dlightUBO );
+	} else {
+		gl_lighttileShader->SetUniform_LightsTextureBindless(
+			GL_BindToTMU( 1, tr.dlightImage ) 
+		);
+	}
 
 	gl_lighttileShader->SetUniform_DepthMapBindless(
 		GL_BindToTMU( 1, tr.depthtile2RenderImage ) 
@@ -5364,6 +5370,12 @@ const RenderCommand *SetupLightsCommand::ExecuteSelf( ) const
 		}
 
 		glUnmapBuffer( bufferTarget );
+		if( !glConfig2.uniformBufferObjectAvailable ) {
+			gl_lighttileShader->SetUniform_LightsTextureBindless(
+				GL_BindToTMU( 1, tr.dlightImage ) 
+			);
+			glTexSubImage2D( GL_TEXTURE_2D, 0, 0, 0, tr.dlightImage->width, tr.dlightImage->height, GL_RGBA, GL_FLOAT, nullptr );
+		}
 		glBindBuffer( bufferTarget, 0 );
 	}
 

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2482,6 +2482,21 @@ static void R_CreateDepthRenderImage()
 		return;
 	}
 
+	if( !glConfig2.uniformBufferObjectAvailable )
+	{
+		int w = 64;
+		int h = 3 * MAX_REF_LIGHTS / w;
+
+		imageParams_t imageParams = {};
+		imageParams.filterType = filterType_t::FT_NEAREST;
+		imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
+
+		imageParams.bits = IF_NOPICMIP;
+		imageParams.bits |= r_highPrecisionRendering.Get() ? IF_RGBA32F : IF_RGBA16F;
+
+		tr.dlightImage = R_CreateImage("_dlightImage", nullptr, w, h, 4, imageParams );
+	}
+
 	if ( r_realtimeLightingRenderer.Get() != Util::ordinal( realtimeLightingRenderer_t::TILED ) )
 	{
 		/* Do not create lightTile images when the tiled renderer is not used.
@@ -2521,7 +2536,12 @@ static void R_CreateDepthRenderImage()
 
 		tr.depthtile2RenderImage = R_CreateImage( "_depthtile2Render", nullptr, w, h, 1, imageParams );
 
-		imageParams.bits = IF_NOPICMIP | IF_RGBA32UI;
+		imageParams.bits = IF_NOPICMIP;
+
+		if ( glConfig2.textureIntegerAvailable && r_highPrecisionRendering.Get() )
+		{
+			imageParams.bits |= IF_RGBA32UI;
+		}
 
 		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, 4, imageParams );
 	}

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2650,6 +2650,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 		FBO_t           *fbos[ MAX_FBOS ];
 
 		GLuint          dlightUBO;
+		image_t         *dlightImage; // if the UBO is not available
 
 		std::vector<VBO_t *> vbos;
 		std::vector<IBO_t *> ibos;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -42,6 +42,12 @@ static void EnableAvailableFeatures()
 	{
 		if ( r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) )
 		{
+			if ( !glConfig2.textureFloatAvailable )
+			{
+				Log::Warn( "Tiled dynamic light renderer disabled because GL_ARB_texture_float is not available.");
+				glConfig2.realtimeLighting = false;
+			}
+
 			if ( !glConfig2.uniformBufferObjectAvailable ) {
 				Log::Warn( "Tiled dynamic light renderer disabled because GL_ARB_uniform_buffer_object is not available." );
 				glConfig2.realtimeLighting = false;
@@ -1069,10 +1075,19 @@ void Render_lightMapping( shaderStage_t *pStage )
 		if ( backEnd.refdef.numShaderLights > 0 )
 		{
 			gl_lightMappingShader->SetUniform_numLights( backEnd.refdef.numLights );
-			gl_lightMappingShader->SetUniformBlock_Lights( tr.dlightUBO );
+
+			if( glConfig2.uniformBufferObjectAvailable )
+			{
+				gl_lightMappingShader->SetUniformBlock_Lights( tr.dlightUBO );
+			} else
+			{
+				gl_lightMappingShader->SetUniform_LightsTextureBindless(
+					GL_BindToTMU( BIND_LIGHTS, tr.dlightImage ) 
+				);
+			}
 
 			// bind u_LightTiles
-			gl_lightMappingShader->SetUniform_LightTilesBindless(
+			gl_lightMappingShader->SetUniform_LightTilesIntBindless(
 				GL_BindToTMU( BIND_LIGHTTILES, tr.lighttileRenderImage )
 			);
 		}

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -980,6 +980,11 @@ static void R_InitLightUBO()
 		glBindBuffer( GL_UNIFORM_BUFFER, tr.dlightUBO );
 		glBufferData( GL_UNIFORM_BUFFER, MAX_REF_LIGHTS * sizeof( shaderLight_t ), nullptr, GL_DYNAMIC_DRAW );
 		glBindBuffer( GL_UNIFORM_BUFFER, 0 );
+	} else {
+		glGenBuffers( 1, &tr.dlightUBO );
+		glBindBuffer( GL_PIXEL_UNPACK_BUFFER, tr.dlightUBO );
+		glBufferData( GL_PIXEL_UNPACK_BUFFER, MAX_REF_LIGHTS * sizeof( shaderLight_t ), nullptr, GL_DYNAMIC_DRAW );
+		glBindBuffer( GL_PIXEL_UNPACK_BUFFER, 0 );
 	}
 }
 
@@ -1113,7 +1118,7 @@ void R_ShutdownVBOs()
 	Com_Free_Aligned( tess.vertsBuffer );
 	Com_Free_Aligned( tess.indexesBuffer );
 
-	if( glConfig2.realtimeLighting ) {
+	if( glConfig2.uniformBufferObjectAvailable ) {
 		glDeleteBuffers( 1, &tr.dlightUBO );
 		tr.dlightUBO = 0;
 	}


### PR DESCRIPTION
#1333 changed how the dynamic lights are distributed into layers: before, the layer was set by the light's index modulo 4. After, the first quarter of lights are in layer 0, the 2nd quarter in layer 1, etc. The distribution is (hopefully) 'random' with the previous algorithm. With the new algorithm they are grouped by when they are added. So the new algorithm is more likely to fail to render some lights because all the lights in an area ended up in one layer instead of being well distributed. 

Also the changes there made the GLSL fail to compile on my machine. I had to add a float cast to the following line:
```
const vec3 tileScale = vec3( r_tileStep, 1.0 / numLayers );
```

I demonstrated the issue with a trail system:
```
fartfire
{
	beam
	{
		shader gfx/weapons/prifle/trail
		segments 300
		width 4 4
		alpha 1 0
		segmentTime 30
		fadeOutTime 2.5
		textureType stretch 1 .1

		dynamicLight 80 { .5 .5 .5 }

		jitter 1 10
	}
}
```

With the old algorithm it looks like this:
![OLDunvanquished_2024-10-11_165403_000](https://github.com/user-attachments/assets/2e972779-ce5b-4237-acf9-74fcffe15f33)

With the new algorithm it looks like this:
![NEWunvanquished_2024-10-11_165132_000](https://github.com/user-attachments/assets/8c206e56-d537-4673-9f3a-def1a4e7f134)

To reproduce,
1. Save the trail system definition above somewhere in the VFS as `scripts/something.trail`.
2. Execute these commands
```
/cg_thirdperson 1
/cg_thirdpersonangle 180
/testts fartfire
```
3. Run forward a while.