### PR TITLE
Make overbright settings fully configurable (default no clamping version)

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1804,7 +1804,7 @@ image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 		return nullptr;
 	}
 
-	if ( imageParams.bits & IF_LIGHTMAP && tr.forceLegacyOverBrightClamping )
+	if ( imageParams.bits & IF_LIGHTMAP && tr.legacyOverBrightClamping )
 	{
 		R_ProcessLightmap( pic[ 0 ], width, height, imageParams.bits );
 	}
@@ -2971,8 +2971,8 @@ void R_InitImages()
 	Because tr.overbrightBits is always 0, tr.identityLight is
 	always 1.0f. We can entirely remove it. */
 
-	tr.mapOverBrightBits = r_mapOverBrightBits.Get();
-	tr.forceLegacyOverBrightClamping = r_forceLegacyOverBrightClamping.Get();
+	tr.mapOverBrightBits = r_overbrightDefaultExponent.Get();
+	tr.legacyOverBrightClamping = r_overbrightDefaultClamp.Get();
 
 	// create default texture and white texture
 	R_CreateBuiltinImages();

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -82,8 +82,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<bool> r_realtimeLighting( "r_realtimeLighting", "enable realtime light rendering", Cvar::NONE, true );
 	cvar_t      *r_realtimeLightingCastShadows;
 	cvar_t      *r_precomputedLighting;
-	Cvar::Cvar<int> r_mapOverBrightBits("r_mapOverBrightBits", "default map light color shift", Cvar::NONE, 2);
-	Cvar::Cvar<bool> r_forceLegacyOverBrightClamping("r_forceLegacyOverBrightClamping", "clamp over bright of legacy maps (enable multiplied color clamping and normalization)", Cvar::NONE, false);
+	Cvar::Cvar<int> r_overbrightDefaultExponent("r_overbrightDefaultExponent", "default map light color shift (multiply by 2^x)", Cvar::NONE, 2);
+	Cvar::Cvar<bool> r_overbrightDefaultClamp("r_overbrightDefaultClamp", "clamp lightmap colors to 1 (in absence of map worldspawn value)", Cvar::NONE, false);
+	Cvar::Cvar<bool> r_overbrightIgnoreMapSettings("r_overbrightIgnoreMapSettings", "force usage of r_overbrightDefaultClamp / r_overbrightDefaultExponent, ignoring worldspawn", Cvar::NONE, false);
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	Cvar::Cvar<bool> r_colorGrading( "r_colorGrading", "Use color grading", Cvar::NONE, true );
 	Cvar::Cvar<bool> r_materialSystem( "r_materialSystem", "Use Material System", Cvar::NONE, false );
@@ -1131,8 +1132,9 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_subdivisions = Cvar_Get( "r_subdivisions", "4", CVAR_LATCH );
 		r_realtimeLightingCastShadows = Cvar_Get( "r_realtimeLightingCastShadows", "1", 0 );
 		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_CHEAT | CVAR_LATCH );
-		Cvar::Latch( r_mapOverBrightBits );
-		Cvar::Latch( r_forceLegacyOverBrightClamping );
+		Cvar::Latch( r_overbrightDefaultExponent );
+		Cvar::Latch( r_overbrightDefaultClamp );
+		Cvar::Latch( r_overbrightIgnoreMapSettings );
 		Cvar::Latch( r_lightMode );
 		Cvar::Latch( r_colorGrading );
 		Cvar::Latch( r_fastsky );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2606,14 +2606,14 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 
 		viewParms_t    viewParms;
 
-		// r_mapOverbrightBits->integer, but can be overridden by mapper using the worldspawn
+		// r_overbrightDefaultExponent, but can be overridden by mapper using the worldspawn
 		int mapOverBrightBits;
 		// pow(2, mapOverbrightBits)
 		float mapLightFactor;
 		// 1 / mapLightFactor
 		float mapInverseLightFactor;
 		// May have to be true on some legacy maps: clamp and normalize multiplied colors.
-		bool forceLegacyOverBrightClamping;
+		bool legacyOverBrightClamping;
 
 		orientationr_t orientation; // for current entity
 
@@ -2737,8 +2737,9 @@ enum class realtimeLightingRenderer_t { LEGACY, TILED };
 	extern Cvar::Cvar<bool> r_realtimeLighting;
 	extern cvar_t *r_realtimeLightingCastShadows;
 	extern cvar_t *r_precomputedLighting;
-	extern Cvar::Cvar<int> r_mapOverBrightBits;
-	extern Cvar::Cvar<bool> r_forceLegacyOverBrightClamping;
+	extern Cvar::Cvar<int> r_overbrightDefaultExponent;
+	extern Cvar::Cvar<bool> r_overbrightDefaultClamp;
+	extern Cvar::Cvar<bool> r_overbrightIgnoreMapSettings;
 	extern Cvar::Range<Cvar::Cvar<int>> r_lightMode;
 	extern Cvar::Cvar<bool> r_colorGrading;
 	extern Cvar::Cvar<bool> r_materialSystem;


### PR DESCRIPTION
Same as #1350 but overbright clamping is NOT disabled by default. So this version would go ahead and change how all Unvanquished and most Tremulous maps are displayed