### PR TITLE
Set vertex colour attr correctly with material system

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1315,11 +1315,13 @@ void ProcessMaterialLightMapping( Material* material, shaderStage_t* pStage, dra
 
 	DAEMON_ASSERT( !( enableDeluxeMapping && enableGridDeluxeMapping ) );
 
-	colorGen_t rgbGen = SetRgbGen( pStage );
+	// useAttrColor has no effect since the lightMapping shader has ATTR_COLOR forced to be always
+	// on (_requiredVertexAttribs). If we removed ATTR_COLOR from there, we would need to detect
+	// implicit vertex lighting as well, not only rgbgen (see SetLightDeluxeMode).
+	/* colorGen_t rgbGen = SetRgbGen( pStage );
 	alphaGen_t alphaGen = SetAlphaGen( pStage );
-
 	material->useAttrColor = rgbGen == colorGen_t::CGEN_VERTEX || rgbGen == colorGen_t::CGEN_ONE_MINUS_VERTEX
-		|| alphaGen == alphaGen_t::AGEN_VERTEX || alphaGen == alphaGen_t::AGEN_ONE_MINUS_VERTEX;
+		|| alphaGen == alphaGen_t::AGEN_VERTEX || alphaGen == alphaGen_t::AGEN_ONE_MINUS_VERTEX; */
 
 	material->enableDeluxeMapping = enableDeluxeMapping;
 	material->enableGridLighting = enableGridLighting;

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1282,6 +1282,12 @@ void ProcessMaterialGeneric3D( Material* material, shaderStage_t* pStage, drawSu
 	material->tcGen_Lightmap = pStage->tcGen_Lightmap;
 	material->deformIndex = pStage->deformIndex;
 
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
+
+	material->useAttrColor = rgbGen == colorGen_t::CGEN_VERTEX || rgbGen == colorGen_t::CGEN_ONE_MINUS_VERTEX
+		|| alphaGen == alphaGen_t::AGEN_VERTEX || alphaGen == alphaGen_t::AGEN_ONE_MINUS_VERTEX;
+
 	gl_genericShaderMaterial->SetTCGenEnvironment( pStage->tcGen_Environment );
 	gl_genericShaderMaterial->SetTCGenLightmap( pStage->tcGen_Lightmap );
 
@@ -1308,6 +1314,12 @@ void ProcessMaterialLightMapping( Material* material, shaderStage_t* pStage, dra
 	bool enableGridDeluxeMapping = ( deluxeMode == deluxeMode_t::GRID );
 
 	DAEMON_ASSERT( !( enableDeluxeMapping && enableGridDeluxeMapping ) );
+
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
+
+	material->useAttrColor = rgbGen == colorGen_t::CGEN_VERTEX || rgbGen == colorGen_t::CGEN_ONE_MINUS_VERTEX
+		|| alphaGen == alphaGen_t::AGEN_VERTEX || alphaGen == alphaGen_t::AGEN_ONE_MINUS_VERTEX;
 
 	material->enableDeluxeMapping = enableDeluxeMapping;
 	material->enableGridLighting = enableGridLighting;
@@ -2151,6 +2163,12 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 	}
 
 	backEnd.currentEntity = &tr.worldEntity;
+
+	if ( material.useAttrColor ) {
+		material.shader->AddVertexAttribBit( ATTR_COLOR );
+	} else {
+		material.shader->DelVertexAttribBit( ATTR_COLOR );
+	}
 
 	GL_State( stateBits );
 	if ( material.usePolygonOffset ) {

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -108,6 +108,8 @@ struct Material {
 	bool enableSpecularMapping;
 	bool enablePhysicalMapping;
 
+	bool useAttrColor = false;
+
 	cullType_t cullType;
 
 	uint32_t sort;
@@ -126,7 +128,8 @@ struct Material {
 
 	bool operator==( const Material& other ) {
 		return program == other.program && stateBits == other.stateBits && vbo == other.vbo && ibo == other.ibo
-			&& fog == other.fog && cullType == other.cullType && usePolygonOffset == other.usePolygonOffset;
+			&& fog == other.fog && cullType == other.cullType && usePolygonOffset == other.usePolygonOffset
+			&& useAttrColor == other.useAttrColor;
 	}
 
 	void AddTexture( Texture* texture ) {


### PR DESCRIPTION
Cherry-picked from #1406.

Before:
![unvanquished-station15-vertexlight-tree](https://github.com/user-attachments/assets/61985367-32bc-4fb9-9acd-c9ad2603e105)

After:
![unvanquished-station15-vertexlight-tree](https://github.com/user-attachments/assets/03626146-7805-402b-90fd-3243b6224f04)

I think this is still not complete actually, as there are also implicitly vertex lit surfaces that don't have `CGEN_VERTEX` set. Vertex lighting can be automatically selected when there is no lightmap. The computer console in Vega is an example. It uses an image loaded as shader.