### PR TITLE
Revert "Merge generic2D shader into generic"

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -43,6 +43,7 @@ ShaderKind shaderKind = ShaderKind::Unknown;
 
 // *INDENT-OFF*
 
+GLShader_generic2D                       *gl_generic2DShader = nullptr;
 GLShader_generic                         *gl_genericShader = nullptr;
 GLShader_genericMaterial                 *gl_genericShaderMaterial = nullptr;
 GLShader_cull                            *gl_cullShader = nullptr;
@@ -2171,6 +2172,31 @@ void GLShader::WriteUniformsToBuffer( uint32_t* buffer ) {
 	}
 }
 
+GLShader_generic2D::GLShader_generic2D( GLShaderManager *manager ) :
+	GLShader( "generic2D", "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
+	u_ColorMap( this ),
+	u_DepthMap( this ),
+	u_TextureMatrix( this ),
+	u_AlphaThreshold( this ),
+	u_ModelMatrix( this ),
+	u_ModelViewProjectionMatrix( this ),
+	u_ColorModulate( this ),
+	u_Color( this ),
+	u_DepthScale( this ),
+	GLDeformStage( this )
+{
+}
+
+void GLShader_generic2D::BuildShaderCompileMacros( std::string& compileMacros )
+{
+	compileMacros += "GENERIC_2D ";
+}
+
+void GLShader_generic2D::SetShaderProgramUniforms( shaderProgram_t *shaderProgram )
+{
+	glUniform1i( glGetUniformLocation( shaderProgram->program, "u_ColorMap" ), 0 );
+}
+
 GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	GLShader( "generic", ATTR_POSITION | ATTR_TEXCOORD | ATTR_QTANGENT, manager ),
 	u_ColorMap( this ),
@@ -2193,8 +2219,7 @@ GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
 	GLCompileMacro_USE_TCGEN_ENVIRONMENT( this ),
 	GLCompileMacro_USE_TCGEN_LIGHTMAP( this ),
-	GLCompileMacro_USE_DEPTH_FADE( this ),
-	GLCompileMacro_GENERIC_2D( this )
+	GLCompileMacro_USE_DEPTH_FADE( this )
 {
 }
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1686,7 +1686,6 @@ protected:
 	  USE_SHADOWING,
 	  LIGHT_DIRECTIONAL,
 	  USE_DEPTH_FADE,
-	  GENERIC_2D,
 	  USE_PHYSICAL_MAPPING,
 	};
 
@@ -2107,26 +2106,6 @@ public:
 
 	void SetDepthFade( bool enable )
 	{
-		SetMacro( enable );
-	}
-};
-
-class GLCompileMacro_GENERIC_2D :
-	GLCompileMacro {
-	public:
-	GLCompileMacro_GENERIC_2D( GLShader* shader ) :
-		GLCompileMacro( shader ) {
-	}
-
-	const char* GetName() const override {
-		return "GENERIC_2D";
-	}
-
-	EGLCompileMacro GetType() const override {
-		return EGLCompileMacro::GENERIC_2D;
-	}
-
-	void SetGeneric2D( bool enable ) {
 		SetMacro( enable );
 	}
 };
@@ -3939,6 +3918,28 @@ class u_Lights :
 	}
 };
 
+// FIXME: this is the same as 'generic' and has no reason for existing.
+// It was added along with RmlUi transforms to add "gl_FragDepth = 0;" to the GLSL,
+// but that turns out not to be needed.
+class GLShader_generic2D :
+	public GLShader,
+	public u_ColorMap,
+	public u_DepthMap,
+	public u_TextureMatrix,
+	public u_AlphaThreshold,
+	public u_ModelMatrix,
+	public u_ModelViewProjectionMatrix,
+	public u_ColorModulate,
+	public u_Color,
+	public u_DepthScale,
+	public GLDeformStage
+{
+public:
+	GLShader_generic2D( GLShaderManager *manager );
+	void BuildShaderCompileMacros( std::string& compileMacros ) override;
+	void SetShaderProgramUniforms( shaderProgram_t *shaderProgram ) override;
+};
+
 class GLShader_generic :
 	public GLShader,
 	public u_ColorMap,
@@ -3961,8 +3962,7 @@ class GLShader_generic :
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
 	public GLCompileMacro_USE_TCGEN_ENVIRONMENT,
 	public GLCompileMacro_USE_TCGEN_LIGHTMAP,
-	public GLCompileMacro_USE_DEPTH_FADE,
-	public GLCompileMacro_GENERIC_2D
+	public GLCompileMacro_USE_DEPTH_FADE
 {
 public:
 	GLShader_generic( GLShaderManager *manager );
@@ -4714,6 +4714,7 @@ std::string GetShaderPath();
 
 extern ShaderKind shaderKind;
 
+extern GLShader_generic2D                       *gl_generic2DShader;
 extern GLShader_generic                         *gl_genericShader;
 extern GLShader_genericMaterial                 *gl_genericShaderMaterial;
 extern GLShader_cull                            *gl_cullShader;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -210,6 +210,7 @@ static void GLSL_InitGPUShadersOrError()
 	gl_shaderManager.GenerateBuiltinHeaders();
 
 	// single texture rendering
+	gl_shaderManager.load( gl_generic2DShader );
 	gl_shaderManager.load( gl_genericShader );
 
 	// standard light mapping
@@ -468,6 +469,7 @@ void GLSL_ShutdownGPUShaders()
 
 	gl_shaderManager.freeAll();
 
+	gl_generic2DShader = nullptr;
 	gl_genericShader = nullptr;
 	gl_genericShaderMaterial = nullptr;
 	gl_cullShader = nullptr;
@@ -814,6 +816,46 @@ void Render_NOP( shaderStage_t * )
 {
 }
 
+static void Render_generic2D( shaderStage_t *pStage )
+{
+	GLimp_LogComment( "--- Render_generic2D ---\n" );
+
+	// Disable depth testing and writing
+	GL_State( ( pStage->stateBits & ~GLS_DEPTHMASK_TRUE ) | GLS_DEPTHTEST_DISABLE );
+
+	gl_generic2DShader->BindProgram( pStage->deformIndex );
+
+	// set uniforms
+	// u_AlphaThreshold
+	gl_generic2DShader->SetUniform_AlphaTest( pStage->stateBits );
+
+	// u_ColorModulate
+	colorGen_t rgbGen = SetRgbGen( pStage );
+	alphaGen_t alphaGen = SetAlphaGen( pStage );
+
+	gl_generic2DShader->SetUniform_ColorModulate( rgbGen, alphaGen );
+
+	// u_Color
+	gl_generic2DShader->SetUniform_Color( tess.svars.color );
+
+	gl_generic2DShader->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
+	gl_generic2DShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
+
+	// u_DeformGen
+	gl_generic2DShader->SetUniform_Time( backEnd.refdef.floatTime - backEnd.currentEntity->e.shaderTime );
+
+	// bind u_ColorMap
+	gl_generic2DShader->SetUniform_ColorMapBindless( BindAnimatedImage( 0, &pStage->bundle[TB_COLORMAP] ) );
+	gl_generic2DShader->SetUniform_TextureMatrix( tess.svars.texMatrices[ TB_COLORMAP ] );
+
+	gl_generic2DShader->SetRequiredVertexPointers();
+
+	Tess_DrawElements();
+	GL_CheckErrors();
+
+	GL_CheckErrors();
+}
+
 void Render_generic3D( shaderStage_t *pStage )
 {
 	GLimp_LogComment( "--- Render_generic3D ---\n" );
@@ -928,13 +970,7 @@ void Render_generic( shaderStage_t *pStage )
 {
 	if ( backEnd.projection2D )
 	{
-		glState.glStateBitsMask = ~uint32_t( GLS_DEPTHMASK_TRUE ) | GLS_DEPTHTEST_DISABLE;
-		gl_genericShader->SetGeneric2D( true );
-
-		Render_generic3D( pStage );
-
-		glState.glStateBitsMask = 0;
-		gl_genericShader->SetGeneric2D( false );
+		Render_generic2D( pStage );
 		return;
 	}
 


### PR DESCRIPTION
This reverts #1483.

This is a loading time regression that causes several useless shader permutations to be built.
With "Merge generic2D shader into generic":
	built 241 glsl shaders in 19483 msec
Without it:
	built 224 glsl shaders in 18827 msec

The GENERIC_2D macro would need to be removed to merge these without introducing unnecessary permutations.