### PR TITLE
Implement GPU lane usage profiling

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -147,6 +147,8 @@ set(RENDERERLIST
 
 set(GLSLSOURCELIST
     ${ENGINE_DIR}/renderer/glsl_source/common_cp.glsl
+    ${ENGINE_DIR}/renderer/glsl_source/shaderProfiler_vp.glsl
+    ${ENGINE_DIR}/renderer/glsl_source/shaderProfiler_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/clearSurfaces_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/cull_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/depthReduction_cp.glsl

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -2016,6 +2016,14 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 	uint32_t stateBits = material.stateBits;
 
 	if ( r_profilerRenderSubGroups.Get() ) {
+		const int materialID = r_profilerRenderSubGroupsStage.Get();
+		if ( materialID != -1 ) {
+			// Make sure we don't skip depth pre-pass materials; ID starts at opaque materials because we can't use this with depth materials
+			if ( ( material.globalID >= materialPacks[0].materials.size() ) && ( material.globalID != materialID + materialPacks[0].materials.size() ) ) {
+				return;
+			}
+		}
+
 		switch ( r_profilerRenderSubGroupsMode.Get() ) {
 			case Util::ordinal( shaderProfilerRenderSubGroupsMode::VS_OPAQUE ):
 			case Util::ordinal( shaderProfilerRenderSubGroupsMode::FS_OPAQUE ):

--- a/src/engine/renderer/ShadeCommon.h
+++ b/src/engine/renderer/ShadeCommon.h
@@ -240,3 +240,29 @@ inline void SetVertexLightingSettings( lightMode_t lightMode, colorGen_t& rgbGen
 		tess.svars.color.SetBlue( 0.0f );
 	}
 }
+
+inline uint GetShaderProfilerRenderSubGroupsMode( const uint32_t stateBits ) {
+	const bool isOpaque = !( stateBits & ( GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS ) );
+	const bool modeOpaque = r_profilerRenderSubGroupsMode.Get() == Util::ordinal( shaderProfilerRenderSubGroupsMode::VS_OPAQUE )
+		|| r_profilerRenderSubGroupsMode.Get() == Util::ordinal( shaderProfilerRenderSubGroupsMode::FS_OPAQUE );
+
+	if ( r_profilerRenderSubGroupsMode.Get() == Util::ordinal( shaderProfilerRenderSubGroupsMode::VS_ALL )
+		|| r_profilerRenderSubGroupsMode.Get() == Util::ordinal( shaderProfilerRenderSubGroupsMode::FS_ALL )
+		|| isOpaque == modeOpaque ) {
+
+		switch ( r_profilerRenderSubGroupsMode.Get() ) {
+			case Util::ordinal( shaderProfilerRenderSubGroupsMode::VS_OPAQUE ):
+			case Util::ordinal( shaderProfilerRenderSubGroupsMode::VS_TRANSPARENT ):
+			case Util::ordinal( shaderProfilerRenderSubGroupsMode::VS_ALL ):
+				return 1;
+			case Util::ordinal( shaderProfilerRenderSubGroupsMode::FS_OPAQUE ):
+			case Util::ordinal( shaderProfilerRenderSubGroupsMode::FS_TRANSPARENT ):
+			case Util::ordinal( shaderProfilerRenderSubGroupsMode::FS_ALL ):
+				return 2;
+			default:
+				break;
+		}
+	}
+
+	return 0;
+}

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -409,6 +409,16 @@ static const std::vector<addedExtension_t> fragmentVertexAddedExtensions = {
 	where the core variables have different names. */
 	{ glConfig2.shaderDrawParametersAvailable, -1, "ARB_shader_draw_parameters" },
 	{ glConfig2.SSBOAvailable, 430, "ARB_shader_storage_buffer_object" },
+	/* Even though these are part of the GL_KHR_shader_subgroup extension, we need to enable
+	the individual extensions for each feature.
+	GL_KHR_shader_subgroup itself can't be used in the shader. */
+	{ glConfig2.shaderSubgroupBasicAvailable, -1, "KHR_shader_subgroup_basic" },
+	{ glConfig2.shaderSubgroupVoteAvailable, -1, "KHR_shader_subgroup_vote" },
+	{ glConfig2.shaderSubgroupArithmeticAvailable, -1, "KHR_shader_subgroup_arithmetic" },
+	{ glConfig2.shaderSubgroupBallotAvailable, -1, "KHR_shader_subgroup_ballot" },
+	{ glConfig2.shaderSubgroupShuffleAvailable, -1, "KHR_shader_subgroup_shuffle" },
+	{ glConfig2.shaderSubgroupShuffleRelativeAvailable, -1, "KHR_shader_subgroup_shuffle_relative" },
+	{ glConfig2.shaderSubgroupQuadAvailable, -1, "KHR_shader_subgroup_quad" },
 };
 
 // Compute version declaration, this has to be separate from other shader stages,
@@ -468,7 +478,7 @@ static void AddConst( std::string& str, const std::string& name, float v1, float
 
 static std::string GenVersionDeclaration( const std::vector<addedExtension_t> &addedExtensions ) {
 	// Declare version.
-	std::string str = Str::Format( "#version %d %s\n",
+	std::string str = Str::Format( "#version %d %s\n\n",
 		glConfig2.shadingLanguageVersion,
 		glConfig2.shadingLanguageVersion >= 150 ? ( glConfig2.glCoreProfile ? "core" : "compatibility" ) : "" );
 
@@ -741,6 +751,11 @@ static std::string GenEngineConstants() {
 	if ( r_materialDebug.Get() )
 	{
 		AddDefine( str, "r_materialDebug", 1 );
+	}
+
+	if ( r_profilerRenderSubGroups.Get() )
+	{
+		AddDefine( str, "r_profilerRenderSubGroups", 1 );
 	}
 
 	if ( glConfig2.vboVertexSkinningAvailable )
@@ -1415,20 +1430,21 @@ std::string GLShaderManager::ShaderPostProcess( GLShader *shader, const std::str
 	*  their values will be sourced from a buffer instead
 	*  Global uniforms (like u_ViewUp and u_ViewOrigin) will still be set as regular uniforms */
 	while( std::getline( shaderTextStream, line, '\n' ) ) {
-		if( !( line.find( "uniform" ) == std::string::npos || line.find( ";" ) == std::string::npos ) ) {
+		bool skip = false;
+		if ( line.find( "uniform" ) < line.find( "//" ) && line.find( ";" ) != std::string::npos ) {
+			for ( GLUniform* uniform : shader->_uniforms ) {
+				if ( !uniform->IsGlobal() && ( line.find( uniform->GetName() ) != std::string::npos ) ) {
+					skip = true;
+					break;
+				}
+			}
+		}
+
+		if ( skip ) {
 			continue;
 		}
-		shaderMain += line + "\n";
-	}
 
-	for ( GLUniform* uniform : shader->_uniforms ) {
-		if ( uniform->IsGlobal() ) {
-			materialDefines += "uniform " + uniform->GetType() + " " + uniform->GetName();
-			if ( uniform->GetComponentSize() ) {
-				materialDefines += "[ " + std::to_string( uniform->GetComponentSize() ) + " ]";
-			}
-			materialDefines += ";\n";
-		}
+		shaderMain += line + "\n";
 	}
 
 	materialDefines += "\n";
@@ -2197,6 +2213,8 @@ GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	u_Bones( this ),
 	u_VertexInterpolation( this ),
 	u_DepthScale( this ),
+	u_ProfilerZero( this ),
+	u_ProfilerRenderSubGroups( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
@@ -2230,6 +2248,8 @@ GLShader_genericMaterial::GLShader_genericMaterial( GLShaderManager* manager ) :
 	u_DepthScale( this ),
 	u_ShowTris( this ),
 	u_MaterialColour( this ),
+	u_ProfilerZero( this ),
+	u_ProfilerRenderSubGroups( this ),
 	GLDeformStage( this ),
 	// GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
@@ -2277,6 +2297,8 @@ GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 	u_LightGridScale( this ),
 	u_numLights( this ),
 	u_Lights( this ),
+	u_ProfilerZero( this ),
+	u_ProfilerRenderSubGroups( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_BSP_SURFACE( this ),
 	GLCompileMacro_USE_VERTEX_SKINNING( this ),
@@ -2346,6 +2368,8 @@ GLShader_lightMappingMaterial::GLShader_lightMappingMaterial( GLShaderManager* m
 	u_Lights( this ),
 	u_ShowTris( this ),
 	u_MaterialColour( this ),
+	u_ProfilerZero( this ),
+	u_ProfilerRenderSubGroups( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_BSP_SURFACE( this ),
 	// GLCompileMacro_USE_VERTEX_SKINNING( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3318,6 +3318,32 @@ class u_MaterialColour :
 	}
 };
 
+// u_Profiler* uniforms are all used for shader profiling, with the corresponding r_profiler* cvars
+// u_ProfilerZero is used to reset the colour in a shader without the shader compiler optimising the rest of the shader out
+class u_ProfilerZero :
+	GLUniform1f {
+	public:
+	u_ProfilerZero( GLShader* shader ) :
+		GLUniform1f( shader, "u_ProfilerZero", true ) {
+	}
+
+	void SetUniform_ProfilerZero() {
+		this->SetValue( 0.0 );
+	}
+};
+
+class u_ProfilerRenderSubGroups :
+	GLUniform1ui {
+	public:
+	u_ProfilerRenderSubGroups( GLShader* shader ) :
+		GLUniform1ui( shader, "u_ProfilerRenderSubGroups", true ) {
+	}
+
+	void SetUniform_ProfilerRenderSubGroups( const uint renderSubGroups ) {
+		this->SetValue( renderSubGroups );
+	}
+};
+
 class u_ModelMatrix :
 	GLUniformMatrix4f
 {
@@ -3913,6 +3939,8 @@ class GLShader_generic :
 	public u_Bones,
 	public u_VertexInterpolation,
 	public u_DepthScale,
+	public u_ProfilerZero,
+	public u_ProfilerRenderSubGroups,
 	public GLDeformStage,
 	public GLCompileMacro_USE_VERTEX_SKINNING,
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
@@ -3943,6 +3971,8 @@ class GLShader_genericMaterial :
 	public u_DepthScale,
 	public u_ShowTris,
 	public u_MaterialColour,
+	public u_ProfilerZero,
+	public u_ProfilerRenderSubGroups,
 	public GLDeformStage,
 	// public GLCompileMacro_USE_VERTEX_SKINNING,
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
@@ -3987,6 +4017,8 @@ class GLShader_lightMapping :
 	public u_LightGridScale,
 	public u_numLights,
 	public u_Lights,
+	public u_ProfilerZero,
+	public u_ProfilerRenderSubGroups,
 	public GLDeformStage,
 	public GLCompileMacro_USE_BSP_SURFACE,
 	public GLCompileMacro_USE_VERTEX_SKINNING,
@@ -4039,6 +4071,8 @@ class GLShader_lightMappingMaterial :
 	public u_Lights,
 	public u_ShowTris,
 	public u_MaterialColour,
+	public u_ProfilerZero,
+	public u_ProfilerRenderSubGroups,
 	public GLDeformStage,
 	public GLCompileMacro_USE_BSP_SURFACE,
 	// public GLCompileMacro_USE_VERTEX_SKINNING,

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -28,7 +28,7 @@ uniform sampler2D	u_ColorMap;
 uniform float		u_AlphaThreshold;
 
 #if !defined(GENERIC_2D)
-uniform float u_InverseLightFactor;
+	uniform float u_InverseLightFactor;
 #endif
 
 #if defined(USE_MATERIAL_SYSTEM)
@@ -43,6 +43,8 @@ IN(smooth) vec4		var_Color;
 IN(smooth) vec2         var_FadeDepth;
 uniform sampler2D       u_DepthMap;
 #endif
+
+#insert shaderProfiler_fp
 
 DECLARE_OUTPUT(vec4)
 
@@ -76,6 +78,8 @@ void	main()
 #if !defined(GENERIC_2D)
 	color.rgb *= u_InverseLightFactor;
 #endif
+	
+	SHADER_PROFILER_SET( color )
 
 	outputColor = color;
 

--- a/src/engine/renderer/glsl_source/generic_vp.glsl
+++ b/src/engine/renderer/glsl_source/generic_vp.glsl
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #insert vertexSimple_vp
 #insert vertexSkinning_vp
 #insert vertexAnimation_vp
+#insert shaderProfiler_vp
 
 uniform mat4		u_TextureMatrix;
 uniform vec3		u_ViewOrigin;
@@ -98,6 +99,8 @@ void	main()
 	vec4 fadeDepth = u_ModelViewProjectionMatrix * (position - u_DepthScale * vec4(LB.normal, 0.0));
 	var_FadeDepth = fadeDepth.zw;
 #endif
+
+	SHADER_PROFILER_SET
 
 	var_Color = color;
 }

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -62,6 +62,8 @@ uniform sampler3D u_LightGrid2;
 	uniform vec3 u_MaterialColour;
 #endif
 
+#insert shaderProfiler_fp
+
 DECLARE_OUTPUT(vec4)
 
 void main()
@@ -227,6 +229,8 @@ void main()
 
 		color.rgb += glow;
 	#endif
+	
+	SHADER_PROFILER_SET( color )
 
 	outputColor = color;
 

--- a/src/engine/renderer/glsl_source/lightMapping_vp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_vp.glsl
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #insert vertexSimple_vp
 #insert vertexSkinning_vp
 #insert vertexAnimation_vp
+#insert shaderProfiler_vp
 
 #if !defined(USE_BSP_SURFACE)
 	#define USE_MODEL_SURFACE
@@ -98,6 +99,8 @@ void main()
 	#if defined(USE_LIGHT_MAPPING) || defined(USE_DELUXE_MAPPING)
 		var_TexLight = lmCoord;
 	#endif
+
+	SHADER_PROFILER_SET
 
 	// transform diffusemap texcoords
 	var_TexCoords = (u_TextureMatrix * vec4(texCoord, 0.0, 1.0)).st;

--- a/src/engine/renderer/glsl_source/shaderProfiler_fp.glsl
+++ b/src/engine/renderer/glsl_source/shaderProfiler_fp.glsl
@@ -1,0 +1,65 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+
+/* shaderProfiler_fp.glsl */
+
+#if defined(r_profilerRenderSubGroups) && !defined(GENERIC_2D) && defined(HAVE_KHR_shader_subgroup_basic) && defined(HAVE_KHR_shader_subgroup_arithmetic)
+	uniform float u_ProfilerZero;
+	uniform uint u_ProfilerRenderSubGroups;
+	IN(flat) float var_SubGroupCount;
+
+	#define SHADER_PROFILER_SET( color ) SetSubGroupColor( color );
+
+	void SetSubGroupColor( inout vec4 color ) {
+		if( u_ProfilerRenderSubGroups != 0 ) {
+			color *= u_ProfilerZero; // Multiply with an 0.0 uniform to stop shader compiler from optmising away the code
+
+			float count = u_ProfilerRenderSubGroups == 2 ? subgroupAdd( 1.0 ) / float( gl_SubgroupSize ) : var_SubGroupCount;
+
+			// Changes the colour to indicate how many active lanes are there in the subgroup
+			color += vec4( count < 0.5 ? count + 0.5 : 0.0,
+				            count >= 0.5 ? count : 0.0,
+							0.0, 1.0 );
+							   
+			/* HACK: use sign to know if there is a light or not, and
+			then if it will receive overbright multiplication or not. */
+			if ( u_InverseLightFactor < 0 )
+			{
+				color *= -u_InverseLightFactor;
+			}
+		}
+	}
+#else
+	#define SHADER_PROFILER_SET( color )
+#endif

--- a/src/engine/renderer/glsl_source/shaderProfiler_vp.glsl
+++ b/src/engine/renderer/glsl_source/shaderProfiler_vp.glsl
@@ -1,0 +1,48 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2024 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+
+/* shaderProfiler_vp.glsl */
+
+#if defined(r_profilerRenderSubGroups) && !defined(GENERIC_2D) && defined(HAVE_KHR_shader_subgroup_basic) && defined(HAVE_KHR_shader_subgroup_arithmetic)
+	uniform uint u_ProfilerRenderSubGroups;
+	OUT(flat) float var_SubGroupCount;
+
+	#define SHADER_PROFILER_SET \
+		if( u_ProfilerRenderSubGroups == 1 ) {\
+			var_SubGroupCount = subgroupAdd( 1.0 ) / float( gl_SubgroupSize );\
+		}
+#else
+	#define SHADER_PROFILER_OUT
+	#define SHADER_PROFILER_SET
+#endif

--- a/src/engine/renderer/shaders.cpp
+++ b/src/engine/renderer/shaders.cpp
@@ -60,6 +60,8 @@
 #include "material_vp.glsl.h"
 #include "material_fp.glsl.h"
 #include "common_cp.glsl.h"
+#include "shaderProfiler_vp.glsl.h"
+#include "shaderProfiler_fp.glsl.h"
 #include "clearSurfaces_cp.glsl.h"
 #include "cull_cp.glsl.h"
 #include "depthReduction_cp.glsl.h"
@@ -121,6 +123,8 @@ std::unordered_map<std::string, std::string> shadermap({
 	{ "reliefMapping_fp.glsl", std::string(reinterpret_cast<const char*>(reliefMapping_fp_glsl), sizeof(reliefMapping_fp_glsl)) },
 	{ "screen_fp.glsl", std::string(reinterpret_cast<const char*>(screen_fp_glsl), sizeof(screen_fp_glsl)) },
 	{ "screen_vp.glsl", std::string(reinterpret_cast<const char*>(screen_vp_glsl), sizeof(screen_vp_glsl)) },
+	{ "shaderProfiler_vp.glsl", std::string( reinterpret_cast< const char* >( shaderProfiler_vp_glsl ), sizeof( shaderProfiler_vp_glsl ) ) },
+	{ "shaderProfiler_fp.glsl", std::string( reinterpret_cast< const char* >( shaderProfiler_fp_glsl ), sizeof( shaderProfiler_fp_glsl ) ) },
 	{ "shadowFill_fp.glsl", std::string(reinterpret_cast<const char*>(shadowFill_fp_glsl), sizeof(shadowFill_fp_glsl)) },
 	{ "shadowFill_vp.glsl", std::string(reinterpret_cast<const char*>(shadowFill_vp_glsl), sizeof(shadowFill_vp_glsl)) },
 	{ "skybox_fp.glsl", std::string(reinterpret_cast<const char*>(skybox_fp_glsl), sizeof(skybox_fp_glsl)) },

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -256,6 +256,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<bool> r_materialDebug( "r_materialDebug", "Enable material debug SSBO", Cvar::NONE, false );
 	cvar_t      *r_showParallelShadowSplits;
 
+	Cvar::Cvar<bool> r_profilerRenderSubGroups( "r_profilerRenderSubGroups", "Enable subgroup profiling in rendering shaders", Cvar::NONE, false );
+	Cvar::Range<Cvar::Cvar<int>> r_profilerRenderSubGroupsMode( "r_profilerRenderSubGroupsMode", "Red: more wasted lanes, green: less wasted lanes; "
+		"0: VS opaque, 1: VS transparent, 2: VS all, 3: FS opaque, 4: FS transparent, 5: FS all", Cvar::NONE,
+		Util::ordinal( shaderProfilerRenderSubGroupsMode::VS_OPAQUE ),
+		Util::ordinal( shaderProfilerRenderSubGroupsMode::VS_OPAQUE ),
+		Util::ordinal( shaderProfilerRenderSubGroupsMode::FS_ALL ) );
+
 	cvar_t      *r_vboFaces;
 	cvar_t      *r_vboCurves;
 	cvar_t      *r_vboTriangles;
@@ -1344,6 +1351,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		Cvar::Latch( r_showGlobalMaterials );
 		Cvar::Latch( r_materialDebug );
 		r_showParallelShadowSplits = Cvar_Get( "r_showParallelShadowSplits", "0", CVAR_CHEAT | CVAR_LATCH );
+
+		Cvar::Latch( r_profilerRenderSubGroups );
 
 		// make sure all the commands added here are also removed in R_Shutdown
 		ri.Cmd_AddCommand( "listImages", R_ListImages_f );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -256,12 +256,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<bool> r_materialDebug( "r_materialDebug", "Enable material debug SSBO", Cvar::NONE, false );
 	cvar_t      *r_showParallelShadowSplits;
 
-	Cvar::Cvar<bool> r_profilerRenderSubGroups( "r_profilerRenderSubGroups", "Enable subgroup profiling in rendering shaders", Cvar::NONE, false );
+	Cvar::Cvar<bool> r_profilerRenderSubGroups( "r_profilerRenderSubGroups", "Enable subgroup profiling in rendering shaders", Cvar::CHEAT, false );
 	Cvar::Range<Cvar::Cvar<int>> r_profilerRenderSubGroupsMode( "r_profilerRenderSubGroupsMode", "Red: more wasted lanes, green: less wasted lanes; "
 		"0: VS opaque, 1: VS transparent, 2: VS all, 3: FS opaque, 4: FS transparent, 5: FS all", Cvar::NONE,
 		Util::ordinal( shaderProfilerRenderSubGroupsMode::VS_OPAQUE ),
 		Util::ordinal( shaderProfilerRenderSubGroupsMode::VS_OPAQUE ),
 		Util::ordinal( shaderProfilerRenderSubGroupsMode::FS_ALL ) );
+	Cvar::Cvar<int> r_profilerRenderSubGroupsStage( "r_profilerRenderSubGroupsStage", "Select a specific"
+		"stage/material ID (if material system is enabled) for subgroup profiling "
+		"(-1 to profile all stages/materials, rendered in their usual order); "
+		"for materials, material IDs start from opaque materials, depth pre-pass materials are ignored", Cvar::NONE, -1 );
 
 	cvar_t      *r_vboFaces;
 	cvar_t      *r_vboCurves;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -308,6 +308,15 @@ enum class cubeProbesAutoBuildMode {
 	ALWAYS
 };
 
+enum class shaderProfilerRenderSubGroupsMode {
+	VS_OPAQUE,
+	VS_TRANSPARENT,
+	VS_ALL,
+	FS_OPAQUE,
+	FS_TRANSPARENT,
+	FS_ALL
+};
+
 	enum class renderSpeeds_t
 	{
 	  RSPEEDS_GENERAL = 1,
@@ -3033,6 +3042,9 @@ enum class cubeProbesAutoBuildMode {
 	extern Cvar::Range<Cvar::Cvar<int>> r_showGlobalMaterials;
 	extern Cvar::Cvar<bool> r_materialDebug;
 	extern cvar_t *r_showParallelShadowSplits;
+
+	extern Cvar::Cvar<bool> r_profilerRenderSubGroups;
+	extern Cvar::Range<Cvar::Cvar<int>> r_profilerRenderSubGroupsMode;
 
 	extern cvar_t *r_vboFaces;
 	extern cvar_t *r_vboCurves;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3045,6 +3045,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 	extern Cvar::Cvar<bool> r_profilerRenderSubGroups;
 	extern Cvar::Range<Cvar::Cvar<int>> r_profilerRenderSubGroupsMode;
+	extern Cvar::Cvar<int> r_profilerRenderSubGroupsStage;
 
 	extern cvar_t *r_vboFaces;
 	extern cvar_t *r_vboCurves;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -966,6 +966,18 @@ void Render_generic3D( shaderStage_t *pStage )
 		);
 	}
 
+	if ( r_profilerRenderSubGroups.Get() ) {
+		const uint mode = GetShaderProfilerRenderSubGroupsMode( pStage->stateBits );
+		if( mode == 0 ) {
+			return;
+		}
+
+		GL_State( pStage->stateBits & ~( GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS ) );
+
+		gl_genericShader->SetUniform_ProfilerZero();
+		gl_genericShader->SetUniform_ProfilerRenderSubGroups( mode );
+	}
+
 	gl_genericShader->SetRequiredVertexPointers();
 
 	Tess_DrawElements();
@@ -1260,6 +1272,18 @@ void Render_lightMapping( shaderStage_t *pStage )
 		gl_lightMappingShader->SetUniform_GlowMapBindless(
 			GL_BindToTMU( BIND_GLOWMAP, pStage->bundle[TB_GLOWMAP].image[0] )
 		);
+	}
+
+	if ( r_profilerRenderSubGroups.Get() ) {
+		const uint mode = GetShaderProfilerRenderSubGroupsMode( stateBits );
+		if ( mode == 0 ) {
+			return;
+		}
+
+		GL_State( stateBits & ~( GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS ) );
+
+		gl_lightMappingShader->SetUniform_ProfilerZero();
+		gl_lightMappingShader->SetUniform_ProfilerRenderSubGroups( mode );
 	}
 
 	gl_lightMappingShader->SetRequiredVertexPointers();

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -966,7 +966,7 @@ void Render_generic3D( shaderStage_t *pStage )
 		);
 	}
 
-	if ( r_profilerRenderSubGroups.Get() ) {
+	if ( r_profilerRenderSubGroups.Get() && !( pStage->stateBits & GLS_DEPTHMASK_TRUE ) ) {
 		const uint mode = GetShaderProfilerRenderSubGroupsMode( pStage->stateBits );
 		if( mode == 0 ) {
 			return;
@@ -1274,7 +1274,7 @@ void Render_lightMapping( shaderStage_t *pStage )
 		);
 	}
 
-	if ( r_profilerRenderSubGroups.Get() ) {
+	if ( r_profilerRenderSubGroups.Get() && !( pStage->stateBits & GLS_DEPTHMASK_TRUE ) ) {
 		const uint mode = GetShaderProfilerRenderSubGroupsMode( stateBits );
 		if ( mode == 0 ) {
 			return;
@@ -2767,12 +2767,20 @@ void Tess_StageIteratorColor()
 	}
 
 	// call shader function
-	uint stage = 0;
+	int stage = 0;
 	for ( shaderStage_t *pStage = tess.surfaceStages; pStage < tess.surfaceLastStage; pStage++ )
 	{
 		if ( !RB_EvalExpression( &pStage->ifExp, 1.0 ) && !( materialSystem.generatingWorldCommandBuffer && pStage->useMaterialSystem ) )
 		{
 			continue;
+		}
+
+		if ( r_profilerRenderSubGroups.Get() && !backEnd.projection2D && !( pStage->stateBits & GLS_DEPTHMASK_TRUE ) ) {
+			const int stageID = r_profilerRenderSubGroupsStage.Get();
+			if( ( stageID != -1 ) && ( stageID != stage ) ) {
+				stage++;
+				continue;
+			}
 		}
 
 		Tess_ComputeColor( pStage );


### PR DESCRIPTION
Add `r_profilerRenderSubGroups` and `r_profilerRenderSubGroupsMode`.

If `r_profilerRenderSubGroups` is enabled and the required subgroup extensions are suported, lightMapping and generic shaders will change their output colour to `dim red->bright red->dim green->bright green` based on how many active lanes in either the VS or FS there are.

Modes:
0: VS opaque
1: VS transparent
2: VS all
3: FS opaque
4: FS transparent
5: FS all

Also improved shader post-processing to leave global uniforms in-place to make this work, and made it consider comments on the same line.

More red = ~more scary~ worse (less active lanes), more green = better (more active lanes)
This is an example of using mode 0 on plat23:
![unvanquished_2024-10-20_225919_000](https://github.com/user-attachments/assets/2b8a5a3f-de43-41a8-b9e3-d1b213fc4027)
Mode 2:
![unvanquished_2024-10-20_225939_000](https://github.com/user-attachments/assets/92306b13-6c92-4810-bd2b-987ab7f1ba0e)
The surfaces resulting from rendering commands with few triangles are the more red ones.
Mode 3:
![unvanquished_2024-10-20_225947_000](https://github.com/user-attachments/assets/66466d02-bbb8-4f2e-b72d-0dc4accf39c6)
Mode 5:
![unvanquished_2024-10-20_225956_000](https://github.com/user-attachments/assets/7a90b5d8-e0fd-456b-a71b-664eeca5aef0)
The triangle edges, for example, have more inactive lanes.

Dense vegetation on map `moonbase`, VS lanes are mostly good:
![unvanquished_2024-10-20_230210_000](https://github.com/user-attachments/assets/5313de72-bd22-475e-b623-f146f0807a29)
But there's a lot of wasted FS lanes:
![unvanquished_2024-10-20_230220_000](https://github.com/user-attachments/assets/47da67ce-c794-48ae-b064-9b37329284dc)

I've originally thought of doing this because of something that caught my attention in one of the error logs that @illwieckz has sent me for some shader change or another. Lanes can become inactive for many reasons: not enough work for the SIMD unit to do, triangle edges, too much register pressure etc... The log illwieckz sent me had a line that said something along the lines of only 1 invocation being active at maximum, so it'd be interesting to see the results of using this on Mesa.

Requires subgroup extensions.