### PR TITLE
Allow changing the amount of dynamic light layers

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -596,6 +596,7 @@ static std::string GenEngineConstants() {
 	AddDefine( str, "M_PI", static_cast< float >( M_PI ) );
 	AddDefine( str, "MAX_SHADOWMAPS", MAX_SHADOWMAPS );
 	AddDefine( str, "MAX_REF_LIGHTS", MAX_REF_LIGHTS );
+	AddDefine( str, "NUM_LIGHT_LAYERS", glConfig2.realtimeLightLayers );
 	AddDefine( str, "TILE_SIZE", TILE_SIZE );
 
 	AddDefine( str, "r_FBufSize", glConfig.vidWidth, glConfig.vidHeight );

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -49,16 +49,13 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #endif
 
 #if defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING) || defined(r_realtimeLighting)
-#if !defined(USE_PHYSICAL_MAPPING)
-#if defined(r_specularMapping)
-	uniform vec2 u_SpecularExponent;
+	#if !defined(USE_PHYSICAL_MAPPING) && defined(r_specularMapping)
+		uniform vec2 u_SpecularExponent;
 
-vec3 computeSpecularity(vec3 lightColor, vec4 materialColor, float NdotH)
-{
-	return lightColor * materialColor.rgb * pow(NdotH, u_SpecularExponent.x * materialColor.a + u_SpecularExponent.y) * r_SpecularScale;
-}
-#endif
-#endif
+		vec3 computeSpecularity( vec3 lightColor, vec4 materialColor, float NdotH ) {
+			return lightColor * materialColor.rgb * pow(NdotH, u_SpecularExponent.x * materialColor.a + u_SpecularExponent.y) * r_SpecularScale;
+		}
+	#endif
 #endif
 
 #if defined(USE_DELUXE_MAPPING) || defined(USE_GRID_DELUXE_MAPPING) || (defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1)

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -222,8 +222,7 @@ const int lightsPerLayer = 16;
 
 uniform usampler3D u_LightTiles;
 
-const uint numLayers = MAX_REF_LIGHTS / 256;
-const vec3 tileScale = vec3( r_tileStep, 1.0 / float( numLayers ) );
+const vec3 tileScale = vec3( r_tileStep, 1.0 / float( NUM_LIGHT_LAYERS ) );
 
 idxs_t fetchIdxs( in vec3 coords, in usampler3D u_LightTiles ) {
 	return texture3D( u_LightTiles, coords );
@@ -245,7 +244,7 @@ void computeDynamicLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4
 {
 	vec2 tile = floor( gl_FragCoord.xy * ( 1.0 / float( TILE_SIZE ) ) ) + 0.5;
 
-	for( uint layer = 0; layer < numLayers; layer++ ) {
+	for( uint layer = 0; layer < NUM_LIGHT_LAYERS; layer++ ) {
 		uint lightCount = 0;
 		idxs_t idxs = fetchIdxs( tileScale * vec3( tile, float( layer ) + 0.5 ), u_LightTiles );
 
@@ -258,7 +257,7 @@ void computeDynamicLights( vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse, vec4
 
 			/* Light IDs are stored relative to the layer
 			Subtract 1 because 0 means there's no light */
-			idx = ( idx - 1 ) * numLayers + layer;
+			idx = ( idx - 1 ) * NUM_LIGHT_LAYERS + layer;
 	  
 			#if defined(USE_REFLECTIVE_SPECULAR)
 				computeDynamicLight( idx, P, normal, viewDir, diffuse, material, color, u_EnvironmentMap0, u_EnvironmentMap1 );

--- a/src/engine/renderer/glsl_source/lighttile_fp.glsl
+++ b/src/engine/renderer/glsl_source/lighttile_fp.glsl
@@ -60,8 +60,6 @@ uniform sampler2D u_DepthMap;
 uniform int u_lightLayer;
 uniform vec3 u_zFar;
 
-const int numLayers = MAX_REF_LIGHTS / 256;
-
 const int lightsPerLayer = 16;
 
 #define idxs_t uvec4
@@ -123,7 +121,7 @@ void main() {
 	only process 1 / 4 of different lights for each layer, extra lights going into the last layer. This can fail to add some lights
 	if 1 / 4 of all lights is more than the amount of lights that each layer can hold (16). To fix this, we'd need to either do this on CPU
 	or use compute shaders with atomics so we can have a variable amount of lights for each tile. */
-	for( uint i = u_lightLayer; i < u_numLights; i += numLayers ) {
+	for( uint i = u_lightLayer; i < u_numLights; i += NUM_LIGHT_LAYERS ) {
 		Light l = GetLight( i );
 		vec3 center = ( u_ModelMatrix * vec4( l.center, 1.0 ) ).xyz;
 		float radius = max( 2.0 * l.radius, 2.0 * 32.0 ); // Avoid artifacts with weak light sources
@@ -139,7 +137,7 @@ void main() {
 		if( radius > 0.0 ) {
 			/* Light IDs are stored relative to the layer
 			Add 1 because 0 means there's no light */
-			pushIdxs( ( i / numLayers ) + 1, lightCount, idxs );
+			pushIdxs( ( i / NUM_LIGHT_LAYERS ) + 1, lightCount, idxs );
 			lightCount++;
 
 			if( lightCount == lightsPerLayer ) {

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -2911,7 +2911,7 @@ void RB_RenderPostDepthLightTile()
 
 	R_BindVBO( tr.lighttileVBO );
 
-	for( int layer = 0; layer < MAX_REF_LIGHTS / 256; layer++ ) {
+	for( int layer = 0; layer < glConfig2.realtimeLightLayers; layer++ ) {
 		R_AttachFBOTexture3D( tr.lighttileRenderImage->texnum, 0, layer );
 		gl_lighttileShader->SetUniform_lightLayer( layer );
 

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2574,7 +2574,7 @@ static void R_CreateDepthRenderImage()
 
 		imageParams.bits = IF_NOPICMIP | IF_RGBA32UI;
 
-		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, 4, imageParams );
+		tr.lighttileRenderImage = R_Create3DImage( "_lighttileRender", nullptr, w, h, glConfig2.realtimeLightLayers, imageParams );
 	}
 }
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -77,7 +77,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 		Util::ordinal(realtimeLightingRenderer_t::TILED),
 		Util::ordinal(realtimeLightingRenderer_t::LEGACY),
 		Util::ordinal(realtimeLightingRenderer_t::TILED) );
-	Cvar::Cvar<bool> r_realtimeLighting( "r_realtimeLighting", "enable realtime light rendering", Cvar::NONE, true );
+	Cvar::Cvar<bool> r_realtimeLighting( "r_realtimeLighting", "Enable realtime light rendering", Cvar::NONE, true );
+	Cvar::Range<Cvar::Cvar<int>> r_realtimeLightLayers( "r_realtimeLightLayers", "Dynamic light layers per tile, each layer holds 16 lights",
+		Cvar::NONE, 4, 1, MAX_REF_LIGHTS / 16 );
 	cvar_t      *r_realtimeLightingCastShadows;
 	cvar_t      *r_precomputedLighting;
 	Cvar::Cvar<int> r_overbrightDefaultExponent("r_overbrightDefaultExponent", "default map light color shift (multiply by 2^x)", Cvar::NONE, 2);
@@ -1205,6 +1207,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		Cvar::Latch( r_realtimeLightingRenderer );
 		Cvar::Latch( r_realtimeLighting );
+		Cvar::Latch( r_realtimeLightLayers );
 		Cvar::Latch( r_preferBindlessTextures );
 		Cvar::Latch( r_materialSystem );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -198,9 +198,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 #define TILE_SHIFT_STEP1 2
 #define TILE_SIZE_STEP1  (1 << TILE_SHIFT_STEP1)
 
-// max. 16 dynamic lights per plane
-#define LIGHT_PLANES ( MAX_REF_LIGHTS / 16 )
-
 struct glFboShim_t
 {
 	/* Functions with same signature and similar purpose can be provided by:

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2882,6 +2882,7 @@ enum class cubeProbesAutoBuildMode {
 	extern Cvar::Cvar<bool> r_drawSky; // Controls whether sky should be drawn or cleared.
 	extern Cvar::Range<Cvar::Cvar<int>> r_realtimeLightingRenderer;
 	extern Cvar::Cvar<bool> r_realtimeLighting;
+	extern Cvar::Range<Cvar::Cvar<int>> r_realtimeLightLayers;
 	extern cvar_t *r_realtimeLightingCastShadows;
 	extern cvar_t *r_precomputedLighting;
 	extern Cvar::Cvar<int> r_overbrightDefaultExponent;

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -137,6 +137,7 @@ struct glconfig2_t
 
 	bool colorGrading;
 	bool realtimeLighting;
+	int realtimeLightLayers;
 	bool shadowMapping;
 	shadowingMode_t shadowingMode;
 	bool deluxeMapping;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -68,6 +68,18 @@ static void EnableAvailableFeatures()
 		}
 	}
 
+	if ( glConfig2.realtimeLighting ) {
+		glConfig2.realtimeLightLayers = r_realtimeLightLayers.Get();
+
+		if ( glConfig2.realtimeLightLayers > glConfig2.max3DTextureSize ) {
+			glConfig2.realtimeLightLayers = glConfig2.max3DTextureSize;
+			Log::Notice( "r_realtimeLightLayers exceeds maximum 3D texture size, using %i instead", glConfig2.max3DTextureSize );
+		}
+
+		Log::Notice( "Using %i dynamic light layers, %i dynamic lights available per tile", glConfig2.realtimeLightLayers,
+			glConfig2.realtimeLightLayers * 16 );
+	}
+
 	glConfig2.colorGrading = r_colorGrading.Get();
 
 	if ( glConfig2.colorGrading )
@@ -1085,19 +1097,16 @@ void Render_lightMapping( shaderStage_t *pStage )
 	if ( glConfig2.realtimeLighting &&
 	     r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) )
 	{
+		gl_lightMappingShader->SetUniform_numLights( tr.refdef.numLights );
+
 		if ( backEnd.refdef.numShaderLights > 0 )
 		{
-			gl_lightMappingShader->SetUniform_numLights( backEnd.refdef.numLights );
 			gl_lightMappingShader->SetUniformBlock_Lights( tr.dlightUBO );
 
 			// bind u_LightTiles
 			gl_lightMappingShader->SetUniform_LightTilesBindless(
 				GL_BindToTMU( BIND_LIGHTTILES, tr.lighttileRenderImage )
 			);
-		}
-		else
-		{
-			gl_lightMappingShader->SetUniform_numLights( 0 );
 		}
 	}
 


### PR DESCRIPTION
Add `r_realtimeLightLayers`, which allows setting the amount of layers in lighttile texture instead of the hardcoded 4, therefore allowing more dynamic lights per tile. This lets one set the cvar to balance between performance and dome dynamic lights not appearing.