### PR TITLE
common: do not cap timedemo at 999fps

### DIFF
--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -870,11 +870,10 @@ void Com_Frame()
 	}
 	else
 	{
-		// Bad things happen if minMsec is 0.
 		// It looks like demo played with cvar_demo_timedemo enabled
 		// are not affected by the rendering bugs related to having
 		// minMsec being lower than 3.
-		minMsec = 1;
+		minMsec = 0;
 	}
 
 	Com_EventLoop();


### PR DESCRIPTION
This is something I totally forgot to submit, it was one of the purpose of me tracking many divisions by zero and other bugs related so small `minMsec` 20 months ago:

- https://github.com/DaemonEngine/Daemon/pull/812

The purpose is to not cap `timedemo` benchmarks at ~999fps (in fact more around 970fps because of time precision).

It goes against the idea of providing a benchmark feature if all hardware and driver would only report ~970fps if they can reach at least reach that.