### PR TITLE
sv_main: let LAN server created with client respond to queries

### DIFF
--- a/src/engine/server/sv_main.cpp
+++ b/src/engine/server/sv_main.cpp
@@ -121,7 +121,7 @@ Cvar::Cvar<ServerPrivate> isPrivate(
 	"2 - Don't reply to status queries but accept connections, "
 	"3 - Only accept LAN connections.",
 #if BUILD_GRAPHICAL_CLIENT || BUILD_TTY_CLIENT
-	Cvar::ROM, ServerPrivate::LanOnly
+	Cvar::ROM, ServerPrivate::NoAdvertise
 #elif BUILD_SERVER
 	Cvar::NONE, ServerPrivate::Public
 #else


### PR DESCRIPTION
By default, no one can list a LAN server that someone else created with a client, change that.