### PR TITLE
Migrate render commands to C++ interface

### DIFF
--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2474,18 +2474,15 @@ void CL_Shutdown()
 
 	Cmd_RemoveCommand( "cmd" );
 	Cmd_RemoveCommand( "configstrings" );
-	Cmd_RemoveCommand( "userinfo" );
 	Cmd_RemoveCommand( "snd_restart" );
 	Cmd_RemoveCommand( "vid_restart" );
 	Cmd_RemoveCommand( "disconnect" );
 	Cmd_RemoveCommand( "connect" );
 	Cmd_RemoveCommand( "localservers" );
 	Cmd_RemoveCommand( "globalservers" );
-	Cmd_RemoveCommand( "rcon" );
 	Cmd_RemoveCommand( "ping" );
 	Cmd_RemoveCommand( "serverstatus" );
 	Cmd_RemoveCommand( "showip" );
-	Cmd_RemoveCommand( "model" );
 
 	CL_ClearKeyBinding();
 	CL_ClearInput();

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2219,12 +2219,6 @@ static bool CL_InitRef()
 	refimport_t ri;
 	refexport_t *ret;
 
-	ri.Cmd_AddCommand = Cmd_AddCommand;
-	ri.Cmd_RemoveCommand = Cmd_RemoveCommand;
-	ri.Cmd_Argc = Cmd_Argc;
-	ri.Cmd_Argv = Cmd_Argv;
-	ri.Cmd_QuoteString = Cmd_QuoteString;
-
 	ri.Milliseconds = Sys::Milliseconds;
 	ri.RealTime = Com_RealTime;
 

--- a/src/engine/renderer/tr_animation.cpp
+++ b/src/engine/renderer/tr_animation.cpp
@@ -581,25 +581,27 @@ skelAnimation_t *R_GetAnimationByHandle( qhandle_t index )
 	return anim;
 }
 
-/*
-================
-R_ListAnimations_f
-================
-*/
-void R_ListAnimations_f()
+class ListAnimationsCmd : public Cmd::StaticCmd
 {
-	int             i;
-	skelAnimation_t *anim;
+public:
+	ListAnimationsCmd() : StaticCmd("listAnimations", "list model animations loaded in renderer") {}
 
-	for ( i = 0; i < tr.numAnimations; i++ )
+	void Run( const Cmd::Args & ) const override
 	{
-		anim = tr.animations[ i ];
+		int             i;
+		skelAnimation_t *anim;
 
-		Log::Notice("'%s'", anim->name );
+		for ( i = 0; i < tr.numAnimations; i++ )
+		{
+			anim = tr.animations[ i ];
+
+			Print( "'%s'", anim->name );
+		}
+
+		Print( "%i total animations", tr.numAnimations );
 	}
-
-	Log::Notice("%8i : Total animations", tr.numAnimations );
-}
+};
+static ListAnimationsCmd listAnimationsCmdRegistration;
 
 /*
 =============

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -5016,6 +5016,10 @@ void R_BuildCubeMaps()
 	}
 }
 
+static Cmd::LambdaCmd buildCubeMapsCmd(
+	"buildcubemaps", "generate cube probes for reflection mapping",
+	[]( const Cmd::Args & ) { R_BuildCubeMaps(); });
+
 /*
 =================
 RE_LoadWorldMap

--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -591,25 +591,27 @@ void R_ShutdownFBOs()
 	}
 }
 
-/*
-============
-R_ListFBOs_f
-============
-*/
-void R_ListFBOs_f()
+class ListFBOsCmd : public Cmd::StaticCmd
 {
-	int   i;
-	FBO_t *fbo;
+public:
+	ListFBOsCmd() : StaticCmd("listFBOs", "list renderer's OpenGL framebuffer objects") {}
 
-	Log::Notice("             size       name" );
-	Log::Notice("----------------------------------------------------------" );
-
-	for ( i = 0; i < tr.numFBOs; i++ )
+	void Run( const Cmd::Args & ) const override
 	{
-		fbo = tr.fbos[ i ];
+		int   i;
+		FBO_t *fbo;
 
-		Log::Notice("  %4i: %4i %4i %s", i, fbo->width, fbo->height, fbo->name );
+		Print("             size       name" );
+		Print("----------------------------------------------------------" );
+
+		for ( i = 0; i < tr.numFBOs; i++ )
+		{
+			fbo = tr.fbos[ i ];
+
+			Print("  %4i: %4i %4i %s", i, fbo->width, fbo->height, fbo->name );
+		}
+
+		Print(" %i FBOs", tr.numFBOs );
 	}
-
-	Log::Notice(" %i FBOs", tr.numFBOs );
-}
+};
+static ListFBOsCmd listFBOsCmdRegistration;

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1532,8 +1532,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		ri.Cmd_RemoveCommand( "shaderexp" );
 		ri.Cmd_RemoveCommand( "gfxinfo" );
-		ri.Cmd_RemoveCommand( "shaderstate" );
-		ri.Cmd_RemoveCommand( "generatemtr" );
 		ri.Cmd_RemoveCommand( "buildcubemaps" );
 
 		ri.Cmd_RemoveCommand( "glsl_restart" );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -518,18 +518,21 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 		return true;
 	}
 
-	/*
-	** R_ListModes_f
-	*/
-	static void R_ListModes_f()
+	class ListModesCmd : public Cmd::StaticCmd
 	{
-		int i;
-
-		for ( i = 0; i < s_numVidModes; i++ )
+	public:
+		ListModesCmd() : StaticCmd("listModes", "list suggested screen/window dimensions") {}
+		void Run( const Cmd::Args& ) const override
 		{
-			Log::Notice("Mode %-2d: %s", i, r_vidModes[ i ].description );
+			int i;
+
+			for ( i = 0; i < s_numVidModes; i++ )
+			{
+				Print("Mode %-2d: %s", i, r_vidModes[ i ].description );
+			}
 		}
-	}
+	};
+	static ListModesCmd listModesCmdRegistration;
 
 	/*
 	==================
@@ -1350,14 +1353,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		Cvar::Latch( r_profilerRenderSubGroups );
 
 		// make sure all the commands added here are also removed in R_Shutdown
-		ri.Cmd_AddCommand( "listImages", R_ListImages_f );
-		ri.Cmd_AddCommand( "listShaders", R_ListShaders_f );
 		ri.Cmd_AddCommand( "shaderexp", R_ShaderExp_f );
-		ri.Cmd_AddCommand( "listSkins", R_ListSkins_f );
-		ri.Cmd_AddCommand( "listModels", R_ListModels_f );
-		ri.Cmd_AddCommand( "listModes", R_ListModes_f );
-		ri.Cmd_AddCommand( "listAnimations", R_ListAnimations_f );
-		ri.Cmd_AddCommand( "listFBOs", R_ListFBOs_f );
 		ri.Cmd_AddCommand( "gfxinfo", GfxInfo_f );
 		ri.Cmd_AddCommand( "buildcubemaps", R_BuildCubeMaps );
 
@@ -1534,16 +1530,9 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 	{
 		Log::Debug("RE_Shutdown( destroyWindow = %i )", destroyWindow );
 
-		ri.Cmd_RemoveCommand( "listModels" );
-		ri.Cmd_RemoveCommand( "listImages" );
-		ri.Cmd_RemoveCommand( "listShaders" );
 		ri.Cmd_RemoveCommand( "shaderexp" );
-		ri.Cmd_RemoveCommand( "listSkins" );
 		ri.Cmd_RemoveCommand( "gfxinfo" );
-		ri.Cmd_RemoveCommand( "listModes" );
 		ri.Cmd_RemoveCommand( "shaderstate" );
-		ri.Cmd_RemoveCommand( "listAnimations" );
-		ri.Cmd_RemoveCommand( "listFBOs" );
 		ri.Cmd_RemoveCommand( "generatemtr" );
 		ri.Cmd_RemoveCommand( "buildcubemaps" );
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -900,7 +900,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 	GfxInfo_f
 	================
 	*/
-	void GfxInfo_f()
+	static void GfxInfo_f()
 	{
 		static const char fsstrings[][16] =
 		{
@@ -1079,31 +1079,44 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		Log::Debug("replaceMaterialMinDimensionIfPresentWithMaxDimension: %d", r_replaceMaterialMinDimensionIfPresentWithMaxDimension->integer );
 	}
 
-	static void GLSL_restart_f()
+	// FIXME: uses regular logging not Print()
+	static Cmd::LambdaCmd gfxInfoCmd(
+		"gfxinfo", "dump graphics driver and configuration info",
+		[]( const Cmd::Args & ) { GfxInfo_f(); });
+
+	class GlslRestartCmd : public Cmd::StaticCmd
 	{
-		// make sure the render thread is stopped
-		R_SyncRenderThread();
+	public:
+		GlslRestartCmd() : StaticCmd(
+			"glsl_restart", "recompile GLSL shaders (useful when shaderpath is set)") {}
 
-		GLSL_ShutdownGPUShaders();
-		GLSL_InitGPUShaders();
-
-		for ( int i = 0; i < tr.numShaders; i++ )
+		void Run( const Cmd::Args & ) const override
 		{
-			shader_t &shader = *tr.shaders[ i ];
-			if ( shader.stages == shader.lastStage || shader.stages[ 0 ].deformIndex == 0 )
-			{
-				continue;
-			}
+			// make sure the render thread is stopped
+			R_SyncRenderThread();
 
-			int deformIndex =
-				gl_shaderManager.getDeformShaderIndex( shader.deforms, shader.numDeforms );
+			GLSL_ShutdownGPUShaders();
+			GLSL_InitGPUShaders();
 
-			for ( shaderStage_t *stage = shader.stages; stage != shader.lastStage; stage++ )
+			for ( int i = 0; i < tr.numShaders; i++ )
 			{
-				stage->deformIndex = deformIndex;
+				shader_t &shader = *tr.shaders[ i ];
+				if ( shader.stages == shader.lastStage || shader.stages[ 0 ].deformIndex == 0 )
+				{
+					continue;
+				}
+
+				int deformIndex =
+					gl_shaderManager.getDeformShaderIndex( shader.deforms, shader.numDeforms );
+
+				for ( shaderStage_t *stage = shader.stages; stage != shader.lastStage; stage++ )
+				{
+					stage->deformIndex = deformIndex;
+				}
 			}
 		}
-	}
+	};
+	static GlslRestartCmd glslRestartCmdRegistration;
 
 	/*
 	===============
@@ -1351,13 +1364,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_showParallelShadowSplits = Cvar_Get( "r_showParallelShadowSplits", "0", CVAR_CHEAT | CVAR_LATCH );
 
 		Cvar::Latch( r_profilerRenderSubGroups );
-
-		// make sure all the commands added here are also removed in R_Shutdown
-		ri.Cmd_AddCommand( "shaderexp", R_ShaderExp_f );
-		ri.Cmd_AddCommand( "gfxinfo", GfxInfo_f );
-		ri.Cmd_AddCommand( "buildcubemaps", R_BuildCubeMaps );
-
-		ri.Cmd_AddCommand( "glsl_restart", GLSL_restart_f );
 	}
 
 	/*
@@ -1529,12 +1535,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 	void RE_Shutdown( bool destroyWindow )
 	{
 		Log::Debug("RE_Shutdown( destroyWindow = %i )", destroyWindow );
-
-		ri.Cmd_RemoveCommand( "shaderexp" );
-		ri.Cmd_RemoveCommand( "gfxinfo" );
-		ri.Cmd_RemoveCommand( "buildcubemaps" );
-
-		ri.Cmd_RemoveCommand( "glsl_restart" );
 
 		if ( tr.registered )
 		{

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2324,8 +2324,6 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 	void               R_ModelBounds( qhandle_t handle, vec3_t mins, vec3_t maxs );
 
-	void               R_ListModels_f();
-
 //====================================================
 	extern refimport_t ri;
 
@@ -3252,9 +3250,6 @@ inline bool checkGLErrors()
 
 	bool   R_GetModeInfo( int *width, int *height, int mode );
 
-	void       R_ListImages_f();
-	void       R_ListSkins_f();
-
 // https://zerowing.idsoftware.com/bugzilla/show_bug.cgi?id=516
 	const void *RB_TakeScreenshotCmd( const void *data );
 
@@ -3308,7 +3303,6 @@ inline bool checkGLErrors()
 	shader_t  *R_FindShaderByName( const char *name );
 	const char *RE_GetShaderNameFromHandle( qhandle_t shader );
 	void      R_InitShaders();
-	void      R_ListShaders_f();
 	void      R_ShaderExp_f();
 	void      R_RemapShader( const char *oldShader, const char *newShader, const char *timeOffset );
 
@@ -3650,7 +3644,6 @@ inline bool checkGLErrors()
 
 	void     R_InitFBOs();
 	void     R_ShutdownFBOs();
-	void     R_ListFBOs_f();
 
 	/*
 	============================================================
@@ -3719,7 +3712,6 @@ inline bool checkGLErrors()
 	qhandle_t RE_RegisterAnimationIQM( const char *name, IQAnim_t *data );
 
 	skelAnimation_t *R_GetAnimationByHandle( qhandle_t hAnim );
-	void            R_ListAnimations_f();
 
 	void            R_AddMD5Surfaces( trRefEntity_t *ent );
 	void            R_AddMD5Interactions( trRefEntity_t *ent, trRefLight_t *light, interactionType_t iaType );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3303,7 +3303,6 @@ inline bool checkGLErrors()
 	shader_t  *R_FindShaderByName( const char *name );
 	const char *RE_GetShaderNameFromHandle( qhandle_t shader );
 	void      R_InitShaders();
-	void      R_ShaderExp_f();
 	void      R_RemapShader( const char *oldShader, const char *newShader, const char *timeOffset );
 
 	/*

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -293,14 +293,6 @@ struct refimport_t
 	void            *( *Hunk_AllocateTempMemory )( int size );
 	void ( *Hunk_FreeTempMemory )( void *block );
 
-	void ( *Cmd_AddCommand )( const char *name, void ( *cmd )() );
-	void ( *Cmd_RemoveCommand )( const char *name );
-
-	int ( *Cmd_Argc )();
-	const char *( *Cmd_Argv )( int i );
-
-	const char *( *Cmd_QuoteString )( const char *text );
-
 	// a -1 return means the file does not exist
 	// nullptr can be passed for buf to just determine existence
 	int ( *FS_ReadFile )( const char *name, void **buf );

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6855,28 +6855,24 @@ public:
 };
 static ListShadersCmd listShadersCmdRegistration;
 
-void R_ShaderExp_f()
+class ShaderExpCmd : public Cmd::StaticCmd
 {
-	std::string buffer;
+public:
+	ShaderExpCmd() : StaticCmd("shaderexp", "evaluate a q3shader expression (RB_EvalExpression)") {}
 
-	for ( int i = 1; i < ri.Cmd_Argc(); i++ )
+	void Run( const Cmd::Args &args ) const override
 	{
-		if ( i > 1 )
-		{
-			buffer += ' ';
-		}
+		std::string expStr = args.ConcatArgs( 1 );
+		const char* buffer_p = expStr.c_str();
+		expression_t exp;
 
-		buffer += ri.Cmd_Argv( i );
+		ParseExpression( &buffer_p, &exp );
+
+		Print( "%i total ops", exp.numOps );
+		Print( "%f result", RB_EvalExpression( &exp, 0 ) );
 	}
-
-	const char* buffer_p = buffer.c_str();
-	expression_t exp;
-
-	ParseExpression( &buffer_p, &exp );
-
-	Log::CommandInteractionMessage( Str::Format( "%i total ops", exp.numOps ) );
-	Log::CommandInteractionMessage( Str::Format( "%f result", RB_EvalExpression( &exp, 0 ) ) );
-}
+};
+static ShaderExpCmd shaderExpCmdRegistration;
 
 /*
 ====================

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6634,224 +6634,226 @@ shader_t       *R_GetShaderByHandle( qhandle_t hShader )
 
 /*
 ===============
-R_ListShaders_f
-
 Dump information on all valid shaders to the console
 A second parameter will cause it to print in sorted order
 ===============
 */
-void R_ListShaders_f()
+class ListShadersCmd : public Cmd::StaticCmd
 {
-	static const std::unordered_map<shaderType_t, std::string> shaderTypeName = {
-		{ shaderType_t::SHADER_2D, "2D" },
-		{ shaderType_t::SHADER_3D_DYNAMIC, "3D_DYNAMIC" },
-		{ shaderType_t::SHADER_3D_STATIC, "3D_STATIC" },
-		{ shaderType_t::SHADER_LIGHT, "LIGHT" },
-	};
+public:
+	ListShadersCmd() : StaticCmd("listShaders", "list q3shaders currently registered in the renderer") {}
 
-	static const std::unordered_map<shaderSort_t, std::string> shaderSortName = {
-		{ shaderSort_t::SS_BAD, "BAD" },
-		{ shaderSort_t::SS_PORTAL, "PORTAL" },
-		{ shaderSort_t::SS_DEPTH, "DEPTH" },
-		{ shaderSort_t::SS_ENVIRONMENT_FOG, "ENV_FOG" },
-		{ shaderSort_t::SS_ENVIRONMENT_NOFOG, "ENV_NOFOG" },
-		{ shaderSort_t::SS_OPAQUE, "OPAQUE" },
-		{ shaderSort_t::SS_DECAL, "DECAL" },
-		{ shaderSort_t::SS_SEE_THROUGH, "SEE_THROUGH" },
-		{ shaderSort_t::SS_BANNER, "BANNER" },
-		{ shaderSort_t::SS_FOG, "FOG" },
-		{ shaderSort_t::SS_UNDERWATER, "UNDERWATER" },
-		{ shaderSort_t::SS_WATER, "WATER" },
-		{ shaderSort_t::SS_FAR, "FAR" },
-		{ shaderSort_t::SS_MEDIUM, "MEDIUM" },
-		{ shaderSort_t::SS_CLOSE, "CLOSE" },
-		{ shaderSort_t::SS_BLEND0, "BLEND0" },
-		{ shaderSort_t::SS_BLEND1, "BLEND1" },
-		{ shaderSort_t::SS_BLEND2, "BLEND2" },
-		{ shaderSort_t::SS_BLEND3, "BLEND3" },
-		{ shaderSort_t::SS_BLEND6, "BLEND6" },
-		{ shaderSort_t::SS_ALMOST_NEAREST, "ALMOST_NEAREST" },
-		{ shaderSort_t::SS_NEAREST, "NEAREST" },
-		{ shaderSort_t::SS_POST_PROCESS, "POST_PROCESS" },
-	};
-
-	static const std::unordered_map<stageType_t, std::string> stageTypeName = {
-		{ stageType_t::ST_COLORMAP, "COLORMAP" },
-		{ stageType_t::ST_GLOWMAP, "GLOWMAP" },
-		{ stageType_t::ST_DIFFUSEMAP, "DIFFUSEMAP" },
-		{ stageType_t::ST_NORMALMAP, "NORMALMAP" },
-		{ stageType_t::ST_HEIGHTMAP, "HEIGHTMAP" },
-		{ stageType_t::ST_PHYSICALMAP, "PHYSICALMAP" },
-		{ stageType_t::ST_SPECULARMAP, "SPECULARMAP" },
-		{ stageType_t::ST_REFLECTIONMAP, "REFLECTIONMAP" },
-		{ stageType_t::ST_REFRACTIONMAP, "REFRACTIONMAP" },
-		{ stageType_t::ST_DISPERSIONMAP, "DISPERSIONMAP" },
-		{ stageType_t::ST_SKYBOXMAP, "SKYBOXMAP" },
-		{ stageType_t::ST_SCREENMAP, "SCREENMAP" },
-		{ stageType_t::ST_PORTALMAP, "PORTALMAP" },
-		{ stageType_t::ST_HEATHAZEMAP, "HEATHAZEMAP" },
-		{ stageType_t::ST_LIQUIDMAP, "LIQUIDMAP" },
-		{ stageType_t::ST_FOGMAP, "FOGMAP" },
-		{ stageType_t::ST_LIGHTMAP, "LIGHTMAP" },
-		{ stageType_t::ST_STYLELIGHTMAP, "STYLELIGHTMAP" },
-		{ stageType_t::ST_STYLECOLORMAP, "STYLECOLORMAP" },
-		{ stageType_t::ST_COLLAPSE_COLORMAP, "COLLAPSE_COLORMAP" },
-		{ stageType_t::ST_COLLAPSE_DIFFUSEMAP, "COLLAPSE_DIFFUSEMAP" },
-		{ stageType_t::ST_COLLAPSE_REFLECTIONMAP, "COLLAPSE_REFLECTIONMAP" },
-		{ stageType_t::ST_ATTENUATIONMAP_XY, "ATTENUATIONMAP_XY" },
-		{ stageType_t::ST_ATTENUATIONMAP_Z, "ATTENUATIONMAP_XZ" },
-	};
-
-	const char *prefix = ri.Cmd_Argc() > 1 ? ri.Cmd_Argv( 1 ) : nullptr;
-
-	// Header names
-	std::string num = "num";
-	std::string shaderType = "shaderType";
-	std::string shaderSort = "shaderSort";
-	std::string stageType = "stageType";
-	std::string interactLight = "interactLight";
-	std::string stageNumber = "stageNumber";
-	std::string shaderName = "shaderName";
-
-	// Number sizes
-	size_t numLen = 5;
-
-	// Header number sizes
-	numLen = std::max( numLen, num.length() );
-	size_t shaderTypeLen = shaderType.length();
-	size_t shaderSortLen = shaderSort.length();
-	size_t stageTypeLen = stageType.length();
-	size_t interactLightLen = interactLight.length();
-
-	// Value size
-	for ( const auto& kv : shaderTypeName )
+	void Run( const Cmd::Args &args ) const override
 	{
-		shaderTypeLen = std::max( shaderTypeLen, kv.second.length() );
-	}
+		static const std::unordered_map<shaderType_t, std::string> shaderTypeName = {
+			{ shaderType_t::SHADER_2D, "2D" },
+			{ shaderType_t::SHADER_3D_DYNAMIC, "3D_DYNAMIC" },
+			{ shaderType_t::SHADER_3D_STATIC, "3D_STATIC" },
+			{ shaderType_t::SHADER_LIGHT, "LIGHT" },
+		};
 
-	for ( const auto& kv : shaderSortName )
-	{
-		shaderSortLen = std::max( shaderSortLen, kv.second.length() );
-	}
+		static const std::unordered_map<shaderSort_t, std::string> shaderSortName = {
+			{ shaderSort_t::SS_BAD, "BAD" },
+			{ shaderSort_t::SS_PORTAL, "PORTAL" },
+			{ shaderSort_t::SS_DEPTH, "DEPTH" },
+			{ shaderSort_t::SS_ENVIRONMENT_FOG, "ENV_FOG" },
+			{ shaderSort_t::SS_ENVIRONMENT_NOFOG, "ENV_NOFOG" },
+			{ shaderSort_t::SS_OPAQUE, "OPAQUE" },
+			{ shaderSort_t::SS_DECAL, "DECAL" },
+			{ shaderSort_t::SS_SEE_THROUGH, "SEE_THROUGH" },
+			{ shaderSort_t::SS_BANNER, "BANNER" },
+			{ shaderSort_t::SS_FOG, "FOG" },
+			{ shaderSort_t::SS_UNDERWATER, "UNDERWATER" },
+			{ shaderSort_t::SS_WATER, "WATER" },
+			{ shaderSort_t::SS_FAR, "FAR" },
+			{ shaderSort_t::SS_MEDIUM, "MEDIUM" },
+			{ shaderSort_t::SS_CLOSE, "CLOSE" },
+			{ shaderSort_t::SS_BLEND0, "BLEND0" },
+			{ shaderSort_t::SS_BLEND1, "BLEND1" },
+			{ shaderSort_t::SS_BLEND2, "BLEND2" },
+			{ shaderSort_t::SS_BLEND3, "BLEND3" },
+			{ shaderSort_t::SS_BLEND6, "BLEND6" },
+			{ shaderSort_t::SS_ALMOST_NEAREST, "ALMOST_NEAREST" },
+			{ shaderSort_t::SS_NEAREST, "NEAREST" },
+			{ shaderSort_t::SS_POST_PROCESS, "POST_PROCESS" },
+		};
 
-	for ( const auto& kv : stageTypeName )
-	{
-		stageTypeLen = std::max( stageTypeLen, kv.second.length() );
-	}
+		static const std::unordered_map<stageType_t, std::string> stageTypeName = {
+			{ stageType_t::ST_COLORMAP, "COLORMAP" },
+			{ stageType_t::ST_GLOWMAP, "GLOWMAP" },
+			{ stageType_t::ST_DIFFUSEMAP, "DIFFUSEMAP" },
+			{ stageType_t::ST_NORMALMAP, "NORMALMAP" },
+			{ stageType_t::ST_HEIGHTMAP, "HEIGHTMAP" },
+			{ stageType_t::ST_PHYSICALMAP, "PHYSICALMAP" },
+			{ stageType_t::ST_SPECULARMAP, "SPECULARMAP" },
+			{ stageType_t::ST_REFLECTIONMAP, "REFLECTIONMAP" },
+			{ stageType_t::ST_REFRACTIONMAP, "REFRACTIONMAP" },
+			{ stageType_t::ST_DISPERSIONMAP, "DISPERSIONMAP" },
+			{ stageType_t::ST_SKYBOXMAP, "SKYBOXMAP" },
+			{ stageType_t::ST_SCREENMAP, "SCREENMAP" },
+			{ stageType_t::ST_PORTALMAP, "PORTALMAP" },
+			{ stageType_t::ST_HEATHAZEMAP, "HEATHAZEMAP" },
+			{ stageType_t::ST_LIQUIDMAP, "LIQUIDMAP" },
+			{ stageType_t::ST_FOGMAP, "FOGMAP" },
+			{ stageType_t::ST_LIGHTMAP, "LIGHTMAP" },
+			{ stageType_t::ST_STYLELIGHTMAP, "STYLELIGHTMAP" },
+			{ stageType_t::ST_STYLECOLORMAP, "STYLECOLORMAP" },
+			{ stageType_t::ST_COLLAPSE_COLORMAP, "COLLAPSE_COLORMAP" },
+			{ stageType_t::ST_COLLAPSE_DIFFUSEMAP, "COLLAPSE_DIFFUSEMAP" },
+			{ stageType_t::ST_COLLAPSE_REFLECTIONMAP, "COLLAPSE_REFLECTIONMAP" },
+			{ stageType_t::ST_ATTENUATIONMAP_XY, "ATTENUATIONMAP_XY" },
+			{ stageType_t::ST_ATTENUATIONMAP_Z, "ATTENUATIONMAP_XZ" },
+		};
 
-	std::string separator = " ";
-	std::stringstream lineStream;
+		const char *prefix = args.Argc() > 1 ? args.Argv( 1 ).c_str() : nullptr;
 
-	// Print header
-	lineStream << std::left;
-	lineStream << std::setw(numLen) << num << separator;
-	lineStream << std::setw(shaderTypeLen) << shaderType << separator;
-	lineStream << std::setw(shaderSortLen) << shaderSort << separator;
-	lineStream << std::setw(stageTypeLen) << stageType << separator;
-	lineStream << std::setw(interactLightLen) << interactLight << separator;
-	lineStream << stageNumber << ":" << shaderName;
+		// Header names
+		std::string num = "num";
+		std::string shaderType = "shaderType";
+		std::string shaderSort = "shaderSort";
+		std::string stageType = "stageType";
+		std::string interactLight = "interactLight";
+		std::string stageNumber = "stageNumber";
+		std::string shaderName = "shaderName";
 
-	std::string lineSeparator( lineStream.str().length(), '-' );
+		// Number sizes
+		size_t numLen = 5;
 
-	Log::CommandInteractionMessage( lineSeparator );
-	Log::CommandInteractionMessage( lineStream.str() );
-	Log::CommandInteractionMessage( lineSeparator );
+		// Header number sizes
+		numLen = std::max( numLen, num.length() );
+		size_t shaderTypeLen = shaderType.length();
+		size_t shaderSortLen = shaderSort.length();
+		size_t stageTypeLen = stageType.length();
+		size_t interactLightLen = interactLight.length();
 
-	size_t totalStageCount = 0;
-	size_t highestShaderStageCount = 0;
-
-	for ( int i = 0; i < tr.numShaders; i++ )
-	{
-		shader_t *shader = ri.Cmd_Argc() > 2 ? tr.sortedShaders[ i ] : tr.shaders[ i ];
-
-		// Only display shaders starting with prefix if prefix is not empty.
-		if ( prefix && !Com_Filter( prefix, shader->name, false ) )
+		// Value size
+		for ( const auto& kv : shaderTypeName )
 		{
-			continue;
+			shaderTypeLen = std::max( shaderTypeLen, kv.second.length() );
 		}
 
-		if ( !shaderTypeName.count( shader->type ) )
+		for ( const auto& kv : shaderSortName )
 		{
-			Log::Debug( "Undocumented shader type %i for shader %s",
-				Util::ordinal( shader->type ), shader->name );
-		}
-		else
-		{
-			shaderType = shaderTypeName.at( shader->type );
+			shaderSortLen = std::max( shaderSortLen, kv.second.length() );
 		}
 
-		if ( !shaderSortName.count( (shaderSort_t) shader->sort ) )
+		for ( const auto& kv : stageTypeName )
 		{
-			Log::Debug( "Undocumented shader sort %f for shader %s",
-				shader->sort, shader->name );
-		}
-		else
-		{
-			shaderSort = shaderSortName.at( (shaderSort_t) shader->sort );
+			stageTypeLen = std::max( stageTypeLen, kv.second.length() );
 		}
 
-		interactLight = shader->interactLight ? "INTERACTLIGHT" : "";
-		shaderName = shader->name;
-		shaderName += shader->defaultShader ? " (DEFAULTED)" : "";
+		std::string separator = " ";
+		std::stringstream lineStream;
 
-		if ( shader->stages == shader->lastStage )
+		// Print header
+		lineStream << std::left;
+		lineStream << std::setw(numLen) << num << separator;
+		lineStream << std::setw(shaderTypeLen) << shaderType << separator;
+		lineStream << std::setw(shaderSortLen) << shaderSort << separator;
+		lineStream << std::setw(stageTypeLen) << stageType << separator;
+		lineStream << std::setw(interactLightLen) << interactLight << separator;
+		lineStream << stageNumber << ":" << shaderName;
+
+		std::string lineSeparator( lineStream.str().length(), '-' );
+
+		Print( lineSeparator );
+		Print( lineStream.str() );
+		Print( lineSeparator );
+
+		size_t totalStageCount = 0;
+		size_t highestShaderStageCount = 0;
+
+		for ( int i = 0; i < tr.numShaders; i++ )
 		{
-			lineStream.clear();
-			lineStream.str("");
+			shader_t *shader = args.Argc() > 2 ? tr.sortedShaders[ i ] : tr.shaders[ i ];
 
-			lineStream << std::left;
-			lineStream << std::setw(numLen) << i << separator;
-			lineStream << std::setw(shaderTypeLen) << shaderType << separator;
-			lineStream << std::setw(shaderSortLen) << shaderSort << separator;
-			lineStream << std::setw(stageTypeLen) << stageType << separator;
-			lineStream << std::setw(interactLightLen) << interactLight << separator;
-			lineStream << "-:" << shaderName;
-
-			Log::CommandInteractionMessage( lineStream.str() );
-			continue;
-		}
-
-		const size_t stageCount = shader->lastStage - shader->stages;
-		totalStageCount += stageCount;
-		highestShaderStageCount = std::max( highestShaderStageCount, stageCount );
-
-		for ( size_t j = 0; j < stageCount; j++ )
-		{
-			shaderStage_t *stage = &shader->stages[ j ];
-
-			if ( !stageTypeName.count( stage->type ) )
+			// Only display shaders starting with prefix if prefix is not empty.
+			if ( prefix && !Com_Filter( prefix, shader->name, false ) )
 			{
-				Log::Debug( "Undocumented stage type %i for shader stage %s:%d",
-					Util::ordinal( stage->type ), shader->name, j );
+				continue;
+			}
+
+			if ( !shaderTypeName.count( shader->type ) )
+			{
+				Log::Debug( "Undocumented shader type %i for shader %s",
+					Util::ordinal( shader->type ), shader->name );
 			}
 			else
 			{
-				stageType = stageTypeName.at( stage->type );
+				shaderType = shaderTypeName.at( shader->type );
 			}
 
-			lineStream.clear();
-			lineStream.str("");
+			if ( !shaderSortName.count( (shaderSort_t) shader->sort ) )
+			{
+				Log::Debug( "Undocumented shader sort %f for shader %s",
+					shader->sort, shader->name );
+			}
+			else
+			{
+				shaderSort = shaderSortName.at( (shaderSort_t) shader->sort );
+			}
 
-			lineStream << std::left;
-			lineStream << std::setw(numLen) << i << separator;
-			lineStream << std::setw(shaderTypeLen) << shaderType << separator;
-			lineStream << std::setw(shaderSortLen) << shaderSort << separator;
-			lineStream << std::setw(stageTypeLen) << stageType << separator;
-			lineStream << std::setw(interactLightLen) << interactLight << separator;
-			lineStream << j << ":" << shaderName;
+			interactLight = shader->interactLight ? "INTERACTLIGHT" : "";
+			shaderName = shader->name;
+			shaderName += shader->defaultShader ? " (DEFAULTED)" : "";
 
-			Log::CommandInteractionMessage( lineStream.str() );
+			if ( shader->stages == shader->lastStage )
+			{
+				lineStream.clear();
+				lineStream.str("");
+
+				lineStream << std::left;
+				lineStream << std::setw(numLen) << i << separator;
+				lineStream << std::setw(shaderTypeLen) << shaderType << separator;
+				lineStream << std::setw(shaderSortLen) << shaderSort << separator;
+				lineStream << std::setw(stageTypeLen) << stageType << separator;
+				lineStream << std::setw(interactLightLen) << interactLight << separator;
+				lineStream << "-:" << shaderName;
+
+				Print( lineStream.str() );
+				continue;
+			}
+
+			const size_t stageCount = shader->lastStage - shader->stages;
+			totalStageCount += stageCount;
+			highestShaderStageCount = std::max( highestShaderStageCount, stageCount );
+
+			for ( size_t j = 0; j < stageCount; j++ )
+			{
+				shaderStage_t *stage = &shader->stages[ j ];
+
+				if ( !stageTypeName.count( stage->type ) )
+				{
+					Log::Debug( "Undocumented stage type %i for shader stage %s:%d",
+						Util::ordinal( stage->type ), shader->name, j );
+				}
+				else
+				{
+					stageType = stageTypeName.at( stage->type );
+				}
+
+				lineStream.clear();
+				lineStream.str("");
+
+				lineStream << std::left;
+				lineStream << std::setw(numLen) << i << separator;
+				lineStream << std::setw(shaderTypeLen) << shaderType << separator;
+				lineStream << std::setw(shaderSortLen) << shaderSort << separator;
+				lineStream << std::setw(stageTypeLen) << stageType << separator;
+				lineStream << std::setw(interactLightLen) << interactLight << separator;
+				lineStream << j << ":" << shaderName;
+
+				Print( lineStream.str() );
+			}
 		}
+
+		Print( lineSeparator );
+		Print( "%i total shaders, %i total stages, largest shader has %i stages",
+			tr.numShaders, totalStageCount, highestShaderStageCount );
+		Print( lineSeparator );
 	}
-
-	std::string summary = Str::Format(
-		"%i total shaders, %i total stages, largest shader has %i stages",
-		tr.numShaders, totalStageCount, highestShaderStageCount );
-
-	Log::CommandInteractionMessage( lineSeparator );
-	Log::CommandInteractionMessage( summary );
-	Log::CommandInteractionMessage( lineSeparator );
-}
+};
+static ListShadersCmd listShadersCmdRegistration;
 
 void R_ShaderExp_f()
 {

--- a/src/engine/renderer/tr_skin.cpp
+++ b/src/engine/renderer/tr_skin.cpp
@@ -327,29 +327,31 @@ skin_t         *R_GetSkinByHandle( qhandle_t hSkin )
 	return tr.skins[ hSkin ];
 }
 
-/*
-===============
-R_ListSkins_f
-===============
-*/
-void R_ListSkins_f()
+class ListSkinsCmd : public Cmd::StaticCmd
 {
-	int    i, j;
-	skin_t *skin;
+public:
+	ListSkinsCmd() : StaticCmd("listSkins", "list model skins") {}
 
-	Log::Notice("------------------" );
-
-	for ( i = 0; i < tr.numSkins; i++ )
+	void Run( const Cmd::Args & ) const override
 	{
-		skin = tr.skins[ i ];
+		int    i, j;
+		skin_t *skin;
 
-		Log::Notice("%3i:%s", i, skin->name );
+		Print("------------------" );
 
-		for ( j = 0; j < skin->numSurfaces; j++ )
+		for ( i = 0; i < tr.numSkins; i++ )
 		{
-			Log::Notice("       %s = %s", skin->surfaces[ j ]->name, skin->surfaces[ j ]->shader->name );
-		}
-	}
+			skin = tr.skins[ i ];
 
-	Log::Notice("------------------" );
-}
+			Print("%3i:%s", i, skin->name );
+
+			for ( j = 0; j < skin->numSurfaces; j++ )
+			{
+				Print("       %s = %s", skin->surfaces[ j ]->name, skin->surfaces[ j ]->shader->name );
+			}
+		}
+
+		Print("------------------" );
+	}
+};
+static ListSkinsCmd listSkinsCmdRegistration;

--- a/src/engine/server/sv_ccmds.cpp
+++ b/src/engine/server/sv_ccmds.cpp
@@ -451,6 +451,5 @@ void SV_RemoveOperatorCommands()
 	Cmd_RemoveCommand( "heartbeat" );
 	Cmd_RemoveCommand( "map_restart" );
 	Cmd_RemoveCommand( "serverinfo" );
-	Cmd_RemoveCommand( "status" );
 	Cmd_RemoveCommand( "systeminfo" );
 }

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -500,10 +500,9 @@ void GLimp_Shutdown()
 	ResetStruct( glState );
 }
 
-static void GLimp_Minimize()
-{
-	SDL_MinimizeWindow( window );
-}
+static Cmd::LambdaCmd minimizeCmd(
+	"minimize", "minimize the window",
+	[]( const Cmd::Args & ) { SDL_MinimizeWindow( window ); });
 
 static void SetSwapInterval( int swapInterval )
 {
@@ -2654,8 +2653,6 @@ bool GLimp_Init()
 	Cvar::Latch( workaround_glDriver_nvidia_v340_disableTextureGather );
 	Cvar::Latch( workaround_glExtension_missingArbFbo_useExtFbo );
 	Cvar::Latch( workaround_glHardware_intel_useFirstProvokinVertex );
-
-	ri.Cmd_AddCommand( "minimize", GLimp_Minimize );
 
 	/* Enable S3TC on Mesa even if libtxc-dxtn is not available
 	The environment variables is currently always set,


### PR DESCRIPTION
Migrate commands to the new interface. That has the benefit of show descriptions for the commands, and using `Print` so that the output is not affected by log suppression.

Most of the diffs are indentation changes, so you might like to review it as follows:
```
git fetch origin pull/1494/head
git show -4 FETCH_HEAD --ignore-space-change
```