### PR TITLE
Fix bug with 2d drawing GL state

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -830,9 +830,6 @@ static void RB_SetGL2D()
 	GL_LoadProjectionMatrix( proj );
 	GL_LoadModelViewMatrix( matrixIdentity );
 
-	// TODO: remove this, state is set wherever drawing is done
-	GL_State( GLS_DEPTHTEST_DISABLE | GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA );
-
 	GL_Cull( cullType_t::CT_TWO_SIDED );
 
 	// set time for 2D shaders

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -929,7 +929,10 @@ void Render_generic( shaderStage_t *pStage )
 {
 	if ( backEnd.projection2D )
 	{
-		glState.glStateBitsMask = ~uint32_t( GLS_DEPTHMASK_TRUE ) | GLS_DEPTHTEST_DISABLE;
+		constexpr uint32_t lockBits = GLS_DEPTHMASK_TRUE | GLS_DEPTHTEST_DISABLE;
+		glState.glStateBitsMask = ~lockBits;
+		GL_State( GLS_DEPTHTEST_DISABLE );
+		glState.glStateBitsMask = lockBits;
 		tr.skipSubgroupProfiler = true;
 
 		Render_generic3D( pStage );


### PR DESCRIPTION
The drawing state can get messed up if you call CG_FillRect right before RmlUi draws anything, and almost everything looks wrong with wrong colors and text being drawn as solid boxes.

Regression in 7b210353ce0b73117baeec32521746c0990bd68c.

![unvanquished_2025-01-25_094335_000](https://github.com/user-attachments/assets/94f17c44-e63b-40d7-b8f2-2d37cde4db63)
