### PR TITLE
Fix portals with r_smp 1

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1610,6 +1610,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 		uint64_t      sort;
 		bool          bspSurface;
 		int fog;
+		int portalNum = -1;
 
 		uint materialsSSBOOffset[ MAX_SHADER_STAGES ];
 		bool initialized[ MAX_SHADER_STAGES ];
@@ -1871,6 +1872,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		int16_t         lightmapNum; // -1 = no lightmap
 		int16_t         fogIndex;
+		int portalNum;
 
 		surfaceType_t   *data; // any of srf*_t
 	};
@@ -1919,6 +1921,12 @@ enum class shaderProfilerRenderSubGroupsMode {
 		byte  unused;
 	};
 
+	struct AABB {
+		vec3_t origin;
+		vec3_t mins;
+		vec3_t maxs;
+	};
+
 // ydnar: optimization
 #define WORLD_MAX_SKY_NODES 32
 
@@ -1944,6 +1952,9 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		int           numSkyNodes;
 		bspNode_t     **skyNodes; // ydnar: don't walk the entire bsp when rendering sky
+
+		int numPortals;
+		AABB *portals;
 
 		VBO_t         *vbo;
 		IBO_t         *ibo;
@@ -3095,7 +3106,7 @@ inline bool checkGLErrors()
 
 	void           R_AddPolygonSurfaces();
 
-	int R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, int fogNum, bool bspSurface = false );
+	int R_AddDrawSurf( surfaceType_t *surface, shader_t *shader, int lightmapNum, int fogNum, bool bspSurface = false, int portalNum = -1 );
 
 	void           R_LocalNormalToWorld( const vec3_t local, vec3_t world );
 	void           R_LocalPointToWorld( const vec3_t local, vec3_t world );

--- a/src/engine/renderer/tr_world.cpp
+++ b/src/engine/renderer/tr_world.cpp
@@ -260,7 +260,7 @@ static void R_AddInteractionSurface( bspSurface_t *surf, trRefLight_t *light, in
 R_AddWorldSurface
 ======================
 */
-static bool R_AddWorldSurface( bspSurface_t *surf, int fogIndex, int planeBits )
+static bool R_AddWorldSurface( bspSurface_t *surf, int fogIndex, int portalNum, int planeBits )
 {
 	if ( surf->viewCount == tr.viewCountNoReset )
 	{
@@ -275,7 +275,7 @@ static bool R_AddWorldSurface( bspSurface_t *surf, int fogIndex, int planeBits )
 		return true;
 	}
 
-	R_AddDrawSurf( surf->data, surf->shader, surf->lightmapNum, fogIndex, true );
+	R_AddDrawSurf( surf->data, surf->shader, surf->lightmapNum, fogIndex, true, portalNum );
 	return true;
 }
 
@@ -329,7 +329,7 @@ void R_AddBSPModelSurfaces( trRefEntity_t *ent )
 
 	for ( i = 0; i < bspModel->numSurfaces; i++ )
 	{
-		R_AddWorldSurface( bspModel->firstSurface + i, fogNum, FRUSTUM_CLIPALL );
+		R_AddWorldSurface( bspModel->firstSurface + i, fogNum, -1, FRUSTUM_CLIPALL );
 	}
 }
 
@@ -389,7 +389,7 @@ static void R_AddLeafSurfaces( bspNode_t *node, int planeBits )
 	{
 		// the surface may have already been added if it
 		// spans multiple leafs
-		R_AddWorldSurface( *view, ( *view )->fogIndex, planeBits );
+		R_AddWorldSurface( *view, ( *view )->fogIndex, ( *mark )->portalNum, planeBits);
 
 		( *mark )->viewCount = tr.viewCountNoReset;
 


### PR DESCRIPTION
Save portal AABBs when loading the map, then use them to cull portals instead of using the vertex buffer. I've considered using a rect instead since portals only really work on flat surfaces, but it wasn't important enough for me to bother given that the surface can be rotated. It might also be worth just using `R_CullBox()` instead of the projection into window coordinates and clipping.

Also fixes the issue mentioned in a comment that said that portal distance should be between the portal surface and view origin, instead of between the closest vertex and view origin.

This also improves performance since the vertex buffer is no longer read from on the CPU.

Fixes #1216 and #1199.