### PR TITLE
renderer: split generic and generic3D

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -214,42 +214,42 @@ void UpdateSurfaceDataGeneric3D( uint32_t* materials, Material& material, drawSu
 	}
 	drawSurf->initialized[stage] = true;
 
-	gl_genericShaderMaterial->BindProgram( material.deformIndex );
+	gl_generic3DShaderMaterial->BindProgram( material.deformIndex );
 
-	gl_genericShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
-	gl_genericShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+	gl_generic3DShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_generic3DShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 
 	// u_AlphaThreshold
-	gl_genericShaderMaterial->SetUniform_AlphaTest( pStage->stateBits );
+	gl_generic3DShaderMaterial->SetUniform_AlphaTest( pStage->stateBits );
 
 	// u_ColorModulate
 	colorGen_t rgbGen = SetRgbGen( pStage );
 	alphaGen_t alphaGen = SetAlphaGen( pStage );
 
 	bool mayUseVertexOverbright = pStage->type == stageType_t::ST_COLORMAP && drawSurf->bspSurface;
-	gl_genericShaderMaterial->SetUniform_ColorModulate( rgbGen, alphaGen, mayUseVertexOverbright );
+	gl_generic3DShaderMaterial->SetUniform_ColorModulate( rgbGen, alphaGen, mayUseVertexOverbright );
 
 	Tess_ComputeColor( pStage );
-	gl_genericShaderMaterial->SetUniform_Color( tess.svars.color );
+	gl_generic3DShaderMaterial->SetUniform_Color( tess.svars.color );
 
 	Tess_ComputeTexMatrices( pStage );
-	gl_genericShaderMaterial->SetUniform_TextureMatrix( tess.svars.texMatrices[TB_COLORMAP] );
+	gl_generic3DShaderMaterial->SetUniform_TextureMatrix( tess.svars.texMatrices[TB_COLORMAP] );
 
 	// bind u_ColorMap
 	if ( pStage->type == stageType_t::ST_STYLELIGHTMAP ) {
-		gl_genericShaderMaterial->SetUniform_ColorMapBindless(
+		gl_generic3DShaderMaterial->SetUniform_ColorMapBindless(
 			GL_BindToTMU( 0, GetLightMap( drawSurf ) )
 		);
 	} else {
-		gl_genericShaderMaterial->SetUniform_ColorMapBindless( BindAnimatedImage( 0, &pStage->bundle[TB_COLORMAP] ) );
+		gl_generic3DShaderMaterial->SetUniform_ColorMapBindless( BindAnimatedImage( 0, &pStage->bundle[TB_COLORMAP] ) );
 	}
 
 	bool hasDepthFade = pStage->hasDepthFade;
 	if ( hasDepthFade ) {
-		gl_genericShaderMaterial->SetUniform_DepthScale( pStage->depthFadeValue );
+		gl_generic3DShaderMaterial->SetUniform_DepthScale( pStage->depthFadeValue );
 	}
 
-	gl_genericShaderMaterial->WriteUniformsToBuffer( materials );
+	gl_generic3DShaderMaterial->WriteUniformsToBuffer( materials );
 }
 
 void UpdateSurfaceDataLightMapping( uint32_t* materials, Material& material, drawSurf_t* drawSurf, const uint32_t stage ) {
@@ -994,30 +994,30 @@ void BindShaderNOP( Material* ) {
 
 void BindShaderGeneric3D( Material* material ) {
 	// Select shader permutation.
-	gl_genericShaderMaterial->SetTCGenEnvironment( material->tcGenEnvironment );
-	gl_genericShaderMaterial->SetTCGenLightmap( material->tcGen_Lightmap );
-	gl_genericShaderMaterial->SetDepthFade( material->hasDepthFade );
+	gl_generic3DShaderMaterial->SetTCGenEnvironment( material->tcGenEnvironment );
+	gl_generic3DShaderMaterial->SetTCGenLightmap( material->tcGen_Lightmap );
+	gl_generic3DShaderMaterial->SetDepthFade( material->hasDepthFade );
 
 	// Bind shader program.
-	gl_genericShaderMaterial->BindProgram( material->deformIndex );
+	gl_generic3DShaderMaterial->BindProgram( material->deformIndex );
 
 	// Set shader uniforms.
 	if ( material->tcGenEnvironment ) {
-		gl_genericShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
-		gl_genericShaderMaterial->SetUniform_ViewUp( backEnd.orientation.axis[2] );
+		gl_generic3DShaderMaterial->SetUniform_ViewOrigin( backEnd.orientation.viewOrigin );
+		gl_generic3DShaderMaterial->SetUniform_ViewUp( backEnd.orientation.axis[2] );
 	}
 
-	gl_genericShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
-	gl_genericShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
+	gl_generic3DShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_generic3DShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 
-	gl_genericShaderMaterial->SetUniform_DepthMapBindless( GL_BindToTMU( 1, tr.currentDepthImage ) );
+	gl_generic3DShaderMaterial->SetUniform_DepthMapBindless( GL_BindToTMU( 1, tr.currentDepthImage ) );
 
 	// u_DeformGen
-	gl_genericShaderMaterial->SetUniform_Time( backEnd.refdef.floatTime - backEnd.currentEntity->e.shaderTime );
+	gl_generic3DShaderMaterial->SetUniform_Time( backEnd.refdef.floatTime - backEnd.currentEntity->e.shaderTime );
 
 	if ( r_profilerRenderSubGroups.Get() ) {
-		gl_genericShaderMaterial->SetUniform_ProfilerZero();
-		gl_genericShaderMaterial->SetUniform_ProfilerRenderSubGroups( GetShaderProfilerRenderSubGroupsMode( material->stateBits ) );
+		gl_generic3DShaderMaterial->SetUniform_ProfilerZero();
+		gl_generic3DShaderMaterial->SetUniform_ProfilerRenderSubGroups( GetShaderProfilerRenderSubGroupsMode( material->stateBits ) );
 	}
 }
 
@@ -1264,7 +1264,7 @@ void ProcessMaterialNOP( Material*, shaderStage_t*, drawSurf_t* ) {
 // ProcessMaterial*() are essentially same as BindShader*(), but only set the GL program id to the material,
 // without actually binding it
 void ProcessMaterialGeneric3D( Material* material, shaderStage_t* pStage, drawSurf_t* ) {
-	material->shader = gl_genericShaderMaterial;
+	material->shader = gl_generic3DShaderMaterial;
 
 	material->tcGenEnvironment = pStage->tcGen_Environment;
 	material->tcGen_Lightmap = pStage->tcGen_Lightmap;
@@ -1276,14 +1276,14 @@ void ProcessMaterialGeneric3D( Material* material, shaderStage_t* pStage, drawSu
 	material->useAttrColor = rgbGen == colorGen_t::CGEN_VERTEX || rgbGen == colorGen_t::CGEN_ONE_MINUS_VERTEX
 		|| alphaGen == alphaGen_t::AGEN_VERTEX || alphaGen == alphaGen_t::AGEN_ONE_MINUS_VERTEX;
 
-	gl_genericShaderMaterial->SetTCGenEnvironment( pStage->tcGen_Environment );
-	gl_genericShaderMaterial->SetTCGenLightmap( pStage->tcGen_Lightmap );
+	gl_generic3DShaderMaterial->SetTCGenEnvironment( pStage->tcGen_Environment );
+	gl_generic3DShaderMaterial->SetTCGenLightmap( pStage->tcGen_Lightmap );
 
 	bool hasDepthFade = pStage->hasDepthFade;
 	material->hasDepthFade = hasDepthFade;
-	gl_genericShaderMaterial->SetDepthFade( hasDepthFade );
+	gl_generic3DShaderMaterial->SetDepthFade( hasDepthFade );
 
-	material->program = gl_genericShaderMaterial->GetProgram( pStage->deformIndex );
+	material->program = gl_generic3DShaderMaterial->GetProgram( pStage->deformIndex );
 }
 
 void ProcessMaterialLightMapping( Material* material, shaderStage_t* pStage, drawSurf_t* drawSurf ) {
@@ -2286,7 +2286,7 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 		if ( material.shaderBinder == BindShaderLightMapping ) {
 			gl_lightMappingShaderMaterial->SetUniform_MaterialColour( color );
 		} else if ( material.shaderBinder == BindShaderGeneric3D ) {
-			gl_genericShaderMaterial->SetUniform_MaterialColour( color );
+			gl_generic3DShaderMaterial->SetUniform_MaterialColour( color );
 		}
 	}
 
@@ -2313,7 +2313,7 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 		if ( material.shaderBinder == &BindShaderLightMapping ) {
 			gl_lightMappingShaderMaterial->SetUniform_ShowTris( 1 );
 		} else if ( material.shaderBinder == &BindShaderGeneric3D ) {
-			gl_genericShaderMaterial->SetUniform_ShowTris( 1 );
+			gl_generic3DShaderMaterial->SetUniform_ShowTris( 1 );
 		}
 
 		GL_State( GLS_DEPTHTEST_DISABLE );
@@ -2322,7 +2322,7 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 		if ( material.shaderBinder == &BindShaderLightMapping ) {
 			gl_lightMappingShaderMaterial->SetUniform_ShowTris( 0 );
 		} else if ( material.shaderBinder == &BindShaderGeneric3D ) {
-			gl_genericShaderMaterial->SetUniform_ShowTris( 0 );
+			gl_generic3DShaderMaterial->SetUniform_ShowTris( 0 );
 		}
 	}
 

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -43,9 +43,10 @@ ShaderKind shaderKind = ShaderKind::Unknown;
 
 // *INDENT-OFF*
 
-GLShader_generic2D                       *gl_generic2DShader = nullptr;
 GLShader_generic                         *gl_genericShader = nullptr;
-GLShader_genericMaterial                 *gl_genericShaderMaterial = nullptr;
+GLShader_generic2D                       *gl_generic2DShader = nullptr;
+GLShader_generic3D                       *gl_generic3DShader = nullptr;
+GLShader_generic3DMaterial               *gl_generic3DShaderMaterial = nullptr;
 GLShader_cull                            *gl_cullShader = nullptr;
 GLShader_depthReduction                  *gl_depthReductionShader = nullptr;
 GLShader_clearSurfaces                   *gl_clearSurfacesShader = nullptr;
@@ -2173,6 +2174,25 @@ void GLShader::WriteUniformsToBuffer( uint32_t* buffer ) {
 	}
 }
 
+GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
+	GLShader( "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
+	u_ColorMap( this ),
+	u_DepthMap( this ),
+	u_TextureMatrix( this ),
+	u_ModelMatrix( this ),
+	u_ModelViewProjectionMatrix( this ),
+	u_ColorModulate( this ),
+	u_Color( this ),
+	GLDeformStage( this )
+{
+}
+
+void GLShader_generic::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
+{
+	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
+	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_DepthMap" ), 1 );
+}
+
 GLShader_generic2D::GLShader_generic2D( GLShaderManager *manager ) :
 	GLShader( "generic2D", "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
 	u_ColorMap( this ),
@@ -2200,8 +2220,8 @@ void GLShader_generic2D::SetShaderProgramUniforms( shaderProgram_t *shaderProgra
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_DepthMap" ), 1 );
 }
 
-GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
-	GLShader( "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
+GLShader_generic3D::GLShader_generic3D( GLShaderManager *manager ) :
+	GLShader( "generic3D", "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
 	u_ColorMap( this ),
 	u_DepthMap( this ),
 	u_TextureMatrix( this ),
@@ -2226,14 +2246,19 @@ GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 {
 }
 
-void GLShader_generic::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
+void GLShader_generic3D::BuildShaderCompileMacros( std::string& compileMacros )
+{
+	compileMacros += "GENERIC_3D ";
+}
+
+void GLShader_generic3D::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_DepthMap" ), 1 );
 }
 
-GLShader_genericMaterial::GLShader_genericMaterial( GLShaderManager* manager ) :
-	GLShader( "genericMaterial", "generic", true, ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
+GLShader_generic3DMaterial::GLShader_generic3DMaterial( GLShaderManager* manager ) :
+	GLShader( "generic3DMaterial", "generic", true, ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
 	u_ColorMap( this ),
 	u_DepthMap( this ),
 	u_TextureMatrix( this ),
@@ -2255,7 +2280,12 @@ GLShader_genericMaterial::GLShader_genericMaterial( GLShaderManager* manager ) :
 	GLCompileMacro_USE_DEPTH_FADE( this ) {
 }
 
-void GLShader_genericMaterial::SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) {
+void GLShader_generic3DMaterial::BuildShaderCompileMacros( std::string& compileMacros )
+{
+	compileMacros += "GENERIC_3D ";
+}
+
+void GLShader_generic3DMaterial::SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_DepthMap" ), 1 );
 }

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3906,10 +3906,24 @@ class u_Lights :
 	}
 };
 
-// This is just a copy of the GLShader_generic, but with a special
-// define for RmlUI transforms. It probably has a lot of unnecessary
-// code that could be pruned.
-// TODO: Write a more minimal 2D rendering shader.
+// Mostly used by debug tools and things only requiring a very simple shader.
+class GLShader_generic :
+	public GLShader,
+	public u_ColorMap,
+	public u_DepthMap,
+	public u_TextureMatrix,
+	public u_ModelMatrix,
+	public u_ModelViewProjectionMatrix,
+	public u_ColorModulate,
+	public u_Color,
+	public GLDeformStage
+{
+public:
+	GLShader_generic( GLShaderManager *manager );
+	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
+};
+
+// Used for 2D UI elements, it has special code for RmlUi transforms.
 class GLShader_generic2D :
 	public GLShader,
 	public u_ColorMap,
@@ -3930,7 +3944,8 @@ public:
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
 
-class GLShader_generic :
+// Full-featured shader for stages with a single texture.
+class GLShader_generic3D :
 	public GLShader,
 	public u_ColorMap,
 	public u_DepthMap,
@@ -3955,11 +3970,12 @@ class GLShader_generic :
 	public GLCompileMacro_USE_DEPTH_FADE
 {
 public:
-	GLShader_generic( GLShaderManager *manager );
+	GLShader_generic3D( GLShaderManager *manager );
+	void BuildShaderCompileMacros( std::string& compileMacros ) override;
 	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
 };
 
-class GLShader_genericMaterial :
+class GLShader_generic3DMaterial :
 	public GLShader,
 	public u_ColorMap,
 	public u_DepthMap,
@@ -3981,10 +3997,12 @@ class GLShader_genericMaterial :
 	public GLCompileMacro_USE_TCGEN_LIGHTMAP,
 	public GLCompileMacro_USE_DEPTH_FADE {
 	public:
-	GLShader_genericMaterial( GLShaderManager* manager );
+	GLShader_generic3DMaterial( GLShaderManager* manager );
+	void BuildShaderCompileMacros( std::string& compileMacros ) override;
 	void SetShaderProgramUniforms( shaderProgram_t* shaderProgram ) override;
 };
 
+// Full-featured shader for multi-textured stages.
 class GLShader_lightMapping :
 	public GLShader,
 	public u_DiffuseMap,
@@ -4716,8 +4734,9 @@ std::string GetShaderPath();
 extern ShaderKind shaderKind;
 
 extern GLShader_generic2D                       *gl_generic2DShader;
+extern GLShader_generic3D                       *gl_generic3DShader;
+extern GLShader_generic3DMaterial               *gl_generic3DShaderMaterial;
 extern GLShader_generic                         *gl_genericShader;
-extern GLShader_genericMaterial                 *gl_genericShaderMaterial;
 extern GLShader_cull                            *gl_cullShader;
 extern GLShader_depthReduction                  *gl_depthReductionShader;
 extern GLShader_clearSurfaces                   *gl_clearSurfacesShader;

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -25,7 +25,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define GENERIC_GLSL
 
 uniform sampler2D	u_ColorMap;
-uniform float		u_AlphaThreshold;
+
+#if defined(GENERIC_2D) || defined(GENERIC_3D)
+	uniform float u_AlphaThreshold;
+#endif
 
 #if defined(USE_MATERIAL_SYSTEM)
 	uniform bool u_ShowTris;
@@ -57,11 +60,13 @@ void	main()
 
 	vec4 color = texture2D(u_ColorMap, var_TexCoords);
 
+#if defined(GENERIC_2D) || defined(GENERIC_3D)
 	if( abs(color.a + u_AlphaThreshold) <= 1.0 )
 	{
 		discard;
 		return;
 	}
+#endif
 
 #if defined(USE_DEPTH_FADE)
 	float depth = texture2D(u_DepthMap, gl_FragCoord.xy / r_FBufSize).x;

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1910,15 +1910,9 @@ static void RB_SetupLightForLighting( trRefLight_t *light )
 
 							GL_PushMatrix();
 
-							gl_genericShader->SetVertexSkinning( false );
-							gl_genericShader->SetVertexAnimation( false );
-							gl_genericShader->SetTCGenEnvironment( false );
-							gl_genericShader->SetTCGenLightmap( false );
-							gl_genericShader->SetDepthFade( false );
 							gl_genericShader->BindProgram( 0 );
 
 							// set uniforms
-							gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 							gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 							gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -2762,14 +2756,8 @@ void RB_RunVisTests( )
 		Tess_UpdateVBOs( );
 		GL_VertexAttribsState( ATTR_POSITION );
 
-		gl_genericShader->SetVertexSkinning( false );
-		gl_genericShader->SetVertexAnimation( false );
-		gl_genericShader->SetTCGenEnvironment( false );
-		gl_genericShader->SetTCGenLightmap( false );
-		gl_genericShader->SetDepthFade( false );
 		gl_genericShader->BindProgram( 0 );
 
-		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_Color( Color::White );
 
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CONST, alphaGen_t::AGEN_CONST );
@@ -3386,18 +3374,12 @@ static void RB_RenderDebugUtils()
 		static const vec3_t minSize = { -2, -2, -2 };
 		static const vec3_t maxSize = { 2,  2,  2 };
 
-		gl_genericShader->SetVertexSkinning( false );
-		gl_genericShader->SetVertexAnimation( false );
-		gl_genericShader->SetTCGenEnvironment( false );
-		gl_genericShader->SetTCGenLightmap( false );
-		gl_genericShader->SetDepthFade( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CUSTOM_RGB, alphaGen_t::AGEN_CUSTOM );
 
 		// bind u_ColorMap
@@ -3527,18 +3509,12 @@ static void RB_RenderDebugUtils()
 		static const vec3_t mins = { -1, -1, -1 };
 		static const vec3_t maxs = { 1, 1, 1 };
 
-		gl_genericShader->SetVertexSkinning( false );
-		gl_genericShader->SetVertexAnimation( false );
-		gl_genericShader->SetTCGenEnvironment( false );
-		gl_genericShader->SetTCGenLightmap( false );
-		gl_genericShader->SetDepthFade( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -3642,18 +3618,12 @@ static void RB_RenderDebugUtils()
 		static const vec3_t mins = { -1, -1, -1 };
 		static const vec3_t maxs = { 1, 1, 1 };
 
-		gl_genericShader->SetVertexSkinning( false );
-		gl_genericShader->SetVertexAnimation( false );
-		gl_genericShader->SetTCGenEnvironment( false );
-		gl_genericShader->SetTCGenLightmap( false );
-		gl_genericShader->SetDepthFade( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -3708,17 +3678,11 @@ static void RB_RenderDebugUtils()
 		static refSkeleton_t skeleton;
 		refSkeleton_t        *skel;
 
-		gl_genericShader->SetVertexSkinning( false );
-		gl_genericShader->SetVertexAnimation( false );
-		gl_genericShader->SetTCGenEnvironment( false );
-		gl_genericShader->SetTCGenLightmap( false );
-		gl_genericShader->SetDepthFade( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -3921,18 +3885,12 @@ static void RB_RenderDebugUtils()
 		int           iaCount;
 		matrix_t      ortho;
 
-		gl_genericShader->SetVertexSkinning( false );
-		gl_genericShader->SetVertexAnimation( false );
-		gl_genericShader->SetTCGenEnvironment( false );
-		gl_genericShader->SetTCGenLightmap( false );
-		gl_genericShader->SetDepthFade( false );
 		gl_genericShader->BindProgram( 0 );
 
 		GL_State( GLS_POLYMODE_LINE | GLS_DEPTHTEST_DISABLE );
 		GL_Cull( cullType_t::CT_TWO_SIDED );
 
 		// set uniforms
-		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CUSTOM_RGB, alphaGen_t::AGEN_CUSTOM );
 
 		// bind u_ColorMap
@@ -4057,15 +4015,9 @@ static void RB_RenderDebugUtils()
 		}
 
 		{
-			gl_genericShader->SetVertexSkinning( false );
-			gl_genericShader->SetVertexAnimation( false );
-			gl_genericShader->SetTCGenEnvironment( false );
-			gl_genericShader->SetTCGenLightmap( false );
-			gl_genericShader->SetDepthFade( false );
 			gl_genericShader->BindProgram( 0 );
 
 			// set uniforms
-			gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 			gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 			gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -4139,15 +4091,9 @@ static void RB_RenderDebugUtils()
 
 		GLimp_LogComment( "--- r_showLightGrid > 0: Rendering light grid\n" );
 
-		gl_genericShader->SetVertexSkinning( false );
-		gl_genericShader->SetVertexAnimation( false );
-		gl_genericShader->SetTCGenEnvironment( false );
-		gl_genericShader->SetTCGenLightmap( false );
-		gl_genericShader->SetDepthFade( false );
 		gl_genericShader->BindProgram( 0 );
 
 		// set uniforms
-		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 		gl_genericShader->SetUniform_Color( Color::Black );
 
@@ -4230,15 +4176,9 @@ static void RB_RenderDebugUtils()
 			return;
 		}
 
-		gl_genericShader->SetVertexSkinning( false );
-		gl_genericShader->SetVertexAnimation( false );
-		gl_genericShader->SetTCGenEnvironment( false );
-		gl_genericShader->SetTCGenLightmap( false );
-		gl_genericShader->SetDepthFade( false );
 		gl_genericShader->BindProgram( 0 );
 
 		// set uniforms
-		gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 		gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_CUSTOM_RGB, alphaGen_t::AGEN_CUSTOM );
 
 		// bind u_ColorMap
@@ -4523,11 +4463,6 @@ void DebugDrawBegin( debugDrawMode_t mode, float size ) {
 			break;
 	}
 
-	gl_genericShader->SetVertexSkinning( false );
-	gl_genericShader->SetVertexAnimation( false );
-	gl_genericShader->SetTCGenEnvironment( false );
-	gl_genericShader->SetTCGenLightmap( false );
-	gl_genericShader->SetDepthFade( false );
 	gl_genericShader->BindProgram( 0 );
 
 	GL_State( GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA );
@@ -4536,7 +4471,6 @@ void DebugDrawBegin( debugDrawMode_t mode, float size ) {
 	GL_VertexAttribsState( ATTR_POSITION | ATTR_COLOR | ATTR_TEXCOORD );
 
 	// set uniforms
-	gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 	gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 	gl_genericShader->SetUniform_Color( colorClear );
 
@@ -5646,17 +5580,11 @@ void RB_ShowImages()
 
 	glFinish();
 
-	gl_genericShader->SetVertexSkinning( false );
-	gl_genericShader->SetVertexAnimation( false );
-	gl_genericShader->SetTCGenEnvironment( false );
-	gl_genericShader->SetTCGenLightmap( false );
-	gl_genericShader->SetDepthFade( false );
 	gl_genericShader->BindProgram( 0 );
 
 	GL_Cull( cullType_t::CT_TWO_SIDED );
 
 	// set uniforms
-	gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 	gl_genericShader->SetUniform_ColorModulate( colorGen_t::CGEN_VERTEX, alphaGen_t::AGEN_VERTEX );
 	gl_genericShader->SetUniform_TextureMatrix( matrixIdentity );
 


### PR DESCRIPTION
Split `gl_genericShader` and `gl_generic3DShader`.

- Dedicate a simple shader without extra uniforms and no permutations for simple things like debug tools.
- Make sure to not have to call this boiler plate everywhere:
```c
gl_genericShader->SetVertexSkinning( false );
gl_genericShader->SetVertexAnimation( false );
gl_genericShader->SetTCGenEnvironment( false );
gl_genericShader->SetTCGenLightmap( false );
gl_genericShader->SetDepthFade( false );
// should be done there: gl_genericShader->BindProgram( 0 );
gl_genericShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
```
- Leverage more of the compiler type checking at build time.

Here are the current usages:

- `gl_genericShader`: Mostly used by debug tools and things only requiring a very simple shader.
- `gl_generic2DShader`: Used for 2D UI elements, it has special code for RmlUi transforms.
- `gl_generic3DShader`: Full-featured shader for stages with a single texture.
- `gl_lightMapping`: Full-featured shader for multi-textured stages.

The `generic2D` and `generic3D` names are temporary names, we can rename them later to something more meaningful, as 2D and 3D can be confusing with 2D and 3D textures but they both receive 2D textures, we may rename them like `genericUI` and `generic<SOMETHING>`. The `Render_generic2D`, `Render_generic3D` and the `Render_generic` wrapper (that only calls code using `gl_generic2DShader` and  `gl_generic3DShader`) may be renamed too in the future.

If it happens that by doing so when compiling `gl_genericShader` we recompile a shader that already exists as a permutation of `gl_generic3DShader`, we may improve caching to deduplicate them (this may even deduplicate some `gl_generic2DShader` too):

- https://github.com/DaemonEngine/Daemon/issues/1435

This split has nothing to do with light overbright, I first implemented it as part of my overbright efforts because such overbright effort was one of the use case where such changes having already be made before would have make things easier. The overbright effort just reminded me I wanted to do that for a long time, so I decided it was the right time to finally do it.
