### PR TITLE
FIx unnecessary generic shader permutations

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2193,8 +2193,7 @@ GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	GLCompileMacro_USE_VERTEX_ANIMATION( this ),
 	GLCompileMacro_USE_TCGEN_ENVIRONMENT( this ),
 	GLCompileMacro_USE_TCGEN_LIGHTMAP( this ),
-	GLCompileMacro_USE_DEPTH_FADE( this ),
-	GLCompileMacro_GENERIC_2D( this )
+	GLCompileMacro_USE_DEPTH_FADE( this )
 {
 }
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2111,26 +2111,6 @@ public:
 	}
 };
 
-class GLCompileMacro_GENERIC_2D :
-	GLCompileMacro {
-	public:
-	GLCompileMacro_GENERIC_2D( GLShader* shader ) :
-		GLCompileMacro( shader ) {
-	}
-
-	const char* GetName() const override {
-		return "GENERIC_2D";
-	}
-
-	EGLCompileMacro GetType() const override {
-		return EGLCompileMacro::GENERIC_2D;
-	}
-
-	void SetGeneric2D( bool enable ) {
-		SetMacro( enable );
-	}
-};
-
 class GLCompileMacro_USE_PHYSICAL_MAPPING :
 	GLCompileMacro
 {
@@ -3961,8 +3941,7 @@ class GLShader_generic :
 	public GLCompileMacro_USE_VERTEX_ANIMATION,
 	public GLCompileMacro_USE_TCGEN_ENVIRONMENT,
 	public GLCompileMacro_USE_TCGEN_LIGHTMAP,
-	public GLCompileMacro_USE_DEPTH_FADE,
-	public GLCompileMacro_GENERIC_2D
+	public GLCompileMacro_USE_DEPTH_FADE
 {
 public:
 	GLShader_generic( GLShaderManager *manager );

--- a/src/engine/renderer/glsl_source/shaderProfiler_fp.glsl
+++ b/src/engine/renderer/glsl_source/shaderProfiler_fp.glsl
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /* shaderProfiler_fp.glsl */
 
-#if defined(r_profilerRenderSubGroups) && !defined(GENERIC_2D) && defined(HAVE_KHR_shader_subgroup_basic) && defined(HAVE_KHR_shader_subgroup_arithmetic)
+#if defined(r_profilerRenderSubGroups) && defined(HAVE_KHR_shader_subgroup_basic) && defined(HAVE_KHR_shader_subgroup_arithmetic)
 	uniform float u_ProfilerZero;
 	uniform uint u_ProfilerRenderSubGroups;
 	IN(flat) float var_SubGroupCount;

--- a/src/engine/renderer/glsl_source/shaderProfiler_vp.glsl
+++ b/src/engine/renderer/glsl_source/shaderProfiler_vp.glsl
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /* shaderProfiler_vp.glsl */
 
-#if defined(r_profilerRenderSubGroups) && !defined(GENERIC_2D) && defined(HAVE_KHR_shader_subgroup_basic) && defined(HAVE_KHR_shader_subgroup_arithmetic)
+#if defined(r_profilerRenderSubGroups) && defined(HAVE_KHR_shader_subgroup_basic) && defined(HAVE_KHR_shader_subgroup_arithmetic)
 	uniform uint u_ProfilerRenderSubGroups;
 	OUT(flat) float var_SubGroupCount;
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2791,6 +2791,8 @@ enum class shaderProfilerRenderSubGroupsMode {
 		frontEndCounters_t pc;
 		int                frontEndMsec; // not in pc due to clearing issue
 
+		bool skipSubgroupProfiler = false;
+
 		vec4_t             clipRegion; // 2D clipping region
 
 		//

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -905,7 +905,7 @@ void Render_generic3D( shaderStage_t *pStage )
 		);
 	}
 
-	if ( r_profilerRenderSubGroups.Get() && !( pStage->stateBits & GLS_DEPTHMASK_TRUE ) ) {
+	if ( r_profilerRenderSubGroups.Get() && !( pStage->stateBits & GLS_DEPTHMASK_TRUE ) && !tr.skipSubgroupProfiler ) {
 		const uint mode = GetShaderProfilerRenderSubGroupsMode( pStage->stateBits );
 		if( mode == 0 ) {
 			return;
@@ -929,12 +929,12 @@ void Render_generic( shaderStage_t *pStage )
 	if ( backEnd.projection2D )
 	{
 		glState.glStateBitsMask = ~uint32_t( GLS_DEPTHMASK_TRUE ) | GLS_DEPTHTEST_DISABLE;
-		gl_genericShader->SetGeneric2D( true );
+		tr.skipSubgroupProfiler = true;
 
 		Render_generic3D( pStage );
 
 		glState.glStateBitsMask = 0;
-		gl_genericShader->SetGeneric2D( false );
+		tr.skipSubgroupProfiler = false;
 		return;
 	}
 


### PR DESCRIPTION
NUKE the GENERIC_2D macro and add `trGlobals_t::skipSubgroupProfiler` to skip the subgroup profiler instead.

Alternative to #1486.