### PR TITLE
Make fog into a stage, fix some issues with it

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -644,6 +644,37 @@ void UpdateSurfaceDataLiquid( uint32_t* materials, Material& material, drawSurf_
 	gl_liquidShaderMaterial->WriteUniformsToBuffer( materials );
 }
 
+void UpdateSurfaceDataFog( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
+	shader_t* shader = drawSurf->shader;
+	shaderStage_t* pStage = &shader->stages[stage];
+
+	const uint32_t paddedOffset = drawSurf->materialsSSBOOffset[stage] * material.shader->GetPaddedSize();
+	materials += paddedOffset;
+
+	bool updated = !drawSurf->initialized[stage] || pStage->colorDynamic || pStage->texMatricesDynamic || pStage->dynamic;
+	if ( !updated ) {
+		return;
+	}
+	drawSurf->initialized[stage] = true;
+
+	const fog_t* fog = material.fog;
+
+	// u_InverseLightFactor
+	gl_fogQuake3ShaderMaterial->SetUniform_InverseLightFactor( tr.mapInverseLightFactor );
+
+	// u_Color
+	gl_fogQuake3ShaderMaterial->SetUniform_Color( fog->color );
+
+	// u_VertexInterpolation
+	if ( material.vertexAnimation ) {
+		gl_fogQuake3ShaderMaterial->SetUniform_VertexInterpolation( 0.0 );
+	}
+
+	gl_fogQuake3ShaderMaterial->SetUniform_Time( backEnd.refdef.floatTime - backEnd.currentEntity->e.shaderTime );
+
+	gl_fogQuake3ShaderMaterial->WriteUniformsToBuffer( materials );
+}
+
 /*
 * Buffer layout:
 * // Static surfaces data:
@@ -947,6 +978,20 @@ void MaterialSystem::GenerateWorldCommandBuffer() {
 
 			stage++;
 		}
+
+		if ( drawSurf->fogSurface ) {
+			const drawSurf_t* fogDrawSurf = drawSurf->fogSurface;
+			const Material* material = &materialPacks[fogDrawSurf->materialPackIDs[0]].materials[fogDrawSurf->materialIDs[0]];
+			uint cmdID = material->surfaceCommandBatchOffset * SURFACE_COMMANDS_PER_BATCH + fogDrawSurf->drawCommandIDs[0];
+			// Add 1 because cmd 0 == no-command
+			surface.surfaceCommandIDs[stage + ( depthPrePass ? 1 : 0 )] = cmdID + 1;
+
+			SurfaceCommand surfaceCommand;
+			surfaceCommand.enabled = 0;
+			surfaceCommand.drawCommand = material->drawCommands[fogDrawSurf->drawCommandIDs[0]].cmd;
+			surfaceCommands[cmdID] = surfaceCommand;
+		}
+
 		memcpy( surfaceDescriptors, &surface, descriptorSize * sizeof( uint32_t ) );
 		surfaceDescriptors += descriptorSize;
 	}
@@ -1176,6 +1221,64 @@ void BindShaderLiquid( Material* material ) {
 	gl_liquidShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 }
 
+void BindShaderFog( Material* material ) {
+	// Select shader permutation.
+	gl_fogQuake3ShaderMaterial->SetVertexAnimation( false );
+
+	// Bind shader program.
+	gl_fogQuake3ShaderMaterial->BindProgram( 0 );
+
+	// Set shader uniforms.
+	const fog_t* fog = material->fog;
+
+	// all fogging distance is based on world Z units
+	vec4_t fogDistanceVector;
+	vec3_t local;
+	VectorSubtract( backEnd.orientation.origin, backEnd.viewParms.orientation.origin, local );
+	fogDistanceVector[0] = -backEnd.orientation.modelViewMatrix[2];
+	fogDistanceVector[1] = -backEnd.orientation.modelViewMatrix[6];
+	fogDistanceVector[2] = -backEnd.orientation.modelViewMatrix[10];
+	fogDistanceVector[3] = DotProduct( local, backEnd.viewParms.orientation.axis[0] );
+
+	// scale the fog vectors based on the fog's thickness
+	VectorScale( fogDistanceVector, fog->tcScale, fogDistanceVector );
+	fogDistanceVector[3] *= fog->tcScale;
+
+	// rotate the gradient vector for this orientation
+	float eyeT;
+	vec4_t fogDepthVector;
+	if ( fog->hasSurface ) {
+		fogDepthVector[0] = fog->surface[0] * backEnd.orientation.axis[0][0] +
+			fog->surface[1] * backEnd.orientation.axis[0][1] + fog->surface[2] * backEnd.orientation.axis[0][2];
+		fogDepthVector[1] = fog->surface[0] * backEnd.orientation.axis[1][0] +
+			fog->surface[1] * backEnd.orientation.axis[1][1] + fog->surface[2] * backEnd.orientation.axis[1][2];
+		fogDepthVector[2] = fog->surface[0] * backEnd.orientation.axis[2][0] +
+			fog->surface[1] * backEnd.orientation.axis[2][1] + fog->surface[2] * backEnd.orientation.axis[2][2];
+		fogDepthVector[3] = -fog->surface[3] + DotProduct( backEnd.orientation.origin, fog->surface );
+
+		eyeT = DotProduct( backEnd.orientation.viewOrigin, fogDepthVector ) + fogDepthVector[3];
+	} else {
+		Vector4Set( fogDepthVector, 0, 0, 0, 1 );
+		eyeT = 1; // non-surface fog always has eye inside
+	}
+
+	// see if the viewpoint is outside
+	// this is needed for clipping distance even for constant fog
+	fogDistanceVector[3] += 1.0 / 512;
+
+	gl_fogQuake3ShaderMaterial->SetUniform_FogDistanceVector( fogDistanceVector );
+	gl_fogQuake3ShaderMaterial->SetUniform_FogDepthVector( fogDepthVector );
+	gl_fogQuake3ShaderMaterial->SetUniform_FogEyeT( eyeT );
+
+	gl_fogQuake3ShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_fogQuake3ShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+
+	// bind u_ColorMap
+	gl_fogQuake3ShaderMaterial->SetUniform_FogMapBindless(
+		GL_BindToTMU( 0, tr.fogImage )
+	);
+}
+
 void ProcessMaterialNONE( Material*, shaderStage_t*, drawSurf_t* ) {
 	ASSERT_UNREACHABLE();
 }
@@ -1306,6 +1409,15 @@ void ProcessMaterialLiquid( Material* material, shaderStage_t* pStage, drawSurf_
 	gl_liquidShaderMaterial->SetReliefMapping( pStage->enableReliefMapping );
 
 	material->program = gl_liquidShaderMaterial->GetProgram( pStage->deformIndex );
+}
+
+void ProcessMaterialFog( Material* material, shaderStage_t* pStage, drawSurf_t* drawSurf ) {
+	material->shader = gl_fogQuake3ShaderMaterial;
+	material->fog = tr.world->fogs + drawSurf->fog;
+
+	gl_fogQuake3ShaderMaterial->SetVertexAnimation( false );
+
+	material->program = gl_fogQuake3ShaderMaterial->GetProgram( pStage->deformIndex );
 }
 
 void MaterialSystem::ProcessStage( drawSurf_t* drawSurf, shaderStage_t* pStage, shader_t* shader, uint32_t* packIDs, uint32_t& stage,
@@ -2045,6 +2157,12 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 		}
 
 		stateBits &= ~( GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS );
+	}
+
+	if( material.shaderBinder == BindShaderFog ) {
+		if ( r_noFog->integer || !r_wolfFog->integer ) {
+			return;
+		}
 	}
 
 	backEnd.currentEntity = &tr.worldEntity;

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -2160,7 +2160,7 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 	}
 
 	if( material.shaderBinder == BindShaderFog ) {
-		if ( r_noFog->integer || !r_wolfFog->integer ) {
+		if ( r_noFog->integer || !r_wolfFog->integer || ( backEnd.refdef.rdflags & RDF_NOWORLDMODEL ) ) {
 			return;
 		}
 	}

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -119,6 +119,8 @@ struct Material {
 	VBO_t* vbo;
 	IBO_t* ibo;
 
+	fog_t* fog = nullptr;
+
 	std::vector<drawSurf_t*> drawSurfs;
 	std::vector<DrawCommand> drawCommands;
 	bool texturesResident = false;
@@ -126,7 +128,7 @@ struct Material {
 
 	bool operator==( const Material& other ) {
 		return program == other.program && stateBits == other.stateBits && vbo == other.vbo && ibo == other.ibo
-			&& cullType == other.cullType && usePolygonOffset == other.usePolygonOffset;
+			&& fog == other.fog && cullType == other.cullType && usePolygonOffset == other.usePolygonOffset;
 	}
 
 	void AddTexture( Texture* texture ) {
@@ -342,6 +344,7 @@ void UpdateSurfaceDataSkybox( uint32_t* materials, Material& material, drawSurf_
 void UpdateSurfaceDataScreen( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
 void UpdateSurfaceDataHeatHaze( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
 void UpdateSurfaceDataLiquid( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
+void UpdateSurfaceDataFog( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage );
 
 void BindShaderNONE( Material* );
 void BindShaderNOP( Material* );
@@ -352,6 +355,7 @@ void BindShaderSkybox( Material* material );
 void BindShaderScreen( Material* material );
 void BindShaderHeatHaze( Material* material );
 void BindShaderLiquid( Material* material );
+void BindShaderFog( Material* material );
 
 void ProcessMaterialNONE( Material*, shaderStage_t*, drawSurf_t* );
 void ProcessMaterialNOP( Material*, shaderStage_t*, drawSurf_t* );
@@ -362,5 +366,6 @@ void ProcessMaterialSkybox( Material* material, shaderStage_t* pStage, drawSurf_
 void ProcessMaterialScreen( Material* material, shaderStage_t* pStage, drawSurf_t* /* drawSurf */ );
 void ProcessMaterialHeatHaze( Material* material, shaderStage_t* pStage, drawSurf_t* drawSurf );
 void ProcessMaterialLiquid( Material* material, shaderStage_t* pStage, drawSurf_t* /* drawSurf */ );
+void ProcessMaterialFog( Material* material, shaderStage_t* pStage, drawSurf_t* drawSurf );
 
 #endif // MATERIAL_H

--- a/src/engine/renderer/ShadeCommon.h
+++ b/src/engine/renderer/ShadeCommon.h
@@ -87,6 +87,16 @@ template<typename Obj> static bool hasExplicitelyDisabledLightMap( Obj* obj )
 	return GetSurfaceShader( obj )->surfaceFlags & SURF_NOLIGHTMAP;
 }
 
+inline size_t GetFogNum( shaderCommands_t* tess )
+{
+	return tess->fogNum;
+}
+
+inline size_t GetFogNum( drawSurf_t* drawSurf )
+{
+	return drawSurf->fogNum();
+}
+
 inline shaderStage_t* GetSurfaceLastStage( shaderCommands_t* tess )
 {
 	return tess->surfaceLastStage;

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2717,7 +2717,7 @@ void GLShader_skyboxMaterial::SetShaderProgramUniforms( shaderProgram_t* shaderP
 
 GLShader_fogQuake3::GLShader_fogQuake3( GLShaderManager *manager ) :
 	GLShader( "fogQuake3", ATTR_POSITION | ATTR_QTANGENT, manager ),
-	u_ColorMap( this ),
+	u_FogMap( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
 	u_InverseLightFactor( this ),
@@ -2735,12 +2735,12 @@ GLShader_fogQuake3::GLShader_fogQuake3( GLShaderManager *manager ) :
 
 void GLShader_fogQuake3::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 {
-	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
+	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_FogMap" ), 0 );
 }
 
 GLShader_fogQuake3Material::GLShader_fogQuake3Material( GLShaderManager* manager ) :
 	GLShader( "fogQuake3Material", "fogQuake3", true, ATTR_POSITION | ATTR_QTANGENT, manager ),
-	u_ColorMap( this ),
+	u_FogMap( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
 	u_InverseLightFactor( this ),
@@ -2756,7 +2756,7 @@ GLShader_fogQuake3Material::GLShader_fogQuake3Material( GLShaderManager* manager
 }
 
 void GLShader_fogQuake3Material::SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) {
-	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
+	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_FogMap" ), 0 );
 }
 
 GLShader_fogGlobal::GLShader_fogGlobal( GLShaderManager *manager ) :

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1038,8 +1038,8 @@ public:
 class GLUniform4f : protected GLUniform
 {
 protected:
-	GLUniform4f( GLShader *shader, const char *name ) :
-	GLUniform( shader, name, "vec4", 4, 4, false )
+	GLUniform4f( GLShader *shader, const char *name, const bool global = false ) :
+	GLUniform( shader, name, "vec4", 4, 4, global )
 	{
 		currentValue[0] = 0.0;
 		currentValue[1] = 0.0;
@@ -2389,6 +2389,22 @@ class u_CloudMap :
 	}
 };
 
+class u_FogMap :
+	GLUniformSampler2D {
+	public:
+	u_FogMap( GLShader* shader ) :
+		GLUniformSampler2D( shader, "u_FogMap", true ) {
+	}
+
+	void SetUniform_FogMapBindless( GLuint64 bindlessHandle ) {
+		this->SetValueBindless( bindlessHandle );
+	}
+
+	GLint GetUniformLocation_FogMap() {
+		return this->GetLocation();
+	}
+};
+
 class u_LightTiles :
 	GLUniformSampler3D {
 	public:
@@ -3662,7 +3678,7 @@ class u_FogDistanceVector :
 {
 public:
 	u_FogDistanceVector( GLShader *shader ) :
-		GLUniform4f( shader, "u_FogDistanceVector" )
+		GLUniform4f( shader, "u_FogDistanceVector", true )
 	{
 	}
 
@@ -3677,7 +3693,7 @@ class u_FogDepthVector :
 {
 public:
 	u_FogDepthVector( GLShader *shader ) :
-		GLUniform4f( shader, "u_FogDepthVector" )
+		GLUniform4f( shader, "u_FogDepthVector", true )
 	{
 	}
 
@@ -3692,7 +3708,7 @@ class u_FogEyeT :
 {
 public:
 	u_FogEyeT( GLShader *shader ) :
-		GLUniform1f( shader, "u_FogEyeT" )
+		GLUniform1f( shader, "u_FogEyeT", true )
 	{
 	}
 
@@ -4342,7 +4358,7 @@ class GLShader_skyboxMaterial :
 
 class GLShader_fogQuake3 :
 	public GLShader,
-	public u_ColorMap,
+	public u_FogMap,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
 	public u_InverseLightFactor,
@@ -4363,7 +4379,7 @@ public:
 
 class GLShader_fogQuake3Material :
 	public GLShader,
-	public u_ColorMap,
+	public u_FogMap,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
 	public u_InverseLightFactor,

--- a/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define FOGQUAKE3_GLSL
 
-uniform sampler2D	u_ColorMap;
+uniform sampler2D u_FogMap;
 
 uniform float u_InverseLightFactor;
 IN(smooth) vec3		var_Position;
@@ -37,7 +37,7 @@ void	main()
 {
 	#insert material_fp
 
-	vec4 color = texture2D(u_ColorMap, var_TexCoords);
+	vec4 color = texture2D(u_FogMap, var_TexCoords);
 
 	color *= var_Color;
 

--- a/src/engine/renderer/glsl_source/material_fp.glsl
+++ b/src/engine/renderer/glsl_source/material_fp.glsl
@@ -61,10 +61,6 @@ samplerCube u_EnvironmentMap1 = samplerCube( u_EnvironmentMap1_initial );
 usampler3D u_LightTiles = usampler3D( u_LightTiles_initial );
 #endif // !COMPUTELIGHT_GLSL
 
-#if defined(FOGQUAKE3_GLSL)
-sampler2D u_ColorMap = sampler2D( u_ColorMap_initial );
-#endif // !FOGQUAKE3_GLSL
-
 #if defined(GENERIC_GLSL)
 sampler2D u_ColorMap = sampler2D( u_ColorMap_initial );
 #if defined(USE_DEPTH_FADE)

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -904,7 +904,7 @@ static void RB_RenderDrawSurfaces( shaderSort_t fromSort, shaderSort_t toSort,
 		entity = drawSurf->entity;
 		shader = drawSurf->shader;
 		lightmapNum = drawSurf->lightmapNum();
-		fogNum = drawSurf->fogNum();
+		fogNum = drawSurf->fog;
 		bspSurface = drawSurf->bspSurface;
 
 		if( entity == &tr.worldEntity ) {

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3520,7 +3520,7 @@ inline bool checkGLErrors()
 	void Render_portal( shaderStage_t *pStage );
 	void Render_heatHaze( shaderStage_t *pStage );
 	void Render_liquid( shaderStage_t *pStage );
-	void Render_fog( shaderStage_t* /* pStage */ );
+	void Render_fog( shaderStage_t* pStage );
 
 	/*
 	============================================================

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1034,6 +1034,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 	  ST_PORTALMAP,
 	  ST_HEATHAZEMAP, // heatHaze post process effect
 	  ST_LIQUIDMAP,
+	  ST_FOGMAP,
 	  ST_LIGHTMAP,
 	  ST_STYLELIGHTMAP,
 	  ST_STYLECOLORMAP,
@@ -1288,6 +1289,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 		} altShader[ MAX_ALTSHADERS ]; // state-based remapping; note that index 0 is unused
 
 		struct shader_t *depthShader;
+		struct shader_t *fogShader;
 		struct shader_t *next;
 	};
 
@@ -1609,6 +1611,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 		shader_t      *shader;
 		uint64_t      sort;
 		bool          bspSurface;
+		int fog;
 
 		uint materialsSSBOOffset[ MAX_SHADER_STAGES ];
 		bool initialized[ MAX_SHADER_STAGES ];
@@ -1618,6 +1621,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 		uint drawCommandIDs[ MAX_SHADER_STAGES ];
 
 		drawSurf_t* depthSurface;
+		drawSurf_t* fogSurface;
 		bool materialSystemSkip = false;
 
 		inline int index() const {
@@ -2737,6 +2741,8 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		// internal shaders
 		shader_t *defaultShader;
+		shader_t *fogEqualShader;
+		shader_t *fogLEShader;
 		shader_t *defaultPointLightShader;
 		shader_t *defaultProjectedLightShader;
 		shader_t *defaultDynamicLightShader;
@@ -3093,7 +3099,7 @@ inline bool checkGLErrors()
 
 	void           R_AddPolygonSurfaces();
 
-	void           R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, int fogNum, bool bspSurface = false );
+	int R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, int fogNum, bool bspSurface = false );
 
 	void           R_LocalNormalToWorld( const vec3_t local, vec3_t world );
 	void           R_LocalPointToWorld( const vec3_t local, vec3_t world );
@@ -3514,6 +3520,7 @@ inline bool checkGLErrors()
 	void Render_portal( shaderStage_t *pStage );
 	void Render_heatHaze( shaderStage_t *pStage );
 	void Render_liquid( shaderStage_t *pStage );
+	void Render_fog( shaderStage_t* /* pStage */ );
 
 	/*
 	============================================================

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2325,7 +2325,7 @@ void Render_liquid( shaderStage_t *pStage )
 	GL_CheckErrors();
 }
 
-void Render_fog( shaderStage_t* /* pStage */ )
+void Render_fog( shaderStage_t* pStage )
 {
 	if ( materialSystem.generatingWorldCommandBuffer ) {
 		Tess_DrawElements();
@@ -2390,14 +2390,7 @@ void Render_fog( shaderStage_t* /* pStage */ )
 	// this is needed for clipping distance even for constant fog
 	fogDistanceVector[ 3 ] += 1.0 / 512;
 
-	if ( tess.surfaceShader->fogPass == fogPass_t::FP_EQUAL )
-	{
-		GL_State( GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA | GLS_DEPTHFUNC_EQUAL );
-	}
-	else
-	{
-		GL_State( GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA );
-	}
+	GL_State( pStage->stateBits );
 
 	gl_fogQuake3Shader->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
 	gl_fogQuake3Shader->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2806,7 +2806,7 @@ void Tess_StageIteratorColor()
 		stage++;
 	}
 
-	if ( !r_noFog->integer && tess.fogNum >= 1 && tess.surfaceShader->fogPass != fogPass_t::FP_NONE )
+	if ( !r_noFog->integer && tess.fogNum >= 1 )
 	{
 		Render_fog();
 	}

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2347,12 +2347,6 @@ void Render_fog( shaderStage_t* /* pStage */ )
 
 	const fog_t* fog = tr.world->fogs + tess.fogNum;
 
-	// Tr3B: use this only to render fog brushes
-	if ( fog->originalBrushNumber < 0 && tess.surfaceShader->sort <= Util::ordinal(shaderSort_t::SS_OPAQUE) )
-	{
-		return;
-	}
-
 	if ( r_logFile->integer )
 	{
 		GLimp_LogComment( va( "--- Render_fog( fogNum = %i, originalBrushNumber = %i ) ---\n", tess.fogNum, fog->originalBrushNumber ) );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2334,13 +2334,7 @@ void Render_fog( shaderStage_t* pStage )
 
 	// no fog pass in snooper
 	// WTF is a snooper?
-	if ( r_noFog->integer || !r_wolfFog->integer )
-	{
-		return;
-	}
-
-	// ydnar: no world, no fogging
-	if ( backEnd.refdef.rdflags & RDF_NOWORLDMODEL )
+	if ( r_noFog->integer || !r_wolfFog->integer || ( backEnd.refdef.rdflags & RDF_NOWORLDMODEL ) )
 	{
 		return;
 	}

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2332,8 +2332,6 @@ void Render_fog( shaderStage_t* pStage )
 		return;
 	}
 
-	// no fog pass in snooper
-	// WTF is a snooper?
 	if ( r_noFog->integer || !r_wolfFog->integer || ( backEnd.refdef.rdflags & RDF_NOWORLDMODEL ) )
 	{
 		return;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -2436,6 +2436,7 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 				continue;
 			}
 
+			// This isn't actually used because we render fog based on the shader, not the stage
 			if ( !Q_stricmp( token, "on" ) )
 			{
 				stage->noFog = false;
@@ -5600,15 +5601,6 @@ static shader_t *MakeShaderPermanent()
 
 	*newShader = shader;
 
-	if ( shader.sort <= Util::ordinal(shaderSort_t::SS_OPAQUE) )
-	{
-		newShader->fogPass = fogPass_t::FP_EQUAL;
-	}
-	else if ( shader.contentFlags & CONTENTS_FOG )
-	{
-		newShader->fogPass = fogPass_t::FP_LE;
-	}
-
 	tr.shaders[ tr.numShaders ] = newShader;
 	newShader->index = tr.numShaders;
 
@@ -5970,6 +5962,14 @@ static shader_t *FinishShader()
 			shader.noShadows = false;
 		}
 	}
+
+	if ( shader.sort <= Util::ordinal( shaderSort_t::SS_OPAQUE ) ) {
+		shader.fogPass = fogPass_t::FP_EQUAL;
+	} else if ( shader.contentFlags & CONTENTS_FOG ) {
+		shader.fogPass = fogPass_t::FP_LE;
+	}
+
+	shader.noFog = shader.noFog || shader.fogPass == fogPass_t::FP_NONE;
 
 	// look for multitexture potential
 	CollapseStages();

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6024,6 +6024,7 @@ static shader_t *FinishShader()
 					maxStages++;
 				}
 
+				// Add 1 for potential fog stages
 				maxStages = PAD( maxStages + 1, 4 ); // Aligned to 4 components
 				materialSystem.maxStages = std::max( maxStages, materialSystem.maxStages );
 			}
@@ -6084,6 +6085,8 @@ static shader_t *FinishShader()
 			maxStages++;
 		}
 
+		// Add 1 for potential depth stages
+		// Add 1 for potential fog stages
 		maxStages = PAD( maxStages + 2, 4 ); // Aligned to 4 components
 		materialSystem.maxStages = std::max( maxStages, materialSystem.maxStages );
 	}


### PR DESCRIPTION
Changes fog from being done based on an if statement in `Tess_StageIteratorColor()` to being added as a surface with one of two new defaut fog shaders - similar to how we add depth pre-pass surfaces. The 2 new default shaders are for fogs with FP_EQUAL and FP_LE fog passes.

- Adds fog to material system. Fog surfaces are added as stages to the main surface, like it's already done with depth pre-pass surfaces.
- Slightly reworked how depth and fog surfaces are linked to the main surface, now `R_AddDrawSurf()` returns the index of the surface, to get the correct one.
- Moved some early-return fog checks to shader parsing/`R_AddDrawSurf()`.
- Added `u_FogMap` since all fogs use the same image, so it can be made global, and cleaned up `Render_fog()` and fog processing a bit.
- Fixes #537 by rendering all fog surfaces with `SS_FOG`, which is done after SSAO.
- Fixed incorrect max stage count for material system.