### PR TITLE
Fix dynamic lights intensity, cleanup

### DIFF
--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -386,7 +386,7 @@ namespace Render {
 	using AddRefEntityToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDREFENTITYTOSCENE>, refEntity_t>;
 	using AddPolyToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDPOLYTOSCENE>, int, std::vector<polyVert_t>>;
 	using AddPolysToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDPOLYSTOSCENE>, int, std::vector<polyVert_t>, int, int>;
-	using AddLightToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDLIGHTTOSCENE>, std::array<float, 3>, float, float, float, float, float, int, int>;
+	using AddLightToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDLIGHTTOSCENE>, std::array<float, 3>, float, float, float, float, float, int>;
 	using SetColorMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_SETCOLOR>, Color::Color>;
 	using SetClipRegionMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_SETCLIPREGION>, std::array<float, 4>>;
 	using ResetClipRegionMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_RESETCLIPREGION>>;

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -174,7 +174,6 @@ enum cgameImport_t
   CG_R_ADDPOLYTOSCENE,
   CG_R_ADDPOLYSTOSCENE,
   CG_R_ADDLIGHTTOSCENE,
-  CG_R_ADDADDITIVELIGHTTOSCENE,
   CG_R_RENDERSCENE,
   CG_R_ADD2DPOLYSINDEXED,
   CG_R_SETMATRIXTRANSFORM,
@@ -388,7 +387,6 @@ namespace Render {
 	using AddPolyToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDPOLYTOSCENE>, int, std::vector<polyVert_t>>;
 	using AddPolysToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDPOLYSTOSCENE>, int, std::vector<polyVert_t>, int, int>;
 	using AddLightToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDLIGHTTOSCENE>, std::array<float, 3>, float, float, float, float, float, int, int>;
-	using AddAdditiveLightToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDADDITIVELIGHTTOSCENE>, std::array<float, 3>, float, float, float, float>;
 	using SetColorMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_SETCOLOR>, Color::Color>;
 	using SetClipRegionMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_SETCLIPREGION>, std::array<float, 4>>;
 	using ResetClipRegionMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_RESETCLIPREGION>>;

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -386,7 +386,7 @@ namespace Render {
 	using AddRefEntityToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDREFENTITYTOSCENE>, refEntity_t>;
 	using AddPolyToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDPOLYTOSCENE>, int, std::vector<polyVert_t>>;
 	using AddPolysToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDPOLYSTOSCENE>, int, std::vector<polyVert_t>, int, int>;
-	using AddLightToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDLIGHTTOSCENE>, std::array<float, 3>, float, float, float, float, float, int>;
+	using AddLightToSceneMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_ADDLIGHTTOSCENE>, std::array<float, 3>, float, float, float, float, int>;
 	using SetColorMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_SETCOLOR>, Color::Color>;
 	using SetClipRegionMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_SETCLIPREGION>, std::array<float, 4>>;
 	using ResetClipRegionMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_RESETCLIPREGION>>;

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1631,12 +1631,6 @@ void CGameVM::CmdBuffer::HandleCommandBufferSyscall(int major, int minor, Util::
                 });
                 break;
 
-            case CG_R_ADDADDITIVELIGHTTOSCENE:
-                HandleMsg<Render::AddAdditiveLightToSceneMsg>(std::move(reader), [this] (const std::array<float, 3>& point, float radius, float r, float g, float b) {
-                    re.AddAdditiveLightToScene(point.data(), radius, 1.0, r, g, b, 0);
-                });
-                break;
-
             case CG_R_SETCOLOR:
                 HandleMsg<Render::SetColorMsg>(std::move(reader), [this] (const Color::Color& color) {
                     re.SetColor(color);

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1626,8 +1626,8 @@ void CGameVM::CmdBuffer::HandleCommandBufferSyscall(int major, int minor, Util::
                 break;
 
             case CG_R_ADDLIGHTTOSCENE:
-                HandleMsg<Render::AddLightToSceneMsg>(std::move(reader), [this] (const std::array<float, 3>& point, float radius, float intensity, float r, float g, float b, int flags) {
-                    re.AddLightToScene(point.data(), radius, intensity, r, g, b, flags);
+                HandleMsg<Render::AddLightToSceneMsg>(std::move(reader), [this] (const std::array<float, 3>& point, float radius, float r, float g, float b, int flags) {
+                    re.AddLightToScene(point.data(), radius, r, g, b, flags);
                 });
                 break;
 

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1626,7 +1626,7 @@ void CGameVM::CmdBuffer::HandleCommandBufferSyscall(int major, int minor, Util::
                 break;
 
             case CG_R_ADDLIGHTTOSCENE:
-                HandleMsg<Render::AddLightToSceneMsg>(std::move(reader), [this] (const std::array<float, 3>& point, float radius, float intensity, float r, float g, float b, int shader, int flags) {
+                HandleMsg<Render::AddLightToSceneMsg>(std::move(reader), [this] (const std::array<float, 3>& point, float radius, float intensity, float r, float g, float b, int flags) {
                     re.AddLightToScene(point.data(), radius, intensity, r, g, b, flags);
                 });
                 break;

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1627,13 +1627,13 @@ void CGameVM::CmdBuffer::HandleCommandBufferSyscall(int major, int minor, Util::
 
             case CG_R_ADDLIGHTTOSCENE:
                 HandleMsg<Render::AddLightToSceneMsg>(std::move(reader), [this] (const std::array<float, 3>& point, float radius, float intensity, float r, float g, float b, int shader, int flags) {
-                    re.AddLightToScene(point.data(), radius, intensity, r, g, b, shader, flags);
+                    re.AddLightToScene(point.data(), radius, intensity, r, g, b, flags);
                 });
                 break;
 
             case CG_R_ADDADDITIVELIGHTTOSCENE:
-                HandleMsg<Render::AddAdditiveLightToSceneMsg>(std::move(reader), [this] (const std::array<float, 3>& point, float intensity, float r, float g, float b) {
-                    re.AddAdditiveLightToScene(point.data(), intensity, r, g, b);
+                HandleMsg<Render::AddAdditiveLightToSceneMsg>(std::move(reader), [this] (const std::array<float, 3>& point, float radius, float r, float g, float b) {
+                    re.AddAdditiveLightToScene(point.data(), radius, 1.0, r, g, b, 0);
                 });
                 break;
 

--- a/src/engine/null/null_renderer.cpp
+++ b/src/engine/null/null_renderer.cpp
@@ -86,7 +86,7 @@ int R_LightForPoint( vec3_t, vec3_t, vec3_t, vec3_t )
 }
 void RE_AddPolyToScene( qhandle_t, int, const polyVert_t* ) { }
 void RE_AddPolysToScene( qhandle_t, int, const polyVert_t*, int ) { }
-void RE_AddLightToScene( const vec3_t, float, float, float, float, float, int ) { }
+void RE_AddLightToScene( const vec3_t, float, float, float, float, int ) { }
 void RE_RenderScene( const refdef_t* ) { }
 void RE_SetColor( const Color::Color& ) { }
 void RE_SetClipRegion( const float* ) { }

--- a/src/engine/null/null_renderer.cpp
+++ b/src/engine/null/null_renderer.cpp
@@ -86,8 +86,7 @@ int R_LightForPoint( vec3_t, vec3_t, vec3_t, vec3_t )
 }
 void RE_AddPolyToScene( qhandle_t, int, const polyVert_t* ) { }
 void RE_AddPolysToScene( qhandle_t, int, const polyVert_t*, int ) { }
-void RE_AddLightToScene( const vec3_t, float, float, float, float, float, qhandle_t, int ) { }
-void RE_AddLightToSceneQ3A( const vec3_t, float, float, float, float ) { }
+void RE_AddLightToScene( const vec3_t, float, float, float, float, float, int ) { }
 void RE_RenderScene( const refdef_t* ) { }
 void RE_SetColor( const Color::Color& ) { }
 void RE_SetClipRegion( const float* ) { }
@@ -227,7 +226,7 @@ refexport_t    *GetRefAPI( int, refimport_t* )
     re.AddPolysToScene = RE_AddPolysToScene;
     // done.
     re.AddLightToScene = RE_AddLightToScene;
-    re.AddAdditiveLightToScene = RE_AddLightToSceneQ3A;
+    re.AddAdditiveLightToScene = RE_AddLightToScene;
 
     re.RenderScene = RE_RenderScene;
 

--- a/src/engine/null/null_renderer.cpp
+++ b/src/engine/null/null_renderer.cpp
@@ -226,7 +226,6 @@ refexport_t    *GetRefAPI( int, refimport_t* )
     re.AddPolysToScene = RE_AddPolysToScene;
     // done.
     re.AddLightToScene = RE_AddLightToScene;
-    re.AddAdditiveLightToScene = RE_AddLightToScene;
 
     re.RenderScene = RE_RenderScene;
 

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -5334,7 +5334,7 @@ const RenderCommand *SetupLightsCommand::ExecuteSelf() const
 
 			VectorCopy( light->l.origin, buffer[i].center );
 			buffer[i].radius = light->l.radius;
-			VectorScale( light->l.color, light->l.scale, buffer[i].color );
+			VectorCopy( light->l.color, buffer[i].color );
 
 			buffer[i].type = Util::ordinal( light->l.rlType );
 			switch( light->l.rlType ) {

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -5310,18 +5310,18 @@ const RenderCommand *GradientPicCommand::ExecuteSelf( ) const
 RB_SetupLights
 =============
 */
-const RenderCommand *SetupLightsCommand::ExecuteSelf( ) const
+const RenderCommand *SetupLightsCommand::ExecuteSelf() const
 {
-	int numLights;
 	GLenum bufferTarget = glConfig2.uniformBufferObjectAvailable ? GL_UNIFORM_BUFFER : GL_PIXEL_UNPACK_BUFFER;
 
 	GLimp_LogComment( "--- SetupLightsCommand::ExecuteSelf ---\n" );
 
-	if( (numLights = refdef.numLights) > 0 ) {
+	const int numLights = refdef.numLights;
+	if( numLights ) {
 		shaderLight_t *buffer;
 
 		glBindBuffer( bufferTarget, tr.dlightUBO );
-		buffer = (shaderLight_t *)glMapBufferRange( bufferTarget,
+		buffer = (shaderLight_t *) glMapBufferRange( bufferTarget,
 							    0, numLights * sizeof( shaderLight_t ),
 							    GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT );
 
@@ -5334,20 +5334,20 @@ const RenderCommand *SetupLightsCommand::ExecuteSelf( ) const
 
 			VectorCopy( light->l.origin, buffer[i].center );
 			buffer[i].radius = light->l.radius;
-			VectorScale( light->l.color, 4.0f * light->l.scale, buffer[i].color );
+			VectorScale( light->l.color, light->l.scale, buffer[i].color );
+
 			buffer[i].type = Util::ordinal( light->l.rlType );
 			switch( light->l.rlType ) {
-			case refLightType_t::RL_PROJ:
-				VectorCopy( light->l.projTarget,
-					    buffer[i].direction );
-				buffer[i].angle = cosf( atan2f( VectorLength( light->l.projUp), VectorLength( light->l.projTarget ) ) );
-				break;
-			case refLightType_t::RL_DIRECTIONAL:
-				VectorCopy( light->l.projTarget,
-					    buffer[i].direction );
-				break;
-			default:
-				break;
+
+				case refLightType_t::RL_PROJ:
+					VectorCopy( light->l.projTarget, buffer[i].direction );
+					buffer[i].angle = cosf( atan2f( VectorLength( light->l.projUp), VectorLength( light->l.projTarget ) ) );
+					break;
+				case refLightType_t::RL_DIRECTIONAL:
+					VectorCopy( light->l.projTarget, buffer[i].direction );
+					break;
+				default:
+					break;
 			}
 		}
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -219,7 +219,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Range<Cvar::Cvar<float>> r_forceAmbient( "r_forceAmbient", "Minimal light amount in lightGrid", Cvar::NONE,
 		0.125f, 0.0f, 0.3f );
 	Cvar::Cvar<float> r_ambientScale( "r_ambientScale", "Scale lightGrid produced by ambientColor keyword by this much", Cvar::CHEAT, 1.0 );
-	cvar_t      *r_lightScale;
 	cvar_t      *r_debugSort;
 	cvar_t      *r_printShaders;
 
@@ -1193,7 +1192,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_facePlaneCull = Cvar_Get( "r_facePlaneCull", "1", 0 );
 
 		Cvar::Latch( r_ambientScale );
-		r_lightScale = Cvar_Get( "r_lightScale", "2", CVAR_CHEAT );
 
 		r_vboFaces = Cvar_Get( "r_vboFaces", "1", CVAR_CHEAT );
 		r_vboCurves = Cvar_Get( "r_vboCurves", "1", CVAR_CHEAT );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1654,8 +1654,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		re.AddPolysToScene = RE_AddPolysToScene;
 		re.LightForPoint = R_LightForPoint;
 
-		re.AddLightToScene = RE_AddDynamicLightToSceneET;
-		re.AddAdditiveLightToScene = RE_AddDynamicLightToSceneQ3A;
+		re.AddLightToScene = RE_AddDynamicLightToScene;
+		re.AddAdditiveLightToScene = RE_AddDynamicLightToScene;
 
 		re.RenderScene = RE_RenderScene;
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1655,7 +1655,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		re.LightForPoint = R_LightForPoint;
 
 		re.AddLightToScene = RE_AddDynamicLightToScene;
-		re.AddAdditiveLightToScene = RE_AddDynamicLightToScene;
 
 		re.RenderScene = RE_RenderScene;
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3690,7 +3690,7 @@ inline bool checkGLErrors()
 	void RE_AddPolyToSceneET( qhandle_t hShader, int numVerts, const polyVert_t *verts );
 	void RE_AddPolysToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts, int numPolys );
 
-	void RE_AddDynamicLightToScene( const vec3_t org, float radius, float intensity, float r, float g, float b, int flags );
+	void RE_AddDynamicLightToScene( const vec3_t org, float radius, float r, float g, float b, int flags );
 
 	void RE_RenderScene( const refdef_t *fd );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3690,8 +3690,7 @@ inline bool checkGLErrors()
 	void RE_AddPolyToSceneET( qhandle_t hShader, int numVerts, const polyVert_t *verts );
 	void RE_AddPolysToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts, int numPolys );
 
-	void RE_AddDynamicLightToSceneET( const vec3_t org, float radius, float intensity, float r, float g, float b, qhandle_t hShader, int flags );
-	void RE_AddDynamicLightToSceneQ3A( const vec3_t org, float intensity, float r, float g, float b );
+	void RE_AddDynamicLightToScene( const vec3_t org, float radius, float intensity, float r, float g, float b, int flags );
 
 	void RE_RenderScene( const refdef_t *fd );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2891,7 +2891,6 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 	extern Cvar::Range<Cvar::Cvar<float>> r_forceAmbient;
 	extern Cvar::Cvar<float> r_ambientScale;
-	extern cvar_t *r_lightScale;
 
 	extern Cvar::Cvar<bool> r_drawSky; // Controls whether sky should be drawn or cleared.
 	extern Cvar::Range<Cvar::Cvar<int>> r_realtimeLightingRenderer;

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -200,7 +200,7 @@ struct refexport_t
 	void ( *AddPolyToScene )( qhandle_t hShader, int numVerts, const polyVert_t *verts );
 	void ( *AddPolysToScene )( qhandle_t hShader, int numVerts, const polyVert_t *verts, int numPolys );
 
-	void ( *AddLightToScene )( const vec3_t org, float radius, float intensity, float r, float g, float b, int flags );
+	void ( *AddLightToScene )( const vec3_t org, float radius, float r, float g, float b, int flags );
 
 	void ( *RenderScene )( const refdef_t *fd );
 

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -200,10 +200,9 @@ struct refexport_t
 	void ( *AddPolyToScene )( qhandle_t hShader, int numVerts, const polyVert_t *verts );
 	void ( *AddPolysToScene )( qhandle_t hShader, int numVerts, const polyVert_t *verts, int numPolys );
 
-	void ( *AddLightToScene )( const vec3_t org, float radius, float intensity, float r, float g, float b,
-	                           qhandle_t hShader, int flags );
+	void ( *AddLightToScene )( const vec3_t org, float radius, float intensity, float r, float g, float b, int flags );
 
-	void ( *AddAdditiveLightToScene )( const vec3_t org, float intensity, float r, float g, float b );
+	void ( *AddAdditiveLightToScene )( const vec3_t org, float radius, float intensity, float r, float g, float b, int flags );
 
 	void ( *RenderScene )( const refdef_t *fd );
 

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -202,8 +202,6 @@ struct refexport_t
 
 	void ( *AddLightToScene )( const vec3_t org, float radius, float intensity, float r, float g, float b, int flags );
 
-	void ( *AddAdditiveLightToScene )( const vec3_t org, float radius, float intensity, float r, float g, float b, int flags );
-
 	void ( *RenderScene )( const refdef_t *fd );
 
 	void ( *SetColor )( const Color::Color& rgba );             // nullptr = 1,1,1,1

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -285,10 +285,8 @@ RE_AddDynamicLightToScene
 ydnar: modified dlight system to support separate radius and intensity
 =====================
 */
-void RE_AddDynamicLightToScene( const vec3_t org, float radius, float intensity, float r, float g, float b, int flags )
+void RE_AddDynamicLightToScene( const vec3_t org, float radius, float r, float g, float b, int flags )
 {
-	trRefLight_t *light;
-
 	if ( !glConfig2.realtimeLighting || !r_drawDynamicLights.Get() )
 	{
 		return;
@@ -304,11 +302,12 @@ void RE_AddDynamicLightToScene( const vec3_t org, float radius, float intensity,
 		return;
 	}
 
-	if ( intensity <= 0 || radius <= 0 )
+	if ( radius <= 0 )
 	{
 		return;
 	}
 
+	trRefLight_t* light;
 	// set last lights restrictInteractionEnd if needed
 	if ( r_numLights > r_firstSceneLight ) {
 		light = &backEndData[ tr.smpFrame ]->lights[ r_numLights - 1 ];
@@ -347,10 +346,9 @@ void RE_AddDynamicLightToScene( const vec3_t org, float radius, float intensity,
 
 	light->additive = true;
 
-	if( light->l.inverseShadows )
-		light->l.scale = -intensity;
-	else
-		light->l.scale = intensity;
+	if ( light->l.inverseShadows ) {
+		VectorNegate( light->l.color, light->l.color );
+	}
 }
 
 static void RE_RenderCubeProbeFace( const refdef_t* originalRefdef ) {

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -299,14 +299,6 @@ void RE_AddDynamicLightToScene( const vec3_t org, float radius, float intensity,
 		return;
 	}
 
-	// set last lights restrictInteractionEnd if needed
-	if ( r_numLights > r_firstSceneLight ) {
-		light = &backEndData[ tr.smpFrame ]->lights[ r_numLights - 1 ];
-		if( light->restrictInteractionFirst >= 0 ) {
-			light->restrictInteractionLast = r_numEntities - r_firstSceneEntity - 1;
-		}
-	}
-
 	if ( r_numLights >= MAX_REF_LIGHTS )
 	{
 		return;
@@ -315,6 +307,14 @@ void RE_AddDynamicLightToScene( const vec3_t org, float radius, float intensity,
 	if ( intensity <= 0 || radius <= 0 )
 	{
 		return;
+	}
+
+	// set last lights restrictInteractionEnd if needed
+	if ( r_numLights > r_firstSceneLight ) {
+		light = &backEndData[ tr.smpFrame ]->lights[ r_numLights - 1 ];
+		if( light->restrictInteractionFirst >= 0 ) {
+			light->restrictInteractionLast = r_numEntities - r_firstSceneEntity - 1;
+		}
 	}
 
 	light = &backEndData[ tr.smpFrame ]->lights[ r_numLights++ ];

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -285,7 +285,7 @@ RE_AddDynamicLightToScene
 ydnar: modified dlight system to support separate radius and intensity
 =====================
 */
-void RE_AddDynamicLightToSceneET( const vec3_t org, float radius, float intensity, float r, float g, float b, qhandle_t, int flags )
+void RE_AddDynamicLightToScene( const vec3_t org, float radius, float intensity, float r, float g, float b, int flags )
 {
 	trRefLight_t *light;
 
@@ -351,11 +351,6 @@ void RE_AddDynamicLightToSceneET( const vec3_t org, float radius, float intensit
 		light->l.scale = -intensity;
 	else
 		light->l.scale = intensity;
-}
-
-void RE_AddDynamicLightToSceneQ3A( const vec3_t org, float radius, float r, float g, float b )
-{
-	RE_AddDynamicLightToSceneET( org, radius, 1.0, r, g, b, 0, 0 );
 }
 
 static void RE_RenderCubeProbeFace( const refdef_t* originalRefdef ) {

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -355,7 +355,7 @@ void RE_AddDynamicLightToSceneET( const vec3_t org, float radius, float intensit
 
 void RE_AddDynamicLightToSceneQ3A( const vec3_t org, float radius, float r, float g, float b )
 {
-	RE_AddDynamicLightToSceneET( org, radius, r_lightScale->value, r, g, b, 0, 0 );
+	RE_AddDynamicLightToSceneET( org, radius, 1.0, r, g, b, 0, 0 );
 }
 
 static void RE_RenderCubeProbeFace( const refdef_t* originalRefdef ) {

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1382,7 +1382,7 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *pStage,
 	gl_forwardLightingShader_omniXYZ->SetUniform_LightOrigin( lightOrigin );
 	gl_forwardLightingShader_omniXYZ->SetUniform_LightColor( lightColor.ToArray() );
 	gl_forwardLightingShader_omniXYZ->SetUniform_LightRadius( light->sphereRadius );
-	gl_forwardLightingShader_omniXYZ->SetUniform_LightScale( light->l.scale );
+	gl_forwardLightingShader_omniXYZ->SetUniform_LightScale( 1.0 );
 	gl_forwardLightingShader_omniXYZ->SetUniform_LightAttenuationMatrix( light->attenuationMatrix2 );
 
 	GL_CheckErrors();
@@ -1557,7 +1557,7 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *pStage,
 	gl_forwardLightingShader_projXYZ->SetUniform_LightOrigin( lightOrigin );
 	gl_forwardLightingShader_projXYZ->SetUniform_LightColor( lightColor.ToArray() );
 	gl_forwardLightingShader_projXYZ->SetUniform_LightRadius( light->sphereRadius );
-	gl_forwardLightingShader_projXYZ->SetUniform_LightScale( light->l.scale );
+	gl_forwardLightingShader_projXYZ->SetUniform_LightScale( 1.0 );
 	gl_forwardLightingShader_projXYZ->SetUniform_LightAttenuationMatrix( light->attenuationMatrix2 );
 
 	GL_CheckErrors();
@@ -1735,7 +1735,7 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *pStage, trRef
 	gl_forwardLightingShader_directionalSun->SetUniform_LightDir( lightDirection );
 	gl_forwardLightingShader_directionalSun->SetUniform_LightColor( lightColor.ToArray() );
 	gl_forwardLightingShader_directionalSun->SetUniform_LightRadius( light->sphereRadius );
-	gl_forwardLightingShader_directionalSun->SetUniform_LightScale( light->l.scale );
+	gl_forwardLightingShader_directionalSun->SetUniform_LightScale( 1.0 );
 	gl_forwardLightingShader_directionalSun->SetUniform_LightAttenuationMatrix( light->attenuationMatrix2 );
 
 	GL_CheckErrors();

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -241,9 +241,7 @@ struct refLight_t
 	vec3_t    origin;
 	quat_t    rotation;
 	vec3_t    center;
-	vec3_t    color; // range from 0.0 to 1.0, should be color normalized
-
-	float scale;
+	vec3_t    color; // should be color normalized
 
 	// omni-directional light specific
 	float     radius;

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -243,7 +243,7 @@ struct refLight_t
 	vec3_t    center;
 	vec3_t    color; // range from 0.0 to 1.0, should be color normalized
 
-	float     scale; // r_lightScale if not set
+	float scale;
 
 	// omni-directional light specific
 	float     radius;

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -353,13 +353,6 @@ void trap_R_AddLightToScene( const vec3_t org, float radius, float intensity, fl
 	cmdBuffer.SendMsg<Render::AddLightToSceneMsg>(myorg, radius, intensity, r, g, b, hShader, flags);
 }
 
-void trap_R_AddAdditiveLightToScene( const vec3_t org, float intensity, float r, float g, float b )
-{
-	std::array<float, 3> myorg;
-	VectorCopy(org, myorg);
-	cmdBuffer.SendMsg<Render::AddAdditiveLightToSceneMsg>(myorg, intensity, r, g, b);
-}
-
 void trap_R_RenderScene( const refdef_t *fd )
 {
 	cmdBuffer.SendMsg<Render::RenderSceneMsg>(*fd);

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -346,11 +346,11 @@ void trap_R_ResetMatrixTransform()
 	cmdBuffer.SendMsg<Render::ResetMatrixTransformMsg>();
 }
 
-void trap_R_AddLightToScene( const vec3_t org, float radius, float intensity, float r, float g, float b, qhandle_t hShader, int flags )
+void trap_R_AddLightToScene( const vec3_t origin, float radius, float intensity, float r, float g, float b, int flags )
 {
 	std::array<float, 3> myorg;
-	VectorCopy(org, myorg);
-	cmdBuffer.SendMsg<Render::AddLightToSceneMsg>(myorg, radius, intensity, r, g, b, hShader, flags);
+	VectorCopy( origin, myorg );
+	cmdBuffer.SendMsg<Render::AddLightToSceneMsg>(myorg, radius, intensity, r, g, b, flags);
 }
 
 void trap_R_RenderScene( const refdef_t *fd )

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -350,7 +350,7 @@ void trap_R_AddLightToScene( const vec3_t origin, float radius, float intensity,
 {
 	std::array<float, 3> myorg;
 	VectorCopy( origin, myorg );
-	cmdBuffer.SendMsg<Render::AddLightToSceneMsg>(myorg, radius, intensity, r, g, b, flags);
+	cmdBuffer.SendMsg<Render::AddLightToSceneMsg>(myorg, radius, r * intensity, g * intensity, b * intensity, flags);
 }
 
 void trap_R_RenderScene( const refdef_t *fd )

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -69,7 +69,6 @@ void            trap_R_AddRefEntityToScene( const refEntity_t *re );
 void            trap_R_AddPolyToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts );
 void            trap_R_AddPolysToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts, int numPolys );
 void            trap_R_AddLightToScene( const vec3_t org, float radius, float intensity, float r, float g, float b, qhandle_t hShader, int flags );
-void            trap_R_AddAdditiveLightToScene( const vec3_t org, float intensity, float r, float g, float b );
 void            trap_R_Add2dPolysIndexedToScene( const polyVert_t *polys, int numVerts, const int *indexes, int numIndexes, int trans_x, int trans_y, qhandle_t shader );
 void            trap_R_SetMatrixTransform( const matrix_t matrix );
 void            trap_R_ResetMatrixTransform();

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -68,7 +68,7 @@ void            trap_R_ClearScene();
 void            trap_R_AddRefEntityToScene( const refEntity_t *re );
 void            trap_R_AddPolyToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts );
 void            trap_R_AddPolysToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts, int numPolys );
-void            trap_R_AddLightToScene( const vec3_t org, float radius, float intensity, float r, float g, float b, qhandle_t hShader, int flags );
+void            trap_R_AddLightToScene( const vec3_t origin, float radius, float intensity, float r, float g, float b, int flags );
 void            trap_R_Add2dPolysIndexedToScene( const polyVert_t *polys, int numVerts, const int *indexes, int numIndexes, int trans_x, int trans_y, qhandle_t shader );
 void            trap_R_SetMatrixTransform( const matrix_t matrix );
 void            trap_R_ResetMatrixTransform();


### PR DESCRIPTION
Cgame-side pr: https://github.com/Unvanquished/Unvanquished/pull/3184
Dynamic light config update for weapon flash colours: https://github.com/UnvanquishedAssets/res-weapons_src.dpkdir/pull/32

- NUKED the weird 4x dynamic light scaling
- NUKED the weird `r_lightScale` cvar, which is used for dynamic lights, but it's a cheat cvar and always set to 2.0, and essentially only used for dynamic lights spawned from movers
- NUKED `RE_AddDynamicLightToSceneQ3A()` and renamed `RE_AddDynamicLightToSceneET()` to `RE_AddDynamicLightToScene()` because they're essentially the same
- NUKED now unused `trap_R_AddAdditiveLightToScene()`
- NUKED light intensity/scale, which was only used to scale the light's colour, just multiply the colour earlier on instead
- Fixed some incorrect memory read before bounds check

Fixes #61:
`hq-beta28`:
Before:
![unvanquished_2024-11-09_184524_000](https://github.com/user-attachments/assets/46238578-300f-4565-89f8-3c9eee0953c4)
After:
![unvanquished_2024-11-09_184725_000](https://github.com/user-attachments/assets/39d031d9-b235-4582-9c80-3d3af0bf1e60)

`tremtest`:
Before:
![unvanquished_2024-11-09_184614_000](https://github.com/user-attachments/assets/6da45671-3f7e-4bf7-a939-2d749c227001)
After:
![unvanquished_2024-11-09_184754_000](https://github.com/user-attachments/assets/360ad073-bccb-49dc-9214-2b4fb55d6dbb)