### PR TITLE
Clean-up GLBuffer interface, use DSA

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -37,18 +37,18 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Material.h"
 #include "ShadeCommon.h"
 
-GLUBO materialsUBO( "materials", 6, GL_MAP_WRITE_BIT, GL_MAP_INVALIDATE_RANGE_BIT );
-GLBuffer texDataBuffer( "texData", 7, GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
-GLUBO lightMapDataUBO( "lightMapData", 8, GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
+GLUBO materialsUBO( "materials", Util::ordinal( BufferBind::MATERIALS ), GL_MAP_WRITE_BIT, GL_MAP_INVALIDATE_RANGE_BIT );
+GLBuffer texDataBuffer( "texData", Util::ordinal( BufferBind::TEX_DATA ), GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
+GLUBO lightMapDataUBO( "lightMapData", Util::ordinal( BufferBind::LIGHTMAP_DATA ), GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
 
-GLSSBO surfaceDescriptorsSSBO( "surfaceDescriptors", 1, GL_MAP_WRITE_BIT, GL_MAP_INVALIDATE_RANGE_BIT );
-GLSSBO surfaceCommandsSSBO( "surfaceCommands", 2, GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
-GLBuffer culledCommandsBuffer( "culledCommands", 3, GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
-GLUBO surfaceBatchesUBO( "surfaceBatches", 0, GL_MAP_WRITE_BIT, GL_MAP_INVALIDATE_RANGE_BIT );
-GLBuffer atomicCommandCountersBuffer( "atomicCommandCounters", 4, GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
-GLSSBO portalSurfacesSSBO( "portalSurfaces", 5, GL_MAP_READ_BIT | GL_MAP_PERSISTENT_BIT, 0 );
+GLSSBO surfaceDescriptorsSSBO( "surfaceDescriptors", Util::ordinal( BufferBind::SURFACE_DESCRIPTORS ), GL_MAP_WRITE_BIT, GL_MAP_INVALIDATE_RANGE_BIT );
+GLSSBO surfaceCommandsSSBO( "surfaceCommands", Util::ordinal( BufferBind::SURFACE_COMMANDS ), GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
+GLBuffer culledCommandsBuffer( "culledCommands", Util::ordinal( BufferBind::CULLED_COMMANDS ), GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
+GLUBO surfaceBatchesUBO( "surfaceBatches", Util::ordinal( BufferBind::SURFACE_BATCHES ), GL_MAP_WRITE_BIT, GL_MAP_INVALIDATE_RANGE_BIT );
+GLBuffer atomicCommandCountersBuffer( "atomicCommandCounters", Util::ordinal( BufferBind::COMMAND_COUNTERS_ATOMIC ), GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
+GLSSBO portalSurfacesSSBO( "portalSurfaces", Util::ordinal( BufferBind::PORTAL_SURFACES ), GL_MAP_READ_BIT | GL_MAP_PERSISTENT_BIT, 0 );
 
-GLSSBO debugSSBO( "debug", 10, GL_MAP_WRITE_BIT, GL_MAP_INVALIDATE_RANGE_BIT );
+GLSSBO debugSSBO( "debug", Util::ordinal( BufferBind::DEBUG ), GL_MAP_WRITE_BIT, GL_MAP_INVALIDATE_RANGE_BIT );
 
 PortalView portalStack[MAX_VIEWS];
 
@@ -1593,11 +1593,11 @@ void MaterialSystem::UpdateDynamicSurfaces() {
 }
 
 void MaterialSystem::UpdateFrameData() {
-	atomicCommandCountersBuffer.BindBufferBase( GL_SHADER_STORAGE_BUFFER );
+	atomicCommandCountersBuffer.BindBufferBase( GL_SHADER_STORAGE_BUFFER, Util::ordinal( BufferBind::COMMAND_COUNTERS_STORAGE ) );
 	gl_clearSurfacesShader->BindProgram( 0 );
 	gl_clearSurfacesShader->SetUniform_Frame( nextFrame );
 	gl_clearSurfacesShader->DispatchCompute( MAX_VIEWS, 1, 1 );
-	atomicCommandCountersBuffer.UnBindBufferBase( GL_SHADER_STORAGE_BUFFER );
+	atomicCommandCountersBuffer.UnBindBufferBase( GL_SHADER_STORAGE_BUFFER, Util::ordinal( BufferBind::COMMAND_COUNTERS_STORAGE ) );
 
 	GL_CheckErrors();
 }

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -574,9 +574,8 @@ void MaterialSystem::GenerateWorldCommandBuffer() {
 
 	texDataBufferType = glConfig2.maxUniformBlockSize >= MIN_MATERIAL_UBO_SIZE ? GL_UNIFORM_BUFFER : GL_SHADER_STORAGE_BUFFER;
 
-	texDataBuffer.BindBuffer( texDataBufferType  );
-	texDataBuffer.BufferStorage( texDataBufferType, ( texData.size() + dynamicTexData.size() ) * TEX_BUNDLE_SIZE, 1, nullptr );
-	texDataBuffer.MapAll( texDataBufferType );
+	texDataBuffer.BufferStorage( ( texData.size() + dynamicTexData.size() ) * TEX_BUNDLE_SIZE, 1, nullptr );
+	texDataBuffer.MapAll();
 	TexBundle* textureBundles = ( TexBundle* ) texDataBuffer.GetData();
 	memset( textureBundles, 0, ( texData.size() + dynamicTexData.size() ) * TEX_BUNDLE_SIZE * sizeof( uint32_t ) );
 
@@ -589,11 +588,9 @@ void MaterialSystem::GenerateWorldCommandBuffer() {
 	dynamicTexDataOffset = texData.size() * TEX_BUNDLE_SIZE;
 	dynamicTexDataSize = dynamicTexData.size() * TEX_BUNDLE_SIZE;
 
-	texDataBuffer.FlushAll( texDataBufferType  );
+	texDataBuffer.FlushAll();
 	texDataBuffer.UnmapBuffer();
-	texDataBuffer.UnBindBuffer( texDataBufferType );
 
-	lightMapDataUBO.BindBuffer();
 	lightMapDataUBO.BufferStorage( MAX_LIGHTMAPS * LIGHTMAP_SIZE, 1, nullptr );
 	lightMapDataUBO.MapAll();
 	uint64_t* lightmapData = ( uint64_t* ) lightMapDataUBO.GetData();
@@ -633,7 +630,6 @@ void MaterialSystem::GenerateWorldCommandBuffer() {
 
 	lightMapDataUBO.FlushAll();
 	lightMapDataUBO.UnmapBuffer();
-	lightMapDataUBO.UnBindBuffer();
 
 	surfaceCommandsCount = totalBatchCount * SURFACE_COMMANDS_PER_BATCH;
 
@@ -643,13 +639,11 @@ void MaterialSystem::GenerateWorldCommandBuffer() {
 	SurfaceCommand* surfaceCommands = ( SurfaceCommand* ) surfaceCommandsSSBO.GetData();
 	memset( surfaceCommands, 0, surfaceCommandsCount * sizeof( SurfaceCommand ) * MAX_VIEWFRAMES );
 
-	culledCommandsBuffer.BindBuffer( GL_SHADER_STORAGE_BUFFER );
-	culledCommandsBuffer.BufferStorage( GL_SHADER_STORAGE_BUFFER,
-		surfaceCommandsCount * INDIRECT_COMMAND_SIZE * MAX_VIEWFRAMES, 1, nullptr );
-	culledCommandsBuffer.MapAll( GL_SHADER_STORAGE_BUFFER );
+	culledCommandsBuffer.BufferStorage( surfaceCommandsCount * INDIRECT_COMMAND_SIZE * MAX_VIEWFRAMES, 1, nullptr );
+	culledCommandsBuffer.MapAll();
 	GLIndirectBuffer::GLIndirectCommand* culledCommands = ( GLIndirectBuffer::GLIndirectCommand* ) culledCommandsBuffer.GetData();
 	memset( culledCommands, 0, surfaceCommandsCount * sizeof( GLIndirectBuffer::GLIndirectCommand ) * MAX_VIEWFRAMES );
-	culledCommandsBuffer.FlushAll( GL_SHADER_STORAGE_BUFFER );
+	culledCommandsBuffer.FlushAll();
 
 	surfaceBatchesUBO.BindBuffer();
 	glBufferData( GL_UNIFORM_BUFFER, MAX_SURFACE_COMMAND_BATCHES * sizeof( SurfaceCommandBatch ), nullptr, GL_STATIC_DRAW );
@@ -675,10 +669,8 @@ void MaterialSystem::GenerateWorldCommandBuffer() {
 		}
 	}
 
-	atomicCommandCountersBuffer.BindBuffer( GL_ATOMIC_COUNTER_BUFFER );
-	atomicCommandCountersBuffer.BufferStorage( GL_ATOMIC_COUNTER_BUFFER,
-		MAX_COMMAND_COUNTERS * MAX_VIEWS, MAX_FRAMES, nullptr );
-	atomicCommandCountersBuffer.MapAll( GL_ATOMIC_COUNTER_BUFFER );
+	atomicCommandCountersBuffer.BufferStorage( MAX_COMMAND_COUNTERS * MAX_VIEWS, MAX_FRAMES, nullptr );
+	atomicCommandCountersBuffer.MapAll();
 	uint32_t* atomicCommandCounters = ( uint32_t* ) atomicCommandCountersBuffer.GetData();
 	memset( atomicCommandCounters, 0, MAX_COMMAND_COUNTERS * MAX_VIEWFRAMES * sizeof( uint32_t ) );
 
@@ -786,19 +778,14 @@ void MaterialSystem::GenerateWorldCommandBuffer() {
 		memcpy( surfaceCommands + surfaceCommandsCount * i, surfaceCommands, surfaceCommandsCount * sizeof( SurfaceCommand ) );
 	}
 
-	surfaceDescriptorsSSBO.BindBuffer();
 	surfaceDescriptorsSSBO.UnmapBuffer();
 
-	surfaceCommandsSSBO.BindBuffer();
 	surfaceCommandsSSBO.UnmapBuffer();
 
-	culledCommandsBuffer.BindBuffer( GL_SHADER_STORAGE_BUFFER );
 	culledCommandsBuffer.UnmapBuffer();
 
-	atomicCommandCountersBuffer.BindBuffer( GL_ATOMIC_COUNTER_BUFFER);
 	atomicCommandCountersBuffer.UnmapBuffer();
 
-	surfaceBatchesUBO.BindBuffer();
 	surfaceBatchesUBO.UnmapBuffer();
 
 	GL_CheckErrors();
@@ -1605,7 +1592,7 @@ void MaterialSystem::UpdateDynamicSurfaces() {
 		texDataBuffer.BindBuffer( texDataBufferType );
 		GL_CheckErrors();
 		TexBundle* textureBundles =
-			( TexBundle* ) texDataBuffer.MapBufferRange( texDataBufferType, dynamicTexDataOffset, dynamicTexDataSize );
+			( TexBundle* ) texDataBuffer.MapBufferRange( dynamicTexDataOffset, dynamicTexDataSize );
 		GL_CheckErrors();
 
 		GenerateTexturesBuffer( dynamicTexData, textureBundles );

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -636,8 +636,8 @@ void MaterialSystem::GenerateWorldCommandBuffer() {
 
 	culledCommandsBuffer.BufferStorage( surfaceCommandsCount * INDIRECT_COMMAND_SIZE * MAX_VIEWFRAMES, 1, nullptr );
 	culledCommandsBuffer.MapAll();
-	GLIndirectBuffer::GLIndirectCommand* culledCommands = ( GLIndirectBuffer::GLIndirectCommand* ) culledCommandsBuffer.GetData();
-	memset( culledCommands, 0, surfaceCommandsCount * sizeof( GLIndirectBuffer::GLIndirectCommand ) * MAX_VIEWFRAMES );
+	GLIndirectCommand* culledCommands = ( GLIndirectCommand* ) culledCommandsBuffer.GetData();
+	memset( culledCommands, 0, surfaceCommandsCount * sizeof( GLIndirectCommand ) * MAX_VIEWFRAMES );
 	culledCommandsBuffer.FlushAll();
 
 	surfaceBatchesUBO.BufferData( MAX_SURFACE_COMMAND_BATCHES * SURFACE_COMMAND_BATCH_SIZE, nullptr, GL_STATIC_DRAW );
@@ -2086,9 +2086,9 @@ void MaterialSystem::RenderMaterials( const shaderSort_t fromSort, const shaderS
 
 void MaterialSystem::RenderIndirect( const Material& material, const uint32_t viewID, const GLenum mode = GL_TRIANGLES ) {
 	glMultiDrawElementsIndirectCountARB( mode, GL_UNSIGNED_INT,
-		BUFFER_OFFSET( material.surfaceCommandBatchOffset * SURFACE_COMMANDS_PER_BATCH * sizeof( GLIndirectBuffer::GLIndirectCommand )
+		BUFFER_OFFSET( material.surfaceCommandBatchOffset * SURFACE_COMMANDS_PER_BATCH * sizeof( GLIndirectCommand )
 		               + ( surfaceCommandsCount * ( MAX_VIEWS * currentFrame + viewID )
-		               * sizeof( GLIndirectBuffer::GLIndirectCommand ) ) ),
+		               * sizeof( GLIndirectCommand ) ) ),
 		material.globalID * sizeof( uint32_t )
 		+ ( MAX_COMMAND_COUNTERS * ( MAX_VIEWS * currentFrame + viewID ) ) * sizeof( uint32_t ),
 		material.drawCommands.size(), 0 );

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1862,6 +1862,42 @@ void MaterialSystem::GeneratePortalBoundingSpheres() {
 	portalSurfacesTmp.clear();
 }
 
+void MaterialSystem::InitGLBuffers() {
+	materialsUBO.GenBuffer();
+	texDataBuffer.GenBuffer();
+	lightMapDataUBO.GenBuffer();
+
+	surfaceDescriptorsSSBO.GenBuffer();
+	surfaceCommandsSSBO.GenBuffer();
+	culledCommandsBuffer.GenBuffer();
+	surfaceBatchesUBO.GenBuffer();
+	atomicCommandCountersBuffer.GenBuffer();
+
+	portalSurfacesSSBO.GenBuffer();
+
+	if ( r_materialDebug.Get() ) {
+		debugSSBO.GenBuffer();
+	}
+}
+
+void MaterialSystem::FreeGLBuffers() {
+	materialsUBO.DelBuffer();
+	texDataBuffer.DelBuffer();
+	lightMapDataUBO.DelBuffer();
+
+	surfaceDescriptorsSSBO.DelBuffer();
+	surfaceCommandsSSBO.DelBuffer();
+	culledCommandsBuffer.DelBuffer();
+	surfaceBatchesUBO.DelBuffer();
+	atomicCommandCountersBuffer.DelBuffer();
+
+	portalSurfacesSSBO.DelBuffer();
+
+	if ( r_materialDebug.Get() ) {
+		debugSSBO.DelBuffer();
+	}
+}
+
 void MaterialSystem::Free() {
 	generatedWorldCommandBuffer = false;
 

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -43,7 +43,15 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static constexpr uint32_t MAX_DRAWCOMMAND_TEXTURES = 64;
 
-/* Similar to GLIndirectBuffer::GLIndirectCommand, but we always set instanceCount to 1 and baseVertex to 0,
+struct GLIndirectCommand {
+	GLuint count;
+	GLuint instanceCount;
+	GLuint firstIndex;
+	GLint baseVertex;
+	GLuint baseInstance;
+};
+
+/* Similar to GLIndirectCommand, but we always set instanceCount to 1 and baseVertex to 0,
  so no need to waste memory on those */
 struct IndirectCompactCommand {
 	GLuint count;

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -277,6 +277,20 @@ struct SurfaceCommandBatch {
 	uint32_t materialIDs[2] { 0, 0 };
 };
 
+enum class BufferBind {
+	MATERIALS = 1, // LightTile UBO uses binding point 0, so avoid it here
+	TEX_DATA = 6,
+	LIGHTMAP_DATA = 2,
+	SURFACE_DESCRIPTORS = 0,
+	SURFACE_COMMANDS = 1,
+	CULLED_COMMANDS = 2,
+	SURFACE_BATCHES = 3,
+	COMMAND_COUNTERS_ATOMIC = 0,
+	COMMAND_COUNTERS_STORAGE = 4, // Avoid needlessly rebinding buffers
+	PORTAL_SURFACES = 5,
+	DEBUG = 10
+};
+
 class MaterialSystem {
 	public:
 	bool generatedWorldCommandBuffer = false;

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -329,6 +329,9 @@ class MaterialSystem {
 
 	void GenerateDepthImages( const int width, const int height, imageParams_t imageParms );
 
+	void InitGLBuffers();
+	void FreeGLBuffers();
+
 	void AddStageTextures( drawSurf_t* drawSurf, const uint32_t stage, Material* material );
 	void AddStage( drawSurf_t* drawSurf, shaderStage_t* pStage, uint32_t stage,
 		const bool mayUseVertexOverbright, const bool vertexLit, const bool fullbright );

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1393,7 +1393,9 @@ std::string GLShaderManager::ShaderPostProcess( GLShader *shader, const std::str
 	                           "	uvec2 u_LightMap;\n"
 	                           "	uvec2 u_DeluxeMap;\n"
 	                           "};\n\n"
-	                           "layout(std140, binding = 8) uniform lightMapDataUBO {\n"
+	                           "layout(std140, binding = "
+		                       + std::to_string( Util::ordinal( BufferBind::LIGHTMAP_DATA ) )
+		                       + ") uniform lightMapDataUBO {\n"
 	                           "	LightMapData lightMapData[256];\n"
 	                           "};\n\n"
 		                       "#define u_LightMap_initial lightMapData[( baseInstance >> 24 ) & 0xFF].u_LightMap\n"

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1530,45 +1530,6 @@ class GLAtomicCounterBuffer : public GLBuffer {
 	}
 };
 
-class GLIndirectBuffer {
-	public:
-	struct GLIndirectCommand {
-		GLuint count;
-		GLuint instanceCount;
-		GLuint firstIndex;
-		GLint baseVertex;
-		GLuint baseInstance;
-	};
-
-	GLIndirectBuffer( const char* name ) {
-	}
-
-	void BindBuffer() {
-		glBindBuffer( GL_DRAW_INDIRECT_BUFFER, handle );
-	}
-
-	GLIndirectCommand* MapBufferRange( const GLsizeiptr count ) {
-		return (GLIndirectCommand*) glMapBufferRange( GL_DRAW_INDIRECT_BUFFER,
-			0, count * sizeof( GLIndirectCommand ),
-			GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT );
-	}
-
-	void UnmapBuffer() const {
-		glUnmapBuffer( GL_DRAW_INDIRECT_BUFFER );
-	}
-
-	void GenBuffer() {
-		glGenBuffers( 1, &handle );
-	}
-
-	void DelBuffer() {
-		glDeleteBuffers( 1, &handle );
-	}
-
-	private:
-	GLuint handle;
-};
-
 class GLCompileMacro
 {
 private:

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1412,6 +1412,10 @@ class GLBuffer {
 		glBindBuffer( target, 0 );
 	}
 
+	void BufferData( const GLsizeiptr size, const void* data, const GLenum usageFlags ) {
+		glNamedBufferData( id, size * sizeof( uint32_t ), data, usageFlags );
+	}
+
 	void BufferStorage( const GLsizeiptr newAreaSize, const GLsizeiptr areaCount, const void* data ) {
 		areaSize = newAreaSize;
 		maxAreas = areaCount;
@@ -1504,6 +1508,7 @@ class GLBuffer {
 	uint32_t* data;
 };
 
+// Shorthands for buffers that are only bound to one specific target
 class GLSSBO : public GLBuffer {
 	public:
 	GLSSBO( const char* name, const GLuint bindingPoint, const GLbitfield flags, const GLbitfield mapFlags ) :

--- a/src/engine/renderer/glsl_source/clearSurfaces_cp.glsl
+++ b/src/engine/renderer/glsl_source/clearSurfaces_cp.glsl
@@ -38,7 +38,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
-layout(std430, binding = 4) writeonly buffer atomicCommandCountersBuffer {
+layout(std430, binding = BIND_COMMAND_COUNTERS_STORAGE) writeonly buffer atomicCommandCountersBuffer {
     uint atomicCommandCounters[MAX_COMMAND_COUNTERS * MAX_VIEWFRAMES];
 };
 

--- a/src/engine/renderer/glsl_source/cull_cp.glsl
+++ b/src/engine/renderer/glsl_source/cull_cp.glsl
@@ -41,15 +41,15 @@ layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) uniform sampler2D depthImage;
 
-layout(std430, binding = 1) readonly restrict buffer surfaceDescriptorsSSBO {
+layout(std430, binding = BIND_SURFACE_DESCRIPTORS) readonly restrict buffer surfaceDescriptorsSSBO {
 	SurfaceDescriptor surfaces[];
 };
 
-layout(std430, binding = 2) writeonly restrict buffer surfaceCommandsSSBO {
+layout(std430, binding = BIND_SURFACE_COMMANDS) writeonly restrict buffer surfaceCommandsSSBO {
 	SurfaceCommand surfaceCommands[];
 };
 
-layout(std430, binding = 5) restrict buffer portalSurfacesSSBO {
+layout(std430, binding = BIND_PORTAL_SURFACES) restrict buffer portalSurfacesSSBO {
 	PortalSurface portalSurfaces[];
 };
 
@@ -57,7 +57,7 @@ layout(std430, binding = 5) restrict buffer portalSurfacesSSBO {
 	#define DEBUG_INVOCATION_SIZE 5
 	#define DEBUG_ID( id ) ( id * DEBUG_INVOCATION_SIZE )
 
-	layout(std430, binding = 10) writeonly restrict buffer debugSSBO {
+	layout(std430, binding = BIND_DEBUG) writeonly restrict buffer debugSSBO {
 		uvec4 debug[];
 	};
 #endif

--- a/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
+++ b/src/engine/renderer/glsl_source/processSurfaces_cp.glsl
@@ -41,19 +41,19 @@ layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
 #define SurfaceCommandBatch uvec4
 
-layout(std430, binding = 2) readonly restrict buffer surfaceCommandsSSBO {
+layout(std430, binding = BIND_SURFACE_COMMANDS) readonly restrict buffer surfaceCommandsSSBO {
 	SurfaceCommand surfaceCommands[];
 };
 
-layout(std430, binding = 3) writeonly restrict buffer culledCommandsSSBO {
+layout(std430, binding = BIND_CULLED_COMMANDS) writeonly restrict buffer culledCommandsSSBO {
 	GLIndirectCommand culledCommands[];
 };
 
-layout(std140, binding = 0) uniform ub_SurfaceBatches {
+layout(std140, binding = BIND_SURFACE_BATCHES) uniform ub_SurfaceBatches {
 	SurfaceCommandBatch surfaceBatches[MAX_SURFACE_COMMAND_BATCHES];
 };
 
-layout (binding = 4) uniform atomic_uint atomicCommandCounters[MAX_COMMAND_COUNTERS * MAX_VIEWFRAMES];
+layout (binding = BIND_COMMAND_COUNTERS_ATOMIC) uniform atomic_uint atomicCommandCounters[MAX_COMMAND_COUNTERS * MAX_VIEWFRAMES];
 
 uniform uint u_Frame;
 uniform uint u_ViewID;

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -102,6 +102,7 @@ struct glconfig2_t
 	bool indirectParametersAvailable;
 	bool shadingLanguage420PackAvailable;
 	bool explicitUniformLocationAvailable;
+	bool directStateAccessAvailable;
 	bool shaderImageLoadStoreAvailable;
 	bool shaderAtomicCountersAvailable;
 	bool shaderAtomicCounterOpsAvailable;

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -726,27 +726,6 @@ static void R_InitLightUBO()
 		glBindBuffer( GL_UNIFORM_BUFFER, 0 );
 	}
 }
-
-static void R_InitMaterialBuffers() {
-	if( glConfig2.usingMaterialSystem ) {
-		materialsUBO.GenBuffer();
-		texDataBuffer.GenBuffer();
-		lightMapDataUBO.GenBuffer();
-
-		surfaceDescriptorsSSBO.GenBuffer();
-		surfaceCommandsSSBO.GenBuffer();
-		culledCommandsBuffer.GenBuffer();
-		surfaceBatchesUBO.GenBuffer();
-		atomicCommandCountersBuffer.GenBuffer();
-		
-		portalSurfacesSSBO.GenBuffer();
-
-		if ( r_materialDebug.Get() ) {
-			debugSSBO.GenBuffer();
-		}
-	}
-}
-
 /*
 ============
 R_InitVBOs
@@ -790,7 +769,9 @@ void R_InitVBOs()
 
 	R_InitLightUBO();
 
-	R_InitMaterialBuffers();
+	if ( glConfig2.usingMaterialSystem ) {
+		materialSystem.InitGLBuffers();
+	}
 
 	GL_CheckErrors();
 }
@@ -861,21 +842,7 @@ void R_ShutdownVBOs()
 	}
 
 	if ( glConfig2.usingMaterialSystem ) {
-		materialsUBO.DelBuffer();
-		texDataBuffer.DelBuffer();
-		lightMapDataUBO.DelBuffer();
-
-		surfaceDescriptorsSSBO.DelBuffer();
-		surfaceCommandsSSBO.DelBuffer();
-		culledCommandsBuffer.DelBuffer();
-		surfaceBatchesUBO.DelBuffer();
-		atomicCommandCountersBuffer.DelBuffer();
-
-		portalSurfacesSSBO.DelBuffer();
-
-		if ( r_materialDebug.Get() ) {
-			debugSSBO.DelBuffer();
-		}
+		materialSystem.FreeGLBuffers();
 	}
 
 	tess.verts = tess.vertsBuffer = nullptr;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -70,6 +70,8 @@ static Cvar::Cvar<bool> r_arb_buffer_storage( "r_arb_buffer_storage",
 	"Use GL_ARB_buffer_storage if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_compute_shader( "r_arb_compute_shader",
 	"Use GL_ARB_compute_shader if available", Cvar::NONE, true );
+static Cvar::Cvar<bool> r_arb_direct_state_access( "r_arb_direct_state_access",
+	"Use GL_ARB_direct_state_access if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_framebuffer_object( "r_arb_framebuffer_object",
 	"Use GL_ARB_framebuffer_object if available", Cvar::NONE, true );
 static Cvar::Cvar<bool> r_arb_explicit_uniform_location( "r_arb_explicit_uniform_location",
@@ -1975,6 +1977,7 @@ static void GLimp_InitExtensions()
 	Cvar::Latch( r_arb_bindless_texture );
 	Cvar::Latch( r_arb_buffer_storage );
 	Cvar::Latch( r_arb_compute_shader );
+	Cvar::Latch( r_arb_direct_state_access );
 	Cvar::Latch( r_arb_explicit_uniform_location );
 	Cvar::Latch( r_arb_framebuffer_object );
 	Cvar::Latch( r_arb_gpu_shader5 );
@@ -2544,11 +2547,15 @@ static void GLimp_InitExtensions()
 	// made required in OpenGL 4.6
 	glConfig2.indirectParametersAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_indirect_parameters, r_arb_indirect_parameters.Get() );
 
+	// made required in OpenGL 4.5
+	glConfig2.directStateAccessAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_direct_state_access, r_arb_direct_state_access.Get() );
+
 	glConfig2.materialSystemAvailable = glConfig2.shaderDrawParametersAvailable && glConfig2.SSBOAvailable
 		&& glConfig2.multiDrawIndirectAvailable && glConfig2.bindlessTexturesAvailable
 		&& glConfig2.computeShaderAvailable && glConfig2.shadingLanguage420PackAvailable
 		&& glConfig2.explicitUniformLocationAvailable && glConfig2.shaderImageLoadStoreAvailable
-		&& glConfig2.shaderAtomicCountersAvailable && glConfig2.indirectParametersAvailable;
+		&& glConfig2.shaderAtomicCountersAvailable && glConfig2.indirectParametersAvailable
+		&& glConfig2.directStateAccessAvailable;
 
 	// This requires GLEW 2.2+, so skip if it's a lower version
 #ifdef GL_KHR_shader_subgroup


### PR DESCRIPTION
The `GLBuffer` has started to become unwieldy when setting up buffers, so I cleaned up its interface and made it use Direct State Access versions of the buffer commands where possible instead. These commands allow modyfing buffers without actually binding them, which makes it much easier. I've also removed a lot of duplicate code from `GLBuffer` itself, as well as the derivative buffers.

`glBufferData` has been moved to `GLBuffer`, in line with the other buffer functions.

Cleaned up buffer binding points as well, now they use an enum, and the shaders use defines for it.

Moved buffer init/free to a more appropriate location as well.

Also NUKED the unused `GLIndirectBuffer` and moved `GLIndirectCommand` to `MaterialSystem.h`.