### PR TITLE
Material system: u_LightFactor must be global

### DIFF
--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2140,7 +2140,7 @@ class u_LightFactor :
 {
 public:
 	u_LightFactor( GLShader *shader ) :
-		GLUniform1f( shader, "u_LightFactor" )
+		GLUniform1f( shader, "u_LightFactor", true )
 	{
 	}
 


### PR DESCRIPTION
This makes the Procyon star chart render, albeit incorrectly.

But that should be fixed soon by #1406.