### PR TITLE
Fix overbright bugs

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -5179,9 +5179,9 @@ void RE_LoadWorldMap( const char *name )
 		}
 	}
 
-	/* Used in GLSL code for the GLSL implementation
-	without color clamping and normalization. */
-	if ( !tr.legacyOverBrightClamping )
+	/* Set GLSL overbright parameters if the legacy clamped overbright isn't used
+	and the lighting mode is not fullbright. */
+	if ( !tr.legacyOverBrightClamping && tr.lightMode != lightMode_t::FULLBRIGHT )
 	{
 		tr.mapLightFactor = pow( 2, tr.mapOverBrightBits );
 		tr.mapInverseLightFactor = 1.0f / tr.mapLightFactor;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1128,7 +1128,7 @@ void Render_lightMapping( shaderStage_t *pStage )
 	// u_InverseLightFactor
 	/* HACK: use sign to know if there is a light or not, and
 	then if it will receive overbright multiplication or not. */
-	bool cancelOverBright = pStage->cancelOverBright || lightMode == lightMode_t::FULLBRIGHT;
+	bool cancelOverBright = pStage->cancelOverBright;
 	float inverseLightFactor = cancelOverBright ? tr.mapInverseLightFactor : -tr.mapInverseLightFactor;
 	gl_lightMappingShader->SetUniform_InverseLightFactor( inverseLightFactor );
 


### PR DESCRIPTION
- `renderer: cancel overbright on added lightmap`

It fixes the perseus glass_02 door.

The code was slightly rewritten too.

- `renderer: disable GLSL overbright on fullbright lightmode globally instead of doing it per-texture`

It fixes rendering fullbright lightmap stages when light mode is not fullbright,
like the starchart512 hologram in procyon map.


Fix Unvanquished/Unvanquished#3161 and #1405:

- https://github.com/Unvanquished/Unvanquished/issues/3161
- https://github.com/DaemonEngine/Daemon/issues/1405