### PR TITLE
Fix texture scroll, optimise texture matrix operations a bit

### DIFF
--- a/src/engine/renderer/tr_shade_calc.cpp
+++ b/src/engine/renderer/tr_shade_calc.cpp
@@ -701,6 +701,38 @@ TEX COORDS
 ====================================================================
 */
 
+static inline void Mat3x2MultiplyScale( matrix_t m, const float x, const float y ) {
+	m[0] *= x;
+	m[4] *= y;
+	m[1] *= x;
+	m[5] *= y;
+}
+
+static inline void Mat3x2MultiplyTranslation( matrix_t m, const float x, const float y ) {
+	m[12] += m[0] * x + m[4] * y;
+	m[13] += m[1] * x + m[5] * y;
+}
+
+static inline void Mat3x2MultiplyZRotation( matrix_t m, const float degrees ) {
+	float angle = DEG2RAD( degrees );
+	float s = sinf( angle );
+	float c = cosf( angle );
+
+	const float tmp[] = { m[0], m[1], m[4], m[5] };
+	m[0] = tmp[0] * c + tmp[2] * s;
+	m[1] = tmp[1] * c + tmp[3] * s;
+	m[4] = tmp[0] * -s + tmp[2] * c;
+	m[5] = tmp[1] * -s + tmp[3] * c;
+}
+
+static inline void Mat3x2MultiplyShear( matrix_t m, const float x, const float y ) {
+	const float tmp[] = { m[0], m[1] };
+	m[0] += m[4] * y;
+	m[1] += m[5] * y;
+	m[4] += tmp[0] * x;
+	m[5] += tmp[1] * x;
+}
+
 static inline void ComputeTextureWrapModifer( const matrix_t matrix, const vec2_t scroll, vec2_t modifier ) {
 	const float xDiv = ( matrix[0] * scroll[0] + matrix[4] * scroll[1] );
 	const float yDiv = ( matrix[1] * scroll[0] + matrix[5] * scroll[1] );
@@ -739,15 +771,15 @@ void RB_CalcTexMatrix( const textureBundle_t *bundle, matrix_t matrix )
 					float x = ( 1.0f / 4.0f );
 					float y = ( wf->phase + backEnd.refdef.floatTime * wf->frequency );
 
-					MatrixMultiplyScale( matrix, 1.0f + ( wf->amplitude * sinf( y ) + wf->base ) * x,
-					                     1.0f + ( wf->amplitude * sinf( y + 0.25f ) + wf->base ) * x, 0.0 );
+					Mat3x2MultiplyScale( matrix, 1.0f + ( wf->amplitude * sinf( y ) + wf->base ) * x,
+					                     1.0f + ( wf->amplitude * sinf( y + 0.25f ) + wf->base ) * x );
 					break;
 				}
 
 			case texMod_t::TMOD_ENTITY_TRANSLATE:
 				{
-					float x = backEnd.currentEntity->e.shaderTexCoord[ 0 ] * backEnd.refdef.floatTime;
-					float y = backEnd.currentEntity->e.shaderTexCoord[ 1 ] * backEnd.refdef.floatTime;
+					float x = backEnd.currentEntity->e.shaderTexCoord[ 0 ];
+					float y = backEnd.currentEntity->e.shaderTexCoord[ 1 ];
 
 					// clamp so coordinates don't continuously get larger, causing problems
 					// with hardware limits
@@ -777,7 +809,7 @@ void RB_CalcTexMatrix( const textureBundle_t *bundle, matrix_t matrix )
 					float x = texMod->scale[ 0 ];
 					float y = texMod->scale[ 1 ];
 
-					MatrixMultiplyScale( matrix, x, y, 0.0 );
+					Mat3x2MultiplyScale( matrix, x, y );
 					break;
 				}
 
@@ -785,9 +817,9 @@ void RB_CalcTexMatrix( const textureBundle_t *bundle, matrix_t matrix )
 				{
 					float p = 1.0f / RB_EvalWaveForm( &texMod->wave );
 
-					MatrixMultiplyTranslation( matrix, 0.5, 0.5, 0.0 );
-					MatrixMultiplyScale( matrix, p, p, 0.0 );
-					MatrixMultiplyTranslation( matrix, -0.5, -0.5, 0.0 );
+					Mat3x2MultiplyTranslation( matrix, 0.5, 0.5 );
+					Mat3x2MultiplyScale( matrix, p, p );
+					Mat3x2MultiplyTranslation( matrix, -0.5, -0.5 );
 					break;
 				}
 
@@ -801,9 +833,9 @@ void RB_CalcTexMatrix( const textureBundle_t *bundle, matrix_t matrix )
 				{
 					float x = -texMod->rotateSpeed * backEnd.refdef.floatTime;
 
-					MatrixMultiplyTranslation( matrix, 0.5, 0.5, 0.0 );
-					MatrixMultiplyZRotation( matrix, x );
-					MatrixMultiplyTranslation( matrix, -0.5, -0.5, 0.0 );
+					Mat3x2MultiplyTranslation( matrix, 0.5, 0.5 );
+					Mat3x2MultiplyZRotation( matrix, x );
+					Mat3x2MultiplyTranslation( matrix, -0.5, -0.5 );
 					break;
 				}
 
@@ -828,7 +860,7 @@ void RB_CalcTexMatrix( const textureBundle_t *bundle, matrix_t matrix )
 					float x = RB_EvalExpression( &texMod->sExp, 0 );
 					float y = RB_EvalExpression( &texMod->tExp, 0 );
 
-					MatrixMultiplyScale( matrix, x, y, 0.0 );
+					Mat3x2MultiplyScale( matrix, x, y );
 					break;
 				}
 
@@ -837,20 +869,20 @@ void RB_CalcTexMatrix( const textureBundle_t *bundle, matrix_t matrix )
 					float x = RB_EvalExpression( &texMod->sExp, 0 );
 					float y = RB_EvalExpression( &texMod->tExp, 0 );
 
-					MatrixMultiplyTranslation( matrix, 0.5, 0.5, 0.0 );
-					MatrixMultiplyScale( matrix, x, y, 0.0 );
-					MatrixMultiplyTranslation( matrix, -0.5, -0.5, 0.0 );
+					Mat3x2MultiplyTranslation( matrix, 0.5, 0.5 );
+					Mat3x2MultiplyScale( matrix, x, y );
+					Mat3x2MultiplyTranslation( matrix, -0.5, -0.5 );
 					break;
 				}
 
 			case texMod_t::TMOD_SHEAR:
 				{
-					float x = RB_EvalExpression( &texMod->sExp, 0 );
-					float y = RB_EvalExpression( &texMod->tExp, 0 );
+					const float x = RB_EvalExpression( &texMod->sExp, 0 );
+					const float y = RB_EvalExpression( &texMod->tExp, 0 );
 
-					MatrixMultiplyTranslation( matrix, 0.5, 0.5, 0.0 );
-					MatrixMultiplyShear( matrix, x, y );
-					MatrixMultiplyTranslation( matrix, -0.5, -0.5, 0.0 );
+					Mat3x2MultiplyTranslation( matrix, 0.5, 0.5 );
+					Mat3x2MultiplyShear( matrix, x, y );
+					Mat3x2MultiplyTranslation( matrix, -0.5, -0.5 );
 					break;
 				}
 
@@ -858,9 +890,9 @@ void RB_CalcTexMatrix( const textureBundle_t *bundle, matrix_t matrix )
 				{
 					float x = RB_EvalExpression( &texMod->rExp, 0 );
 
-					MatrixMultiplyTranslation( matrix, 0.5, 0.5, 0.0 );
-					MatrixMultiplyZRotation( matrix, x );
-					MatrixMultiplyTranslation( matrix, -0.5, -0.5, 0.0 );
+					Mat3x2MultiplyTranslation( matrix, 0.5, 0.5 );
+					Mat3x2MultiplyZRotation( matrix, x );
+					Mat3x2MultiplyTranslation( matrix, -0.5, -0.5 );
 					break;
 				}
 


### PR DESCRIPTION
Fixes #1278.

The previous code assumed that a texture with a scroll textureMod would always wrap around when `scroll * backEnd.refdef.floatTime == floor( scroll * backEnd.refdef.floatTime )`. This is incorrect if the texture matrix had already been modified by another texMod, so the relevant values are no longer 1.0f and 0.0f. Fix this by using `scrollPeriod[0] / ( matrix[0] + matrix[4] )` and `scrollPeriod[0] / ( matrix[0] + matrix[4] )` to get the actual time at which wrap-around for `x` and `y` will occur, and use `fmodf( backEnd.refdef.floatTime, period )` to get the part that is equivalent to just using `backEnd.refdef.floatTime`, but without the value getting continuously larger.

Also NUKED some useless matrix computations from texMod scroll, and added some functions to only calculate the relevant part of a matrix for texture matrices.

This change can be observed on:
Map `tds`, `r_forceRendererTime 49999` and `r_forceRendererTime 50000`:
Old:
https://imgsli.com/MzQ0MjYy
New:
https://imgsli.com/MzQ0MjY1
Map `pulse`, `r_forceRendererTime 50000` and `r_forceRendererTime 50001`:
Old:
https://imgsli.com/MzQ0MjY0
New:
https://imgsli.com/MzQ0MjY2