### PR TITLE
Some dynamic buffer-related clean-up and fixes

### DIFF
--- a/src/engine/renderer/tr_animation.cpp
+++ b/src/engine/renderer/tr_animation.cpp
@@ -683,7 +683,7 @@ void R_AddMD5Surfaces( trRefEntity_t *ent )
 	// see if we are in a fog volume
 	fogNum = R_FogWorldBox( ent->worldBounds );
 
-	if ( !r_vboModels->integer || !model->numVBOSurfaces ||
+	if ( !r_vboModels.Get() || !model->numVBOSurfaces ||
 	     ( !glConfig2.vboVertexSkinningAvailable && ent->e.skeleton.type == refSkeletonType_t::SK_ABSOLUTE ) )
 	{
 		shader_t *shader;
@@ -983,7 +983,7 @@ void R_AddMD5Interactions( trRefEntity_t *ent, trRefLight_t *light, interactionT
 
 	cubeSideBits = R_CalcLightCubeSideBits( light, ent->worldBounds );
 
-	if ( !r_vboModels->integer || !model->numVBOSurfaces ||
+	if ( !r_vboModels.Get() || !model->numVBOSurfaces ||
 	     ( !glConfig2.vboVertexSkinningAvailable && ent->e.skeleton.type == refSkeletonType_t::SK_ABSOLUTE ) )
 	{
 		shader_t *shader = nullptr;

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -285,7 +285,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_vboFaces;
 	cvar_t      *r_vboCurves;
 	cvar_t      *r_vboTriangles;
-	cvar_t      *r_vboModels;
+	Cvar::Cvar<bool> r_vboModels( "r_vboModels", "Use static GPU VBOs/IBOs for models", Cvar::NONE, true );
 	cvar_t      *r_vboVertexSkinning;
 
 	cvar_t      *r_mergeLeafSurfaces;
@@ -1212,7 +1212,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_vboFaces = Cvar_Get( "r_vboFaces", "1", CVAR_CHEAT );
 		r_vboCurves = Cvar_Get( "r_vboCurves", "1", CVAR_CHEAT );
 		r_vboTriangles = Cvar_Get( "r_vboTriangles", "1", CVAR_CHEAT );
-		r_vboModels = Cvar_Get( "r_vboModels", "1", CVAR_LATCH );
+		Cvar::Latch( r_vboModels );
 		r_vboVertexSkinning = Cvar_Get( "r_vboVertexSkinning", "1",  CVAR_LATCH );
 
 		r_mergeLeafSurfaces = Cvar_Get( "r_mergeLeafSurfaces", "1",  CVAR_LATCH );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3113,7 +3113,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 	extern cvar_t *r_vboFaces;
 	extern cvar_t *r_vboCurves;
 	extern cvar_t *r_vboTriangles;
-	extern cvar_t *r_vboModels;
+	extern Cvar::Cvar<bool> r_vboModels;
 	extern cvar_t *r_vboVertexSkinning;
 
 	extern cvar_t *r_mergeLeafSurfaces;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3414,7 +3414,6 @@ inline bool checkGLErrors()
 		vec4_t texCoords;
 	};
 
-#ifdef GL_ARB_sync
 	struct glRingbuffer_t {
 		// the BO is logically split into DYN_BUFFER_SEGMENTS
 		// segments, the active segment is the one the CPU may write
@@ -3428,7 +3427,6 @@ inline bool checkGLErrors()
 		// sync is always undefined
 		GLsync         syncs[ DYN_BUFFER_SEGMENTS ];
 	};
-#endif
 
 	struct shaderCommands_t
 	{
@@ -3498,10 +3496,8 @@ inline bool checkGLErrors()
 		VBO_t       *vbo;
 		IBO_t       *ibo;
 
-#ifdef GL_ARB_sync
 		glRingbuffer_t  vertexRB;
 		glRingbuffer_t  indexRB;
-#endif
 	};
 
 	alignas(16) extern shaderCommands_t tess;

--- a/src/engine/renderer/tr_mesh.cpp
+++ b/src/engine/renderer/tr_mesh.cpp
@@ -306,7 +306,7 @@ void R_AddMDVSurfaces( trRefEntity_t *ent )
 	fogNum = R_FogWorldBox( ent->worldBounds );
 
 	// draw all surfaces
-	if ( r_vboModels->integer && model->numVBOSurfaces )
+	if ( r_vboModels.Get() && model->numVBOSurfaces )
 	{
 		srfVBOMDVMesh_t *vboSurface;
 
@@ -416,7 +416,7 @@ void R_AddMDVInteractions( trRefEntity_t *ent, trRefLight_t *light, interactionT
 	cubeSideBits = R_CalcLightCubeSideBits( light, ent->worldBounds );
 
 	// generate interactions with all surfaces
-	if ( r_vboModels->integer && model->numVBOSurfaces )
+	if ( r_vboModels.Get() && model->numVBOSurfaces )
 	{
 		// new brute force method: just render everthing with static VBOs
 		srfVBOMDVMesh_t *vboSurface;

--- a/src/engine/renderer/tr_model_iqm.cpp
+++ b/src/engine/renderer/tr_model_iqm.cpp
@@ -767,7 +767,7 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 	}
 
 	// convert data where necessary and create VBO
-	if( r_vboModels->integer && glConfig2.vboVertexSkinningAvailable
+	if( r_vboModels.Get() && glConfig2.vboVertexSkinningAvailable
 	    && IQModel->num_joints <= glConfig2.maxVertexSkinningBones ) {
 
 		uint16_t *boneFactorBuf = (uint16_t*)ri.Hunk_AllocateTempMemory( IQModel->num_vertexes * ( 4 * sizeof(uint16_t) ) );

--- a/src/engine/renderer/tr_model_md3.cpp
+++ b/src/engine/renderer/tr_model_md3.cpp
@@ -152,13 +152,13 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 		LL( md3Surf->ofsXyzNormals );
 		LL( md3Surf->ofsEnd );
 
-		if ( md3Surf->numVerts > SHADER_MAX_VERTEXES )
+		if ( !r_vboModels.Get() && md3Surf->numVerts > SHADER_MAX_VERTEXES )
 		{
 			Sys::Drop( "R_LoadMD3: %s has more than %i verts on a surface (%i)",
 			           modName, SHADER_MAX_VERTEXES, md3Surf->numVerts );
 		}
 
-		if ( md3Surf->numTriangles * 3 > SHADER_MAX_INDEXES )
+		if ( !r_vboModels.Get() && md3Surf->numTriangles * 3 > SHADER_MAX_INDEXES )
 		{
 			Sys::Drop( "R_LoadMD3: %s has more than %i triangles on a surface (%i)",
 			           modName, SHADER_MAX_INDEXES / 3, md3Surf->numTriangles );

--- a/src/engine/renderer/tr_model_md5.cpp
+++ b/src/engine/renderer/tr_model_md5.cpp
@@ -340,7 +340,7 @@ bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 		token = COM_ParseExt2( &buf_p, false );
 		surf->numVerts = atoi( token );
 
-		if ( surf->numVerts > SHADER_MAX_VERTEXES )
+		if ( !r_vboModels.Get() && surf->numVerts > SHADER_MAX_VERTEXES )
 		{
 			Sys::Drop( "R_LoadMD5: '%s' has more than %i verts on a surface (%i)",
 			           modName, SHADER_MAX_VERTEXES, surf->numVerts );
@@ -417,7 +417,7 @@ bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 		token = COM_ParseExt2( &buf_p, false );
 		surf->numTriangles = atoi( token );
 
-		if ( surf->numTriangles > SHADER_MAX_TRIANGLES )
+		if ( !r_vboModels.Get() && surf->numTriangles > SHADER_MAX_TRIANGLES )
 		{
 			Sys::Drop( "R_LoadMD5: '%s' has more than %i triangles on a surface (%i)",
 			           modName, SHADER_MAX_TRIANGLES, surf->numTriangles );

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2388,7 +2388,6 @@ static void GLimp_InitExtensions()
 		glConfig2.getProgramBinaryAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_get_program_binary, formats > 0 );
 	}
 
-	glConfig2.bufferStorageAvailable = false;
 	glConfig2.bufferStorageAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_buffer_storage, r_arb_buffer_storage.Get() );
 
 	// made required since OpenGL 3.1


### PR DESCRIPTION
- NUKED useless GL_ARB_buffer_storage and GL_ARB_sync macro checks.
- Fix bogus checks for SHADER_MAX_VERTEXES and SHADER_MAX_INDEXES for cases where the dynamic buffers are not being used by adding a check for `r_vboModels`. Also changed it to a new-style cvar.
- Some small clean-up of Ringbuffer functions and more stuff in logs.