### PR TITLE
Fix out of order shader log messages

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1727,6 +1727,12 @@ std::vector<GLShaderManager::InfoLogEntry> GLShaderManager::ParseInfoLog( const 
 		}
 	}
 
+	// Messages in the log can sometimes be out of order
+	std::sort( out.begin(), out.end(),
+		[]( const InfoLogEntry& lhs, const InfoLogEntry& rhs ) {
+			return lhs.line < rhs.line;
+		} );
+
 	return out;
 }
 


### PR DESCRIPTION
This can sometimes happen, leading to missing log entries when printing the log. Fixes that by sorting them first.