### PR TITLE
Merge generic2D shader into generic

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -43,7 +43,6 @@ ShaderKind shaderKind = ShaderKind::Unknown;
 
 // *INDENT-OFF*
 
-GLShader_generic2D                       *gl_generic2DShader = nullptr;
 GLShader_generic                         *gl_genericShader = nullptr;
 GLShader_genericMaterial                 *gl_genericShaderMaterial = nullptr;
 GLShader_cull                            *gl_cullShader = nullptr;
@@ -2172,31 +2171,6 @@ void GLShader::WriteUniformsToBuffer( uint32_t* buffer ) {
 	}
 }
 
-GLShader_generic2D::GLShader_generic2D( GLShaderManager *manager ) :
-	GLShader( "generic2D", "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
-	u_ColorMap( this ),
-	u_DepthMap( this ),
-	u_TextureMatrix( this ),
-	u_AlphaThreshold( this ),
-	u_ModelMatrix( this ),
-	u_ModelViewProjectionMatrix( this ),
-	u_ColorModulate( this ),
-	u_Color( this ),
-	u_DepthScale( this ),
-	GLDeformStage( this )
-{
-}
-
-void GLShader_generic2D::BuildShaderCompileMacros( std::string& compileMacros )
-{
-	compileMacros += "GENERIC_2D ";
-}
-
-void GLShader_generic2D::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
-{
-	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
-}
-
 GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	GLShader( "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
 	u_ColorMap( this ),
@@ -2219,7 +2193,8 @@ GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
 	GLCompileMacro_USE_TCGEN_ENVIRONMENT( this ),
 	GLCompileMacro_USE_TCGEN_LIGHTMAP( this ),
-	GLCompileMacro_USE_DEPTH_FADE( this )
+	GLCompileMacro_USE_DEPTH_FADE( this ),
+	GLCompileMacro_GENERIC_2D( this )
 {
 }
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1686,6 +1686,7 @@ protected:
 	  USE_SHADOWING,
 	  LIGHT_DIRECTIONAL,
 	  USE_DEPTH_FADE,
+	  GENERIC_2D,
 	  USE_PHYSICAL_MAPPING,
 	};
 
@@ -2106,6 +2107,26 @@ public:
 
 	void SetDepthFade( bool enable )
 	{
+		SetMacro( enable );
+	}
+};
+
+class GLCompileMacro_GENERIC_2D :
+	GLCompileMacro {
+	public:
+	GLCompileMacro_GENERIC_2D( GLShader* shader ) :
+		GLCompileMacro( shader ) {
+	}
+
+	const char* GetName() const override {
+		return "GENERIC_2D";
+	}
+
+	EGLCompileMacro GetType() const override {
+		return EGLCompileMacro::GENERIC_2D;
+	}
+
+	void SetGeneric2D( bool enable ) {
 		SetMacro( enable );
 	}
 };
@@ -3918,28 +3939,6 @@ class u_Lights :
 	}
 };
 
-// FIXME: this is the same as 'generic' and has no reason for existing.
-// It was added along with RmlUi transforms to add "gl_FragDepth = 0;" to the GLSL,
-// but that turns out not to be needed.
-class GLShader_generic2D :
-	public GLShader,
-	public u_ColorMap,
-	public u_DepthMap,
-	public u_TextureMatrix,
-	public u_AlphaThreshold,
-	public u_ModelMatrix,
-	public u_ModelViewProjectionMatrix,
-	public u_ColorModulate,
-	public u_Color,
-	public u_DepthScale,
-	public GLDeformStage
-{
-public:
-	GLShader_generic2D( GLShaderManager *manager );
-	void BuildShaderCompileMacros( std::string& compileMacros ) override;
-	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
-};
-
 class GLShader_generic :
 	public GLShader,
 	public u_ColorMap,
@@ -3962,7 +3961,8 @@ class GLShader_generic :
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
 	public GLCompileMacro_USE_TCGEN_ENVIRONMENT,
 	public GLCompileMacro_USE_TCGEN_LIGHTMAP,
-	public GLCompileMacro_USE_DEPTH_FADE
+	public GLCompileMacro_USE_DEPTH_FADE,
+	public GLCompileMacro_GENERIC_2D
 {
 public:
 	GLShader_generic( GLShaderManager *manager );
@@ -4714,7 +4714,6 @@ std::string GetShaderPath();
 
 extern ShaderKind shaderKind;
 
-extern GLShader_generic2D                       *gl_generic2DShader;
 extern GLShader_generic                         *gl_genericShader;
 extern GLShader_genericMaterial                 *gl_genericShaderMaterial;
 extern GLShader_cull                            *gl_cullShader;


### PR DESCRIPTION
Based on #1479.

The only difference is in a compile macro that's used to skip UI for subgroup profiling, which doesn't require a whole new shader.