### PR TITLE
identify the game by its name in SDL

### DIFF
--- a/src/engine/client/ClientApplication.cpp
+++ b/src/engine/client/ClientApplication.cpp
@@ -85,6 +85,20 @@ class ClientApplication : public Application {
             // Don't set this for TTY applications as they really aren't DPI aware. Let them scale.
             SDL_SetHint(SDL_HINT_WINDOWS_DPI_AWARENESS, "system");
 #endif
+
+#if defined(__linux__) && defined(BUILD_GRAPHICAL_CLIENT)
+            // identify the game by its name in certain
+            // volume control / power control applets,
+            // for example, the one found on KDE:
+            // "Unvanquished is currently blocking sleep."
+            // instead of "My SDL application ..."
+            // this feature was introduced in SDL 2.0.22
+            SDL_SetHint("SDL_APP_NAME", PRODUCT_NAME);
+            // SDL_hints.h: #define SDL_HINT_APP_NAME "SDL_APP_NAME"
+            // don't use the macro here, in case
+            // SDL doesn't use current headers.
+#endif
+
             Hunk_Init();
 
             Com_Init();


### PR DESCRIPTION
The comment in the code is pretty self explanatory. This has been tested on KDE only. 

Screenshots demonstrating what this fixes are below. I do not believe this has any effect on macOS or Windows, documentation suggests this relates to dbus. Hopefully I have done this correctly.

Documentation here:
https://discourse.libsdl.org/t/sdl-add-sdl-hint-app-name-and-dbus-inhibition-hint/32698
https://wiki.libsdl.org/SDL2/SDL_HINT_APP_NAME

OLD:
![old](https://github.com/user-attachments/assets/a1c4d4e6-f13f-4af7-a26e-45d197921471)

NEW:
![new](https://github.com/user-attachments/assets/e3a7da1b-06ce-40d6-af6e-18916eac0d63)
