### PR TITLE
Use dGPU if both dGPU and iGPU are available on Windows

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -26,6 +26,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "DetectGLVendors.h"
 #include "Material.h"
 
+#ifdef _WIN32
+	extern "C" {
+		// Use dGPU if both dGPU and iGPU are available
+		// https://developer.download.nvidia.com/devzone/devcenter/gamegraphics/files/OptimusRenderingPolicies.pdf
+		__declspec( dllexport ) uint32_t NvOptimusEnablement = 0x00000001;
+		// https://gpuopen.com/learn/amdpowerxpressrequesthighperformance/
+		__declspec( dllexport ) uint32_t AmdPowerXpressRequestHighPerformance = 0x00000001;
+	}
+#endif
+
 	glconfig_t  glConfig;
 	glconfig2_t glConfig2;
 


### PR DESCRIPTION
Normally, to use the dGPU on Windows 10/11, you need to manually set it for the executable in Windows settings. This will set some registry values to tell the NVidia/AMD drivers to use the dGPU here.

I've confirmed that this works on Win10 with an NVidia dGPU, now just waiting for someone to test it with AMD.