### PR TITLE
Don't process binds if KEYCATCH_UI was just disabled

### DIFF
--- a/src/engine/client/cl_keys.cpp
+++ b/src/engine/client/cl_keys.cpp
@@ -584,12 +584,13 @@ void CL_KeyDownEvent( const Keyboard::Key& key1, const Keyboard::Key& key2, unsi
 		return;
 	}
 
-	bool uiConsumed = cgvm.CGameKeyDownEvent( key1, false );
+	bool uiConsumed = cls.keyCatchers & KEYCATCH_UI_KEY;
+	uiConsumed |= cgvm.CGameKeyDownEvent( key1, false );
 	uiConsumed |= cgvm.CGameKeyDownEvent( key2, false ); // non-short-circuiting!
 
 	// do binds only if KEYCATCH_UI_KEY is off and also the UI didn't indicate that it
 	// consumed the key
-	if ( uiConsumed || ( cls.keyCatchers & KEYCATCH_UI_KEY ) )
+	if ( uiConsumed )
 	{
 		return;
 	}


### PR DESCRIPTION
Decide whether to process binds based on the key catcher state before the key down event(s) are processed, not after. This is important to avoid double-processing a key if the UI turns off its key catcher in response to a key press.

Fixes https://github.com/Unvanquished/Unvanquished/issues/3113.