### PR TITLE
Fix backEnd.currentVAO

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -341,11 +341,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 				return false;
 			}
 
-			if( glConfig2.glCoreProfile ) {
-				glGenVertexArrays( 1, &backEnd.currentVAO );
-				glBindVertexArray( backEnd.currentVAO );
-			}
-
 			glState.tileStep[ 0 ] = TILE_SIZE * ( 1.0f / glConfig.vidWidth );
 			glState.tileStep[ 1 ] = TILE_SIZE * ( 1.0f / glConfig.vidHeight );
 
@@ -379,6 +374,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 		{
 			GLSL_ShutdownGPUShaders();
 			GLSL_InitGPUShaders();
+		}
+
+		if ( glConfig2.glCoreProfile ) {
+			glGenVertexArrays( 1, &backEnd.currentVAO );
+			glBindVertexArray( backEnd.currentVAO );
 		}
 
 		GL_CheckErrors();


### PR DESCRIPTION
This was previously getting reset in `R_Init()`, so it was always 0 after a map was loaded. This also meant that the call to `glDeleteVertexArrays()`  in `RE_Shutdown()` was silently erroring out if a map was loaded (or `vid_restart` used).