### PR TITLE
Add r_materialSystemSkip

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -2061,6 +2061,10 @@ void MaterialSystem::RenderMaterials( const shaderSort_t fromSort, const shaderS
 		return;
 	}
 
+	if ( r_materialSystemSkip.Get() ) {
+		return;
+	}
+
 	if ( frameStart ) {
 		renderedMaterials.clear();
 		UpdateDynamicSurfaces();

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -4767,7 +4767,7 @@ This is done so various debugging facilities will work properly
 */
 static void RB_RenderPostProcess()
 {
-	if ( glConfig2.usingMaterialSystem ) {
+	if ( glConfig2.usingMaterialSystem && !r_materialSystemSkip.Get() ) {
 		// Dispatch the cull compute shaders for queued once we're done with post-processing
 		// We'll only use the results from those shaders in the next frame so we don't block the pipeline
 		materialSystem.CullSurfaces();

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -91,6 +91,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<bool> r_materialSystem( "r_materialSystem", "Use Material System", Cvar::NONE, false );
 	Cvar::Cvar<bool> r_gpuFrustumCulling( "r_gpuFrustumCulling", "Use frustum culling on the GPU for the Material System", Cvar::NONE, true );
 	Cvar::Cvar<bool> r_gpuOcclusionCulling( "r_gpuOcclusionCulling", "Use occlusion culling on the GPU for the Material System", Cvar::NONE, false );
+	Cvar::Cvar<bool> r_materialSystemSkip( "r_materialSystemSkip", "Temporarily skip Material System rendering, using only core renderer instead", Cvar::NONE, false );
 	cvar_t      *r_lightStyles;
 	cvar_t      *r_exportTextures;
 	cvar_t      *r_heatHaze;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2912,6 +2912,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 	extern Cvar::Cvar<bool> r_materialSystem;
 	extern Cvar::Cvar<bool> r_gpuFrustumCulling;
 	extern Cvar::Cvar<bool> r_gpuOcclusionCulling;
+	extern Cvar::Cvar<bool> r_materialSystemSkip;
 	extern cvar_t *r_lightStyles;
 	extern cvar_t *r_exportTextures;
 	extern cvar_t *r_heatHaze;

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1999,7 +1999,7 @@ static void R_SortDrawSurfs()
 	// check for any pass through drawing, which
 	// may cause another view to be rendered first
 	// Material system does its own handling of portal surfaces
-	if ( glConfig2.usingMaterialSystem ) {
+	if ( glConfig2.usingMaterialSystem && !r_materialSystemSkip.Get() ) {
 		if ( tr.viewParms.portalLevel == 0 ) {
 			materialSystem.AddPortalSurfaces();
 			currentView = 0;
@@ -2524,7 +2524,7 @@ void R_RenderView( viewParms_t *parms )
 
 	R_SetupFrustum();
 
-	if ( glConfig2.usingMaterialSystem ) {
+	if ( glConfig2.usingMaterialSystem && !r_materialSystemSkip.Get() ) {
 		tr.viewParms.viewID = tr.viewCount;
 		materialSystem.QueueSurfaceCull( tr.viewCount, tr.viewParms.pvsOrigin, (frustum_t*) tr.viewParms.frustums[0] );
 		materialSystem.AddAutospriteSurfaces();


### PR DESCRIPTION
Picked from #1473.

This makes debugging issues that are present on material system but not core renderer (or vice versa), as well as comparing performance, much faster, since it can be changed without any sort of restart.