### PR TITLE
q_math: do tracing in id Software/J.M.P. van Waveren's QuatFromMatrix() implementation like Martin John Baker's one did, fix model distortion with GCC 14

### DIFF
--- a/src/engine/qcommon/q_math.cpp
+++ b/src/engine/qcommon/q_math.cpp
@@ -2870,11 +2870,11 @@ void QuatFromMatrix( quat_t q, const matrix_t m )
 	/* For the +1 that deviates from the original implementation,
 	see https://github.com/DaemonEngine/Daemon/issues/1527 */
 
-	float t, s;
+	float t = m[ 0 ] + m[ 5 ] + m[ 10 ] + 1.0f;
+	float s;
 
-	if ( m[ 0 ] + m[ 5 ] + m[ 10 ] + 1.0f > 0.0f )
+	if ( t > 0.0f )
 	{
-		t = m[ 0 ] + m[ 5 ] + m[ 10 ] + 1.0f;
 		s = ( 1.0f / sqrtf( t ) ) * 0.5f;
 
 		q[ 3 ] = s * t;

--- a/src/engine/qcommon/q_math.cpp
+++ b/src/engine/qcommon/q_math.cpp
@@ -2866,9 +2866,13 @@ void QuatFromMatrix( quat_t q, const matrix_t m )
 	 *
 	 *	   http://www.intel.com/cd/ids/developer/asmo-na/eng/293748.htm
 	 */
+
+	/* For the +1 that deviates from the original implementation,
+	see https://github.com/DaemonEngine/Daemon/issues/1527 */
+
 	float t, s;
 
-	if ( m[ 0 ] + m[ 5 ] + m[ 10 ] > 0.0f )
+	if ( m[ 0 ] + m[ 5 ] + m[ 10 ] + 1.0f > 0.0f )
 	{
 		t = m[ 0 ] + m[ 5 ] + m[ 10 ] + 1.0f;
 		s = ( 1.0f / sqrtf( t ) ) * 0.5f;

--- a/src/engine/qcommon/q_math.cpp
+++ b/src/engine/qcommon/q_math.cpp
@@ -2875,7 +2875,7 @@ void QuatFromMatrix( quat_t q, const matrix_t m )
 
 	if ( t > 0.0f )
 	{
-		s = ( 1.0f / sqrtf( t ) ) * 0.5f;
+		s = Q_rsqrt( t ) * 0.5f;
 
 		q[ 3 ] = s * t;
 		q[ 2 ] = ( m[ 1 ] - m[ 4 ] ) * s;
@@ -2886,7 +2886,7 @@ void QuatFromMatrix( quat_t q, const matrix_t m )
 	else if ( m[ 0 ] > m[ 5 ] && m[ 0 ] > m[ 10 ] )
 	{
 		t = m[ 0 ] - m[ 5 ] - m[ 10 ] + 1.0f;
-		s = ( 1.0f / sqrtf( t ) ) * 0.5f;
+		s = Q_rsqrt( t ) * 0.5f;
 
 		q[ 0 ] = s * t;
 		q[ 1 ] = ( m[ 1 ] + m[ 4 ] ) * s;
@@ -2897,7 +2897,7 @@ void QuatFromMatrix( quat_t q, const matrix_t m )
 	else if ( m[ 5 ] > m[ 10 ] )
 	{
 		t = -m[ 0 ] + m[ 5 ] - m[ 10 ] + 1.0f;
-		s = ( 1.0f / sqrtf( t ) ) * 0.5f;
+		s = Q_rsqrt( t ) * 0.5f;
 
 		q[ 1 ] = s * t;
 		q[ 0 ] = ( m[ 1 ] + m[ 4 ] ) * s;
@@ -2908,7 +2908,7 @@ void QuatFromMatrix( quat_t q, const matrix_t m )
 	else
 	{
 		t = -m[ 0 ] - m[ 5 ] + m[ 10 ] + 1.0f;
-		s = ( 1.0f / sqrtf( t ) ) * 0.5f;
+		s = Q_rsqrt( t ) * 0.5f;
 
 		q[ 2 ] = s * t;
 		q[ 3 ] = ( m[ 1 ] - m[ 4 ] ) * s;

--- a/src/engine/qcommon/q_math.cpp
+++ b/src/engine/qcommon/q_math.cpp
@@ -1976,7 +1976,7 @@ void MatrixFromQuat( matrix_t m, const quat_t q )
 	 *	February 27th 2005
 	 *	J.M.P. van Waveren
 	 *
-	 *	http://www.intel.com/cd/ids/developer/asmo-na/eng/293748.htm
+	 *	https://web.archive.org/web/20100818052330/http://cache-www.intel.com/cd/00/00/29/37/293748_293748.pdf
 	 */
 	float x2, y2, z2 /*, w2*/;
 	float yy2, xy2;
@@ -2864,7 +2864,7 @@ void QuatFromMatrix( quat_t q, const matrix_t m )
 	 *	   February 27th 2005
 	 *	   J.M.P. van Waveren
 	 *
-	 *	   http://www.intel.com/cd/ids/developer/asmo-na/eng/293748.htm
+	 *	   https://web.archive.org/web/20100818052330/http://cache-www.intel.com/cd/00/00/29/37/293748_293748.pdf
 	 */
 
 	/* For the +1 that deviates from the original implementation,


### PR DESCRIPTION
Do tracing in [id Software/J.M.P. van Waveren's QuatFromMatrix() implementation](https://web.archive.org/web/20100818052330/http://cache-www.intel.com/cd/00/00/29/37/293748_293748.pdf) like the one we have by Martin John Baker's did, fix model distortion with GCC 14.

Fix #1527:

- https://github.com/DaemonEngine/Daemon/issues/1527

It adds `+1` to the first trace

Fix Unvanquished/Unvanquished#3140:

- https://github.com/Unvanquished/Unvanquished/issues/3140

What's curious is that the Martin John Baker's page says they also removed the `+1`:

> // I removed + 1.0f; [see discussion with Ethan](http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/ethan.htm)

But it also says (but we didn't use any epsilon):

> // I changed M_EPSILON to 0

The said “_discussion with Ethan Tira-Thompson_” says:

> Hi Martin, 
>
> I was looking at the matrixToQuaternion page, and I think the "Better code" and "C++ code" sections may have a problem with numerical stability as Tr + 1 may approach 0 in some cases. The test for greater-than-epsilon helps, but a better solution may be found in the implementation from the Wild Magic package by Dave Eberly:
> http://www.geometrictools.com/LibFoundation/Mathematics/Wm4Quaternion.inl
> (See "FromRotationMatrix" function)
>
> There, they compare Tr > 0 (instead of Tr+1 > 0) for the initial conditional, thus avoiding getting close to 0 in the 0.5 / sqrt(Tr + 1) which follows it.
>
> Do you have any thoughts, does this make sense to you? The implications of falling into the 'else' clause are the main concern here, but that seems safe, and appears to work in practice.
>
> Thanks!

Then follows a lengthy discussion about “danger of division by zero or square root of a negative number” and “danger of division by zero or square root of a negative number”, maybe it was safe to rule out those concerns with no fast math but we need to take care of this with fast math?

Actually using that `+1` means one compute is twice the same, so it may even be faster.

On a side note, the document by id Software/J.M.P. van Waveren mentions this:

> The above routine also uses a fast reciprocal square root approximation, referencing works like the Chris Lomont one I quoted there when improving `Q_rsqrt()`:

- https://github.com/DaemonEngine/Daemon/pull/1458

So I made the code also use `Q_rsqrt()`.