### PR TITLE
Fix bad return type for Square() template

### DIFF
--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -459,7 +459,7 @@ inline void CrossProduct( const vec3_t v1, const vec3_t v2, vec3_t cross )
 }
 
 template<typename A>
-A Square( A a )
+decltype(std::declval<A>() * std::declval<A>()) Square( const A &a )
 {
 	return a * a;
 }


### PR DESCRIPTION
It didn't take into account promotion to integer for types smaller than int.

Fixes #1533.