### PR TITLE
Set engine command flags

### DIFF
--- a/src/common/Command.cpp
+++ b/src/common/Command.cpp
@@ -493,11 +493,13 @@ namespace Cmd {
         return *Cmd::GetEnv();
     }
 
+#ifndef BUILD_ENGINE
     StaticCmd::StaticCmd(std::string name, std::string description)
     :CmdBase(0){
         //Register this command statically
         AddCommand(std::move(name), *this, std::move(description));
     }
+#endif
 
     StaticCmd::StaticCmd(std::string name, const int flags, std::string description)
     :CmdBase(flags){
@@ -509,9 +511,11 @@ namespace Cmd {
         return {};
     }
 
+#ifndef BUILD_ENGINE
     LambdaCmd::LambdaCmd(std::string name, std::string description, RunFn run, CompleteFn complete)
     :StaticCmd(std::move(name), std::move(description)), run(run), complete(complete) {
     }
+#endif
     LambdaCmd::LambdaCmd(std::string name, int flags, std::string description, RunFn run, CompleteFn complete)
     :StaticCmd(std::move(name), flags, std::move(description)), run(run), complete(complete) {
     }
@@ -528,7 +532,7 @@ class InjectFaultCmd : public Cmd::StaticCmd
 {
 public:
     InjectFaultCmd() : StaticCmd(
-        VM_STRING_PREFIX "injectFault", "make the program error and crash") {}
+        VM_STRING_PREFIX "injectFault", Cmd::BASE, "make the program error and crash") {}
 
     void Run(const Cmd::Args& args) const override
     {

--- a/src/common/Command.h
+++ b/src/common/Command.h
@@ -41,15 +41,18 @@ namespace Cmd {
      * mass removal of commands.
      */
     enum {
-        BASE             = BIT(0),
-        CVAR             = BIT(1),
-        ALIAS            = BIT(2),
-        SYSTEM           = BIT(3),
-        RENDERER         = BIT(4),
-        AUDIO            = BIT(5),
-        SGAME_VM         = BIT(6),
-        CGAME_VM         = BIT(7),
-        KEY_BINDING      = BIT(8),
+        BASE             = BIT(0), // anything in the dummy app?
+        SERVER           = BIT(1),
+        CLIENT           = BIT(2), // client stuff other than renderer, audio, keys
+        RENDERER         = BIT(3),
+        AUDIO            = BIT(4),
+        KEY_BINDING      = BIT(5),
+
+        // ones you should not use when defining a StaticCmd
+        SGAME_VM         = BIT(27),
+        CGAME_VM         = BIT(28),
+        CVAR             = BIT(29), // auto-generated cvar show/set command
+        ALIAS            = BIT(30),
         PROXY_FOR_OLD    = BIT(31) // OLD: The command has been registered through the proxy function in cmd.c
     };
 
@@ -154,14 +157,19 @@ namespace Cmd {
      * instanciated and removes it when it is destroyed. A typical usage is
      *
      *  class MyCmd : public Cmd::StaticCmd {
-     *      MyCmd() : Cmd::StaticCmd("my_command", NAMESPACE, "my_description"){}
+     *      MyCmd() : Cmd::StaticCmd("my_command", Cmd::NAMESPACE, "my_description"){}
      *      //Other stuff
      *  };
      *  static MyCmd MyCmdRegistration;
+     *
+     * The 'namespace' flag(s) is mandatory in the engine (so that the command will appear
+     * in /listCmds),  but ignored in the gamelogic (there they automatically get [CS]GAME_VM).
      */
     class StaticCmd : public CmdBase {
         protected:
+#ifndef BUILD_ENGINE
             StaticCmd(std::string name, std::string description);
+#endif
             StaticCmd(std::string name, int flags, std::string description);
     };
 
@@ -180,7 +188,9 @@ namespace Cmd {
         public:
             using RunFn = std::function<void(const Args&)>;
             using CompleteFn = std::function<CompletionResult(int, const Args&, Str::StringRef)>;
+#ifndef BUILD_ENGINE
             LambdaCmd(std::string name, std::string description, RunFn run, CompleteFn complete = NoopComplete);
+#endif
             LambdaCmd(std::string name, int flags, std::string description, RunFn run, CompleteFn complete = NoopComplete);
 
             void Run(const Args& args) const override;

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -292,7 +292,7 @@ class DemoRecordStopCmd: public Cmd::StaticCmd
 {
 public:
     DemoRecordStopCmd()
-        : Cmd::StaticCmd("demo_record_stop", Cmd::SYSTEM, "Stops recording a demo")
+        : Cmd::StaticCmd("demo_record_stop", Cmd::CLIENT, "Stops recording a demo")
     {}
 
     void Run(const Cmd::Args&) const override
@@ -312,7 +312,7 @@ class DemoRecordCmd : public Cmd::StaticCmd
 {
 public:
     DemoRecordCmd()
-        : Cmd::StaticCmd("demo_record", Cmd::SYSTEM, "Begins recording a demo from the current position")
+        : Cmd::StaticCmd("demo_record", Cmd::CLIENT, "Begins recording a demo from the current position")
     {}
 
     void Run(const Cmd::Args& args) const override
@@ -562,7 +562,7 @@ void CL_ReadDemoMessage()
 
 class DemoPlayCmd: public Cmd::StaticCmd {
     public:
-        DemoPlayCmd(): Cmd::StaticCmd("demo_play", Cmd::SYSTEM, "Starts playing a demo file") {
+        DemoPlayCmd(): Cmd::StaticCmd("demo_play", Cmd::CLIENT, "Starts playing a demo file") {
         }
 
         void Run(const Cmd::Args& args) const override {
@@ -1223,7 +1223,7 @@ class RconCmd: public Cmd::StaticCmd
 {
 public:
 	RconCmd():
-		StaticCmd("rcon", Cmd::SYSTEM, "Sends a remote console command")
+		StaticCmd("rcon", Cmd::CLIENT, "Sends a remote console command")
 	{}
 
 	void Run(const Cmd::Args& args) const override
@@ -1287,7 +1287,7 @@ class RconDiscoverCmd: public Cmd::StaticCmd
 {
 public:
 	RconDiscoverCmd():
-		StaticCmd("rconDiscover", Cmd::SYSTEM, "Sends a request to the server to populate rcon.client cvars")
+		StaticCmd("rconDiscover", Cmd::CLIENT, "Sends a request to the server to populate rcon.client cvars")
 	{}
 
 	void Run(const Cmd::Args&) const override
@@ -1528,7 +1528,7 @@ class DemoVideoCmd: public Cmd::StaticCmd
 {
 public:
     DemoVideoCmd()
-        : Cmd::StaticCmd("demo_video", Cmd::SYSTEM,
+        : Cmd::StaticCmd("demo_video", Cmd::CLIENT,
                          "Begins recording a video from the current demo")
     {}
 
@@ -1586,7 +1586,7 @@ class DemoStopVideoCmd: public Cmd::StaticCmd
 {
 public:
     DemoStopVideoCmd()
-        : Cmd::StaticCmd("demo_video_stop", Cmd::SYSTEM, "Stops recording a video")
+        : Cmd::StaticCmd("demo_video_stop", Cmd::CLIENT, "Stops recording a video")
     {}
 
     void Run(const Cmd::Args&) const override

--- a/src/engine/framework/BaseCommands.cpp
+++ b/src/engine/framework/BaseCommands.cpp
@@ -1010,7 +1010,7 @@ namespace Cmd {
 
     class ShowFPSCommand : public Cmd::StaticCmd {
     public:
-        ShowFPSCommand() : StaticCmd("showfps", "prints engine frame rate") {}
+        ShowFPSCommand() : StaticCmd("showfps", Cmd::BASE, "prints engine frame rate") {}
 
         void Run(const Cmd::Args&) const override {
             Print("FPS: %.1f", Application::GetFPS());

--- a/src/engine/framework/CommandSystem.cpp
+++ b/src/engine/framework/CommandSystem.cpp
@@ -351,12 +351,11 @@ namespace Cmd {
             void Run(const Cmd::Args& args) const override {
                 CommandMap& commands = GetCommandMap();
 
-                std::vector<const commandRecord_t*> matches;
-                std::vector<const std::string*> matchesNames;
+                std::vector<CommandMap::const_iterator> matches;
                 unsigned long maxNameLength = 0;
 
                 //Find all the matching commands and their names
-                for (auto it = commands.cbegin(); it != commands.cend(); ++it) {
+                for (CommandMap::const_iterator it = commands.cbegin(); it != commands.cend(); ++it) {
                     const commandRecord_t& record = it->second;
 
                     // /listCmds's argument is used for prefix matching
@@ -365,16 +364,19 @@ namespace Cmd {
                     }
 
                     if (record.cmd->GetFlags() & showCmdFlags) {
-                        matches.push_back(&it->second);
-                        matchesNames.push_back(&it->first);
+                        matches.push_back(it);
                         maxNameLength = std::max<size_t>(maxNameLength, it->first.size());
                     }
                 }
 
+                // TODO: case insensitive compare function?
+                std::sort(matches.begin(), matches.end(),
+                    [](CommandMap::const_iterator a, CommandMap::const_iterator b) { return a->first < b->first; });
+
                 //Print the matches, keeping the description aligned
-                for (unsigned i = 0; i < matches.size(); i++) {
-                    int toFill = maxNameLength - matchesNames[i]->size();
-                    Print("  %s%s %s", matchesNames[i]->c_str(), std::string(toFill, ' ').c_str(), matches[i]->description.c_str());
+                for (CommandMap::const_iterator it : matches) {
+                    int toFill = maxNameLength - it->first.size();
+                    Print("  %s%s %s", it->first, std::string(toFill, ' '), it->second.description);
                 }
 
                 Print("%zu commands", matches.size());

--- a/src/engine/framework/CommandSystem.cpp
+++ b/src/engine/framework/CommandSystem.cpp
@@ -396,11 +396,12 @@ namespace Cmd {
 
     static ListCmdsCmd listCmdsRegistration("listCmds", BASE, "lists all the commands", ~(CVAR|ALIAS));
     static ListCmdsCmd listBaseCmdsRegistration("listBaseCmds", BASE, "lists all the base commands", BASE);
-    static ListCmdsCmd listSystemCmdsRegistration("listSystemCmds", BASE | SYSTEM, "lists all the system commands", SYSTEM);
+    static ListCmdsCmd listServerCmdsRegistration("listServerCmds", BASE | SERVER, "lists all the server commands", SERVER);
+    static ListCmdsCmd listClientCmdsRegistration("listClientCmds", BASE | CLIENT, "lists all the client commands", CLIENT | RENDERER | AUDIO | KEY_BINDING);
     static ListCmdsCmd listRendererCmdsRegistration("listRendererCmds", BASE | RENDERER, "lists all the renderer commands", RENDERER);
     static ListCmdsCmd listAudioCmdsRegistration("listAudioCmds", BASE | AUDIO, "lists all the audio commands", AUDIO);
-    static ListCmdsCmd listCGameCmdsRegistration("listCGameCmds", BASE | CGAME_VM, "lists all the client-side game commands", CGAME_VM);
-    static ListCmdsCmd listGameCmdsRegistration("listSGameCmds", BASE | SGAME_VM, "lists all the server-side game commands", CGAME_VM);
     static ListCmdsCmd listKeyCmdsRegistration("listKeyBindingCmds", BASE | KEY_BINDING, "lists all the key binding commands", KEY_BINDING);
+    static ListCmdsCmd listCGameCmdsRegistration("listCGameCmds", BASE, "lists all the client-side game commands", CGAME_VM);
+    static ListCmdsCmd listGameCmdsRegistration("listSGameCmds", BASE, "lists all the server-side game commands", SGAME_VM);
     static ListCmdsCmd listOldStyleCmdsRegistration("listOldStyleCmds", BASE, "lists all the commands registered through the C interface", PROXY_FOR_OLD);
 }

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -766,7 +766,7 @@ bool FS_ComparePaks(char* neededpaks, int len)
 class WhichCmd: public Cmd::StaticCmd {
 public:
 	WhichCmd()
-		: Cmd::StaticCmd("which", Cmd::SYSTEM, "shows which pak a file is in") {}
+		: Cmd::StaticCmd("which", Cmd::BASE, "shows which pak a file is in") {}
 
 	void Run(const Cmd::Args& args) const override
 	{
@@ -797,7 +797,7 @@ static WhichCmd WhichCmdRegistration;
 class ListPathsCmd: public Cmd::StaticCmd {
 public:
 	ListPathsCmd()
-		: Cmd::StaticCmd("listPaths", Cmd::SYSTEM, "list filesystem search paths") {}
+		: Cmd::StaticCmd("listPaths", Cmd::BASE, "list filesystem search paths") {}
 
 	void Run(const Cmd::Args&) const override
 	{
@@ -810,7 +810,7 @@ static ListPathsCmd ListPathsCmdRegistration;
 
 class DirCmd: public Cmd::StaticCmd {
 public:
-	DirCmd(): Cmd::StaticCmd("dir", Cmd::SYSTEM, "list all files in a given directory with the option to pass a filter") {}
+	DirCmd(): Cmd::StaticCmd("dir", Cmd::BASE, "list all files in a given directory with the option to pass a filter") {}
 
 	void Run(const Cmd::Args& args) const override
 	{

--- a/src/engine/renderer/tr_animation.cpp
+++ b/src/engine/renderer/tr_animation.cpp
@@ -584,7 +584,8 @@ skelAnimation_t *R_GetAnimationByHandle( qhandle_t index )
 class ListAnimationsCmd : public Cmd::StaticCmd
 {
 public:
-	ListAnimationsCmd() : StaticCmd("listAnimations", "list model animations loaded in renderer") {}
+	ListAnimationsCmd() : StaticCmd(
+		"listAnimations", Cmd::RENDERER, "list model animations loaded in renderer") {}
 
 	void Run( const Cmd::Args & ) const override
 	{

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -5030,7 +5030,7 @@ void R_BuildCubeMaps()
 }
 
 static Cmd::LambdaCmd buildCubeMapsCmd(
-	"buildcubemaps", "generate cube probes for reflection mapping",
+	"buildcubemaps", Cmd::RENDERER, "generate cube probes for reflection mapping",
 	[]( const Cmd::Args & ) { R_BuildCubeMaps(); });
 
 /*

--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -594,7 +594,7 @@ void R_ShutdownFBOs()
 class ListFBOsCmd : public Cmd::StaticCmd
 {
 public:
-	ListFBOsCmd() : StaticCmd("listFBOs", "list renderer's OpenGL framebuffer objects") {}
+	ListFBOsCmd() : StaticCmd("listFBOs", Cmd::RENDERER, "list renderer's OpenGL framebuffer objects") {}
 
 	void Run( const Cmd::Args & ) const override
 	{

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -140,7 +140,7 @@ void GL_TextureMode( const char *string )
 class ListImagesCmd : public Cmd::StaticCmd
 {
 public:
-	ListImagesCmd() : StaticCmd("listImages", "list images loaded in renderer") {}
+	ListImagesCmd() : StaticCmd("listImages", Cmd::RENDERER, "list images loaded in renderer") {}
 
 	void Run( const Cmd::Args &args ) const override
 	{

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -525,7 +525,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	class ListModesCmd : public Cmd::StaticCmd
 	{
 	public:
-		ListModesCmd() : StaticCmd("listModes", "list suggested screen/window dimensions") {}
+		ListModesCmd() : StaticCmd("listModes", Cmd::RENDERER, "list suggested screen/window dimensions") {}
 		void Run( const Cmd::Args& ) const override
 		{
 			int i;
@@ -1085,14 +1085,14 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 	// FIXME: uses regular logging not Print()
 	static Cmd::LambdaCmd gfxInfoCmd(
-		"gfxinfo", "dump graphics driver and configuration info",
+		"gfxinfo", Cmd::RENDERER, "dump graphics driver and configuration info",
 		[]( const Cmd::Args & ) { GfxInfo_f(); });
 
 	class GlslRestartCmd : public Cmd::StaticCmd
 	{
 	public:
 		GlslRestartCmd() : StaticCmd(
-			"glsl_restart", "recompile GLSL shaders (useful when shaderpath is set)") {}
+			"glsl_restart", Cmd::RENDERER, "recompile GLSL shaders (useful when shaderpath is set)") {}
 
 		void Run( const Cmd::Args & ) const override
 		{

--- a/src/engine/renderer/tr_model.cpp
+++ b/src/engine/renderer/tr_model.cpp
@@ -309,7 +309,7 @@ void R_ModelInit()
 class ListModelsCmd : public Cmd::StaticCmd
 {
 public:
-	ListModelsCmd() : StaticCmd("listModels", "list loaded 3D models") {}
+	ListModelsCmd() : StaticCmd("listModels", Cmd::RENDERER, "list loaded 3D models") {}
 
 	void Run( const Cmd::Args &args ) const override
 	{

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6641,7 +6641,8 @@ A second parameter will cause it to print in sorted order
 class ListShadersCmd : public Cmd::StaticCmd
 {
 public:
-	ListShadersCmd() : StaticCmd("listShaders", "list q3shaders currently registered in the renderer") {}
+	ListShadersCmd() : StaticCmd(
+		"listShaders", Cmd::RENDERER, "list q3shaders currently registered in the renderer") {}
 
 	void Run( const Cmd::Args &args ) const override
 	{
@@ -6858,7 +6859,8 @@ static ListShadersCmd listShadersCmdRegistration;
 class ShaderExpCmd : public Cmd::StaticCmd
 {
 public:
-	ShaderExpCmd() : StaticCmd("shaderexp", "evaluate a q3shader expression (RB_EvalExpression)") {}
+	ShaderExpCmd() : StaticCmd(
+		"shaderexp", Cmd::RENDERER, "evaluate a q3shader expression (RB_EvalExpression)") {}
 
 	void Run( const Cmd::Args &args ) const override
 	{

--- a/src/engine/renderer/tr_skin.cpp
+++ b/src/engine/renderer/tr_skin.cpp
@@ -330,7 +330,7 @@ skin_t         *R_GetSkinByHandle( qhandle_t hSkin )
 class ListSkinsCmd : public Cmd::StaticCmd
 {
 public:
-	ListSkinsCmd() : StaticCmd("listSkins", "list model skins") {}
+	ListSkinsCmd() : StaticCmd("listSkins", Cmd::RENDERER, "list model skins") {}
 
 	void Run( const Cmd::Args & ) const override
 	{

--- a/src/engine/server/sv_ccmds.cpp
+++ b/src/engine/server/sv_ccmds.cpp
@@ -47,7 +47,7 @@ These commands can only be entered from stdin or by a remote operator datagram
 class MapCmd: public Cmd::StaticCmd {
     public:
         MapCmd(Str::StringRef name, Str::StringRef description, bool cheat):
-            Cmd::StaticCmd(name, Cmd::SYSTEM, description), cheat(cheat) {
+            Cmd::StaticCmd(name, Cmd::SERVER, description), cheat(cheat) {
         }
 
         void Run(const Cmd::Args& args) const override {
@@ -255,7 +255,7 @@ class StatusCmd: public Cmd::StaticCmd
 {
 public:
 	StatusCmd():
-		StaticCmd("status", Cmd::SYSTEM, "Shows a table with server and player information")
+		StaticCmd("status", Cmd::SERVER, "Shows a table with server and player information")
 	{}
 
 	void Run(const Cmd::Args&) const override
@@ -402,7 +402,7 @@ class ListMapsCmd: public Cmd::StaticCmd
 {
 public:
 	ListMapsCmd():
-		StaticCmd("listmaps", Cmd::SYSTEM, "Lists all maps available to the server")
+		StaticCmd("listmaps", Cmd::SERVER, "Lists all maps available to the server")
 	{}
 
 	void Run(const Cmd::Args&) const override

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -501,7 +501,7 @@ void GLimp_Shutdown()
 }
 
 static Cmd::LambdaCmd minimizeCmd(
-	"minimize", "minimize the window",
+	"minimize", Cmd::CLIENT, "minimize the window",
 	[]( const Cmd::Args & ) { SDL_MinimizeWindow( window ); });
 
 static void SetSwapInterval( int swapInterval )


### PR DESCRIPTION
As @VReaperV discovered while reviewing #1494, `listCmds` can't list a command if it has no flags defined. Fix this by defining flags for all the engine commands and disabling the constructor that doesn't define flags.