### PR TITLE
tr_model_iqm: detect and rewrite NaN in IQM model

### DIFF
--- a/src/engine/renderer/tr_model_iqm.cpp
+++ b/src/engine/renderer/tr_model_iqm.cpp
@@ -408,6 +408,36 @@ static bool LoadIQMFile( const void *buffer, unsigned filesize, const char *mod_
 	return true;
 }
 
+static size_t SanitizeFloatVertexArray( iqmHeader_t *header, iqmVertexArray_t *vertexarray,
+	const char *array_name, const char *mod_name )
+{
+	float *input = ( float* ) IQMPtr( header, vertexarray->offset );
+
+	size_t nanCount = 0;
+
+	for ( unsigned int i = 0; i < header->num_vertexes; i++, input += vertexarray->size )
+	{
+		for ( unsigned int j = 0; j < vertexarray->size; j++ )
+		{
+			if ( !Math::IsFinite ( input[ j ] ) )
+			{
+				Log::Debug( "IQM model “%s” has NaN in %s[%d][%d].", mod_name, array_name, i, j );
+				input[ j ] = 0.0f;
+				nanCount++;
+			}
+		}
+	}
+
+	return nanCount;
+}
+
+template<typename T>
+static void CopyVertexArray( iqmHeader_t *header, iqmVertexArray_t *vertexarray, T* dest )
+{
+	unsigned int n = header->num_vertexes * vertexarray->size;
+	memcpy( dest, IQMPtr( header, vertexarray->offset ), static_cast<size_t>(n) * sizeof( T ) );
+}
+
 /*
 =================
 BuildTangents
@@ -415,21 +445,20 @@ BuildTangents
 Compute Tangent and Bitangent vectors from the IQM 4-float input data
 =================
 */
-void BuildTangents( int n, float *input, float *normals, float *tangents,
-		    float *bitangents )
+static void BuildTangents( iqmHeader_t *header, iqmVertexArray_t *vertexarray,
+	float *normals, float *tangents, float *bitangents )
 {
-	int i;
-	vec3_t crossProd;
+	float *input = (float*)IQMPtr( header, vertexarray->offset );
 
-	for( i = 0; i < n; i++ ) {
+	for ( unsigned int i = 0; i < header->num_vertexes; i++, input += 4,
+		normals += 3, tangents += 3, bitangents += 3 )
+	{
 		VectorCopy( input, tangents );
-		CrossProduct( normals, input, crossProd );
-		VectorScale( crossProd, input[ 3 ], bitangents );
+		float sign = input[ 3 ];
 
-		input      += 4;
-		normals    += 3;
-		tangents   += 3;
-		bitangents += 3;
+		vec3_t crossProd;
+		CrossProduct( normals, tangents, crossProd );
+		VectorScale( crossProd, sign, bitangents );
 	}
 }
 
@@ -625,6 +654,8 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 		IQModel->jointParents[i] = joint->parent;
 	}
 
+	size_t nanCount = 0;
+
 	// calculate pose transforms
 	framedata = ( short unsigned int* )IQMPtr( header, header->ofs_frames );
 	trans = poses;
@@ -634,6 +665,23 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 			vec3_t	translate;
 			quat_t	rotate;
 			vec3_t	scale;
+
+			for ( size_t k = 0; k < 10; k++ )
+			{
+				if ( !Math::IsFinite ( pose->channeloffset[ k ] ) )
+				{
+					Log::Debug( "IQM model “%s” frame %d has NaN in pose[%d]->channeloffset[%d].", mod_name, i, j, k );
+					pose->channeloffset[ k ] = 0.0f;
+					nanCount++;
+				}
+
+				if ( !Math::IsFinite ( pose->channelscale[ k ] ) )
+				{
+					Log::Debug( "IQM model “%s” frame %d has NaN in pose[%d]->channelscale[%d].", mod_name, i, j, k );
+					pose->channelscale[ k ] = 0.0f;
+					nanCount++;
+				}
+			}
 
 			translate[0] = pose->channeloffset[0];
 			if( pose->mask & 0x001)
@@ -685,72 +733,74 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 	// copy vertexarrays and indexes
 	vertexarray = static_cast<iqmVertexArray_t*>( IQMPtr( header, header->ofs_vertexarrays ) );
 	for(unsigned i = 0; i < header->num_vertexarrays; i++, vertexarray++ ) {
-		int	n;
-
-		// total number of values
-		n = header->num_vertexes * vertexarray->size;
-
 		switch( vertexarray->type ) {
 		case IQM_POSITION:
 			ClearBounds( IQModel->bounds[ 0 ], IQModel->bounds[ 1 ] );
-			memcpy( IQModel->positions,
-				    IQMPtr( header, vertexarray->offset ),
-				    n * sizeof(float) );
-			for( int j = 0; j < n; j += vertexarray->size ) {
-				AddPointToBounds( &IQModel->positions[ j ],
-						  IQModel->bounds[ 0 ],
-						  IQModel->bounds[ 1 ] );
-			}
-			IQModel->internalScale = BoundsMaxExtent( IQModel->bounds[ 0 ], IQModel->bounds[ 1 ] );
-			if( IQModel->internalScale > 0.0f ) {
-				float inverseScale = 1.0f / IQModel->internalScale;
-				for( int j = 0; j < n; j += vertexarray->size ) {
-					VectorScale( &IQModel->positions[ j ],
-						     inverseScale,
-						     &IQModel->positions[ j ] );
+
+			nanCount += SanitizeFloatVertexArray( header, vertexarray, "position", mod_name );
+			CopyVertexArray( header, vertexarray, IQModel->positions );
+
+			{
+				unsigned int n = header->num_vertexes * vertexarray->size;
+
+				for ( unsigned int j = 0; j < n; j += vertexarray->size )
+				{
+					AddPointToBounds( &IQModel->positions[ j ], IQModel->bounds[ 0 ], IQModel->bounds[ 1 ] );
+				}
+
+				IQModel->internalScale = BoundsMaxExtent( IQModel->bounds[ 0 ], IQModel->bounds[ 1 ] );
+
+				if ( IQModel->internalScale > 0.0f )
+				{
+					float inverseScale = 1.0f / IQModel->internalScale;
+
+					for ( unsigned int j = 0; j < n; j += vertexarray->size )
+					{
+						VectorScale( &IQModel->positions[ j ], inverseScale, &IQModel->positions[ j ] );
+					}
 				}
 			}
 
 			break;
 		case IQM_NORMAL:
-			memcpy( IQModel->normals,
-				    IQMPtr( header, vertexarray->offset ),
-				    n * sizeof(float) );
+			nanCount += SanitizeFloatVertexArray( header, vertexarray, "normal", mod_name );
+			CopyVertexArray( header, vertexarray, IQModel->normals );
 			break;
 		case IQM_TANGENT:
-			BuildTangents( header->num_vertexes,
-				       ( float* )IQMPtr( header, vertexarray->offset ),
-				       IQModel->normals, IQModel->tangents,
-				       IQModel->bitangents );
+			nanCount += SanitizeFloatVertexArray( header, vertexarray, "tangents", mod_name );
+			BuildTangents( header, vertexarray, IQModel->normals, IQModel->tangents, IQModel->bitangents );
 			break;
 		case IQM_TEXCOORD:
-			for( int j = 0; j < n; j++ ) {
-				IQModel->texcoords[ j ] = ((float *)IQMPtr( header, vertexarray->offset ))[ j ];
-			}
+			nanCount += SanitizeFloatVertexArray( header, vertexarray, "texcoord", mod_name );
+			CopyVertexArray( header, vertexarray, IQModel->texcoords );
 			break;
 		case IQM_BLENDINDEXES:
-			memcpy( IQModel->blendIndexes,
-				    IQMPtr( header, vertexarray->offset ),
-				    n * sizeof(byte) );
+			CopyVertexArray( header, vertexarray, IQModel->blendIndexes );
 			break;
 		case IQM_BLENDWEIGHTS:
+			// blendWeights[*][0] is always rewritten later.
+			CopyVertexArray( header, vertexarray, IQModel->blendWeights );
 			weights = static_cast<u8vec4_t *>( IQMPtr( header, vertexarray->offset ) );
-			for(unsigned j = 0; j < header->num_vertexes; j++ ) {
-				IQModel->blendWeights[ 4 * j + 0 ] = 255 - weights[ j ][ 1 ] - weights[ j ][ 2 ] - weights[ j ][ 3 ];
-				IQModel->blendWeights[ 4 * j + 1 ] = weights[ j ][ 1 ];
-				IQModel->blendWeights[ 4 * j + 2 ] = weights[ j ][ 2 ];
-				IQModel->blendWeights[ 4 * j + 3 ] = weights[ j ][ 3 ];
-			}
 			break;
 		case IQM_COLOR:
-			memcpy( IQModel->colors,
-				    IQMPtr( header, vertexarray->offset ),
-				    n * sizeof(byte) );
+			CopyVertexArray( header, vertexarray, IQModel->colors );
 			break;
 		}
 	}
 
-	if ( !weights )
+	if ( nanCount )
+	{
+		Log::Warn( "IQM Model “%s” contains %d NaN.", mod_name, nanCount );
+	}
+
+	if ( weights )
+	{
+		for ( unsigned j = 0; j < header->num_vertexes; j++ )
+		{
+			IQModel->blendWeights[ 4 * j + 0 ] = 255 - weights[ j ][ 1 ] - weights[ j ][ 2 ] - weights[ j ][ 3 ];
+		}
+	}
+	else
 	{
 		for ( unsigned j = 0; j < header->num_vertexes; j++ )
 		{


### PR DESCRIPTION
Rewrite `NaN` in model IQM input.

The `prifle_view.iqm` model has some `NaN` in the input data:

- https://github.com/Unvanquished/Unvanquished/issues/3252

When such model file is used, it is impossible to get anything useful when trapping for invalid operations because the first call of `R_TBNtoQtangents()` when loading the model will stop the execution.

There are other floats in the IQM file, we may want to not hack `BuildTangents()` and sanitize all the floats in the future with a generic function, but this works for now.

Here is the IQE text equivalent of the IQM format, there are many float fields like that:

```
pq 0 0 0 0.707107008 0.000172803004 0.707107008 -0

vp -7.02030039 -5.93917179 -10.5407791
vn -0.373933047 -0.803014815 -0.464048833
vx 0.618980289 0.156532541 -0.769649923 -1
vt 0.857393026 0.983985007
vb 9 1
```

Here is an example of broken input, the current code currently only cares about `vx`.

```
vp -4.99237871 -17.1318531 -6.18218517
vn -0.0307731722 8.04468016e-07 -0.999526381
vx nan nan nan 1
vt 0.548720002 0.101943001
vb 1 1
```