### PR TITLE
Implement MSAA

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1171,6 +1171,9 @@ void BindShaderHeatHaze( Material* material ) {
 	gl_heatHazeShaderMaterial->SetUniform_DeformEnable( true );
 
 	// draw to background image
+	if ( r_msaa.Get() ) {
+		GL_BlitMSAAToFBO( tr.mainFBO[backEnd.currentMainFBO] );
+	}
 	R_BindFBO( tr.mainFBO[1 - backEnd.currentMainFBO] );
 }
 
@@ -2302,6 +2305,11 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 		R_BindFBO( tr.mainFBO[backEnd.currentMainFBO] );
 
 		RenderIndirect( material, viewID );
+
+		if ( r_msaa.Get() ) {
+			GL_BlitFBOToMSAA( tr.mainFBO[backEnd.currentMainFBO] );
+			R_BindFBO( tr.msaaFBO );
+		}
 	}
 
 	if ( r_showTris->integer

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -208,6 +208,26 @@ GLuint64 GL_BindToTMU( int unit, image_t *image )
 	return 0;
 }
 
+void GL_BlitFBOToMSAA( FBO_t* fbo ) {
+	R_BindFBO( GL_READ_FRAMEBUFFER, fbo );
+	R_BindFBO( GL_DRAW_FRAMEBUFFER, tr.msaaFBO );
+	glBlitFramebuffer( 0, 0, fbo->width, fbo->height, 0, 0, tr.msaaFBO->width, tr.msaaFBO->height,
+		GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT, GL_NEAREST );
+
+	R_BindFBO( GL_DRAW_FRAMEBUFFER, fbo );
+	glState.currentFBO = nullptr;
+}
+
+void GL_BlitMSAAToFBO( FBO_t* fbo ) {
+	R_BindFBO( GL_READ_FRAMEBUFFER, tr.msaaFBO );
+	R_BindFBO( GL_DRAW_FRAMEBUFFER, fbo );
+	glBlitFramebuffer( 0, 0, tr.msaaFBO->width, tr.msaaFBO->height, 0, 0, fbo->width, fbo->height,
+		GL_COLOR_BUFFER_BIT /* | GL_DEPTH_BUFFER_BIT */, GL_NEAREST );
+
+	R_BindFBO( GL_READ_FRAMEBUFFER, fbo );
+	glState.currentFBO = nullptr;
+}
+
 void GL_BlendFunc( GLenum sfactor, GLenum dfactor )
 {
 	if ( glState.blendSrc != ( signed ) sfactor || glState.blendDst != ( signed ) dfactor )
@@ -3082,6 +3102,9 @@ void RB_RenderBloom()
 
 		GL_PopMatrix(); // special 1/4th of the screen contrastRenderFBO ortho
 
+		if ( r_msaa.Get() ) {
+			GL_BlitMSAAToFBO( tr.mainFBO[backEnd.currentMainFBO] );
+		}
 		R_BindFBO( tr.contrastRenderFBO );
 		GL_ClearColor( 0.0f, 0.0f, 0.0f, 1.0f );
 		glClear( GL_COLOR_BUFFER_BIT );
@@ -3148,6 +3171,11 @@ void RB_RenderBloom()
 		                  backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
 	}
 
+	if ( r_msaa.Get() ) {
+		GL_BlitFBOToMSAA( tr.mainFBO[backEnd.currentMainFBO] );
+		R_BindFBO( tr.msaaFBO );
+	}
+
 	// go back to 3D
 	GL_PopMatrix();
 
@@ -3169,6 +3197,10 @@ void RB_RenderMotionBlur()
 	GL_Cull( cullType_t::CT_TWO_SIDED );
 
 	gl_motionblurShader->BindProgram( 0 );
+
+	if ( r_msaa.Get() ) {
+		GL_BlitMSAAToFBO( tr.mainFBO[backEnd.currentMainFBO] );
+	}
 
 	// Swap main FBOs
 	gl_motionblurShader->SetUniform_ColorMapBindless(
@@ -3195,6 +3227,11 @@ void RB_RenderMotionBlur()
 	Tess_InstantQuad( *gl_motionblurShader,
 	                   backEnd.viewParms.viewportX, backEnd.viewParms.viewportY,
 	                   backEnd.viewParms.viewportWidth, backEnd.viewParms.viewportHeight );
+
+	if ( r_msaa.Get() ) {
+		GL_BlitFBOToMSAA( tr.mainFBO[backEnd.currentMainFBO] );
+		R_BindFBO( tr.msaaFBO );
+	}
 
 	GL_PopMatrix();
 
@@ -4628,7 +4665,11 @@ static void RB_RenderView( bool depthPass )
 	backEnd.pc.c_surfaces += backEnd.viewParms.numDrawSurfs;
 
 	// disable offscreen rendering
-	R_BindFBO( tr.mainFBO[ backEnd.currentMainFBO ] );
+	if ( r_msaa.Get() ) {
+		R_BindFBO( tr.msaaFBO );
+	} else {
+		R_BindFBO( tr.mainFBO[backEnd.currentMainFBO] );
+	}
 
 	// we will need to change the projection matrix before drawing
 	// 2D images again

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -830,7 +830,8 @@ level 1 has only numLayers/2 layers. There are still numLayers pointers in
 the dataArray for every mip level, the unneeded elements at the end aren't used.
 ===============
 */
-void R_UploadImage( const char *name, const byte **dataArray, int numLayers, int numMips, image_t *image, const imageParams_t &imageParams )
+void R_UploadImage( const char *name, const byte **dataArray, int numLayers, int numMips, image_t *image, const imageParams_t &imageParams,
+	const uint32_t samples, const bool fixedSampleLocations )
 {
 	const byte *data;
 	byte       *scaledBuffer = nullptr;
@@ -897,6 +898,14 @@ void R_UploadImage( const char *name, const byte **dataArray, int numLayers, int
 		default:
 			target = GL_TEXTURE_2D;
 			break;
+	}
+
+	if ( samples ) {
+		if ( target == GL_TEXTURE_2D ) {
+			target = GL_TEXTURE_2D_MULTISAMPLE;
+		} else {
+			Log::Warn( "Multisampling is currently only supported for 2D textures (image: %s)", name );
+		}
 	}
 
 	if ( image->bits & ( IF_DEPTH16 | IF_DEPTH24 | IF_DEPTH32 ) )
@@ -1153,11 +1162,19 @@ void R_UploadImage( const char *name, const byte **dataArray, int numLayers, int
 			default:
 				if ( image->bits & IF_PACKED_DEPTH24_STENCIL8 )
 				{
-					glTexImage2D( target, 0, internalFormat, scaledWidth, scaledHeight, 0, format, GL_UNSIGNED_INT_24_8, nullptr );
+					if ( samples ) {
+						glTexImage2DMultisample( target, samples, internalFormat, scaledWidth, scaledHeight, fixedSampleLocations );
+					} else {
+						glTexImage2D( target, 0, internalFormat, scaledWidth, scaledHeight, 0, format, GL_UNSIGNED_INT_24_8, nullptr );
+					}
 				}
 				else
 				{
-					glTexImage2D( target, 0, internalFormat, scaledWidth, scaledHeight, 0, format, GL_UNSIGNED_BYTE, scaledBuffer );
+					if ( samples ) {
+						glTexImage2DMultisample( target, samples, internalFormat, scaledWidth, scaledHeight, fixedSampleLocations );
+					} else {
+						glTexImage2D( target, 0, internalFormat, scaledWidth, scaledHeight, 0, format, GL_UNSIGNED_BYTE, scaledBuffer );
+					}
 				}
 
 				break;
@@ -1222,149 +1239,146 @@ void R_UploadImage( const char *name, const byte **dataArray, int numLayers, int
 	GL_CheckErrors();
 
 	// set filter type
-	switch ( image->filterType )
-	{
-		case filterType_t::FT_DEFAULT:
+	if ( !samples ) {
+		switch ( image->filterType ) {
+			case filterType_t::FT_DEFAULT:
 
-			// set texture anisotropy
-			if ( glConfig2.textureAnisotropyAvailable )
-			{
-				glTexParameterf( image->type, GL_TEXTURE_MAX_ANISOTROPY_EXT, glConfig2.textureAnisotropy );
-			}
+				// set texture anisotropy
+				if ( glConfig2.textureAnisotropyAvailable ) {
+					glTexParameterf( image->type, GL_TEXTURE_MAX_ANISOTROPY_EXT, glConfig2.textureAnisotropy );
+				}
 
-			glTexParameterf( image->type, GL_TEXTURE_MIN_FILTER, gl_filter_min );
-			glTexParameterf( image->type, GL_TEXTURE_MAG_FILTER, gl_filter_max );
-			break;
+				glTexParameterf( image->type, GL_TEXTURE_MIN_FILTER, gl_filter_min );
+				glTexParameterf( image->type, GL_TEXTURE_MAG_FILTER, gl_filter_max );
+				break;
 
-		case filterType_t::FT_LINEAR:
-			glTexParameterf( image->type, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
-			glTexParameterf( image->type, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
-			break;
+			case filterType_t::FT_LINEAR:
+				glTexParameterf( image->type, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
+				glTexParameterf( image->type, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+				break;
 
-		case filterType_t::FT_NEAREST:
-			glTexParameterf( image->type, GL_TEXTURE_MIN_FILTER, GL_NEAREST );
-			glTexParameterf( image->type, GL_TEXTURE_MAG_FILTER, GL_NEAREST );
-			break;
+			case filterType_t::FT_NEAREST:
+				glTexParameterf( image->type, GL_TEXTURE_MIN_FILTER, GL_NEAREST );
+				glTexParameterf( image->type, GL_TEXTURE_MAG_FILTER, GL_NEAREST );
+				break;
 
-		default:
-			Log::Warn("unknown filter type for image '%s'", image->name );
-			glTexParameterf( image->type, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
-			glTexParameterf( image->type, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
-			break;
+			default:
+				Log::Warn( "unknown filter type for image '%s'", image->name );
+				glTexParameterf( image->type, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
+				glTexParameterf( image->type, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+				break;
+		}
 	}
 
 	GL_CheckErrors();
 
 	// set wrap type
-	if ( image->wrapType.s == image->wrapType.t )
-        {
-                switch ( image->wrapType.s )
-                {
-                        case wrapTypeEnum_t::WT_REPEAT:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_REPEAT );
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_REPEAT );
-                                break;
+	if ( !samples ) {
+		if ( image->wrapType.s == image->wrapType.t ) {
+			switch ( image->wrapType.s ) {
+				case wrapTypeEnum_t::WT_REPEAT:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_REPEAT );
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_REPEAT );
+					break;
 
-                        case wrapTypeEnum_t::WT_CLAMP:
-                        case wrapTypeEnum_t::WT_EDGE_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
-                                break;
-                        case wrapTypeEnum_t::WT_ONE_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
-                                glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, oneClampBorder );
-                                break;
-                        case wrapTypeEnum_t::WT_ZERO_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
-                                glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, zeroClampBorder );
-                                break;
+				case wrapTypeEnum_t::WT_CLAMP:
+				case wrapTypeEnum_t::WT_EDGE_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+					break;
+				case wrapTypeEnum_t::WT_ONE_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+					glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, oneClampBorder );
+					break;
+				case wrapTypeEnum_t::WT_ZERO_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+					glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, zeroClampBorder );
+					break;
 
-                        case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
-                                glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, alphaZeroClampBorder );
-                                break;
+				case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+					glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, alphaZeroClampBorder );
+					break;
 
-                        default:
-								Log::Warn("unknown wrap type for image '%s'", image->name );
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_REPEAT );
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_REPEAT );
-                                break;
-                }
-        } else {
-        	// warn about mismatched clamp types if both require a border colour to be set
-                if ( ( image->wrapType.s == wrapTypeEnum_t::WT_ZERO_CLAMP || image->wrapType.s == wrapTypeEnum_t::WT_ONE_CLAMP || image->wrapType.s == wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP ) &&
-	             ( image->wrapType.t == wrapTypeEnum_t::WT_ZERO_CLAMP || image->wrapType.t == wrapTypeEnum_t::WT_ONE_CLAMP || image->wrapType.t == wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP ) )
-        	{
-					Log::Warn("mismatched wrap types for image '%s'", image->name );
-                }
+				default:
+					Log::Warn( "unknown wrap type for image '%s'", image->name );
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_REPEAT );
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_REPEAT );
+					break;
+			}
+		} else {
+			// warn about mismatched clamp types if both require a border colour to be set
+			if ( ( image->wrapType.s == wrapTypeEnum_t::WT_ZERO_CLAMP || image->wrapType.s == wrapTypeEnum_t::WT_ONE_CLAMP || image->wrapType.s == wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP ) &&
+				( image->wrapType.t == wrapTypeEnum_t::WT_ZERO_CLAMP || image->wrapType.t == wrapTypeEnum_t::WT_ONE_CLAMP || image->wrapType.t == wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP ) ) {
+				Log::Warn( "mismatched wrap types for image '%s'", image->name );
+			}
 
-                switch ( image->wrapType.s )
-                {
-                        case wrapTypeEnum_t::WT_REPEAT:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_REPEAT );
-                                break;
+			switch ( image->wrapType.s ) {
+				case wrapTypeEnum_t::WT_REPEAT:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_REPEAT );
+					break;
 
-                        case wrapTypeEnum_t::WT_CLAMP:
-                        case wrapTypeEnum_t::WT_EDGE_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
-                                break;
+				case wrapTypeEnum_t::WT_CLAMP:
+				case wrapTypeEnum_t::WT_EDGE_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
+					break;
 
-                        case wrapTypeEnum_t::WT_ONE_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
-                                glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, oneClampBorder );
-                                break;
+				case wrapTypeEnum_t::WT_ONE_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+					glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, oneClampBorder );
+					break;
 
-                        case wrapTypeEnum_t::WT_ZERO_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
-                                glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, zeroClampBorder );
-                                break;
+				case wrapTypeEnum_t::WT_ZERO_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+					glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, zeroClampBorder );
+					break;
 
-                        case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
-                                glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, alphaZeroClampBorder );
-                                break;
+				case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER );
+					glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, alphaZeroClampBorder );
+					break;
 
-                        default:
-								Log::Warn("unknown wrap type for image '%s' axis S", image->name );
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_REPEAT );
-                                break;
-                }
+				default:
+					Log::Warn( "unknown wrap type for image '%s' axis S", image->name );
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_S, GL_REPEAT );
+					break;
+			}
 
-                switch ( image->wrapType.t )
-                {
-                        case wrapTypeEnum_t::WT_REPEAT:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_REPEAT );
-                                break;
+			switch ( image->wrapType.t ) {
+				case wrapTypeEnum_t::WT_REPEAT:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_REPEAT );
+					break;
 
-                        case wrapTypeEnum_t::WT_CLAMP:
-                        case wrapTypeEnum_t::WT_EDGE_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
-                                break;
+				case wrapTypeEnum_t::WT_CLAMP:
+				case wrapTypeEnum_t::WT_EDGE_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
+					break;
 
-                        case wrapTypeEnum_t::WT_ONE_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
-                                glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, oneClampBorder );
-                                break;
+				case wrapTypeEnum_t::WT_ONE_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+					glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, oneClampBorder );
+					break;
 
-                        case wrapTypeEnum_t::WT_ZERO_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
-                                glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, zeroClampBorder );
-                                break;
+				case wrapTypeEnum_t::WT_ZERO_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+					glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, zeroClampBorder );
+					break;
 
-                        case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
-                                glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, alphaZeroClampBorder );
-                                break;
+				case wrapTypeEnum_t::WT_ALPHA_ZERO_CLAMP:
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER );
+					glTexParameterfv( image->type, GL_TEXTURE_BORDER_COLOR, alphaZeroClampBorder );
+					break;
 
-                        default:
-								Log::Warn("unknown wrap type for image '%s' axis T", image->name );
-                                glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_REPEAT );
-                                break;
-                }
-        }
+				default:
+					Log::Warn( "unknown wrap type for image '%s' axis T", image->name );
+					glTexParameterf( image->type, GL_TEXTURE_WRAP_T, GL_REPEAT );
+					break;
+			}
+		}
+	}
 
 	GL_CheckErrors();
 
@@ -1453,7 +1467,8 @@ static void R_ExportTexture( image_t *image )
 R_CreateImage
 ================
 */
-image_t *R_CreateImage( const char *name, const byte **pic, int width, int height, int numMips, const imageParams_t &imageParams )
+image_t *R_CreateImage( const char *name, const byte **pic, int width, int height, int numMips, const imageParams_t &imageParams,
+	const uint32_t samples, const bool fixedSampleLocations )
 {
 	Log::Debug( "Creating image %s (%d×%d, %d mips)", name, width, height, numMips );
 
@@ -1466,8 +1481,13 @@ image_t *R_CreateImage( const char *name, const byte **pic, int width, int heigh
 		return nullptr;
 	}
 
-	image->type = GL_TEXTURE_2D;
-	image->texture->target = GL_TEXTURE_2D;
+	if ( samples ) {
+		image->type = GL_TEXTURE_2D_MULTISAMPLE;
+		image->texture->target = GL_TEXTURE_2D_MULTISAMPLE;
+	} else {
+		image->type = GL_TEXTURE_2D;
+		image->texture->target = GL_TEXTURE_2D;
+	}
 
 	image->width = width;
 	image->height = height;
@@ -1476,7 +1496,7 @@ image_t *R_CreateImage( const char *name, const byte **pic, int width, int heigh
 	image->filterType = imageParams.filterType;
 	image->wrapType = imageParams.wrapType;
 
-	R_UploadImage( name, pic, 1, numMips, image, imageParams );
+	R_UploadImage( name, pic, 1, numMips, image, imageParams, samples, fixedSampleLocations );
 
 	if( r_exportTextures->integer ) {
 		R_ExportTexture( image );
@@ -2605,12 +2625,20 @@ static void R_CreateCurrentRenderImage()
 	tr.currentRenderImage[0] = R_CreateImage( "_currentRender[0]", nullptr, width, height, 1, imageParams );
 	tr.currentRenderImage[1] = R_CreateImage( "_currentRender[1]", nullptr, width, height, 1, imageParams );
 
+	if ( r_msaa.Get() ) {
+		tr.currentRenderImageMSAA = R_CreateImage( "_currentRenderMSAA", nullptr, width, height, 1, imageParams, r_msaa.Get(), false );
+	}
+
 	imageParams = {};
 	imageParams.bits = IF_NOPICMIP | IF_PACKED_DEPTH24_STENCIL8;
 	imageParams.filterType = filterType_t::FT_NEAREST;
 	imageParams.wrapType = wrapTypeEnum_t::WT_CLAMP;
 
 	tr.currentDepthImage = R_CreateImage( "_currentDepth", nullptr, width, height, 1, imageParams );
+
+	if( r_msaa.Get() ) {
+		tr.currentDepthImageMSAA = R_CreateImage( "_currentDepthMSAA", nullptr, width, height, 1, imageParams, r_msaa.Get(), false );
+	}
 
 	if ( glConfig2.usingMaterialSystem ) {
 		materialSystem.GenerateDepthImages( width, height, imageParams );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -282,6 +282,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<float> r_bloomBlur( "r_bloomBlur", "Bloom strength", Cvar::NONE, 1.0 );
 	Cvar::Cvar<int> r_bloomPasses( "r_bloomPasses", "Amount of bloom passes in each direction", Cvar::NONE, 2 );
 	cvar_t      *r_FXAA;
+	Cvar::Range<Cvar::Cvar<int>> r_msaa( "r_msaa", "Amount of MSAA samples. 0 to disable", Cvar::NONE, 0, 0, 64 );
 	cvar_t      *r_ssao;
 
 	cvar_t      *r_evsmPostProcess;
@@ -1190,6 +1191,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		Cvar::Latch( r_bloom );
 		r_FXAA = Cvar_Get( "r_FXAA", "0", CVAR_LATCH | CVAR_ARCHIVE );
+		Cvar::Latch( r_msaa );
 		r_ssao = Cvar_Get( "r_ssao", "0", CVAR_LATCH | CVAR_ARCHIVE );
 
 		// temporary variables that can change at any time

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2718,6 +2718,8 @@ enum class shaderProfilerRenderSubGroupsMode {
 		image_t    *bloomRenderFBOImage[ 2 ];
 		image_t    *currentRenderImage[ 2 ];
 		image_t    *currentDepthImage;
+		image_t    *currentRenderImageMSAA;
+		image_t    *currentDepthImageMSAA;
 		image_t    *depthtile1RenderImage;
 		image_t    *depthtile2RenderImage;
 		image_t    *lighttileRenderImage;
@@ -2736,6 +2738,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		// framebuffer objects
 		FBO_t *mainFBO[ 2 ];
+		FBO_t *msaaFBO;
 		FBO_t *depthtile1FBO;
 		FBO_t *depthtile2FBO;
 		FBO_t *lighttileFBO;
@@ -3069,6 +3072,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 	extern Cvar::Cvar<float> r_bloomBlur;
 	extern Cvar::Cvar<int> r_bloomPasses;
 	extern cvar_t *r_FXAA;
+	extern Cvar::Range<Cvar::Cvar<int>> r_msaa;
 	extern cvar_t *r_ssao;
 
 	extern cvar_t *r_evsmPostProcess;
@@ -3198,6 +3202,8 @@ inline bool checkGLErrors()
 	void GL_BindProgram( shaderProgram_t *program );
 	GLuint64 GL_BindToTMU( int unit, image_t *image );
 	void GL_BindNullProgram();
+	void GL_BlitFBOToMSAA( FBO_t* fbo );
+	void GL_BlitMSAAToFBO( FBO_t* fbo );
 	void GL_SetDefaultState();
 	void GL_SelectTexture( int unit );
 	void GL_TextureMode( const char *string );
@@ -3282,7 +3288,8 @@ inline bool checkGLErrors()
 	image_t *R_FindImageFile( const char *name, imageParams_t &imageParams );
 	image_t *R_FindCubeImage( const char *name, imageParams_t &imageParams );
 
-	image_t *R_CreateImage( const char *name, const byte **pic, int width, int height, int numMips, const imageParams_t &imageParams );
+	image_t *R_CreateImage( const char *name, const byte **pic, int width, int height, int numMips, const imageParams_t &imageParams,
+		const uint32_t samples = 0, const bool fixedSampleLocations = true );
 
 	image_t *R_CreateCubeImage( const char *name, const byte *pic[ 6 ], int width, int height, const imageParams_t &imageParams );
 	image_t *R_Create3DImage( const char *name, const byte *pic, int width, int height, int depth, const imageParams_t &imageParams );
@@ -3291,7 +3298,8 @@ inline bool checkGLErrors()
 	qhandle_t RE_GenerateTexture( const byte *pic, int width, int height );
 
 	image_t *R_AllocImage( const char *name, bool linkIntoHashTable );
-	void R_UploadImage( const char *name, const byte **dataArray, int numLayers, int numMips, image_t *image, const imageParams_t &imageParams );
+	void R_UploadImage( const char *name, const byte **dataArray, int numLayers, int numMips, image_t *image, const imageParams_t &imageParams,
+		const uint32_t samples = 0, const bool fixedSampleLocations = true );
 
 	void    RE_GetTextureSize( int textureID, int *width, int *height );
 
@@ -3653,6 +3661,7 @@ inline bool checkGLErrors()
 	void     R_AttachFBOTextureDepth( int texId );
 
 	void     R_BindFBO( FBO_t *fbo );
+	void     R_BindFBO( const GLenum target, FBO_t* fbo );
 	void     R_BindNullFBO();
 
 	void     R_InitFBOs();

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -73,6 +73,8 @@ struct glconfig2_t
 	int max3DTextureSize;
 	int maxCubeMapTextureSize;
 	int maxTextureUnits;
+	int maxColorTextureSamples;
+	int maxDepthTextureSamples;
 
 	char     shadingLanguageVersionString[ MAX_STRING_CHARS ];
 	int      shadingLanguageVersion;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2052,6 +2052,8 @@ static void GLimp_InitExtensions()
 	glGetIntegerv( GL_MAX_TEXTURE_SIZE, &glConfig.maxTextureSize );
 	glGetIntegerv( GL_MAX_3D_TEXTURE_SIZE, &glConfig2.max3DTextureSize );
 	glGetIntegerv( GL_MAX_CUBE_MAP_TEXTURE_SIZE_ARB, &glConfig2.maxCubeMapTextureSize );
+	glGetIntegerv( GL_MAX_COLOR_TEXTURE_SAMPLES, &glConfig2.maxColorTextureSamples );
+	glGetIntegerv( GL_MAX_DEPTH_TEXTURE_SAMPLES, &glConfig2.maxDepthTextureSamples );
 
 	// Stubbed or broken drivers may report garbage.
 


### PR DESCRIPTION
Implements #532.

Add `r_msaa`. When set to > 0, an MSAA FBO will be created with that many samples. This FBO will be used for rendering, other than when it requires sampling from current render/depth image. When such rendering is required the MSAA FBO will be blit into the main FBO and vice versa, to resolve the MSAA texture.