### PR TITLE
Clean up snapshot mess with #including gamelogic

### DIFF
--- a/src/engine/client/cg_api.h
+++ b/src/engine/client/cg_api.h
@@ -25,10 +25,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CGAPI_H
 
 #include "engine/qcommon/q_shared.h"
-#ifdef BUILD_CGAME
-// TODO: find a better way that does not depend on a gamelogic file from an engine file
-#include "shared/bg_public.h"
-#endif
 
 #define CMD_BACKUP               64
 #define CMD_MASK                 ( CMD_BACKUP - 1 )
@@ -41,7 +37,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // Snapshots are generated at regular time intervals by the server,
 // but they may not be sent if a client's rate level is exceeded, or
 // they may be dropped by the network.
-struct snapshot_t
+
+// This particular struct is missing player state, which is added by other
+// snapshot structs building on it.
+struct snapshotBase_t
 {
 	int           snapFlags; // SNAPFLAG_RATE_DELAYED, etc
 	int           ping;
@@ -50,17 +49,18 @@ struct snapshot_t
 
 	byte          areamask[ MAX_MAP_AREA_BYTES ]; // portalarea visibility bits
 
-#ifdef BUILD_CGAME
-	playerState_t ps; // complete information about the current player at this time
-#else
-	OpaquePlayerState ps;
-#endif
-
 	// all of the entities that need to be presented at the time of this snapshot
 	std::vector<entityState_t> entities;
 
 	// text based server commands to execute when this snapshot becomes current
 	std::vector<std::string> serverCommands;
+};
+
+// used for IPC
+struct ipcSnapshot_t
+{
+	snapshotBase_t b;
+	OpaquePlayerState ps;
 };
 
 struct cgClientState_t

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -29,35 +29,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "common/KeyIdentification.h"
 
 namespace Util {
-	template<> struct SerializeTraits<snapshot_t> {
-#ifdef BUILD_ENGINE
-		static void Write(Writer& stream, const snapshot_t& snap)
+	template<> struct SerializeTraits<ipcSnapshot_t> {
+		static void Write(Writer& stream, const ipcSnapshot_t& snap)
 		{
-
-			stream.Write<uint32_t>(snap.snapFlags);
-			stream.Write<uint32_t>(snap.ping);
-			stream.Write<uint32_t>(snap.serverTime);
-			stream.WriteData(&snap.areamask, MAX_MAP_AREA_BYTES);
+			stream.Write<uint32_t>(snap.b.snapFlags);
+			stream.Write<uint32_t>(snap.b.ping);
+			stream.Write<uint32_t>(snap.b.serverTime);
+			stream.WriteData(&snap.b.areamask, MAX_MAP_AREA_BYTES);
 			stream.Write<OpaquePlayerState>(snap.ps);
-			stream.Write<std::vector<entityState_t>>(snap.entities);
-			stream.Write<std::vector<std::string>>(snap.serverCommands);
+			stream.Write<std::vector<entityState_t>>(snap.b.entities);
+			stream.Write<std::vector<std::string>>(snap.b.serverCommands);
 		}
-#endif
-#ifdef BUILD_CGAME
-		static snapshot_t Read(Reader& stream)
+
+		static ipcSnapshot_t Read(Reader& stream)
 		{
-			snapshot_t snap;
-			snap.snapFlags = stream.Read<uint32_t>();
-			snap.ping = stream.Read<uint32_t>();
-			snap.serverTime = stream.Read<uint32_t>();
-			stream.ReadData(&snap.areamask, MAX_MAP_AREA_BYTES);
-			auto ops = stream.Read<OpaquePlayerState>();
-			memcpy(&snap.ps, &ops, sizeof(snap.ps));
-			snap.entities = stream.Read<std::vector<entityState_t>>();
-			snap.serverCommands = stream.Read<std::vector<std::string>>();
+			ipcSnapshot_t snap;
+			snap.b.snapFlags = stream.Read<uint32_t>();
+			snap.b.ping = stream.Read<uint32_t>();
+			snap.b.serverTime = stream.Read<uint32_t>();
+			stream.ReadData(&snap.b.areamask, MAX_MAP_AREA_BYTES);
+			snap.ps = stream.Read<OpaquePlayerState>();
+			snap.b.entities = stream.Read<std::vector<entityState_t>>();
+			snap.b.serverCommands = stream.Read<std::vector<std::string>>();
 			return snap;
 		}
-#endif
 	};
 
 	// For skeletons, only send the bones which are used
@@ -265,7 +260,7 @@ using GetCurrentSnapshotNumberMsg = IPC::SyncMessage<
 >;
 using GetSnapshotMsg = IPC::SyncMessage<
 	IPC::Message<IPC::Id<VM::QVM, CG_GETSNAPSHOT>, int>,
-	IPC::Reply<bool, snapshot_t>
+	IPC::Reply<bool, ipcSnapshot_t>
 >;
 using GetCurrentCmdNumberMsg = IPC::SyncMessage<
 	IPC::Message<IPC::Id<VM::QVM, CG_GETCURRENTCMDNUMBER>>,

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -281,7 +281,7 @@ void CL_FillServerCommands(std::vector<std::string>& commands, int start, int en
 CL_GetSnapshot
 ====================
 */
-bool CL_GetSnapshot( int snapshotNumber, snapshot_t *snapshot )
+bool CL_GetSnapshot( int snapshotNumber, ipcSnapshot_t *snapshot )
 {
 	clSnapshot_t *clSnap;
 
@@ -305,14 +305,14 @@ bool CL_GetSnapshot( int snapshotNumber, snapshot_t *snapshot )
 	}
 
 	// write the snapshot
-	snapshot->snapFlags = clSnap->snapFlags;
-	snapshot->ping = clSnap->ping;
-	snapshot->serverTime = clSnap->serverTime;
-	memcpy( snapshot->areamask, clSnap->areamask, sizeof( snapshot->areamask ) );
+	snapshot->b.snapFlags = clSnap->snapFlags;
+	snapshot->b.ping = clSnap->ping;
+	snapshot->b.serverTime = clSnap->serverTime;
+	memcpy( snapshot->b.areamask, clSnap->areamask, sizeof( snapshot->b.areamask ) );
 	snapshot->ps = clSnap->ps;
-	snapshot->entities = clSnap->entities;
+	snapshot->b.entities = clSnap->entities;
 
-	CL_FillServerCommands(snapshot->serverCommands, clc.lastExecutedServerCommand + 1, clSnap->serverCommandNum);
+	CL_FillServerCommands(snapshot->b.serverCommands, clc.lastExecutedServerCommand + 1, clSnap->serverCommandNum);
 	clc.lastExecutedServerCommand = clSnap->serverCommandNum;
 
 	return true;
@@ -1149,7 +1149,7 @@ void CGameVM::QVMSyscall(int syscallNum, Util::Reader& reader, IPC::Channel& cha
 			break;
 
 		case CG_GETSNAPSHOT:
-			IPC::HandleMsg<GetSnapshotMsg>(channel, std::move(reader), [this] (int number, bool& res, snapshot_t& snapshot) {
+			IPC::HandleMsg<GetSnapshotMsg>(channel, std::move(reader), [this] (int number, bool& res, ipcSnapshot_t& snapshot) {
 				res = CL_GetSnapshot(number, &snapshot);
 			});
 			break;

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -84,7 +84,7 @@ void trap_GetCurrentSnapshotNumber( int *snapshotNumber, int *serverTime )
 	VM::SendMsg<GetCurrentSnapshotNumberMsg>(*snapshotNumber, *serverTime);
 }
 
-bool trap_GetSnapshot( int snapshotNumber, snapshot_t *snapshot )
+bool trap_GetSnapshot( int snapshotNumber, ipcSnapshot_t *snapshot )
 {
 	bool res;
 	VM::SendMsg<GetSnapshotMsg>(snapshotNumber, res, *snapshot);

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -86,7 +86,7 @@ int             trap_R_LerpTag( orientation_t *tag, const refEntity_t *refent, c
 void            trap_R_GetTextureSize( qhandle_t handle, int *x, int *y );
 qhandle_t       trap_R_GenerateTexture( const byte *data, int x, int y );
 void            trap_GetCurrentSnapshotNumber( int *snapshotNumber, int *serverTime );
-bool        trap_GetSnapshot( int snapshotNumber, snapshot_t *snapshot );
+bool        trap_GetSnapshot( int snapshotNumber, ipcSnapshot_t *snapshot );
 int             trap_GetCurrentCmdNumber();
 bool        trap_GetUserCmd( int cmdNumber, usercmd_t *ucmd );
 void            trap_SetUserCmdValue( int stateValue, int flags, float sensitivityScale );


### PR DESCRIPTION
A shared header defined snapshot_t which was used in both the client and cgame, but with different definitions of the player state struct. For the cgame definition of playerState_t it included the file shared/bg_public.h from the gamelogic.
Instead of this define an ipcSnapshot_t type which has a consistent definition and is used for IPC messages. Now snapshot_t will be defined and used only in the cgame.

Companion: https://github.com/Unvanquished/Unvanquished/pull/3182