### PR TITLE
tr_shader: skip standalone lightmaps, they are assumed to be buggy

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5177,6 +5177,15 @@ static void FinishStages()
 	bool shaderHasNoLight = true;
 	bool lightStageFound = false;
 
+	/* Skip standalone lightmaps, they are assumed to be buggy,
+	see: https://github.com/DaemonEngine/Daemon/issues/322 */
+	if ( numStages == 1 && stages[ 0 ].type == stageType_t::ST_LIGHTMAP )
+	{
+		Log::Warn("Skipping standalone lightmap in shader '%s', assumed to be buggy.", shader.name);
+		stages[ 0 ].active = false;
+		numStages = 0;
+	}
+
 	for ( size_t s = 0; s < numStages; s++ )
 	{
 		shaderStage_t *stage = &stages[ s ];


### PR DESCRIPTION
Skip standalone lightmaps, they are assumed to be buggy, fixes #322:

- https://github.com/DaemonEngine/Daemon/issues/322

Extracted from:

- https://github.com/DaemonEngine/Daemon/pull/1406