### PR TITLE
Don't do dynamic light computations if there are no dynamic lights

### DIFF
--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -243,6 +243,10 @@ void computeDynamicLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4
 	inout vec4 color, in usampler3D u_LightTiles )
 #endif // !USE_REFLECTIVE_SPECULAR
 {
+	if( u_numLights == 0 ) {
+		return;
+	}
+
 	vec2 tile = floor( gl_FragCoord.xy * ( 1.0 / float( TILE_SIZE ) ) ) + 0.5;
 
 	for( uint layer = 0; layer < numLayers; layer++ ) {

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -2830,6 +2830,10 @@ void RB_RenderPostDepthLightTile()
 		return;
 	}
 
+	if ( !backEnd.refdef.numLights ) {
+		return;
+	}
+
 	vec3_t zParams;
 	int w, h;
 


### PR DESCRIPTION
Avoid the overhead of fetching all or most of the lighttile texture and running shaders that do nothing when there are no dynamic lights.