### PR TITLE
Fix entity baseline overflow

### DIFF
--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -153,6 +153,8 @@ struct clientActive_t
 	clSnapshot_t  snapshots[ PACKET_BACKUP ];
 
 	entityState_t entityBaselines[ MAX_GENTITIES ]; // for delta compression when not in previous frame
+
+	bool reading; // For gamestate that is split between different msg_t
 };
 
 extern clientActive_t cl;

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -248,12 +248,13 @@ enum svc_ops_e
   svc_bad,
   svc_nop,
   svc_gamestate,
+  svc_gamestatePartial,
   svc_configstring, // [short] [string] only in gamestate messages
   svc_baseline, // only in gamestate messages
   svc_serverCommand, // [string] to be executed by client game module
   svc_download, // [short] size [size bytes]
   svc_snapshot,
-  svc_EOF,
+  svc_EOF
 };
 
 //

--- a/src/engine/server/sv_client.cpp
+++ b/src/engine/server/sv_client.cpp
@@ -385,6 +385,16 @@ void SV_SendClientGameState( client_t *client )
 
 		MSG_WriteByte( &msg, svc_baseline );
 		MSG_WriteDeltaEntity( &msg, &nullstate, base, true );
+
+		if ( MAX_MSGLEN - msg.cursize < 128 ) {
+			// We have too many entities to put them all into one msg_t, so split it here
+			MSG_WriteByte( &msg, svc_gamestatePartial );
+			SV_SendMessageToClient( &msg, client );
+
+			MSG_Init( &msg, msgBuffer, sizeof( msgBuffer ) );
+			MSG_WriteLong( &msg, client->lastClientCommand );
+			MSG_WriteByte( &msg, svc_gamestate );
+		}
 	}
 
 	MSG_WriteByte( &msg, svc_EOF );


### PR DESCRIPTION
Split net messages if there are too many baselines. I don't like the solution too much because it only works for this exact issue, but I guess it'll do.

The layouts in https://users.unvanquished.net/~reaper/maps/layouts/spacetracks/ can be used to test this with map `spacetracks`.

Fixes https://github.com/Unvanquished/Unvanquished/issues/2124.