### PR TITLE
Multiply with var_Color in lightMapping after u_AlphaThreshold check

### DIFF
--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -57,6 +57,8 @@ void	main()
 
 	vec4 color = texture2D(u_ColorMap, var_TexCoords);
 
+	color *= var_Color;
+
 	if( abs(color.a + u_AlphaThreshold) <= 1.0 )
 	{
 		discard;
@@ -68,8 +70,6 @@ void	main()
 	float fadeDepth = 0.5 * var_FadeDepth.x / var_FadeDepth.y + 0.5;
 	color.a *= smoothstep(gl_FragCoord.z, fadeDepth, depth);
 #endif
-
-	color *= var_Color;
 	
 	SHADER_PROFILER_SET( color )
 


### PR DESCRIPTION
Fixes an issue creating a void effect, where vertex + color/diffuse map produces different results in depth pre-pass `generic` and `lightMapping` shaders, due to different check/multiplication order.

Fixes #119. I've also tried moving the multiplication before the check in `generic` shader, but it ended up making surfaces disappear based on distance to them.