### PR TITLE
Remove useless depth-related stuff from 2D rendering

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2184,8 +2184,7 @@ GLShader_generic2D::GLShader_generic2D( GLShaderManager *manager ) :
 	u_ColorModulate( this ),
 	u_Color( this ),
 	u_DepthScale( this ),
-	GLDeformStage( this ),
-	GLCompileMacro_USE_DEPTH_FADE( this )
+	GLDeformStage( this )
 {
 }
 
@@ -2197,7 +2196,6 @@ void GLShader_generic2D::BuildShaderCompileMacros( std::string& compileMacros )
 void GLShader_generic2D::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
 {
 	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
-	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_DepthMap" ), 1 );
 }
 
 GLShader_generic::GLShader_generic( GLShaderManager *manager ) :

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3906,10 +3906,9 @@ class u_Lights :
 	}
 };
 
-// This is just a copy of the GLShader_generic, but with a special
-// define for RmlUI transforms. It probably has a lot of unnecessary
-// code that could be pruned.
-// TODO: Write a more minimal 2D rendering shader.
+// FIXME: this is the same as 'generic' and has no reason for existing.
+// It was added along with RmlUi transforms to add "gl_FragDepth = 0;" to the GLSL,
+// but that turns out not to be needed.
 class GLShader_generic2D :
 	public GLShader,
 	public u_ColorMap,

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3921,8 +3921,7 @@ class GLShader_generic2D :
 	public u_ColorModulate,
 	public u_Color,
 	public u_DepthScale,
-	public GLDeformStage,
-	public GLCompileMacro_USE_DEPTH_FADE
+	public GLDeformStage
 {
 public:
 	GLShader_generic2D( GLShaderManager *manager );

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -75,10 +75,6 @@ void	main()
 
 	outputColor = color;
 
-#if defined(GENERIC_2D)
-	gl_FragDepth = 0;
-#endif
-
 // Debugging.
 #if defined(r_showVertexColors) && !defined(GENERIC_2D)
 	outputColor = vec4(0.0, 0.0, 0.0, 0.0);

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -827,6 +827,7 @@ static void RB_SetGL2D()
 	GL_LoadProjectionMatrix( proj );
 	GL_LoadModelViewMatrix( matrixIdentity );
 
+	// TODO: remove this, state is set wherever drawing is done
 	GL_State( GLS_DEPTHTEST_DISABLE | GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA );
 
 	GL_Cull( cullType_t::CT_TWO_SIDED );

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -824,6 +824,9 @@ static void RB_SetGL2D()
 	GL_Scissor( 0, 0, glConfig.vidWidth, glConfig.vidHeight );
 
 	MatrixOrthogonalProjection( proj, 0, glConfig.vidWidth, glConfig.vidHeight, 0, 0, 1 );
+	// zero the z coordinate so it's never near/far clipped
+	proj[ 2 ] = proj[ 6 ] = proj[ 10 ] = proj[ 14 ] = 0;
+
 	GL_LoadProjectionMatrix( proj );
 	GL_LoadModelViewMatrix( matrixIdentity );
 

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -132,7 +132,6 @@ struct glconfig2_t
 	bool uniformBufferObjectAvailable;
 	bool mapBufferRangeAvailable;
 	bool syncAvailable;
-	bool depthClampAvailable;
 	bool halfFloatVertexAvailable;
 
 	bool colorGrading;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -823,7 +823,8 @@ static void Render_generic2D( shaderStage_t *pStage )
 {
 	GLimp_LogComment( "--- Render_generic2D ---\n" );
 
-	GL_State( pStage->stateBits );
+	// Disable depth testing and writing
+	GL_State( ( pStage->stateBits & ~GLS_DEPTHMASK_TRUE ) | GLS_DEPTHTEST_DISABLE );
 
 	gl_generic2DShader->BindProgram( pStage->deformIndex );
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -851,20 +851,10 @@ static void Render_generic2D( shaderStage_t *pStage )
 	gl_generic2DShader->SetUniform_ColorMapBindless( BindAnimatedImage( 0, &pStage->bundle[TB_COLORMAP] ) );
 	gl_generic2DShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
 
-	if ( glConfig2.depthClampAvailable )
-	{
-		glEnable( GL_DEPTH_CLAMP );
-	}
-
 	gl_generic2DShader->SetRequiredVertexPointers();
 
 	Tess_DrawElements();
 	GL_CheckErrors();
-
-	if ( glConfig2.depthClampAvailable )
-	{
-		glDisable( GL_DEPTH_CLAMP );
-	}
 
 	GL_CheckErrors();
 }

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -825,13 +825,7 @@ static void Render_generic2D( shaderStage_t *pStage )
 
 	GL_State( pStage->stateBits );
 
-	bool hasDepthFade = pStage->hasDepthFade;
-	bool needDepthMap = pStage->hasDepthFade;
-
-	// choose right shader program ----------------------------------
-	gl_generic2DShader->SetDepthFade( hasDepthFade );
 	gl_generic2DShader->BindProgram( pStage->deformIndex );
-	// end choose right shader program ------------------------------
 
 	// set uniforms
 	// u_AlphaThreshold
@@ -859,18 +853,6 @@ static void Render_generic2D( shaderStage_t *pStage )
 	if ( glConfig2.depthClampAvailable )
 	{
 		glEnable( GL_DEPTH_CLAMP );
-	}
-
-	if ( hasDepthFade )
-	{
-		gl_generic2DShader->SetUniform_DepthScale( pStage->depthFadeValue );
-	}
-
-	if ( needDepthMap )
-	{
-		gl_generic2DShader->SetUniform_DepthMapBindless(
-			GL_BindToTMU( 1, tr.currentDepthImage ) 
-		);
 	}
 
 	gl_generic2DShader->SetRequiredVertexPointers();

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -755,11 +755,16 @@ static std::string ContextDescription( const glConfiguration& configuration )
 
 static void GLimp_SetAttributes( const glConfiguration &configuration )
 {
+	// FIXME: 3 * 4 = 12 which is more than 8
 	int perChannelColorBits = configuration.colorBits == 24 ? 8 : 4;
 
 	SDL_GL_SetAttribute( SDL_GL_RED_SIZE, perChannelColorBits );
 	SDL_GL_SetAttribute( SDL_GL_GREEN_SIZE, perChannelColorBits );
 	SDL_GL_SetAttribute( SDL_GL_BLUE_SIZE, perChannelColorBits );
+
+	// Depth/stencil channels are not needed since all 3D rendering is done in FBOs
+	SDL_GL_SetAttribute( SDL_GL_DEPTH_SIZE, 0 );
+	SDL_GL_SetAttribute( SDL_GL_STENCIL_SIZE, 0 );
 	SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 );
 
 	if ( !r_glAllowSoftware->integer )

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -70,8 +70,6 @@ static Cvar::Cvar<bool> r_arb_buffer_storage( "r_arb_buffer_storage",
 	"Use GL_ARB_buffer_storage if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_compute_shader( "r_arb_compute_shader",
 	"Use GL_ARB_compute_shader if available", Cvar::NONE, true );
-static Cvar::Cvar<bool> r_arb_depth_clamp( "r_arb_depth_clamp",
-	"Use GL_ARB_depth_clamp if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_framebuffer_object( "r_arb_framebuffer_object",
 	"Use GL_ARB_framebuffer_object if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_explicit_uniform_location( "r_arb_explicit_uniform_location",
@@ -1973,7 +1971,6 @@ static void GLimp_InitExtensions()
 	Cvar::Latch( r_arb_bindless_texture );
 	Cvar::Latch( r_arb_buffer_storage );
 	Cvar::Latch( r_arb_compute_shader );
-	Cvar::Latch( r_arb_depth_clamp );
 	Cvar::Latch( r_arb_explicit_uniform_location );
 	Cvar::Latch( r_arb_framebuffer_object );
 	Cvar::Latch( r_arb_gpu_shader5 );
@@ -2394,9 +2391,6 @@ static void GLimp_InitExtensions()
 
 	// made required in OpenGL 3.2
 	glConfig2.syncAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_sync, r_arb_sync.Get() );
-
-	// made required in OpenGL 3.2
-	glConfig2.depthClampAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_CORE, ARB_depth_clamp, r_arb_depth_clamp.Get() );
 
 	// made required in OpenGL 4.3
 	glConfig2.computeShaderAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_compute_shader, r_arb_compute_shader.Get() );


### PR DESCRIPTION
Disable depth fade, depth testing, depth writing for 2D rendering. Don't create a depth or stencil channel in the default framebuffer.

Instead of using the "depth clamp" GL extension (which disables clipping based on the z-coordinate), set the projection matrix to make z always 0. This is relevant if we use 3d CSS transformations like [these](https://polypane.app/css-3d-transform-examples/). 