### PR TITLE
cmake: do not use space in compiler string definition, it is not compatible with the standalone MinGW for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,9 +363,8 @@ function(ADD_PRECOMPILED_HEADER Target)
     set(Header ${COMMON_DIR}/Common.h)
 
     # Compiler-specific PCH support
-    try_c_cxx_flag(PCH "-pch")
-
-    if (PCH)
+    if ((DAEMON_CXX_COMPILER_GCC_COMPATIBILITY OR DAEMON_CXX_COMPILER_Clang_COMPATIBILITY)
+    AND NOT DAEMON_CXX_COMPILER_ICC)
         # CMAKE_CXX_COMPILER_ARG1 is used with compilers using subcommands.
         # For example when doing: cmake -D'CMAKE_CXX_COMPILER'='zig;c++'
         # CMAKE_CXX_COMPILER will be "zig",
@@ -381,10 +380,11 @@ function(ADD_PRECOMPILED_HEADER Target)
         add_dependencies(${Target} ${Target}-pch)
 
         # PNaCl clang doesn't support -include-pch properly
-        if (DAEMON_CXX_COMPILER_NAME STREQUAL "PNaCl")
-            set_property(TARGET ${Target} APPEND PROPERTY COMPILE_OPTIONS "-include;${OBJ_DIR}/${Target}.h;-Winvalid-pch")
-        else()
+        if (DAEMON_CXX_COMPILER_Clang_COMPATIBILITY
+        AND NOT DAEMON_CXX_COMPILER_PNaCl)
             set_property(TARGET ${Target} APPEND PROPERTY COMPILE_OPTIONS "-include-pch;${OBJ_DIR}/${Target}.h.gch")
+        else()
+            set_property(TARGET ${Target} APPEND PROPERTY COMPILE_OPTIONS "-include;${OBJ_DIR}/${Target}.h;-Winvalid-pch")
         endif()
     elseif (MSVC)
         # /Fp sets the PCH path used by either of the /Yc and /Yu options.

--- a/cmake/DaemonCompiler.cmake
+++ b/cmake/DaemonCompiler.cmake
@@ -194,7 +194,7 @@ foreach(lang C;CXX)
 		if (DAEMON_${lang}_COMPILER_Clang_COMPATIBILITY)
 			if (NOT DAEMON_${lang}_COMPILER_NAME STREQUAL "Clang")
 				set(DAEMON_${lang}_COMPILER_EXTENDED_VERSION
-					"${DAEMON_${lang}_COMPILER_VERSION}/clang-${DAEMON_${lang}_COMPILER_Clang_VERSION}")
+					"${DAEMON_${lang}_COMPILER_VERSION}/Clang_${DAEMON_${lang}_COMPILER_Clang_VERSION}")
 			endif()
 		elseif (DAEMON_${lang}_COMPILER_GCC_COMPATIBILITY)
 			if (NOT DAEMON_${lang}_COMPILER_NAME STREQUAL "GCC")
@@ -213,7 +213,7 @@ foreach(lang C;CXX)
 					# GCC we are looking for.
 					if ("${CUSTOM_${lang}_GCC_OUTPUT}" MATCHES "\ngcc version ")
 						set(DAEMON_${lang}_COMPILER_EXTENDED_VERSION
-							"${DAEMON_${lang}_COMPILER_VERSION}/gcc-${DAEMON_${lang}_COMPILER_GCC_VERSION}")
+							"${DAEMON_${lang}_COMPILER_VERSION}/GCC_${DAEMON_${lang}_COMPILER_GCC_VERSION}")
 					endif()
 				endif()
 			endif()
@@ -225,11 +225,17 @@ foreach(lang C;CXX)
 	endif()
 
 	set(DAEMON_${lang}_COMPILER_STRING
-		"${DAEMON_${lang}_COMPILER_NAME} ${DAEMON_${lang}_COMPILER_EXTENDED_VERSION} ${DAEMON_${lang}_COMPILER_BASENAME}")
+		"${DAEMON_${lang}_COMPILER_NAME}_${DAEMON_${lang}_COMPILER_EXTENDED_VERSION}:${DAEMON_${lang}_COMPILER_BASENAME}")
+
+	if (CMAKE_CXX_COMPILER_ARG1)
+		set(DAEMON_${lang}_COMPILER_STRING "${DAEMON_${lang}_COMPILER_STRING}:${CMAKE_CXX_COMPILER_ARG1}")
+	endif()
 
 	message(STATUS "Detected ${${lang}_NAME} compiler: ${DAEMON_${lang}_COMPILER_STRING}")
 
-	add_definitions(-DDAEMON_${lang}_COMPILER_${DAEMON_${lang}_COMPILER_NAME}=1)
+	set(compiler_var_name "DAEMON_${lang}_COMPILER_${DAEMON_${lang}_COMPILER_NAME}")
+	set(${compiler_var_name} ON)
+	add_definitions(-D${compiler_var_name}=1)
 
 	# Preprocessor definitions containing '#' may not be passed on the compiler
 	# command line because many compilers do not support it.

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -438,9 +438,9 @@ elseif (NOT NACL)
 
 	if (ARCH STREQUAL "amd64")
 		# K8 or EM64T minimum: AMD Athlon 64 ClawHammer, Intel Xeon Nocona, Intel Pentium 4 model F (Prescott revision EO), VIA Nano.
-		if ("${DAEMON_CXX_COMPILER_NAME}" STREQUAL "ICC")
+		if (DAEMON_CXX_COMPILER_ICC)
 			set(GCC_GENERIC_ARCH "pentium4")
-		elseif ("${DAEMON_CXX_COMPILER_NAME}" STREQUAL "Zig")
+		elseif (DAEMON_CXX_COMPILER_Zig)
 			set(GCC_GENERIC_ARCH "x86_64")
 		else()
 			set(GCC_GENERIC_ARCH "x86-64")


### PR DESCRIPTION
Do not use space in compiler string definition, it is not compatible with the standalone MinGW for Windows.

Fix #1497:

- https://github.com/DaemonEngine/Daemon/pull/1497