### PR TITLE
renderer: reverse r_fastSky as r_drawSky

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -33,7 +33,7 @@ backEndData_t  *backEndData[ SMP_FRAMES ];
 backEndState_t backEnd;
 
 static Cvar::Cvar<bool> r_clear( "r_clear", "Clear screen before painting over it on every frame", Cvar::NONE, false );
-Cvar::Cvar<bool> r_fastsky( "r_fastsky", "Clear sky instead of drawing it", Cvar::NONE, false );
+Cvar::Cvar<bool> r_drawSky( "r_drawSky", "Draw the sky (clear the sky if disabled)", Cvar::NONE, true );
 
 void GL_Bind( image_t *image )
 {
@@ -5404,8 +5404,8 @@ const RenderCommand *ClearBufferCommand::ExecuteSelf( ) const
 	// ensures that depth writes are enabled for the depth clear
 	GL_State( GLS_DEFAULT );
 
-	// Clear relevant buffers, r_fastsky always require clearing.
-	if ( r_clear.Get() || r_fastsky.Get() ) {
+	// Clear relevant buffers, not drawing the sky always require clearing.
+	if ( r_clear.Get() || !r_drawSky.Get() ) {
 		clearBits |= GL_COLOR_BUFFER_BIT;
 	}
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1130,7 +1130,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		Cvar::Latch( r_forceLegacyOverBrightClamping );
 		Cvar::Latch( r_lightMode );
 		Cvar::Latch( r_colorGrading );
-		Cvar::Latch( r_fastsky );
+		Cvar::Latch( r_drawSky );
 		r_lightStyles = Cvar_Get( "r_lightStyles", "1", CVAR_LATCH | CVAR_ARCHIVE );
 		r_exportTextures = Cvar_Get( "r_exportTextures", "0", 0 );
 		r_heatHaze = Cvar_Get( "r_heatHaze", "1", CVAR_LATCH | CVAR_ARCHIVE );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2722,7 +2722,7 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	extern cvar_t *r_ambientScale;
 	extern cvar_t *r_lightScale;
 
-	extern Cvar::Cvar<bool> r_fastsky; // Controls whether sky should be cleared or drawn.
+	extern Cvar::Cvar<bool> r_drawSky; // Controls whether sky should be drawn or cleared.
 	extern Cvar::Range<Cvar::Cvar<int>> r_realtimeLightingRenderer;
 	extern Cvar::Cvar<bool> r_realtimeLighting;
 	extern cvar_t *r_realtimeLightingCastShadows;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -245,7 +245,7 @@ static void GLSL_InitGPUShadersOrError()
 		}
 	}
 
-	if ( !r_fastsky.Get() )
+	if ( r_drawSky.Get() )
 	{
 		// skybox drawing for abitrary polygons
 		gl_shaderManager.load( gl_skyboxShader );

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -49,7 +49,7 @@ void Tess_StageIteratorSky()
 
 	tr.drawingSky = false;
 
-	if ( r_fastsky.Get() )
+	if ( !r_drawSky.Get() )
 	{
 		return;
 	}


### PR DESCRIPTION
We usually do end-users options the positive way, and this would be more consistent in option window where people ticks the boxes for enabling things.