### PR TITLE
Fix heatHaze with material system

### DIFF
--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -315,6 +315,7 @@ class MaterialSystem {
 
 	bool AddPortalSurface( uint32_t viewID, PortalSurface* portalSurfs );
 
+	void RenderIndirect( const Material& material, const uint32_t viewID );
 	void RenderMaterial( Material& material, const uint32_t viewID );
 	void UpdateFrameData();
 };

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2786,6 +2786,7 @@ GLShader_heatHazeMaterial::GLShader_heatHazeMaterial( GLShaderManager* manager )
 	u_TextureMatrix( this ),
 	u_ViewOrigin( this ),
 	u_ViewUp( this ),
+	u_DeformEnable( this ),
 	u_DeformMagnitude( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1333,6 +1333,10 @@ void GLShaderManager::CompileAndLinkGPUShaderProgram( GLShader *shader, shaderPr
 
 // This will generate all the extra code for material system shaders
 std::string GLShaderManager::ShaderPostProcess( GLShader *shader, const std::string& shaderText ) {
+	if ( !shader->std430Size ) {
+		return shaderText;
+	}
+
 	std::string newShaderText;
 	std::string materialStruct = "\nstruct Material {\n";
 	std::string materialBlock = "layout(std430, binding = 0) readonly buffer materialsSSBO {\n"
@@ -1986,7 +1990,9 @@ void GLShader::PostProcessUniforms() {
 	}
 	_uniforms = tmp;
 
-	padding = ( structAlignment - ( structSize % structAlignment ) ) % structAlignment;
+	if ( structSize > 0 ) {
+		padding = ( structAlignment - ( structSize % structAlignment ) ) % structAlignment;
+	}
 	std430Size = structSize;
 	for ( GLUniform* uniform : globalUniforms ) {
 		_uniforms.emplace_back( uniform );

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -578,8 +578,8 @@ class GLUniformSampler1D : protected GLUniformSampler {
 
 class GLUniformSampler2D : protected GLUniformSampler {
 	protected:
-	GLUniformSampler2D( GLShader* shader, const char* name ) :
-		GLUniformSampler( shader, name, "sampler2D", 1 ) {
+	GLUniformSampler2D( GLShader* shader, const char* name, const bool global = false ) :
+		GLUniformSampler( shader, name, "sampler2D", 1, global ) {
 	}
 
 	inline GLint GetLocation() {
@@ -825,8 +825,8 @@ class GLUniform1Bool : protected GLUniform {
 class GLUniform1f : protected GLUniform
 {
 protected:
-	GLUniform1f( GLShader *shader, const char *name ) :
-	GLUniform( shader, name, "float", 1, 1, false )
+	GLUniform1f( GLShader *shader, const char *name, const bool global = false ) :
+	GLUniform( shader, name, "float", 1, 1, global )
 	{
 	}
 
@@ -2476,7 +2476,7 @@ class u_CurrentMap :
 	GLUniformSampler2D {
 	public:
 	u_CurrentMap( GLShader* shader ) :
-		GLUniformSampler2D( shader, "u_CurrentMap" ) {
+		GLUniformSampler2D( shader, "u_CurrentMap", true ) {
 	}
 
 	void SetUniform_CurrentMapBindless( GLuint64 bindlessHandle ) {
@@ -3368,7 +3368,7 @@ class u_ModelViewMatrixTranspose :
 {
 public:
 	u_ModelViewMatrixTranspose( GLShader *shader ) :
-		GLUniformMatrix4f( shader, "u_ModelViewMatrixTranspose" )
+		GLUniformMatrix4f( shader, "u_ModelViewMatrixTranspose", true )
 	{
 	}
 
@@ -3383,7 +3383,7 @@ class u_ProjectionMatrixTranspose :
 {
 public:
 	u_ProjectionMatrixTranspose( GLShader *shader ) :
-		GLUniformMatrix4f( shader, "u_ProjectionMatrixTranspose" )
+		GLUniformMatrix4f( shader, "u_ProjectionMatrixTranspose", true )
 	{
 	}
 
@@ -3675,6 +3675,18 @@ public:
 
 	void SetUniform_FogEyeT( float value )
 	{
+		this->SetValue( value );
+	}
+};
+
+class u_DeformEnable :
+	GLUniform1f {
+	public:
+	u_DeformEnable( GLShader* shader ) :
+		GLUniform1f( shader, "u_DeformEnable", true ) {
+	}
+
+	void SetUniform_DeformEnable( const bool value ) {
 		this->SetValue( value );
 	}
 };
@@ -4391,6 +4403,7 @@ class GLShader_heatHazeMaterial :
 	public u_TextureMatrix,
 	public u_ViewOrigin,
 	public u_ViewUp,
+	public u_DeformEnable,
 	public u_DeformMagnitude,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,

--- a/src/engine/renderer/glsl_source/heatHaze_fp.glsl
+++ b/src/engine/renderer/glsl_source/heatHaze_fp.glsl
@@ -29,6 +29,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 uniform sampler2D	u_CurrentMap;
 uniform float		u_AlphaThreshold;
 
+#if defined(MATERIAL_SYSTEM)
+	uniform float u_DeformEnable;
+#endif
+
 IN(smooth) vec2		var_TexCoords;
 IN(smooth) float	var_Deform;
 
@@ -51,7 +55,14 @@ void	main()
 	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	// offset by the scaled normal and clamp it to 0.0 - 1.0
-	st += normal.xy * var_Deform;
+	
+	#if defined(MATERIAL_SYSTEM)
+		// Use a global uniform for heatHaze with material system to avoid duplicating all of the shader stage data
+		st += normal.xy * var_Deform * u_DeformEnable;
+	#else
+		st += normal.xy * var_Deform;
+	#endif
+
 	st = clamp(st, 0.0, 1.0);
 
 	color = texture2D(u_CurrentMap, st);

--- a/src/engine/renderer/glsl_source/material_fp.glsl
+++ b/src/engine/renderer/glsl_source/material_fp.glsl
@@ -72,10 +72,6 @@ sampler2D u_DepthMap = sampler2D( u_DepthMap_initial );
 #endif
 #endif // !GENERIC_GLSL
 
-#if defined(HEATHAZE_GLSL)
-sampler2D u_CurrentMap = sampler2D( u_CurrentMap_initial );
-#endif // !HEATHAZE_GLSL
-
 #if defined(LIGHTMAPPING_GLSL)
 sampler2D u_DiffuseMap = sampler2D( u_DiffuseMap_initial );
 sampler2D u_MaterialMap = sampler2D( u_MaterialMap_initial );
@@ -87,7 +83,6 @@ sampler3D u_LightGrid2 = sampler3D( u_LightGrid2_initial );
 #endif // !LIGHTMAPPING_GLSL
 
 #if defined(LIQUID_GLSL)
-sampler2D u_CurrentMap = sampler2D( u_CurrentMap_initial );
 sampler2D u_PortalMap = sampler2D( u_PortalMap_initial );
 sampler2D u_DepthMap = sampler2D( u_DepthMap_initial );
 sampler3D u_LightGrid1 = sampler3D( u_LightGrid1_initial );
@@ -111,10 +106,6 @@ sampler2D u_HeightMap = sampler2D( u_NormalMap_initial );
 #endif // !USE_HEIGHTMAP_IN_NORMALMAP
 #endif // USE_RELIEF_MAPPING
 #endif // !RELIEFMAPPING_GLSL
-
-#if defined(SCREEN_GLSL)
-sampler2D u_CurrentMap = sampler2D( u_CurrentMap_initial );
-#endif // !SCREEN_GLSL
 
 #if defined(SKYBOX_GLSL)
 samplerCube u_ColorMapCube = samplerCube( u_ColorMapCube_initial );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2110,8 +2110,8 @@ void Render_heatHaze( shaderStage_t *pStage )
 
 	GLimp_LogComment( "--- Render_heatHaze ---\n" );
 
-	// Skip this until heatHaze is working with material system
 	if ( materialSystem.generatingWorldCommandBuffer ) {
+		Tess_DrawElements();
 		return;
 	}
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5476,8 +5476,6 @@ static void SetStagesRenderers()
 				};
 				break;
 			case stageType_t::ST_HEATHAZEMAP:
-				/* Comment from the Material code:
-				FIXME: This requires 2 draws per surface stage rather than 1. */
 				stageRendererOptions = {
 					&Render_heatHaze,
 					&UpdateSurfaceDataHeatHaze, &BindShaderHeatHaze, &ProcessMaterialHeatHaze,


### PR DESCRIPTION
Do a second rendering for heatHaze materials. This is done instead of making heatHaze into to stages to avoid duplicating the memory (+possible extra material padding).

Added a `u_DeformEnable` uniform to the material heaHaze shader variant, which is global, because `u_DeformMagnitude` is set to 0.0 for the second rendering of the surface/surfaces, but it must be put into SSBO because it can differ between stages/surfaces.

Fixes #1365.