### PR TITLE
Fix MD3 with r_vboModels 0

### DIFF
--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -880,7 +880,7 @@ static void Tess_SurfaceMDV( mdvSurface_t *srf )
 		binormals = (vec3_t *)ri.Hunk_AllocateTempMemory( numVertexes * sizeof( vec3_t ) );
 		normals = (vec3_t *)ri.Hunk_AllocateTempMemory( numVertexes * sizeof( vec3_t ) );
 
-		for ( i = 0; i < numVertexes; i++ )
+		for ( i = 0; i < numVertexes; i++, newVert++, oldVert++, oldNormal++, newNormal++ )
 		{
 			VectorClear( tangents[ i ] );
 			VectorClear( binormals[ i ] );


### PR DESCRIPTION
Make MD3 models appear (and have normal mapping) when `r_vboModels` is disabled.