### PR TITLE
Simplify overbright implementation

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2210,7 +2210,6 @@ GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this ),
 	u_ColorModulate( this ),
 	u_Color( this ),
 	u_Bones( this ),
@@ -2243,7 +2242,6 @@ GLShader_genericMaterial::GLShader_genericMaterial( GLShaderManager* manager ) :
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this ),
 	u_ColorModulate( this ),
 	u_Color( this ),
 	u_DepthScale( this ),
@@ -2285,7 +2283,7 @@ GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 	u_ViewOrigin( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this ),
+	u_LightFactor( this ),
 	u_Bones( this ),
 	u_VertexInterpolation( this ),
 	u_ReliefDepthScale( this ),
@@ -2354,7 +2352,7 @@ GLShader_lightMappingMaterial::GLShader_lightMappingMaterial( GLShaderManager* m
 	u_ViewOrigin( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this ),
+	u_LightFactor( this ),
 	u_ReliefDepthScale( this ),
 	u_ReliefOffsetBias( this ),
 	u_NormalScale( this ),
@@ -2413,7 +2411,6 @@ GLShader_forwardLighting_omniXYZ::GLShader_forwardLighting_omniXYZ( GLShaderMana
 	u_ViewOrigin( this ),
 	u_LightOrigin( this ),
 	u_LightColor( this ),
-	u_InverseLightFactor( this ),
 	u_LightRadius( this ),
 	u_LightScale( this ),
 	u_LightAttenuationMatrix( this ),
@@ -2467,7 +2464,6 @@ GLShader_forwardLighting_projXYZ::GLShader_forwardLighting_projXYZ( GLShaderMana
 	u_ViewOrigin( this ),
 	u_LightOrigin( this ),
 	u_LightColor( this ),
-	u_InverseLightFactor( this ),
 	u_LightRadius( this ),
 	u_LightScale( this ),
 	u_LightAttenuationMatrix( this ),
@@ -2532,7 +2528,6 @@ GLShader_forwardLighting_directionalSun::GLShader_forwardLighting_directionalSun
 	u_ViewOrigin( this ),
 	u_LightDir( this ),
 	u_LightColor( this ),
-	u_InverseLightFactor( this ),
 	u_LightRadius( this ),
 	u_LightScale( this ),
 	u_LightAttenuationMatrix( this ),
@@ -2622,7 +2617,6 @@ GLShader_reflection::GLShader_reflection( GLShaderManager *manager ):
 	u_NormalScale( this ),
 	u_VertexInterpolation( this ),
 	u_CameraPosition( this ),
-	u_InverseLightFactor( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_VERTEX_SKINNING( this ),
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
@@ -2651,7 +2645,6 @@ GLShader_reflectionMaterial::GLShader_reflectionMaterial( GLShaderManager* manag
 	u_ReliefOffsetBias( this ),
 	u_NormalScale( this ),
 	u_CameraPosition( this ),
-	u_InverseLightFactor( this ),
 	GLDeformStage( this ),
 	GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP( this ),
 	GLCompileMacro_USE_RELIEF_MAPPING( this ) {
@@ -2673,8 +2666,7 @@ GLShader_skybox::GLShader_skybox( GLShaderManager *manager ) :
 	u_UseCloudMap( this ),
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
-	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this )
+	u_ModelViewProjectionMatrix( this )
 {
 }
 
@@ -2694,9 +2686,8 @@ GLShader_skyboxMaterial::GLShader_skyboxMaterial( GLShaderManager* manager ) :
 	u_UseCloudMap( this ),
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
-	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this ) {
-}
+	u_ModelViewProjectionMatrix( this )
+{}
 
 void GLShader_skyboxMaterial::SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
@@ -2708,7 +2699,6 @@ GLShader_fogQuake3::GLShader_fogQuake3( GLShaderManager *manager ) :
 	u_FogMap( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this ),
 	u_Color( this ),
 	u_Bones( this ),
 	u_VertexInterpolation( this ),
@@ -2731,7 +2721,6 @@ GLShader_fogQuake3Material::GLShader_fogQuake3Material( GLShaderManager* manager
 	u_FogMap( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this ),
 	u_Color( this ),
 	u_FogDistanceVector( this ),
 	u_FogDepthVector( this ),
@@ -2751,7 +2740,6 @@ GLShader_fogGlobal::GLShader_fogGlobal( GLShaderManager *manager ) :
 	u_ViewMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
 	u_UnprojectMatrix( this ),
-	u_InverseLightFactor( this ),
 	u_Color( this ),
 	u_FogDistanceVector( this ),
 	u_FogDepthVector( this )
@@ -2861,8 +2849,7 @@ void GLShader_portal::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 GLShader_contrast::GLShader_contrast( GLShaderManager *manager ) :
 	GLShader( "contrast", ATTR_POSITION, manager ),
 	u_ColorMap( this ),
-	u_ModelViewProjectionMatrix( this ),
-	u_InverseLightFactor( this )
+	u_ModelViewProjectionMatrix( this )
 {
 }
 
@@ -2878,7 +2865,6 @@ GLShader_cameraEffects::GLShader_cameraEffects( GLShaderManager *manager ) :
 	u_ColorModulate( this ),
 	u_TextureMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_LightFactor( this ),
 	u_DeformMagnitude( this ),
 	u_InverseGamma( this )
 {

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2150,21 +2150,6 @@ public:
 	}
 };
 
-class u_InverseLightFactor :
-	GLUniform1f
-{
-public:
-	u_InverseLightFactor( GLShader *shader ) :
-		GLUniform1f( shader, "u_InverseLightFactor" )
-	{
-	}
-
-	void SetUniform_InverseLightFactor( const float inverseLightFactor )
-	{
-		this->SetValue( inverseLightFactor );
-	}
-};
-
 class u_ColorMap :
 	GLUniformSampler2D {
 	public:
@@ -3617,7 +3602,7 @@ public:
 	{
 		this->SetValue( v );
 	}
-	void SetUniform_ColorModulate( colorGen_t colorGen, alphaGen_t alphaGen )
+	void SetUniform_ColorModulate( colorGen_t colorGen, alphaGen_t alphaGen, bool vertexOverbright = false )
 	{
 		vec4_t v;
 		bool needAttrib = false;
@@ -3631,7 +3616,16 @@ public:
 		{
 			case colorGen_t::CGEN_VERTEX:
 				needAttrib = true;
-				VectorSet( v, 1, 1, 1 );
+				if ( vertexOverbright )
+				{
+					// vertexOverbright is only needed for non-lightmapped cases. When there is a
+					// lightmap, this is done by multiplying with the overbright-scaled white image
+					VectorSet( v, tr.mapLightFactor, tr.mapLightFactor, tr.mapLightFactor );
+				}
+				else
+				{
+					VectorSet( v, 1, 1, 1 );
+				}
 				break;
 
 			case colorGen_t::CGEN_ONE_MINUS_VERTEX:
@@ -3946,7 +3940,6 @@ class GLShader_generic :
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor,
 	public u_ColorModulate,
 	public u_Color,
 	public u_Bones,
@@ -3976,7 +3969,6 @@ class GLShader_genericMaterial :
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor,
 	public u_ColorModulate,
 	public u_Color,
 	public u_DepthScale,
@@ -4015,7 +4007,7 @@ class GLShader_lightMapping :
 	public u_ViewOrigin,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor,
+	public u_LightFactor,
 	public u_Bones,
 	public u_VertexInterpolation,
 	public u_ReliefDepthScale,
@@ -4067,7 +4059,7 @@ class GLShader_lightMappingMaterial :
 	public u_ViewOrigin,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor,
+	public u_LightFactor,
 	public u_ReliefDepthScale,
 	public u_ReliefOffsetBias,
 	public u_NormalScale,
@@ -4113,7 +4105,6 @@ class GLShader_forwardLighting_omniXYZ :
 	public u_ViewOrigin,
 	public u_LightOrigin,
 	public u_LightColor,
-	public u_InverseLightFactor,
 	public u_LightRadius,
 	public u_LightScale,
 	public u_LightAttenuationMatrix,
@@ -4157,7 +4148,6 @@ class GLShader_forwardLighting_projXYZ :
 	public u_ViewOrigin,
 	public u_LightOrigin,
 	public u_LightColor,
-	public u_InverseLightFactor,
 	public u_LightRadius,
 	public u_LightScale,
 	public u_LightAttenuationMatrix,
@@ -4208,7 +4198,6 @@ class GLShader_forwardLighting_directionalSun :
 	public u_ViewOrigin,
 	public u_LightDir,
 	public u_LightColor,
-	public u_InverseLightFactor,
 	public u_LightRadius,
 	public u_LightScale,
 	public u_LightAttenuationMatrix,
@@ -4275,7 +4264,6 @@ class GLShader_reflection :
 	public u_NormalScale,
 	public u_VertexInterpolation,
 	public u_CameraPosition,
-	public u_InverseLightFactor,
 	public GLDeformStage,
 	public GLCompileMacro_USE_VERTEX_SKINNING,
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
@@ -4300,7 +4288,6 @@ class GLShader_reflectionMaterial :
 	public u_ReliefOffsetBias,
 	public u_NormalScale,
 	public u_CameraPosition,
-	public u_InverseLightFactor,
 	public GLDeformStage,
 	public GLCompileMacro_USE_HEIGHTMAP_IN_NORMALMAP,
 	public GLCompileMacro_USE_RELIEF_MAPPING {
@@ -4319,8 +4306,7 @@ class GLShader_skybox :
 	public u_UseCloudMap,
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
-	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor
+	public u_ModelViewProjectionMatrix
 {
 public:
 	GLShader_skybox( GLShaderManager *manager );
@@ -4337,8 +4323,7 @@ class GLShader_skyboxMaterial :
 	public u_UseCloudMap,
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
-	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor {
+	public u_ModelViewProjectionMatrix {
 	public:
 	GLShader_skyboxMaterial( GLShaderManager* manager );
 	void SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) override;
@@ -4349,7 +4334,6 @@ class GLShader_fogQuake3 :
 	public u_FogMap,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor,
 	public u_Color,
 	public u_Bones,
 	public u_VertexInterpolation,
@@ -4370,7 +4354,6 @@ class GLShader_fogQuake3Material :
 	public u_FogMap,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor,
 	public u_Color,
 	public u_FogDistanceVector,
 	public u_FogDepthVector,
@@ -4389,7 +4372,6 @@ class GLShader_fogGlobal :
 	public u_ViewMatrix,
 	public u_ModelViewProjectionMatrix,
 	public u_UnprojectMatrix,
-	public u_InverseLightFactor,
 	public u_Color,
 	public u_FogDistanceVector,
 	public u_FogDepthVector
@@ -4484,8 +4466,7 @@ public:
 class GLShader_contrast :
 	public GLShader,
 	public u_ColorMap,
-	public u_ModelViewProjectionMatrix,
-	public u_InverseLightFactor
+	public u_ModelViewProjectionMatrix
 {
 public:
 	GLShader_contrast( GLShaderManager *manager );
@@ -4499,7 +4480,6 @@ class GLShader_cameraEffects :
 	public u_ColorModulate,
 	public u_TextureMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_LightFactor,
 	public u_DeformMagnitude,
 	public u_InverseGamma
 {

--- a/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
+++ b/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
@@ -28,8 +28,6 @@ uniform sampler2D u_CurrentMap;
 uniform sampler3D u_ColorMap3D;
 #endif
 
-uniform float u_LightFactor;
-
 uniform vec4      u_ColorModulate;
 uniform float     u_InverseGamma;
 
@@ -43,8 +41,6 @@ void	main()
 	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	vec4 color = texture2D(u_CurrentMap, st);
-
-	color.rgb *= u_LightFactor;
 
 	color = clamp(color, 0.0, 1.0);
 

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -23,6 +23,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define COMPUTELIGHT_GLSL
 
+uniform float u_LightFactor;
+
 #if !defined(USE_BSP_SURFACE)
 	#define USE_MODEL_SURFACE
 #endif
@@ -55,6 +57,8 @@ vec4 EnvironmentalSpecularFactor( vec3 viewDir, vec3 normal )
 		float directedScale = 2.0 - ambientScale;
 		ambientColor = ambientScale * texel.rgb;
 		lightColor = directedScale * texel.rgb;
+		ambientColor *= u_LightFactor;
+		lightColor *= u_LightFactor;
 	}
 #endif
 

--- a/src/engine/renderer/glsl_source/contrast_fp.glsl
+++ b/src/engine/renderer/glsl_source/contrast_fp.glsl
@@ -24,8 +24,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 uniform sampler2D	u_ColorMap;
 
-uniform float u_InverseLightFactor;
-
 const vec4			LUMINANCE_VECTOR = vec4(0.2125, 0.7154, 0.0721, 0.0);
 
 #if __VERSION__ > 120
@@ -58,8 +56,6 @@ void	main()
 	color += f(texture2D(u_ColorMap, st + vec2(1.0, -1.0) * scale));
 	color += f(texture2D(u_ColorMap, st + vec2(1.0, 1.0) * scale));
 	color *= 0.25;
-
-	color.rgb *= u_InverseLightFactor;
 
 	outputColor = color;
 }

--- a/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
@@ -25,7 +25,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 uniform sampler2D	u_ColorMap; // fog texture
 uniform sampler2D	u_DepthMap;
 
-uniform float u_InverseLightFactor;
 uniform vec3		u_ViewOrigin;
 uniform vec4		u_FogDistanceVector;
 uniform vec4		u_FogDepthVector;
@@ -55,8 +54,6 @@ void	main()
 	st.t = 1.0;
 
 	vec4 color = texture2D(u_ColorMap, st);
-
-	color.rgb *= u_InverseLightFactor;
 
 	outputColor = u_Color * color;
 }

--- a/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
@@ -26,7 +26,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 uniform sampler2D u_FogMap;
 
-uniform float u_InverseLightFactor;
 IN(smooth) vec3		var_Position;
 IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec4		var_Color;
@@ -40,8 +39,6 @@ void	main()
 	vec4 color = texture2D(u_FogMap, var_TexCoords);
 
 	color *= var_Color;
-
-	color.rgb *= u_InverseLightFactor;
 
 	outputColor = color;
 

--- a/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
+++ b/src/engine/renderer/glsl_source/forwardLighting_fp.glsl
@@ -22,7 +22,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* forwardLighting_fp.glsl */
 
+// computeSpecularity is the only thing used from this file
 #insert computeLight_fp
+
 #insert reliefMapping_fp
 
 /* swizzle one- and two-component textures to RG */
@@ -68,7 +70,6 @@ uniform vec3		u_LightDir;
 uniform vec3		u_LightOrigin;
 #endif
 uniform vec3		u_LightColor;
-uniform float u_InverseLightFactor;
 uniform float		u_LightRadius;
 uniform float       u_LightScale;
 uniform float		u_AlphaThreshold;
@@ -1015,7 +1016,6 @@ void	main()
 	color.rgb *= attenuationZ;
 #endif
 	color.rgb *= abs(u_LightScale);
-	color.rgb *= u_InverseLightFactor;
 	color.rgb *= shadow;
 
 	color.rgb *= var_Color.rgb;

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -27,10 +27,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 uniform sampler2D	u_ColorMap;
 uniform float		u_AlphaThreshold;
 
-#if !defined(GENERIC_2D)
-	uniform float u_InverseLightFactor;
-#endif
-
 #if defined(USE_MATERIAL_SYSTEM)
 	uniform bool u_ShowTris;
 	uniform vec3 u_MaterialColour;
@@ -74,10 +70,6 @@ void	main()
 #endif
 
 	color *= var_Color;
-
-#if !defined(GENERIC_2D)
-	color.rgb *= u_InverseLightFactor;
-#endif
 	
 	SHADER_PROFILER_SET( color )
 
@@ -92,9 +84,5 @@ void	main()
 	outputColor = vec4(0.0, 0.0, 0.0, 0.0);
 #elif defined(USE_MATERIAL_SYSTEM) && defined(r_showGlobalMaterials)
 	outputColor.rgb = u_MaterialColour;
-
-	#if !defined(GENERIC_2D) && !defined(USE_DEPTH_FADE)
-		outputColor.rgb *= u_InverseLightFactor;
-	#endif
 #endif
 }

--- a/src/engine/renderer/glsl_source/reflection_CB_fp.glsl
+++ b/src/engine/renderer/glsl_source/reflection_CB_fp.glsl
@@ -30,8 +30,6 @@ uniform samplerCube	u_ColorMapCube;
 uniform vec3		u_ViewOrigin;
 uniform mat4		u_ModelMatrix;
 
-uniform float u_InverseLightFactor;
-
 IN(smooth) vec3		var_Position;
 IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec4		var_Tangent;
@@ -73,8 +71,6 @@ void	main()
 	#if defined(r_showCubeProbes)
 		viewDir = normalize(var_Position);
 		outputColor = textureCube(u_ColorMapCube, viewDir);
-
-		outputColor.rgb *= u_InverseLightFactor;
 	#endif
 	// outputColor = vec4(1.0, 0.0, 0.0, 1.0);
 }

--- a/src/engine/renderer/glsl_source/shaderProfiler_fp.glsl
+++ b/src/engine/renderer/glsl_source/shaderProfiler_fp.glsl
@@ -51,13 +51,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 			color += vec4( count < 0.5 ? count + 0.5 : 0.0,
 				            count >= 0.5 ? count : 0.0,
 							0.0, 1.0 );
-							   
-			/* HACK: use sign to know if there is a light or not, and
-			then if it will receive overbright multiplication or not. */
-			if ( u_InverseLightFactor < 0 )
-			{
-				color *= -u_InverseLightFactor;
-			}
 		}
 	}
 #else

--- a/src/engine/renderer/glsl_source/skybox_fp.glsl
+++ b/src/engine/renderer/glsl_source/skybox_fp.glsl
@@ -28,7 +28,6 @@ const float radiusWorld = 4096.0; // Value used by quake 3 skybox code
 
 uniform samplerCube	u_ColorMapCube;
 
-uniform float u_InverseLightFactor;
 uniform sampler2D	u_CloudMap;
 
 uniform bool        u_UseCloudMap;
@@ -76,8 +75,6 @@ void	main()
 		discard;
 		return;
 	}
-
-	color.rgb *= u_InverseLightFactor;
 
 	outputColor = color;
 }

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1921,7 +1921,6 @@ static void RB_SetupLightForLighting( trRefLight_t *light )
 							gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 							gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 							gl_genericShader->SetUniform_Color( Color::Black );
-							// TODO: set u_InverseLightFactor!
 
 							GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
 							GL_Cull( cullType_t::CT_TWO_SIDED );
@@ -2774,7 +2773,6 @@ void RB_RunVisTests( )
 		gl_genericShader->SetUniform_Color( Color::White );
 
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CONST, alphaGen_t::AGEN_CONST );
-		gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 		gl_genericShader->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
 		gl_genericShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 
@@ -2980,9 +2978,6 @@ void RB_RenderGlobalFog()
 
 	gl_fogGlobalShader->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );  // world space
 
-	// u_InverseLightFactor
-	gl_fogGlobalShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
-
 	{
 		fog_t *fog;
 
@@ -3076,9 +3071,6 @@ void RB_RenderBloom()
 
 		// render contrast downscaled to 1/4th of the screen
 		gl_contrastShader->BindProgram( 0 );
-
-		// u_InverseLightFactor
-		gl_contrastShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 		gl_contrastShader->SetUniform_ColorMapBindless(
 			GL_BindToTMU( 0, tr.currentRenderImage[backEnd.currentMainFBO] )
@@ -3240,7 +3232,7 @@ void RB_RenderSSAO()
 
 	if ( r_ssao->integer < 0 ) {
 		// clear the screen to show only SSAO
-		GL_ClearColor( tr.mapInverseLightFactor, tr.mapInverseLightFactor, tr.mapInverseLightFactor, 1.0 );
+		GL_ClearColor( 1.0, 1.0, 1.0, 1.0 );
 		glClear( GL_COLOR_BUFFER_BIT );
 	}
 
@@ -3354,9 +3346,6 @@ void RB_CameraPostFX()
 	// enable shader, set arrays
 	gl_cameraEffectsShader->BindProgram( 0 );
 
-	// u_LightFactor
-	gl_cameraEffectsShader->SetUniform_LightFactor( tr.mapLightFactor );
-
 	gl_cameraEffectsShader->SetUniform_ColorModulate( backEnd.viewParms.gradingWeights );
 
 	gl_cameraEffectsShader->SetUniform_InverseGamma( 1.0 / r_gamma->value );
@@ -3410,7 +3399,6 @@ static void RB_RenderDebugUtils()
 		// set uniforms
 		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CUSTOM_RGB, alphaGen_t::AGEN_CUSTOM );
-		gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 		// bind u_ColorMap
 		gl_genericShader->SetUniform_ColorMapBindless(
@@ -3553,7 +3541,6 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
-		gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 		// bind u_ColorMap
 		gl_genericShader->SetUniform_ColorMapBindless(
@@ -3669,7 +3656,6 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
-		gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 		// bind u_ColorMap
 		gl_genericShader->SetUniform_ColorMapBindless(
@@ -3735,7 +3721,6 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
-		gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 		// bind u_ColorMap
 		gl_genericShader->SetUniform_ColorMapBindless(
@@ -3949,7 +3934,6 @@ static void RB_RenderDebugUtils()
 		// set uniforms
 		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CUSTOM_RGB, alphaGen_t::AGEN_CUSTOM );
-		gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 		// bind u_ColorMap
 		gl_genericShader->SetUniform_ColorMapBindless(
@@ -4027,8 +4011,6 @@ static void RB_RenderDebugUtils()
 		gl_reflectionShader->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
 		gl_reflectionShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 
-		gl_reflectionShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
-
 		if ( r_showCubeProbes.Get() == Util::ordinal( showCubeProbesMode::GRID ) ) {
 			// Debug rendering can be really slow here
 			for ( auto it = tr.cubeProbeGrid.begin(); it != tr.cubeProbeGrid.end(); it++ ) {
@@ -4086,7 +4068,6 @@ static void RB_RenderDebugUtils()
 			gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 			gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 			gl_genericShader->SetUniform_Color( Color::Black );
-			gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 			GL_State( GLS_DEFAULT );
 			GL_Cull( cullType_t::CT_TWO_SIDED );
@@ -4169,7 +4150,6 @@ static void RB_RenderDebugUtils()
 		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
-		gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 		GL_State( GLS_DEFAULT );
 		GL_Cull( cullType_t::CT_TWO_SIDED );
@@ -4260,7 +4240,6 @@ static void RB_RenderDebugUtils()
 		// set uniforms
 		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CUSTOM_RGB, alphaGen_t::AGEN_CUSTOM );
-		gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 		// bind u_ColorMap
 		gl_genericShader->SetUniform_ColorMapBindless(
@@ -4560,7 +4539,6 @@ void DebugDrawBegin( debugDrawMode_t mode, float size ) {
 	gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 	gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 	gl_genericShader->SetUniform_Color( colorClear );
-	gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 	// bind u_ColorMap
 	gl_genericShader->SetUniform_ColorMapBindless(
@@ -5681,7 +5659,6 @@ void RB_ShowImages()
 	gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 	gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 	gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
-	gl_genericShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
 
 	GL_SelectTexture( 0 );
 

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -5112,7 +5112,6 @@ void RE_LoadWorldMap( const char *name )
 	tr.modelLight = lightMode_t::FULLBRIGHT;
 	tr.modelDeluxe = deluxeMode_t::NONE;
 	tr.mapLightFactor = 1.0f;
-	tr.mapInverseLightFactor = 1.0f;
 
 	// Use fullbright lighting for everything if the world is fullbright.
 	if ( tr.worldLight != lightMode_t::FULLBRIGHT )
@@ -5189,7 +5188,6 @@ void RE_LoadWorldMap( const char *name )
 	if ( !tr.legacyOverBrightClamping && tr.lightMode != lightMode_t::FULLBRIGHT )
 	{
 		tr.mapLightFactor = pow( 2, tr.mapOverBrightBits );
-		tr.mapInverseLightFactor = 1.0f / tr.mapLightFactor;
 	}
 
 	tr.worldLoaded = true;

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2587,13 +2587,19 @@ static void R_CreateCurrentRenderImage()
 
 	if ( r_highPrecisionRendering.Get() )
 	{
-		if ( !glConfig2.textureRGBA16BlendAvailable )
+		if ( !glConfig2.textureFloatAvailable )
 		{
-			Log::Warn( "High-precision current render disabled because RGBA16 framebuffer blending is not available" );
+			Log::Warn( "High-precision current render disabled because RGBA16F framebuffer is not available" );
 		}
 		else
 		{
-			imageParams.bits |= IF_RGBA16;
+			// Use float color buffer so that we can store intermediate results of a multi-stage
+			// shader which are greater than 1. For example, the sum of multiple lightmaps from
+			// a light style, or simply a single overbright-scaled lightmap which we did not
+			// manage to collapse with the diffuse.
+			// Besides preventing clamping of the color buffer itself, using a float color buffer
+			// also prevents the fragment shader's output color from being clamped before blending.
+			imageParams.bits |= IF_RGBA16F;
 		}
 	}
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1075,8 +1075,6 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		bool            dpMaterial;
 
-		bool cancelOverBright;
-
 		// Core renderer (code path for when only OpenGL Core is available, or compatible OpenGL 2).
 		stageRenderer_t colorRenderer;
 
@@ -2769,8 +2767,6 @@ enum class shaderProfilerRenderSubGroupsMode {
 		int mapOverBrightBits;
 		// pow(2, mapOverbrightBits)
 		float mapLightFactor;
-		// 1 / mapLightFactor
-		float mapInverseLightFactor;
 		// May have to be true on some legacy maps: clamp and normalize multiplied colors.
 		bool legacyOverBrightClamping;
 

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -335,12 +335,6 @@ void RE_AddDynamicLightToSceneET( const vec3_t org, float radius, float intensit
 	light->l.color[ 1 ] = g;
 	light->l.color[ 2 ] = b;
 
-	if ( r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) )
-	{
-		// Cancel overBright on dynamic lights.
-		VectorScale( light->l.color, tr.mapInverseLightFactor, light->l.color );
-	}
-
 	light->l.inverseShadows = (flags & REF_INVERSE_DLIGHT) != 0;
 	light->l.noShadows = !r_realtimeLightingCastShadows->integer && !light->l.inverseShadows;
 

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -102,9 +102,6 @@ void Tess_StageIteratorSky()
 
 	gl_skyboxShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 
-	// u_InverseLightFactor
-	gl_skyboxShader->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
-
 	gl_skyboxShader->SetRequiredVertexPointers();
 
 	// draw the outer skybox


### PR DESCRIPTION
AIUI overbright simply means that the lightmaps and light grid should be scaled from 0 to 4, instead of 0 to 1, so we can represent a larger range of brightness. But image colors are only allowed to go from 0 to 1. This is a big problem... if we are using GL 1 (hence, perhaps, the mysterious "hardware implementations"). But we have shaders, so all we have to do is multiply by 4 whenever we read one of those special light textures. Problem solved?

I tried this approach and it looks the same to me, consistent with the complex cancellng system that we had before. Also fixes the Perseus glass and Procyon star chart issues addressed in #1404.

An explanation for the canceling approach is given in #1050:
> We cannot overBright separate stage as stage are clamped within [0.0, 1.0] when blending multiple stages together, meaning the result of the multiplication of a separate light stage with a light factor will be clamped before blending it with the color map.

But this is not an accurate representation of how shaders work. Each stage acts independently and directly on the color and depth buffers. There is no scratch area where shader stages are blended before going into the color buffer.

I would expect this to ameliorate the color banding problems with low-precision color buffers since now we don't give up 2 bits of precision to make room for canceling.

I haven't tried vertex lighting yet. Not sure how it's supposed to work with overbright.