### PR TITLE
Fix instant quad 'stageIteratorFunc == NULL' error

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2695,6 +2695,7 @@ void Tess_ComputeTexMatrices( shaderStage_t *pStage )
 }
 
 // Used for things which are never intended to be rendered
+// (or in the case of Tess_InstantQuad, they're rendered but not via Tess_End)
 void Tess_StageIteratorDummy()
 {
 	Log::Warn( "non-drawing tessellation overflow" );

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -544,7 +544,7 @@ void Tess_InstantQuad( u_ModelViewProjectionMatrix &shader, const float x, const
 {
 	GLimp_LogComment( "--- Tess_InstantQuad ---\n" );
 
-	Tess_Clear();
+	Tess_Begin( Tess_StageIteratorDummy, nullptr, nullptr, true, -1, 0 );
 
 	matrix_t modelViewMatrix;
 	MatrixCopy( matrixIdentity, modelViewMatrix );


### PR DESCRIPTION
This happens when I load plat23 with the dummy gamelogic. The surface rendering function calls Tess_CheckVBOAndIBO, which calls Tess_EndBegin, which is unhappy that there is no stage iterator set.