### PR TITLE
DaemonCompiler: do not omit main parameter name in C

### DIFF
--- a/cmake/DaemonCompiler/DaemonCompiler.c
+++ b/cmake/DaemonCompiler/DaemonCompiler.c
@@ -160,6 +160,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 // Make the compilation succeeds if architecture is supported.
-int main(int, char**) {
+int main(int argc, char** argv) {
 	return 0;
 }


### PR DESCRIPTION
Do not omit main parameter name in C.

Fixes #1505:

- https://github.com/DaemonEngine/Daemon/issues/1505

This produced those errors:

```
../../daemon/cmake/DaemonCompiler/DaemonCompiler.c:163:13: error: parameter name omitted
int main(int, char**) {
            ^
../../daemon/cmake/DaemonCompiler/DaemonCompiler.c:163:21: error: parameter name omitted
int main(int, char**) {
                    ^
7 warnings and 2 errors generated.
```

Actually my first implementation of parsing the output of `cc -dM -E` could not be subject to that (no compilation was involved at all).