### PR TITLE
Fix latch cvars not being archived

### DIFF
--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -505,6 +505,7 @@ namespace Cvar {
         it->second->flags |= INTERNAL_LATCH;
 
         if (it->second->latchedValue) {
+            cvar_modifiedFlags |= it->second->flags;
             it->second->value = std::move(*it->second->latchedValue);
             it->second->latchedValue = Util::nullopt;
             SetCCvar(*it->second);


### PR DESCRIPTION
Fixes https://github.com/Unvanquished/Unvanquished/issues/3120.

I suspect this is only now showing up due to removing useless cvar sets on cgame load with
https://github.com/Unvanquished/Unvanquished/pull/3099.