### PR TITLE
Add `USE_FLOAT_EXCEPTIONS` to enable floating point exceptions

### DIFF
--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -148,13 +148,20 @@ else()
     set(WARNMODE "no-")
 endif()
 
+# Compiler options
+option(USE_FLOAT_EXCEPTIONS "Use floating point exceptions with common.floatException.* cvars" OFF)
 option(USE_FAST_MATH "Use fast math" ON)
 
-# Compiler options
+if (USE_FLOAT_EXCEPTIONS)
+	add_definitions(-DDAEMON_USE_FLOAT_EXCEPTIONS)
+endif()
+
 if (MSVC)
     set_c_cxx_flag("/MP")
 
-	if (USE_FAST_MATH)
+	if (USE_FLOAT_EXCEPTIONS)
+		set_c_cxx_flag("/fp:strict")
+	elseif (USE_FAST_MATH)
 		set_c_cxx_flag("/fp:fast")
 	endif()
 
@@ -259,6 +266,15 @@ else()
 	# Optimizations.
 	if (USE_FAST_MATH)
 		set_c_cxx_flag("-ffast-math")
+	endif()
+
+	if (USE_FLOAT_EXCEPTIONS)
+		# Floating point exceptions requires trapping math
+		# to avoid false positives on architectures with SSE.
+		set_c_cxx_flag("-ftrapping-math")
+		# GCC prints noisy warnings saying -ftrapping-math implies this.
+		set_c_cxx_flag("-fno-associative-math")
+		# Other optimizations from -ffast-math can be kept.
 	endif()
 
 	# Use hidden symbol visibility if possible.

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -161,6 +161,9 @@ if (MSVC)
 
 	if (USE_FLOAT_EXCEPTIONS)
 		set_c_cxx_flag("/fp:strict")
+		# Don't switch on C4305 "truncation from 'double' to 'float'" every
+		# time an unsuffixed decimal constant is used
+		set_c_cxx_flag("/wd4305")
 	elseif (USE_FAST_MATH)
 		set_c_cxx_flag("/fp:fast")
 	endif()

--- a/src/common/Command.cpp
+++ b/src/common/Command.cpp
@@ -542,8 +542,8 @@ public:
                 .detach();
         } else {
             if (!DoFault(args)) {
-                Print("Usage: %s (drop | error | segfault | intdiv | floatdiv | unreachable"
-                      " | exception | throw | terminate | abort | freeze <seconds>) [thread]",
+                Print("Usage: %s (drop | error | segfault | intdiv | floatinvalid | floatdiv | floatoverflow"
+                      " | unreachable | exception | throw | terminate | abort | freeze <seconds>) [thread]",
                       args.Argv(0));
             }
         }
@@ -573,9 +573,15 @@ private:
         } else if (how == "intdiv") {
             volatile int n = 0;
             n = n / n;
+		} else if (how == "floatinvalid") {
+			volatile float f = -1.0f;
+			f = sqrtf(f);
         } else if (how == "floatdiv") {
-            volatile float x = 0;
-            x = x / x;
+            volatile float f = 0;
+            f = 1 / f;
+		} else if (how == "floatoverflow") {
+			volatile float f = std::numeric_limits<float>::max();
+			f = 2 * f;
         } else if (how == "unreachable") { // May print the usage string :)
             UNREACHABLE();
         } else if (how == "exception") { // std::exception

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -699,9 +699,15 @@ inline vec_t VectorNormalize( vec3_t v )
 // that length != 0, nor does it return length
 inline void VectorNormalizeFast( vec3_t v )
 {
-	vec_t ilength = Q_rsqrt_fast( DotProduct( v, v ) );
+	vec_t length = DotProduct( v, v );
 
-	VectorScale( v, ilength, v );
+#if DAEMON_USE_FLOAT_EXCEPTIONS
+	if ( length )
+#endif
+	{
+		vec_t ilength = Q_rsqrt_fast( length );
+		VectorScale( v, ilength, v );
+	}
 }
 
 inline vec_t VectorNormalize2( const vec3_t v, vec3_t out )


### PR DESCRIPTION
- Add `USE_FLOAT_EXCEPTIONS` to enable floating point exceptions  (disabled by default)
- Add `USE_FAST_MATH` to enable or disable fast math (enabled by default)

When `USE_FLOAT_EXCEPTIONS` is used, nothing is done unless some of those cvars are enabled:

- `common.floatExceptions.invalid`
- `common.floatExceptions.divByZero`
- `common.floatExceptions.overflow`

The `USE_FLOAT_EXCEPTIONS` option is required to specialize the build to make it possible to enable them.

The `common.floatExceptions.test` cvar enables some code doing bad floating point operations on purpose to test how they are handled.

Status:

Platform|Implemented|Tested
-|-|-
Linux GCC amd64|✅️|✅️
Linux GCC i686|✅️|✅️
Linux Clang amd64|✅️|✅️
Windows MinGW amd64|✅️|✅️
Windows MinGW i686|✅️|✅️
Windows MSVC amd64|✅️|
Windows MSVC i686|✅️|
macOS Clang amd64|✅️|✅️
macOS Clang arm64|✅️|
FreeBSD Clang amd64|✅️|✅️