### PR TITLE
Refactor game build configuration and build dll as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,7 @@ option(USE_STATIC_LIBS "Tries to use static libs where possible. Only works for 
 
 # Game VM modules are built with a recursive invocation of CMake, by which all the configuration
 # options are lost, except ones we explicitly choose to pass.
-set(DEFAULT_NACL_VM_INHERITED_OPTIONS
+set(DEFAULT_VMS_INHERITED_OPTIONS
     BE_VERBOSE
     BUILD_CGAME
     BUILD_SGAME
@@ -160,15 +160,16 @@ set(DEFAULT_NACL_VM_INHERITED_OPTIONS
     USE_COMPILER_INTRINSICS
     USE_DEBUG_OPTIMIZE
     USE_HARDENING
+    USE_LTO
     USE_PEDANTIC
     USE_PRECOMPILED_HEADER
     USE_RECOMMENDED_C_STANDARD
     USE_RECOMMENDED_CXX_STANDARD
     USE_WERROR
 )
-set(NACL_VM_INHERITED_OPTIONS "${DEFAULT_NACL_VM_INHERITED_OPTIONS}" CACHE STRING
-    "Semicolon-separated list of options for which NaCl game VMs should use the same value as the other binaries")
-mark_as_advanced(NACL_VM_INHERITED_OPTIONS)
+set(VMS_INHERITED_OPTIONS "${DEFAULT_VMS_INHERITED_OPTIONS}" CACHE STRING
+    "Semicolon-separated list of options for which game VMs should use the same value as the other binaries")
+mark_as_advanced(VMS_INHERITED_OPTIONS)
 
 ################################################################################
 # Directories

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -348,9 +348,15 @@ else()
 		try_c_cxx_flag(WSTACK_PROTECTOR "-Wstack-protector")
 
 		if (NOT NACL OR (NACL AND GAME_PIE))
-			try_c_cxx_flag(FPIE "-fPIE")
-			if (NOT APPLE)
-				try_linker_flag(LINKER_PIE "-pie")
+			if (FORK EQUAL 2 AND BUILD_GAME_NATIVE_DLL)
+				try_c_cxx_flag(FPIC "-fPIC")
+				try_linker_flag(LINKER_PIC "-pic")
+			else()
+				try_c_cxx_flag(FPIE "-fPIE")
+
+				if (NOT APPLE)
+					try_linker_flag(LINKER_PIE "-pie")
+				endif()
 			endif()
 		endif()
 

--- a/cmake/DaemonGame.cmake
+++ b/cmake/DaemonGame.cmake
@@ -87,173 +87,170 @@ else()
 	set(NACL_TARGETS "")
 endif()
 
+function(buildGameModule module_slug)
+	set(module_target "${GAMEMODULE_NAME}-${module_slug}")
+
+	set(module_target_args "${module_target}" ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${COMMONLIST})
+
+	if (module_slug STREQUAL "native-dll")
+		add_library(${module_target_args})
+		set_target_properties(${module_target} PROPERTIES
+			PREFIX ""
+			COMPILE_DEFINITIONS "BUILD_VM_IN_PROCESS")
+	else()
+		add_executable(${module_target_args})
+	endif()
+
+	set_target_properties(${module_target} PROPERTIES
+		COMPILE_DEFINITIONS "VM_NAME=${GAMEMODULE_NAME};${GAMEMODULE_DEFINITIONS};BUILD_VM"
+		COMPILE_OPTIONS "${GAMEMODULE_FLAGS}"
+		FOLDER ${GAMEMODULE_NAME}
+	)
+
+	if (module_slug STREQUAL "nacl")
+		set_target_properties(${module_target} PROPERTIES
+			OUTPUT_NAME "${GAMEMODULE_NAME}"
+			SUFFIX "${PLATFORM_EXE_SUFFIX}")
+	endif()
+
+	target_link_libraries(${module_target} ${GAMEMODULE_LIBS} ${LIBS_BASE})
+
+	ADD_PRECOMPILED_HEADER(${module_target})
+endfunction()
+
+function(gameSubProject)
+	ExternalProject_Add(${VMS_PROJECT}
+		SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+		BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${VMS_PROJECT}
+		CMAKE_GENERATOR ${VM_GENERATOR}
+		CMAKE_ARGS
+			-DFORK=2
+			-DDAEMON_DIR=${Daemon_SOURCE_DIR}
+			-DDEPS_DIR=${DEPS_DIR}
+			-DBUILD_CLIENT=OFF
+			-DBUILD_TTY_CLIENT=OFF
+			-DBUILD_SERVER=OFF
+			${ARGV}
+			${INHERITED_OPTION_ARGS}
+		INSTALL_COMMAND ""
+	)
+
+	# Force the rescan and rebuild of the subproject.
+	ExternalProject_Add_Step(${VMS_PROJECT} forcebuild
+		COMMAND ${CMAKE_COMMAND} -E remove
+			${CMAKE_CURRENT_BINARY_DIR}/${VMS_PROJECT}-prefix/src/${VMS_PROJECT}-stamp/${VMS_PROJECT}-configure
+		COMMENT "Forcing build step for '${VMS_PROJECT}'"
+		DEPENDEES build
+		ALWAYS 1
+	)
+endfunction()
+
 function(GAMEMODULE)
-    # ParseArguments setup
-    set(oneValueArgs NAME)
-    set(multiValueArgs DEFINITIONS FLAGS FILES LIBS)
-    cmake_parse_arguments(GAMEMODULE "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+	# ParseArguments setup
+	set(oneValueArgs NAME)
+	set(multiValueArgs DEFINITIONS FLAGS FILES LIBS)
+	cmake_parse_arguments(GAMEMODULE "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if (NOT NACL)
-        if (BUILD_GAME_NATIVE_DLL)
-            add_library(${GAMEMODULE_NAME}-native-dll MODULE ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${COMMONLIST})
-            target_link_libraries(${GAMEMODULE_NAME}-native-dll ${GAMEMODULE_LIBS} ${LIBS_BASE})
-            set_target_properties(${GAMEMODULE_NAME}-native-dll PROPERTIES
-                PREFIX ""
-                COMPILE_DEFINITIONS "VM_NAME=${GAMEMODULE_NAME};${GAMEMODULE_DEFINITIONS};BUILD_VM;BUILD_VM_IN_PROCESS"
-                COMPILE_OPTIONS "${GAMEMODULE_FLAGS}"
-                FOLDER ${GAMEMODULE_NAME}
-            )
-            ADD_PRECOMPILED_HEADER(${GAMEMODULE_NAME}-native-dll)
-        endif()
+	if (NOT FORK)
+		if (BUILD_GAME_NACL)
+			set(FORK 1 PARENT_SCOPE)
+		endif()
 
-        if (BUILD_GAME_NATIVE_EXE)
-            add_executable(${GAMEMODULE_NAME}-native-exe ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${COMMONLIST})
-            target_link_libraries(${GAMEMODULE_NAME}-native-exe ${GAMEMODULE_LIBS} ${LIBS_BASE})
-            set_target_properties(${GAMEMODULE_NAME}-native-exe PROPERTIES
-                COMPILE_DEFINITIONS "VM_NAME=${GAMEMODULE_NAME};${GAMEMODULE_DEFINITIONS};BUILD_VM"
-                COMPILE_OPTIONS "${GAMEMODULE_FLAGS}"
-                FOLDER ${GAMEMODULE_NAME}
-            )
-            ADD_PRECOMPILED_HEADER(${GAMEMODULE_NAME}-native-exe)
-        endif()
+		if (BUILD_GAME_NATIVE_DLL)
+			buildGameModule("native-dll")
+		endif()
 
-        if (NOT FORK AND BUILD_GAME_NACL)
-            if (CMAKE_GENERATOR MATCHES "Visual Studio")
-                set(VM_GENERATOR "NMake Makefiles")
-            else()
-                set(VM_GENERATOR ${CMAKE_GENERATOR})
-            endif()
+		if (BUILD_GAME_NATIVE_EXE)
+			buildGameModule("native-exe")
+		endif()
+	endif()
 
-            set(FORK 1 PARENT_SCOPE)
-            include(ExternalProject)
-            set(inherited_option_args)
+	if (FORK EQUAL 1)
+		if (CMAKE_GENERATOR MATCHES "Visual Studio")
+			set(VM_GENERATOR "NMake Makefiles")
+		else()
+			set(VM_GENERATOR ${CMAKE_GENERATOR})
+		endif()
 
-            foreach(inherited_option ${NACL_VM_INHERITED_OPTIONS})
-                set(inherited_option_args ${inherited_option_args}
-                    "-D${inherited_option}=${${inherited_option}}")
-            endforeach(inherited_option)
+		include(ExternalProject)
+		set(INHERITED_OPTION_ARGS)
 
-            if (USE_NACL_SAIGO)
-                add_custom_target(nacl-vms ALL)
-                unset(NACL_VMS_PROJECTS)
+		foreach(inherited_option ${VMS_INHERITED_OPTIONS})
+			set(INHERITED_OPTION_ARGS ${INHERITED_OPTION_ARGS}
+				"-D${inherited_option}=${${inherited_option}}")
+		endforeach(inherited_option)
 
-                foreach(NACL_TARGET ${NACL_TARGETS})
-                    if (NACL_TARGET STREQUAL "i686")
-                        set(SAIGO_ARCH "i686")
-                    elseif (NACL_TARGET STREQUAL "amd64")
-                        set(SAIGO_ARCH "x86_64")
-                    elseif (NACL_TARGET STREQUAL "armhf")
-                        set(SAIGO_ARCH "arm")
-                    else()
-                        message(FATAL_ERROR "Unknown NaCl architecture ${NACL_TARGET}")
-                    endif()
+		if (BUILD_GAME_NACL)
+			if (USE_NACL_SAIGO)
+				add_custom_target(nacl-vms ALL)
+				unset(VMS_PROJECTS)
 
-                    set(NACL_VMS_PROJECT nacl-vms-${NACL_TARGET})
-                    list(APPEND NACL_VMS_PROJECTS ${NACL_VMS_PROJECT})
-                    add_dependencies(nacl-vms ${NACL_VMS_PROJECT})
+				foreach(NACL_TARGET ${NACL_TARGETS})
+					if (NACL_TARGET STREQUAL "i686")
+						set(SAIGO_ARCH "i686")
+					elseif (NACL_TARGET STREQUAL "amd64")
+						set(SAIGO_ARCH "x86_64")
+					elseif (NACL_TARGET STREQUAL "armhf")
+						set(SAIGO_ARCH "arm")
+					else()
+						message(FATAL_ERROR "Unknown NaCl architecture ${NACL_TARGET}")
+					endif()
 
-                    ExternalProject_Add(${NACL_VMS_PROJECT}
-                        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                        BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${NACL_VMS_PROJECT}
-                        CMAKE_GENERATOR ${VM_GENERATOR}
-                        CMAKE_ARGS
-                            -DFORK=2
-                            -DCMAKE_TOOLCHAIN_FILE=${Daemon_SOURCE_DIR}/cmake/toolchain-saigo.cmake
-                            -DDAEMON_DIR=${Daemon_SOURCE_DIR}
-                            -DDEPS_DIR=${DEPS_DIR}
-                            -DBUILD_GAME_NACL=ON
-                            -DUSE_NACL_SAIGO=ON
-                            -DNACL_TARGET=${NACL_TARGET}
-                            -DSAIGO_ARCH=${SAIGO_ARCH}
-                            -DBUILD_GAME_NATIVE_DLL=OFF
-                            -DBUILD_GAME_NATIVE_EXE=OFF
-                            -DBUILD_CLIENT=OFF
-                            -DBUILD_TTY_CLIENT=OFF
-                            -DBUILD_SERVER=OFF
-                            ${inherited_option_args}
-                        INSTALL_COMMAND ""
-                    )
+					set(VMS_PROJECT nacl-vms-${NACL_TARGET})
+					list(APPEND VMS_PROJECTS ${VMS_PROJECT})
+					add_dependencies(nacl-vms ${VMS_PROJECT})
 
-                    # Force the rescan and rebuild of the subproject.
-                    ExternalProject_Add_Step(${NACL_VMS_PROJECT} forcebuild
-                        COMMAND ${CMAKE_COMMAND} -E remove
-                            ${CMAKE_CURRENT_BINARY_DIR}/${NACL_VMS_PROJECT}-prefix/src/${NACL_VMS_PROJECT}-stamp/${NACL_VMS_PROJECT}-configure
-                        COMMENT "Forcing build step for '${NACL_VMS_PROJECT}'"
-                        DEPENDEES build
-                        ALWAYS 1
-                    )
-                endforeach()
-            else()
-                set(NACL_VMS_PROJECT nacl-vms)
-                set(NACL_VMS_PROJECTS ${NACL_VMS_PROJECT})
+					gameSubProject(
+						-DCMAKE_TOOLCHAIN_FILE=${Daemon_SOURCE_DIR}/cmake/toolchain-saigo.cmake
+						-DBUILD_GAME_NACL=ON
+						-DBUILD_GAME_NATIVE_DLL=OFF
+						-DBUILD_GAME_NATIVE_EXE=OFF
+						-DUSE_NACL_SAIGO=ON
+						-DSAIGO_ARCH=${SAIGO_ARCH}
+						-DNACL_TARGET=${NACL_TARGET}
+					)
+				endforeach()
+			else()
+				set(VMS_PROJECT nacl-vms)
+				set(VMS_PROJECTS ${VMS_PROJECT})
 
-                # Workaround a bug where CMake ExternalProject lists-as-args are cut on first “;”
-                string(REPLACE ";" "," NACL_TARGETS_STRING "${NACL_TARGETS}")
+				# Workaround a bug where CMake ExternalProject lists-as-args are cut on first “;”
+				string(REPLACE ";" "," NACL_TARGETS_STRING "${NACL_TARGETS}")
 
-                ExternalProject_Add(${NACL_VMS_PROJECT}
-                    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${NACL_VMS_PROJECT}
-                    CMAKE_GENERATOR ${VM_GENERATOR}
-                    CMAKE_ARGS
-                        -DFORK=2
-                        -DCMAKE_TOOLCHAIN_FILE=${Daemon_SOURCE_DIR}/cmake/toolchain-pnacl.cmake
-                        -DDAEMON_DIR=${Daemon_SOURCE_DIR}
-                        -DDEPS_DIR=${DEPS_DIR}
-                        -DBUILD_GAME_NACL=ON
-                        -DNACL_TARGETS_STRING=${NACL_TARGETS_STRING}
-                        -DBUILD_GAME_NATIVE_DLL=OFF
-                        -DBUILD_GAME_NATIVE_EXE=OFF
-                        -DBUILD_CLIENT=OFF
-                        -DBUILD_TTY_CLIENT=OFF
-                        -DBUILD_SERVER=OFF
-                        ${inherited_option_args}
-                    INSTALL_COMMAND ""
-                )
+				gameSubProject(
+					-DCMAKE_TOOLCHAIN_FILE=${Daemon_SOURCE_DIR}/cmake/toolchain-pnacl.cmake
+					-DBUILD_GAME_NACL=ON
+					-DBUILD_GAME_NATIVE_DLL=OFF
+					-DBUILD_GAME_NATIVE_EXE=OFF
+					-DNACL_TARGETS_STRING=${NACL_TARGETS_STRING}
+				)
+			endif()
+		endif()
 
-                # Force the rescan and rebuild of the subproject.
-                ExternalProject_Add_Step(${NACL_VMS_PROJECT} forcebuild
-                    COMMAND ${CMAKE_COMMAND} -E remove
-                        ${CMAKE_CURRENT_BINARY_DIR}/${NACL_VMS_PROJECT}-prefix/src/${NACL_VMS_PROJECT}-stamp/${NACL_VMS_PROJECT}-configure
-                    COMMENT "Forcing build step for '${NACL_VMS_PROJECT}'"
-                    DEPENDEES build
-                    ALWAYS 1
-                )
-            endif()
-            set(NACL_VMS_PROJECTS ${NACL_VMS_PROJECTS} PARENT_SCOPE)
-        endif()
-    else()
-        if (FORK EQUAL 2)
-            if(USE_NACL_SAIGO)
-                set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-            else()
-                # Put the .nexe and .pexe files in the same directory as the engine
-                set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/..)
-            endif()
-        endif()
+		set(VMS_PROJECTS ${VMS_PROJECTS} PARENT_SCOPE)
+	elseif (FORK EQUAL 2)
+		if (BUILD_GAME_NACL)
+			if (USE_NACL_SAIGO)
+				set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+			else()
+				# Put the .nexe and .pexe files in the same directory as the engine.
+				set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/..)
+			endif()
 
-        add_executable(${GAMEMODULE_NAME}-nacl ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${COMMONLIST})
-        target_link_libraries(${GAMEMODULE_NAME}-nacl ${GAMEMODULE_LIBS} ${LIBS_BASE})
-        # PLATFORM_EXE_SUFFIX is .pexe when building with PNaCl
-        # as translating to .nexe is a separate task.
-        set_target_properties(${GAMEMODULE_NAME}-nacl PROPERTIES
-            OUTPUT_NAME ${GAMEMODULE_NAME}${PLATFORM_EXE_SUFFIX}
-            COMPILE_DEFINITIONS "VM_NAME=${GAMEMODULE_NAME};${GAMEMODULE_DEFINITIONS};BUILD_VM"
-            COMPILE_OPTIONS "${GAMEMODULE_FLAGS}"
-            FOLDER ${GAMEMODULE_NAME}
-        )
-        ADD_PRECOMPILED_HEADER(${GAMEMODULE_NAME}-nacl)
+			buildGameModule("nacl")
 
-        # Revert a workaround for a bug where CMake ExternalProject lists-as-args are cut on first “;”
-        string(REPLACE "," ";" NACL_TARGETS "${NACL_TARGETS_STRING}")
+			if (USE_NACL_SAIGO)
+				# Finalize NaCl executables for supported architectures.
+				saigo_finalize(${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/.. ${GAMEMODULE_NAME} ${NACL_TARGET})
+			else()
+				# Revert a workaround for a bug where CMake ExternalProject lists-as-args are cut on first “;”
+				string(REPLACE "," ";" NACL_TARGETS "${NACL_TARGETS_STRING}")
 
-        if (USE_NACL_SAIGO)
-            # Finalize NaCl executables for supported architectures.
-            saigo_finalize(${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/.. ${GAMEMODULE_NAME} ${NACL_TARGET})
-        else()
-            # Generate NaCl executables for supported architectures.
-            foreach(NACL_TARGET ${NACL_TARGETS})
-                pnacl_finalize(${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${GAMEMODULE_NAME} ${NACL_TARGET})
-            endforeach()
-        endif()
-    endif()
+				# Generate NaCl executables for supported architectures.
+				foreach(NACL_TARGET ${NACL_TARGETS})
+					pnacl_finalize(${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${GAMEMODULE_NAME} ${NACL_TARGET})
+				endforeach()
+			endif()
+		endif()
+	endif()
 endfunction()

--- a/cmake/DaemonGame.cmake
+++ b/cmake/DaemonGame.cmake
@@ -157,7 +157,11 @@ function(GAMEMODULE)
 		endif()
 
 		if (BUILD_GAME_NATIVE_DLL)
-			buildGameModule("native-dll")
+			if (USE_HARDENING)
+				set(FORK 1 PARENT_SCOPE)
+			else()
+				buildGameModule("native-dll")
+			endif()
 		endif()
 
 		if (BUILD_GAME_NATIVE_EXE)
@@ -179,6 +183,17 @@ function(GAMEMODULE)
 			set(INHERITED_OPTION_ARGS ${INHERITED_OPTION_ARGS}
 				"-D${inherited_option}=${${inherited_option}}")
 		endforeach(inherited_option)
+
+		if (BUILD_GAME_NATIVE_DLL AND USE_HARDENING)
+			set(VMS_PROJECT dll-vms)
+			set(VMS_PROJECTS ${VMS_PROJECT})
+
+			gameSubProject(
+				-DBUILD_GAME_NACL=OFF
+				-DBUILD_GAME_NATIVE_DLL=ON
+				-DBUILD_GAME_NATIVE_EXE=OFF
+			)
+		endif()
 
 		if (BUILD_GAME_NACL)
 			if (USE_NACL_SAIGO)
@@ -229,7 +244,12 @@ function(GAMEMODULE)
 
 		set(VMS_PROJECTS ${VMS_PROJECTS} PARENT_SCOPE)
 	elseif (FORK EQUAL 2)
-		if (BUILD_GAME_NACL)
+		if (BUILD_GAME_NATIVE_DLL)
+			# Put the .dll and .so files in the same directory as the engine.
+			set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/..)
+
+			buildGameModule("native-dll")
+		elseif (BUILD_GAME_NACL)
 			if (USE_NACL_SAIGO)
 				set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 			else()


### PR DESCRIPTION
Refactor game build configuration to reuse the same code in parent build or subproject build and mutualize code between vm type build.

Also build hardened dll game with sub cmake to use different compilation flags.

Obsoletes:

- https://github.com/DaemonEngine/Daemon/pull/1481

See on game side:

- https://github.com/Unvanquished/Unvanquished/pull/3270