### PR TITLE
Add RSF_FORCE_LIGHTMAP

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1319,6 +1319,8 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		int		autoSpriteMode;
 
+		bool forceLightMap;
+
 		uint8_t         numDeforms;
 		deformStage_t   deforms[ MAX_SHADER_DEFORMS ];
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5869,6 +5869,16 @@ static shader_t *FinishShader()
 	numStages = MAX_SHADER_STAGES;
 	GroupActiveStages();
 
+	if ( shader.forceLightMap ) {
+		for( size_t stage = 0; stage < numStages; stage++ ) {
+			shaderStage_t* pStage = &stages[numStages];
+
+			if ( pStage->type == stageType_t::ST_COLORMAP ) {
+				pStage->type = stageType_t::ST_DIFFUSEMAP;
+			}
+		}
+	}
+
 	// set appropriate stage information
 	for ( size_t stage = 0; stage < numStages; stage++ )
 	{
@@ -6231,6 +6241,11 @@ shader_t       *R_FindShader( const char *name, shaderType_t type, int flags )
 	if ( flags & RSF_SPRITE )
 	{
 		shader.entitySpriteFaceViewDirection = true;
+	}
+
+	if ( flags & RSF_FORCE_LIGHTMAP )
+	{
+		shader.forceLightMap = true;
 	}
 
 	// attempt to define shader from an explicit parameter file

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5870,12 +5870,10 @@ static shader_t *FinishShader()
 	GroupActiveStages();
 
 	if ( shader.forceLightMap && numStages == 1 ) {
-		for( size_t stage = 0; stage < numStages; stage++ ) {
-			shaderStage_t* pStage = &stages[stage];
+		shaderStage_t* pStage = &stages[0];
 
-			if ( pStage->type == stageType_t::ST_COLORMAP ) {
-				pStage->type = stageType_t::ST_DIFFUSEMAP;
-			}
+		if ( pStage->type == stageType_t::ST_COLORMAP ) {
+			pStage->type = stageType_t::ST_DIFFUSEMAP;
 		}
 	}
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -5869,9 +5869,9 @@ static shader_t *FinishShader()
 	numStages = MAX_SHADER_STAGES;
 	GroupActiveStages();
 
-	if ( shader.forceLightMap ) {
+	if ( shader.forceLightMap && numStages == 1 ) {
 		for( size_t stage = 0; stage < numStages; stage++ ) {
-			shaderStage_t* pStage = &stages[numStages];
+			shaderStage_t* pStage = &stages[stage];
 
 			if ( pStage->type == stageType_t::ST_COLORMAP ) {
 				pStage->type = stageType_t::ST_DIFFUSEMAP;

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -90,7 +90,7 @@ enum RegisterShaderFlags_t {
 	RSF_NOMIP = BIT( 2 ),
 	RSF_FITSCREEN = BIT( 3 ),
 	RSF_LIGHT_ATTENUATION = BIT( 4 ),
-	RSF_NOLIGHTSCALE = BIT( 5 ), // TODO(0.56): delete, does nothing
+	RSF_FORCE_LIGHTMAP = BIT( 5 ), // Used to make particles/trails work with the lightGrid in GLSL
 	RSF_SPRITE = BIT( 6 ),
 };
 


### PR DESCRIPTION
Cgame-side pr: https://github.com/Unvanquished/Unvanquished/pull/3306

Replaces RSF_NOLIGHTSCALE.

If this flag is used when registering a shader, all `ST_COLORMAP` stages will be changed to `ST_DIFFUSEMAP`. This is intended for use with particles and trails, to make them use the lightGrid in the GLSL code.

Improves performance with particle systems and trails, e. g. with firebombs, and a massive performance improvement on map https://users.unvanquished.net/~sweet/pkg/map-jota_3.0.dpk in the outside area.

There's for the most part no difference in how the particles/trails look, the only differences are due to the GLSL lightGrid being more precise.