### PR TITLE
Fix glsl_restart with material system

### DIFF
--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -93,6 +93,10 @@ struct Material {
 	GLuint program = 0;
 	GLShader* shader;
 
+	// Used only for glsl_restart
+	shaderStage_t* refStage;
+	drawSurf_t refDrawSurf;
+
 	int deformIndex;
 	bool tcGenEnvironment;
 	bool tcGen_Lightmap;
@@ -368,6 +372,8 @@ class MaterialSystem {
 	void GenerateTexturesBuffer( std::vector<TextureData>& textures, TexBundle* textureBundles );
 
 	void AddAllWorldSurfaces();
+
+	void GLSLRestart();
 
 	void Free();
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1128,6 +1128,12 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 					stage->deformIndex = deformIndex;
 				}
 			}
+
+			if ( glConfig2.usingMaterialSystem ) {
+				/* GLSL shaders linked to materials will be invalidated by glsl_restart,
+				so we need to reset them here */
+				materialSystem.GLSLRestart();
+			}
 		}
 	};
 	static GlslRestartCmd glslRestartCmdRegistration;


### PR DESCRIPTION
Fixes `glsl_restart` with material system by resetting the shaders for each material.