### PR TITLE
Fix R_CreateImage() crash with r_logFile

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -3101,8 +3101,9 @@ qhandle_t RE_GenerateTexture( const byte *pic, int width, int height )
 		return 0;
 	}
 
-	const char *name = va( "rocket%d", numTextures++ );
 	R_SyncRenderThread();
+
+	const char *name = va( "rocket%d", numTextures++ );
 
 	imageParams_t imageParams = {};
 	imageParams.bits = IF_NOPICMIP;


### PR DESCRIPTION
Fixes a crash resulting from `va()` overflow. Fixes #1020.