### PR TITLE
Fix crash in GenerateWorldMaterials()

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1486,6 +1486,8 @@ void MaterialSystem::ProcessStage( drawSurf_t* drawSurf, shaderStage_t* pStage, 
 *  A material represents a distinct global OpenGL state (e. g. blend function, depth test, depth write etc.)
 *  Materials can have a dependency on other materials to make sure that consecutive stages are rendered in the proper order */
 void MaterialSystem::GenerateWorldMaterials() {
+	R_SyncRenderThread();
+
 	const int current_r_nocull = r_nocull->integer;
 	const int current_r_drawworld = r_drawworld->integer;
 	r_nocull->integer = 1;
@@ -1493,8 +1495,6 @@ void MaterialSystem::GenerateWorldMaterials() {
 	generatingWorldCommandBuffer = true;
 
 	Log::Debug( "Generating world materials" );
-
-	R_SyncRenderThread();
 
 	++tr.viewCountNoReset;
 	R_AddWorldSurfaces();


### PR DESCRIPTION
If the cgame sends some 2D rendering commands in the first frame before calling RenderScene as described in
https://github.com/Unvanquished/Unvanquished/pull/3305, it could cause a crash. Fix this by not setting generatingWorldCommandBuffer prematurely while those commands are executing.