### PR TITLE
Add the `contact` cvar and server info string to contain contact information to reach out the server admin when needed

### DIFF
--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -124,11 +124,11 @@ void Info_Print( const char *s )
 			*o = 0;
 		}
 
-		Log::Notice( key );
+		Log::defaultLogger.WithoutSuppression().Notice( key );
 
 		if ( !*s )
 		{
-			Log::Notice( "MISSING VALUE" );
+			Log::defaultLogger.WithoutSuppression().Notice( "MISSING VALUE" );
 			return;
 		}
 
@@ -147,7 +147,7 @@ void Info_Print( const char *s )
 			s++;
 		}
 
-		Log::Notice( "%s", value );
+		Log::defaultLogger.WithoutSuppression().Notice( value );
 	}
 }
 

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -52,6 +52,9 @@ static Cvar::Cvar<std::string> cvar_pakname(
 	"pakname", "pak containing current map", Cvar::SERVERINFO | Cvar::ROM, "");
 static Cvar::Cvar<std::string> sv_paks(
 	"sv_paks", "currently loaded paks", Cvar::SYSTEMINFO | Cvar::ROM, "");
+static Cvar::Cvar<std::string> cvar_contact(
+	"contact", "contact information to reach out to the server admin when needed: forum or chat nickname, mail address…",
+	Cvar::SERVERINFO, "" );
 static Cvar::Cvar<bool> sv_useBaseline(
 	"sv_useBaseline", "send entity baseline for non-snapshot delta compression", Cvar::NONE, true);
 
@@ -437,6 +440,14 @@ void SV_SpawnServer(std::string pakname, std::string mapname)
 	SV_ShutdownGameProgs();
 
 	PrintBanner( "Server Initialization" )
+
+	if ( !SV_Private(ServerPrivate::NoAdvertise)
+		&& sv_networkScope.Get() >= 2
+		&& cvar_contact.Get().empty() )
+	{
+		Log::Warn( "The contact information isn't set, it is requested for public servers." );
+	}
+
 	Log::Notice( "Map: %s", mapname );
 
 	// if not running a dedicated server CL_MapLoading will connect the client to the server


### PR DESCRIPTION
- sv_init: add the `contact` cvar and server info string to contain contact information to reach out the server admin when needed
- common: disable logging suppression in `Info_Print()` (used by commands like `/systeminfo` and `/serverinfo`)
