### PR TITLE
Tweak material system cvars

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1065,7 +1065,7 @@ void GLShaderManager::InitShader( GLShader* shader ) {
 		shader->_computeShaderText = ProcessInserts( shader->_computeShaderText, offset );
 	}
 
-	if ( glConfig2.materialSystemAvailable && shader->_useMaterialSystem ) {
+	if ( glConfig2.usingMaterialSystem && shader->_useMaterialSystem ) {
 		shader->_vertexShaderText = ShaderPostProcess( shader, shader->_vertexShaderText );
 		shader->_fragmentShaderText = ShaderPostProcess( shader, shader->_fragmentShaderText );
 	}

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -404,7 +404,7 @@ static const std::vector<addedExtension_t> fragmentVertexAddedExtensions = {
 	{ glConfig2.textureIntegerAvailable, 0, "EXT_texture_integer" },
 	{ glConfig2.textureRGAvailable, 0, "ARB_texture_rg" },
 	{ glConfig2.uniformBufferObjectAvailable, 140, "ARB_uniform_buffer_object" },
-	{ glConfig2.bindlessTexturesAvailable, -1, "ARB_bindless_texture" },
+	{ glConfig2.usingBindlessTextures, -1, "ARB_bindless_texture" },
 	/* ARB_shader_draw_parameters set to -1, because we might get a 4.6 GL context,
 	where the core variables have different names. */
 	{ glConfig2.shaderDrawParametersAvailable, -1, "ARB_shader_draw_parameters" },
@@ -426,7 +426,7 @@ static const std::vector<addedExtension_t> computeAddedExtensions = {
 	/* ARB_shader_atomic_counter_ops set to -1,
 	because we might get a 4.6 GL context, where the core functions have different names. */
 	{ glConfig2.shaderAtomicCounterOpsAvailable, -1, "ARB_shader_atomic_counter_ops" },
-	{ glConfig2.bindlessTexturesAvailable, -1, "ARB_bindless_texture" },
+	{ glConfig2.usingBindlessTextures, -1, "ARB_bindless_texture" },
 	/* Even though these are part of the GL_KHR_shader_subgroup extension, we need to enable
 	the individual extensions for each feature.
 	GL_KHR_shader_subgroup itself can't be used in the shader. */
@@ -545,7 +545,7 @@ static std::string GenFragmentHeader() {
 			"#define DECLARE_OUTPUT(type) /* empty*/\n";
 	}
 
-	if ( glConfig2.bindlessTexturesAvailable ) {
+	if ( glConfig2.usingBindlessTextures ) {
 		str += "layout(bindless_sampler) uniform;\n";
 	}
 
@@ -569,7 +569,7 @@ static std::string GenComputeHeader() {
 	AddDefine( str, "MAX_SURFACE_COMMAND_BATCHES", MAX_SURFACE_COMMAND_BATCHES );
 	AddDefine( str, "MAX_COMMAND_COUNTERS", MAX_COMMAND_COUNTERS );
 
-	if ( glConfig2.bindlessTexturesAvailable ) {
+	if ( glConfig2.usingBindlessTextures ) {
 		str += "layout(bindless_image) uniform;\n";
 	}
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -502,8 +502,8 @@ public:
 class GLUniformSampler : protected GLUniform {
 	protected:
 	GLUniformSampler( GLShader* shader, const char* name, const char* type, const GLuint size ) :
-		GLUniform( shader, name, type, glConfig2.bindlessTexturesAvailable ? size * 2 : size,
-									   glConfig2.bindlessTexturesAvailable ? size * 2 : size, false, 0, true ) {
+		GLUniform( shader, name, type, glConfig2.usingBindlessTextures ? size * 2 : size,
+									   glConfig2.usingBindlessTextures ? size * 2 : size, false, 0, true ) {
 	}
 
 	inline GLint GetLocation() {
@@ -532,14 +532,14 @@ class GLUniformSampler : protected GLUniform {
 	void SetValueBindless( GLint64 value ) {
 		currentValueBindless = value;
 
-		if ( glConfig2.bindlessTexturesAvailable && ( !_shader->UseMaterialSystem() || _global ) ) {
+		if ( glConfig2.usingBindlessTextures && ( !_shader->UseMaterialSystem() || _global ) ) {
 			glUniformHandleui64ARB( GetLocation(), currentValueBindless );
 		}
 	}
 
 	uint32_t* WriteToBuffer( uint32_t* buffer ) override {
 		uint32_t* bufferNext = buffer;
-		if ( glConfig2.bindlessTexturesAvailable ) {
+		if ( glConfig2.usingBindlessTextures ) {
 			memcpy( buffer, &currentValueBindless, sizeof( GLuint64 ) );
 			bufferNext += 2;
 		} else {

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4661,7 +4661,7 @@ static void RB_RenderView( bool depthPass )
 	}
 
 	if( depthPass ) {
-		if ( glConfig2.materialSystemAvailable ) {
+		if ( glConfig2.usingMaterialSystem ) {
 			materialSystem.RenderMaterials( shaderSort_t::SS_DEPTH, shaderSort_t::SS_DEPTH, backEnd.viewParms.viewID );
 		}
 		RB_RenderDrawSurfaces( shaderSort_t::SS_DEPTH, shaderSort_t::SS_DEPTH, DRAWSURFACES_ALL );
@@ -4678,7 +4678,7 @@ static void RB_RenderView( bool depthPass )
 			tr.refdef.blurVec[2] != 0.0f )
 	{
 		// draw everything that is not the gun
-		if ( glConfig2.materialSystemAvailable ) {
+		if ( glConfig2.usingMaterialSystem ) {
 			materialSystem.RenderMaterials( shaderSort_t::SS_ENVIRONMENT_FOG, shaderSort_t::SS_OPAQUE, backEnd.viewParms.viewID );
 		}
 		RB_RenderDrawSurfaces( shaderSort_t::SS_ENVIRONMENT_FOG, shaderSort_t::SS_OPAQUE, DRAWSURFACES_ALL_FAR );
@@ -4691,7 +4691,7 @@ static void RB_RenderView( bool depthPass )
 	else
 	{
 		// draw everything that is opaque
-		if ( glConfig2.materialSystemAvailable ) {
+		if ( glConfig2.usingMaterialSystem ) {
 			materialSystem.RenderMaterials( shaderSort_t::SS_ENVIRONMENT_FOG, shaderSort_t::SS_OPAQUE, backEnd.viewParms.viewID );
 		}
 		RB_RenderDrawSurfaces( shaderSort_t::SS_ENVIRONMENT_FOG, shaderSort_t::SS_OPAQUE, DRAWSURFACES_ALL );
@@ -4723,7 +4723,7 @@ static void RB_RenderView( bool depthPass )
 	RB_RenderGlobalFog();
 
 	// draw everything that is translucent
-	if ( glConfig2.materialSystemAvailable ) {
+	if ( glConfig2.usingMaterialSystem ) {
 		materialSystem.RenderMaterials( shaderSort_t::SS_ENVIRONMENT_NOFOG, shaderSort_t::SS_POST_PROCESS, backEnd.viewParms.viewID );
 	}
 	RB_RenderDrawSurfaces( shaderSort_t::SS_ENVIRONMENT_NOFOG, shaderSort_t::SS_POST_PROCESS, DRAWSURFACES_ALL );
@@ -4765,7 +4765,7 @@ This is done so various debugging facilities will work properly
 */
 static void RB_RenderPostProcess()
 {
-	if ( glConfig2.materialSystemAvailable ) {
+	if ( glConfig2.usingMaterialSystem ) {
 		// Dispatch the cull compute shaders for queued once we're done with post-processing
 		// We'll only use the results from those shaders in the next frame so we don't block the pipeline
 		materialSystem.CullSurfaces();

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -61,7 +61,7 @@ void GL_Bind( image_t *image )
 		texnum = tr.blackImage->texnum;
 	}
 
-	if ( glConfig2.bindlessTexturesAvailable ) {
+	if ( glConfig2.usingBindlessTextures ) {
 		tr.textureManager.BindReservedTexture( image->type, texnum );
 		return;
 	}
@@ -182,7 +182,7 @@ GLuint64 GL_BindToTMU( int unit, image_t *image )
 		image = tr.defaultImage;
 	}
 
-	if ( glConfig2.bindlessTexturesAvailable ) {
+	if ( glConfig2.usingBindlessTextures ) {
 		if ( materialSystem.generatingWorldCommandBuffer ) {
 			materialSystem.AddTexture( image->texture );
 			return image->texture->bindlessTextureHandle;
@@ -4818,7 +4818,7 @@ void RE_UploadCinematic( int cols, int rows, const byte *data, int client, bool 
 		glTexParameterfv( GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, Color::Black.ToArray() );
 
 		// Getting bindless handle makes the texture immutable, so generate it again because we used glTexParameter*
-		if ( glConfig2.bindlessTexturesAvailable ) {
+		if ( glConfig2.usingBindlessTextures ) {
 			tr.cinematicImage[ client ]->texture->GenBindlessHandle();
 		}
 	}

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -4821,7 +4821,7 @@ void R_BuildCubeMaps()
 			int msecUnused1;
 			int msecUnused2;
 			// Material system writes culled surfaces for the next frame, so we need to render twice with it to cull correctly
-			if ( glConfig2.materialSystemAvailable ) {
+			if ( glConfig2.usingMaterialSystem ) {
 				tr.refdef.pixelTarget = nullptr;
 
 				RE_BeginFrame();

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2476,7 +2476,7 @@ static void R_CreateCurrentRenderImage()
 
 	tr.currentDepthImage = R_CreateImage( "_currentDepth", nullptr, width, height, 1, imageParams );
 
-	if ( glConfig2.materialSystemAvailable ) {
+	if ( glConfig2.usingMaterialSystem ) {
 		materialSystem.GenerateDepthImages( width, height, imageParams );
 	}
 }

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -129,7 +129,7 @@ void GL_TextureMode( const char *string )
 			}
 
 			// Getting bindless handle makes the texture immutable, so generate it again because we used glTexParameter*
-			if ( glConfig2.bindlessTexturesAvailable ) {
+			if ( glConfig2.usingBindlessTextures ) {
 				image->texture->GenBindlessHandle();
 			}
 		}

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -86,7 +86,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<bool> r_colorGrading( "r_colorGrading", "Use color grading", Cvar::NONE, true );
 	Cvar::Cvar<bool> r_materialSystem( "r_materialSystem", "Use Material System", Cvar::NONE, false );
 	Cvar::Cvar<bool> r_gpuFrustumCulling( "r_gpuFrustumCulling", "Use frustum culling on the GPU for the Material System", Cvar::NONE, true );
-	Cvar::Cvar<bool> r_gpuOcclusionCulling( "r_gpuOcclusionCulling", "Use occlusion culling on the GPU for the Material System", Cvar::NONE, true );
+	Cvar::Cvar<bool> r_gpuOcclusionCulling( "r_gpuOcclusionCulling", "Use occlusion culling on the GPU for the Material System", Cvar::NONE, false );
 	cvar_t      *r_lightStyles;
 	cvar_t      *r_exportTextures;
 	cvar_t      *r_heatHaze;

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -84,6 +84,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<bool> r_forceLegacyOverBrightClamping("r_forceLegacyOverBrightClamping", "clamp over bright of legacy maps (enable multiplied color clamping and normalization)", Cvar::NONE, false);
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	Cvar::Cvar<bool> r_colorGrading( "r_colorGrading", "Use color grading", Cvar::NONE, true );
+	Cvar::Cvar<bool> r_preferBindlessTextures( "r_preferBindlessTextures", "use bindless textures even when material system is off", Cvar::NONE, false );
 	Cvar::Cvar<bool> r_materialSystem( "r_materialSystem", "Use Material System", Cvar::NONE, false );
 	Cvar::Cvar<bool> r_gpuFrustumCulling( "r_gpuFrustumCulling", "Use frustum culling on the GPU for the Material System", Cvar::NONE, true );
 	Cvar::Cvar<bool> r_gpuOcclusionCulling( "r_gpuOcclusionCulling", "Use occlusion culling on the GPU for the Material System", Cvar::NONE, false );
@@ -1202,6 +1203,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		Cvar::Latch( r_realtimeLightingRenderer );
 		Cvar::Latch( r_realtimeLighting );
+		Cvar::Latch( r_preferBindlessTextures );
 		Cvar::Latch( r_materialSystem );
 
 		r_drawworld = Cvar_Get( "r_drawworld", "1", CVAR_CHEAT );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2731,6 +2731,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	extern Cvar::Cvar<bool> r_forceLegacyOverBrightClamping;
 	extern Cvar::Range<Cvar::Cvar<int>> r_lightMode;
 	extern Cvar::Cvar<bool> r_colorGrading;
+	extern Cvar::Cvar<bool> r_preferBindlessTextures;
 	extern Cvar::Cvar<bool> r_materialSystem;
 	extern Cvar::Cvar<bool> r_gpuFrustumCulling;
 	extern Cvar::Cvar<bool> r_gpuOcclusionCulling;

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -835,7 +835,7 @@ static void SetFarClip()
 		vec3_t v;
 		float  distance;
 
-		if ( glConfig2.materialSystemAvailable ) {
+		if ( glConfig2.usingMaterialSystem ) {
 			VectorCopy( materialSystem.worldViewBounds[0], tr.viewParms.visBounds[0] );
 			VectorCopy( materialSystem.worldViewBounds[1], tr.viewParms.visBounds[1] );
 		}
@@ -1992,7 +1992,7 @@ static void R_SortDrawSurfs()
 	int          sort;
 
 	// it is possible for some views to not have any surfaces
-	if ( !glConfig2.materialSystemAvailable && tr.viewParms.numDrawSurfs < 1 )
+	if ( !glConfig2.usingMaterialSystem && tr.viewParms.numDrawSurfs < 1 )
 	{
 		// we still need to add it for hyperspace cases
 		R_AddDrawViewCmd( false );
@@ -2053,7 +2053,7 @@ static void R_SortDrawSurfs()
 	// check for any pass through drawing, which
 	// may cause another view to be rendered first
 	// Material system does its own handling of portal surfaces
-	if ( glConfig2.materialSystemAvailable ) {
+	if ( glConfig2.usingMaterialSystem ) {
 		if ( tr.viewParms.portalLevel == 0 ) {
 			materialSystem.AddPortalSurfaces();
 			currentView = 0;
@@ -2578,7 +2578,7 @@ void R_RenderView( viewParms_t *parms )
 
 	R_SetupFrustum();
 
-	if ( glConfig2.materialSystemAvailable ) {
+	if ( glConfig2.usingMaterialSystem ) {
 		tr.viewParms.viewID = tr.viewCount;
 		materialSystem.QueueSurfaceCull( tr.viewCount, tr.viewParms.pvsOrigin, (frustum_t*) tr.viewParms.frustums[0] );
 		materialSystem.AddAutospriteSurfaces();

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -44,6 +44,9 @@ Maryland 20850 USA.
 
 extern Cvar::Modified<Cvar::Cvar<bool>> r_fullscreen;
 
+// Note: some of these (particularly ones dealing with GL extensions) are only updated on
+// an explicit vid_restart - see GLimp_InitExtensions(). Others are updated on every map change
+// - see EnableAvailableFeatures().
 struct glconfig2_t
 {
 	bool textureCompressionRGTCAvailable;
@@ -109,7 +112,8 @@ struct glconfig2_t
 	bool shaderSubgroupShuffleRelativeAvailable;
 	bool shaderSubgroupClusteredAvailable;
 	bool shaderSubgroupQuadAvailable;
-	bool materialSystemAvailable;
+	bool materialSystemAvailable; // do the driver/hardware support it
+	bool usingMaterialSystem; // are we using it right now
 	bool gpuShader4Available;
 	bool gpuShader5Available;
 	bool textureGatherAvailable;

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -93,7 +93,8 @@ struct glconfig2_t
 	bool textureIntegerAvailable;
 	bool textureRGAvailable;
 	bool computeShaderAvailable;
-	bool bindlessTexturesAvailable;
+	bool bindlessTexturesAvailable; // do the driver/hardware support it
+	bool usingBindlessTextures; // are we using them right now
 	bool shaderDrawParametersAvailable;
 	bool SSBOAvailable;
 	bool multiDrawIndirectAvailable;

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -484,7 +484,7 @@ static void RE_RenderCubeProbeFace( const refdef_t* originalRefdef ) {
 		}
 	}
 
-	if ( glConfig2.materialSystemAvailable ) {
+	if ( glConfig2.usingMaterialSystem ) {
 		// Material system writes culled surfaces for the next frame, so we need to render twice with it to cull correctly
 		R_SyncRenderThread();
 		RE_RenderScene( &refdef );
@@ -655,11 +655,11 @@ void RE_RenderScene( const refdef_t *fd )
 	R_AddClearBufferCmd();
 	R_AddSetupLightsCmd();
 
-	if ( glConfig2.materialSystemAvailable && !materialSystem.generatedWorldCommandBuffer ) {
+	if ( glConfig2.usingMaterialSystem && !materialSystem.generatedWorldCommandBuffer ) {
 		materialSystem.GenerateWorldMaterials();
 	}
 
-	if ( glConfig2.materialSystemAvailable ) {
+	if ( glConfig2.usingMaterialSystem ) {
 		materialSystem.StartFrame();
 	}
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 /*
 =================================================================================
 THIS ENTIRE FILE IS BACK END!
+^ Not true, EnableAvailableFeatures() right below this isn't.
 
 This file deals with applying shaders to surface data in the tess struct.
 =================================================================================
@@ -140,6 +141,8 @@ static void EnableAvailableFeatures()
 			}
 		}
 	}
+
+	glConfig2.usingMaterialSystem = r_materialSystem.Get() && glConfig2.materialSystemAvailable;
 }
 
 // For shaders that require map data for compile-time values 
@@ -152,7 +155,7 @@ void GLSL_InitWorldShaders() {
 	gl_shaderManager.GenerateWorldHeaders();
 
 	// Material system shaders that are always loaded if material system is available
-	if ( glConfig2.materialSystemAvailable ) {
+	if ( glConfig2.usingMaterialSystem ) {
 		gl_shaderManager.load( gl_cullShader );
 	}
 }
@@ -180,7 +183,7 @@ static void GLSL_InitGPUShadersOrError()
 	gl_shaderManager.load( gl_lightMappingShader );
 
 	// Material system shaders that are always loaded if material system is available
-	if ( glConfig2.materialSystemAvailable )
+	if ( glConfig2.usingMaterialSystem )
 	{
 		gl_shaderManager.load( gl_genericShaderMaterial );
 		gl_shaderManager.load( gl_lightMappingShaderMaterial );
@@ -239,7 +242,7 @@ static void GLSL_InitGPUShadersOrError()
 		// bumped cubemap reflection for abitrary polygons ( EMBM )
 		gl_shaderManager.load( gl_reflectionShader );
 
-		if ( glConfig2.materialSystemAvailable )
+		if ( glConfig2.usingMaterialSystem )
 		{
 			gl_shaderManager.load( gl_reflectionShaderMaterial );
 		}
@@ -250,7 +253,7 @@ static void GLSL_InitGPUShadersOrError()
 		// skybox drawing for abitrary polygons
 		gl_shaderManager.load( gl_skyboxShader );
 
-		if ( glConfig2.materialSystemAvailable )
+		if ( glConfig2.usingMaterialSystem )
 		{
 			gl_shaderManager.load( gl_skyboxShaderMaterial );
 		}
@@ -261,7 +264,7 @@ static void GLSL_InitGPUShadersOrError()
 		// Q3A volumetric fog
 		gl_shaderManager.load( gl_fogQuake3Shader );
 
-		if ( glConfig2.materialSystemAvailable )
+		if ( glConfig2.usingMaterialSystem )
 		{
 			gl_shaderManager.load( gl_fogQuake3ShaderMaterial );
 		}
@@ -275,7 +278,7 @@ static void GLSL_InitGPUShadersOrError()
 		// heatHaze post process effect
 		gl_shaderManager.load( gl_heatHazeShader );
 
-		if ( glConfig2.materialSystemAvailable )
+		if ( glConfig2.usingMaterialSystem )
 		{
 			gl_shaderManager.load( gl_heatHazeShaderMaterial );
 		}
@@ -286,7 +289,7 @@ static void GLSL_InitGPUShadersOrError()
 		// screen post process effect
 		gl_shaderManager.load( gl_screenShader );
 
-		if ( glConfig2.materialSystemAvailable )
+		if ( glConfig2.usingMaterialSystem )
 		{
 			gl_shaderManager.load( gl_screenShaderMaterial );
 		}
@@ -325,7 +328,7 @@ static void GLSL_InitGPUShadersOrError()
 	{
 		gl_shaderManager.load( gl_liquidShader );
 
-		if ( glConfig2.materialSystemAvailable )
+		if ( glConfig2.usingMaterialSystem )
 		{
 			gl_shaderManager.load( gl_liquidShaderMaterial );
 		}

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -143,6 +143,8 @@ static void EnableAvailableFeatures()
 	}
 
 	glConfig2.usingMaterialSystem = r_materialSystem.Get() && glConfig2.materialSystemAvailable;
+	glConfig2.usingBindlessTextures = glConfig2.usingMaterialSystem ||
+		( r_preferBindlessTextures.Get() && glConfig2.bindlessTexturesAvailable );
 }
 
 // For shaders that require map data for compile-time values 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5980,7 +5980,7 @@ static shader_t *FinishShader()
 		{
 			ret->depthShader = nullptr;
 
-			if ( glConfig2.materialSystemAvailable && !tr.worldLoaded ) {
+			if ( glConfig2.usingMaterialSystem && !tr.worldLoaded ) {
 				uint8_t maxStages = 0;
 				for ( shaderStage_t* pStage = ret->stages; pStage < ret->lastStage; pStage++ ) {
 					maxStages++;
@@ -6040,7 +6040,7 @@ static shader_t *FinishShader()
 		ret->depthShader = nullptr;
 	}
 
-	if ( glConfig2.materialSystemAvailable && !tr.worldLoaded ) {
+	if ( glConfig2.usingMaterialSystem && !tr.worldLoaded ) {
 		uint8_t maxStages = 0;
 		for ( shaderStage_t* pStage = ret->stages; pStage < ret->lastStage; pStage++ ) {
 			maxStages++;

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -728,7 +728,7 @@ static void R_InitLightUBO()
 }
 
 static void R_InitMaterialBuffers() {
-	if( glConfig2.materialSystemAvailable ) {
+	if( glConfig2.usingMaterialSystem ) {
 		materialsSSBO.GenBuffer();
 
 		surfaceDescriptorsSSBO.GenBuffer();
@@ -858,7 +858,7 @@ void R_ShutdownVBOs()
 		tr.dlightUBO = 0;
 	}
 
-	if ( glConfig2.materialSystemAvailable ) {
+	if ( glConfig2.usingMaterialSystem ) {
 		materialsSSBO.DelBuffer();
 
 		surfaceDescriptorsSSBO.DelBuffer();

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -60,12 +60,12 @@ static Cvar::Range<Cvar::Cvar<int>> r_glDebugSeverity(
 	Cvar::NONE, 2, 1, 4);
 
 // OpenGL extension cvars.
-/* Driver bug: Mesa versions > 24.0.9 produce garbage rendering when r_arb_bindless_texture is enabled,
+/* Driver bug: Mesa versions > 24.0.9 produce garbage rendering when bindless textures are enabled,
 and the shader compiler crashes with material shaders
 24.0.9 is the latest known working version, 24.1.1 is the earliest known broken version
 So this defaults to disabled */
 static Cvar::Cvar<bool> r_arb_bindless_texture( "r_arb_bindless_texture",
-	"Use GL_ARB_bindless_texture if available", Cvar::NONE, false );
+	"Use GL_ARB_bindless_texture if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_buffer_storage( "r_arb_buffer_storage",
 	"Use GL_ARB_buffer_storage if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_compute_shader( "r_arb_compute_shader",
@@ -2429,7 +2429,7 @@ static void GLimp_InitExtensions()
 					}
 
 					if ( foundMesa241 && workaround_glDriver_mesa_v241_disableBindlessTexture.Get() ) {
-						logger.Warn( "Found buggy %s%s%s driver, disabling ARB_bindless_texture.",
+						logger.Notice( "^1Found buggy %s%s%s driver, disabling ARB_bindless_texture.",
 							str1, str2, str3 );
 						bindlessTextureEnabled = false;
 					}
@@ -2468,13 +2468,13 @@ static void GLimp_InitExtensions()
 
 				if ( foundOglp && workaround_glDriver_amd_oglp_disableBindlessTexture.Get() )
 				{
-					logger.Warn( "Found buggy AMD OGLP driver, disabling ARB_bindless_texture." );
+					logger.Notice( "^1Found buggy AMD OGLP driver, disabling ARB_bindless_texture." );
 					bindlessTextureEnabled = false;
 				}
 
 				if ( foundAdrenalin && workaround_glDriver_amd_adrenalin_disableBindlessTexture.Get() )
 				{
-					logger.Warn( "Found buggy AMD Adrenalin driver, disabling ARB_bindless_texture." );
+					logger.Notice( "^1Found buggy AMD Adrenalin driver, disabling ARB_bindless_texture." );
 					bindlessTextureEnabled = false;
 				}
 			}

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2515,8 +2515,7 @@ static void GLimp_InitExtensions()
 		&& glConfig2.multiDrawIndirectAvailable && glConfig2.bindlessTexturesAvailable
 		&& glConfig2.computeShaderAvailable && glConfig2.shadingLanguage420PackAvailable
 		&& glConfig2.explicitUniformLocationAvailable && glConfig2.shaderImageLoadStoreAvailable
-		&& glConfig2.shaderAtomicCountersAvailable && glConfig2.indirectParametersAvailable
-		&& r_materialSystem.Get(); // Allow disabling it without disabling any extensions
+		&& glConfig2.shaderAtomicCountersAvailable && glConfig2.indirectParametersAvailable;
 
 	// This requires GLEW 2.2+, so skip if it's a lower version
 #ifdef GL_KHR_shader_subgroup
@@ -2554,7 +2553,7 @@ static void GLimp_InitExtensions()
 
 	// Currently this functionality is only used by material system shaders
 	if ( glConfig2.materialSystemAvailable ) {
-		Log::Warn( "Using outdated GLEW version, GL_KHR_shader_subgroup unavailable."
+		logger.Notice( "^1Using outdated GLEW version, GL_KHR_shader_subgroup unavailable."
 			"Update GLEW to 2.2+ to be able to use this extension" );
 	}
 #endif


### PR DESCRIPTION
- Disable GPU occlusion culling by default. @VReaperV and I agreed in an IRC chat a while back that it is not ready yet.
- Make it so that material system can be toggled with a single cvar, and updates on map change like all other latched renderer cvars. Right now it requires setting 2 cvars and only updates on a full renderer reload with `vid_restart`.