### PR TITLE
WIP: implement colorspace support (sRGB, etc.)

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -160,6 +160,7 @@ set(GLSLSOURCELIST
     ${ENGINE_DIR}/renderer/glsl_source/blur_vp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/cameraEffects_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/cameraEffects_vp.glsl
+    ${ENGINE_DIR}/renderer/glsl_source/colorSpace.glsl
     ${ENGINE_DIR}/renderer/glsl_source/computeLight_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/contrast_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/contrast_vp.glsl

--- a/src/common/Color.h
+++ b/src/common/Color.h
@@ -38,6 +38,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Compiler.h"
 #include "Math.h"
 
+#define convertFromSRGB( v ) (v <= 0.04045f ? v * (1.0f / 12.92f) : pow((v + 0.055f) * (1.0f / 1.055f), 2.4f))
+
 namespace Color {
 
 /*
@@ -254,6 +256,20 @@ public:
 	CONSTEXPR_FUNCTION_RELAXED void SetAlpha( component_type v ) NOEXCEPT
 	{
 		data_[ 3 ] = v;
+	}
+
+	CONSTEXPR_FUNCTION_RELAXED component_type ConvertFromSRGB( component_type v ) NOEXCEPT
+	{
+		float f = float( v ) / 255.0f;
+		f = convertFromSRGB( f );
+		return component_type( f * 255 );
+	}
+
+	CONSTEXPR_FUNCTION_RELAXED void ConvertFromSRGB() NOEXCEPT
+	{
+		SetRed( ConvertFromSRGB( Red() ) );
+		SetGreen( ConvertFromSRGB( Green() ) );
+		SetBlue( ConvertFromSRGB( Blue() ) );
 	}
 
 	CONSTEXPR_FUNCTION_RELAXED BasicColor& operator*=( float factor ) NOEXCEPT

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -158,6 +158,9 @@ void UpdateSurfaceDataGeneric3D( uint32_t* materials, shaderStage_t* pStage, boo
 	Tess_ComputeColor( pStage );
 	gl_genericShaderMaterial->SetUniform_Color( tess.svars.color );
 
+	// u_LinearizeTexture
+	gl_genericShaderMaterial->SetUniform_LinearizeTexture( pStage->linearizeTexture );
+
 	bool hasDepthFade = pStage->hasDepthFade;
 	if ( hasDepthFade ) {
 		gl_genericShaderMaterial->SetUniform_DepthScale( pStage->depthFadeValue );
@@ -190,6 +193,9 @@ void UpdateSurfaceDataLightMapping( uint32_t* materials, shaderStage_t* pStage, 
 
 	// u_AlphaThreshold
 	gl_lightMappingShaderMaterial->SetUniform_AlphaTest( pStage->stateBits );
+
+	// u_LinearizeTexture
+	gl_lightMappingShaderMaterial->SetUniform_LinearizeTexture( pStage->linearizeTexture );
 
 	// HeightMap
 	if ( pStage->enableReliefMapping ) {
@@ -268,6 +274,9 @@ void UpdateSurfaceDataSkybox( uint32_t* materials, shaderStage_t* pStage, bool, 
 	gl_skyboxShaderMaterial->SetUniform_AlphaTest( GLS_ATEST_NONE );
 
 	gl_skyboxShaderMaterial->WriteUniformsToBuffer( materials );
+
+	// u_LinearizeTexture
+	gl_skyboxShaderMaterial->SetUniform_LinearizeTexture( pStage->linearizeTexture );
 }
 
 void UpdateSurfaceDataScreen( uint32_t* materials, shaderStage_t* pStage, bool, bool, bool ) {
@@ -360,6 +369,8 @@ void UpdateSurfaceDataFog( uint32_t* materials, shaderStage_t* pStage, bool, boo
 	materials += pStage->bufferOffset;
 
 	gl_fogQuake3ShaderMaterial->WriteUniformsToBuffer( materials );
+
+	gl_fogQuake3ShaderMaterial->SetUniform_LinearizeTexture( tr.worldLinearizeTexture );
 }
 
 /*

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -802,6 +802,11 @@ static std::string GenEngineConstants() {
 		AddConst( str, "r_RimExponent", r_rimExponent->value );
 	}
 
+	if ( r_cheapSRGB.Get() )
+	{
+		AddDefine( str, "r_cheapSRGB", 1 );
+	}
+
 	if ( r_showLightTiles->integer )
 	{
 		AddDefine( str, "r_showLightTiles", 1 );
@@ -2261,6 +2266,7 @@ GLShader_generic::GLShader_generic( GLShaderManager *manager ) :
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_ColorModulateColorGen( this ),
 	u_Color( this ),
 	u_Bones( this ),
@@ -2293,6 +2299,7 @@ GLShader_genericMaterial::GLShader_genericMaterial( GLShaderManager* manager ) :
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_ColorModulateColorGen( this ),
 	u_Color( this ),
 	u_DepthScale( this ),
@@ -2334,6 +2341,7 @@ GLShader_lightMapping::GLShader_lightMapping( GLShaderManager *manager ) :
 	u_ViewOrigin( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_Bones( this ),
 	u_VertexInterpolation( this ),
 	u_ReliefDepthScale( this ),
@@ -2402,6 +2410,7 @@ GLShader_lightMappingMaterial::GLShader_lightMappingMaterial( GLShaderManager* m
 	u_ViewOrigin( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_ReliefDepthScale( this ),
 	u_ReliefOffsetBias( this ),
 	u_NormalScale( this ),
@@ -2712,6 +2721,7 @@ GLShader_skybox::GLShader_skybox( GLShaderManager *manager ) :
 	u_CloudHeight( this ),
 	u_UseCloudMap( this ),
 	u_AlphaThreshold( this ),
+	u_LinearizeTexture( this ),
 	u_ModelViewProjectionMatrix( this )
 {
 }
@@ -2730,6 +2740,7 @@ GLShader_skyboxMaterial::GLShader_skyboxMaterial( GLShaderManager* manager ) :
 	u_CloudHeight( this ),
 	u_UseCloudMap( this ),
 	u_AlphaThreshold( this ),
+	u_LinearizeTexture( this ),
 	u_ModelViewProjectionMatrix( this )
 {}
 
@@ -2743,6 +2754,7 @@ GLShader_fogQuake3::GLShader_fogQuake3( GLShaderManager *manager ) :
 	u_FogMap( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_ColorGlobal( this ),
 	u_Bones( this ),
 	u_VertexInterpolation( this ),
@@ -2765,6 +2777,7 @@ GLShader_fogQuake3Material::GLShader_fogQuake3Material( GLShaderManager* manager
 	u_FogMap( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_ColorGlobal( this ),
 	u_FogDistanceVector( this ),
 	u_FogDepthVector( this ),
@@ -2782,6 +2795,7 @@ GLShader_fogGlobal::GLShader_fogGlobal( GLShaderManager *manager ) :
 	u_DepthMap( this ),
 	u_ModelViewProjectionMatrix( this ),
 	u_UnprojectMatrix( this ),
+	u_LinearizeTexture( this ),
 	u_Color( this ),
 	u_FogDistanceVector( this )
 {
@@ -2896,7 +2910,8 @@ GLShader_cameraEffects::GLShader_cameraEffects( GLShaderManager *manager ) :
 	u_ColorModulate( this ),
 	u_TextureMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
-	u_InverseGamma( this )
+	u_InverseGamma( this ),
+	u_DelinearizeScreen( this )
 {
 }
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2879,6 +2879,36 @@ public:
 	}
 };
 
+class u_LinearizeTexture :
+	GLUniform1i
+{
+public:
+	u_LinearizeTexture( GLShader *shader ) :
+		GLUniform1i( shader, "u_LinearizeTexture" )
+	{
+	}
+
+	void SetUniform_LinearizeTexture( const int value )
+	{
+		this->SetValue( value );
+	}
+};
+
+class u_DelinearizeScreen :
+	GLUniform1i
+{
+public:
+	u_DelinearizeScreen( GLShader *shader ) :
+		GLUniform1i( shader, "u_DelinearizeScreen" )
+	{
+	}
+
+	void SetUniform_DelinearizeScreen( const int value )
+	{
+		this->SetValue( value );
+	}
+};
+
 class u_ShadowBlur :
 	GLUniform1f
 {
@@ -3907,6 +3937,7 @@ class GLShader_generic :
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_ColorModulateColorGen,
 	public u_Color,
 	public u_Bones,
@@ -3936,6 +3967,7 @@ class GLShader_genericMaterial :
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_ColorModulateColorGen,
 	public u_Color,
 	public u_DepthScale,
@@ -3974,6 +4006,7 @@ class GLShader_lightMapping :
 	public u_ViewOrigin,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_Bones,
 	public u_VertexInterpolation,
 	public u_ReliefDepthScale,
@@ -4025,6 +4058,7 @@ class GLShader_lightMappingMaterial :
 	public u_ViewOrigin,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_ReliefDepthScale,
 	public u_ReliefOffsetBias,
 	public u_NormalScale,
@@ -4268,6 +4302,7 @@ class GLShader_skybox :
 	public u_CloudHeight,
 	public u_UseCloudMap,
 	public u_AlphaThreshold,
+	public u_LinearizeTexture,
 	public u_ModelViewProjectionMatrix
 {
 public:
@@ -4283,6 +4318,7 @@ class GLShader_skyboxMaterial :
 	public u_CloudHeight,
 	public u_UseCloudMap,
 	public u_AlphaThreshold,
+	public u_LinearizeTexture,
 	public u_ModelViewProjectionMatrix {
 	public:
 	GLShader_skyboxMaterial( GLShaderManager* manager );
@@ -4294,6 +4330,7 @@ class GLShader_fogQuake3 :
 	public u_FogMap,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_ColorGlobal,
 	public u_Bones,
 	public u_VertexInterpolation,
@@ -4314,6 +4351,7 @@ class GLShader_fogQuake3Material :
 	public u_FogMap,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_LinearizeTexture,
 	public u_ColorGlobal,
 	public u_FogDistanceVector,
 	public u_FogDepthVector,
@@ -4330,6 +4368,7 @@ class GLShader_fogGlobal :
 	public u_DepthMap,
 	public u_ModelViewProjectionMatrix,
 	public u_UnprojectMatrix,
+	public u_LinearizeTexture,
 	public u_Color,
 	public u_FogDistanceVector
 {
@@ -4427,7 +4466,8 @@ class GLShader_cameraEffects :
 	public u_ColorModulate,
 	public u_TextureMatrix,
 	public u_ModelViewProjectionMatrix,
-	public u_InverseGamma
+	public u_InverseGamma,
+	public u_DelinearizeScreen
 {
 public:
 	GLShader_cameraEffects( GLShaderManager *manager );

--- a/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
+++ b/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
@@ -22,8 +22,11 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* cameraEffects_fp.glsl */
 
+#insert colorSpace
+
 uniform sampler2D u_CurrentMap;
 
+uniform bool u_DelinearizeScreen;
 #if defined(r_colorGrading)
 uniform sampler3D u_ColorMap3D;
 #endif
@@ -41,6 +44,8 @@ void	main()
 	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	vec4 color = texture2D(u_CurrentMap, st);
+
+	convertToSRGB(color.rgb, u_DelinearizeScreen);
 
 	color = clamp(color, 0.0, 1.0);
 

--- a/src/engine/renderer/glsl_source/colorSpace.glsl
+++ b/src/engine/renderer/glsl_source/colorSpace.glsl
@@ -1,0 +1,107 @@
+#define SRGB_MIX
+
+uniform int u_LinearizeTexture;
+
+void convertFromSRGB(inout vec3 color, in bool condition) {
+	if (condition)
+	{
+	#if defined(r_cheapSRGB)
+		float gamma = 2.2;
+		color = pow(color, vec3(gamma));
+
+	#elif defined(SRGB_NAIVE)
+		// (((c) <= 0.04045f) ? (c) * (1.0f / 12.92f) : (float)pow(((c) + 0.055f)*(1.0f/1.055f), 2.4f))
+
+		float threshold = 0.0031308f;
+
+		color.r = color.r <= threshold ? color.r * (1.0f / 12.92f) : pow((color.r + 0.055f) * (1.0f / 1.055f), 2.4f);
+		color.g = color.g <= threshold ? color.g * (1.0f / 12.92f) : pow((color.g + 0.055f) * (1.0f / 1.055f), 2.4f);
+		color.b = color.b <= threshold ? color.b * (1.0f / 12.92f) : pow((color.b + 0.055f) * (1.0f / 1.055f), 2.4f);
+	#elif defined(SRGB_FBOOL)
+		float threshold = 0.0031308f;
+
+		vec3 yes = vec3(float(color.r <= threshold), float(color.g <= threshold), float(color.b <= threshold));
+		vec3 no = yes * -1.0f + 1.0f;
+
+		vec3 low = color * (1.0f / 12.92f);
+		vec3 high = pow((color + 0.055f) * (1.0f / 1.055f), vec3(2.4f));
+
+		color = (yes * low) + (no * high);
+	#elif defined(SRGB_BOOL)
+		float threshold = 0.0031308f;
+
+		bvec3 yes = bvec3(color.r <= threshold, color.g <= threshold, color.b <= threshold);
+		bvec3 no = bvec3(!yes.x, !yes.y, !yes.z);
+
+		vec3 low = color * (1.0f / 12.92f);
+		vec3 high = pow((color + 0.055f) * (1.0f / 1.055f), vec3(2.4f));
+
+		color = (float(yes) * low) + (float(no) * high);
+	#elif defined(SRGB_MIX)
+		float threshold = 0.0031308f;
+
+		bvec3 cutoff = lessThan(color, vec3(threshold));
+		vec3 low = color / vec3(12.92f);
+		vec3 high = pow((color + vec3(0.055f)) / vec3(1.055f), vec3(2.4f));
+
+		color = mix(high, low, cutoff);
+	#else
+		#error undefined SRGB computation
+	#endif
+	}
+}
+
+void convertFromSRGB(inout vec3 color, in int condition) {
+	convertFromSRGB(color, condition != 0);
+}
+
+void convertToSRGB(inout vec3 color, in bool condition) {
+	if (condition)
+	{
+	#if defined(r_cheapSRGB)
+		float gamma = 2.2;
+		color = pow(color, vec3(1/gamma));
+	#elif defined(SRGB_NAIVE)
+		// (((c) < 0.0031308f) ? (c) * 12.92f : 1.055f * (float)pow((c), 1.0f/2.4f) - 0.055f)
+		float threshold = 0.0031308f;
+
+		color.r = color.r < threshold ? color.r * 12.92f : 1.055f * pow(color.r, 1.0f / 2.4f) - 0.055f;
+		color.g = color.g < threshold ? color.g * 12.92f : 1.055f * pow(color.g, 1.0f / 2.4f) - 0.055f;
+		color.b = color.b < threshold ? color.b * 12.92f : 1.055f * pow(color.b, 1.0f / 2.4f) - 0.055f;
+	#elif defined(SRGB_FBOOL)
+		float threshold = 0.0031308f;
+
+		vec3 yes = vec3(float(color.r < threshold), float(color.g < threshold), float(color.b < threshold));
+		vec3 no = yes * -1.0f + 1.0f;
+
+		vec3 low = color * 12.92f;
+		vec3 high = pow(color, vec3(1.0f / 2.4f)) - 0.055f;
+
+		color = (yes * low) + (no * high);
+	#elif defined(SRGB_BOOL)
+		float threshold = 0.0031308f;
+
+		bvec3 yes = bvec3(color.r < threshold, color.g < threshold, color.b < threshold);
+		bvec3 no = bvec3(!yes.x, !yes.y, !yes.z);
+
+		vec3 low = color * 12.92f;
+		vec3 high = pow(color, vec3(1.0f / 2.4f)) - 0.055f;
+
+		color = (float(yes) * low) + (float(no) * high);
+	#elif defined(SRGB_MIX)
+		float threshold = 0.0031308f;
+
+		bvec3 cutoff = lessThan(color, vec3(threshold));
+		vec3 low = vec3(12.92f) * color;
+		vec3 high = vec3(1.055f) * pow(color, vec3(1.0f / 2.4f)) - vec3(0.055f);
+
+		color = mix(high, low, cutoff);
+	#else
+		#error undefined SRGB computation
+	#endif
+	}
+}
+
+void convertToSRGB(inout vec3 color, in int condition) {
+	convertToSRGB(color, condition != 0);
+}

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -67,13 +67,8 @@ vec4 EnvironmentalSpecularFactor( vec3 viewDir, vec3 normal )
 		ambientColor = ambientScale * texel.rgb;
 		lightColor = directedScale * texel.rgb;
 
-		#if defined(r_cheapSRGB)
-			/* The light grid conversion from sRGB is done in C++ code
-			when loading it, meaning it's done before interpolation. */
-		#else
-			convertFromSRGB(lightColor, linearizeLightMap);
-			convertFromSRGB(ambientColor, linearizeLightMap);
-		#endif
+		/* The light grid conversion from sRGB is done in C++ code
+		when loading it, so it's done before interpolation. */
 
 		ambientColor *= lightFactor;
 		lightColor *= lightFactor;

--- a/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* fogGlobal_fp.glsl */
 
+#insert colorSpace
+
 uniform sampler2D	u_ColorMap; // fog texture
 uniform sampler2D	u_DepthMap;
 
@@ -51,6 +53,8 @@ void	main()
 	st.t = 1.0;
 
 	vec4 color = texture2D(u_ColorMap, st);
+
+	convertFromSRGB(color.rgb, u_LinearizeTexture);
 
 	outputColor = unpackUnorm4x8( u_Color ) * color;
 }

--- a/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* fogQuake3_fp.glsl */
 
+#insert colorSpace
+
 #define FOGQUAKE3_GLSL
 
 uniform sampler2D u_FogMap;
@@ -39,6 +41,8 @@ void	main()
 	vec4 color = texture2D(u_FogMap, var_TexCoords);
 
 	color *= var_Color;
+
+	convertFromSRGB(color.rgb, u_LinearizeTexture);
 
 	outputColor = color;
 

--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* generic_fp.glsl */
 
+#insert colorSpace
+
 #define GENERIC_GLSL
 
 uniform sampler2D	u_ColorMap;
@@ -62,6 +64,10 @@ void	main()
 		discard;
 		return;
 	}
+
+#if !defined(GENERIC_2D)
+	convertFromSRGB(color.rgb, u_LinearizeTexture);
+#endif
 
 #if defined(USE_DEPTH_FADE)
 	float depth = texture2D(u_DepthMap, gl_FragCoord.xy / r_FBufSize).x;

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 /* lightMapping_fp.glsl */
 
 #insert common
+#insert colorSpace
 #insert computeLight_fp
 #insert reliefMapping_fp
 
@@ -101,13 +102,25 @@ void main()
 	vec4 diffuse = texture2D(u_DiffuseMap, texCoords);
 
 	// Apply vertex blend operation like: alphaGen vertex.
-	diffuse *= var_Color;
+	diffuse.a *= var_Color.a;
 
 	if(abs(diffuse.a + u_AlphaThreshold) <= 1.0)
 	{
 		discard;
 		return;
 	}
+
+	/* HACK: emulate three-bits bitfield
+	even: no color map linearization (first bit)
+	less than 2: no light map linearization (second bit)
+	positive: no material map linearization (extra bit) */
+	bool linearizeColorMap = bool(u_LinearizeTexture % 2);
+	bool linearizeLightMap = abs(u_LinearizeTexture) > 1;
+	bool linearizeMaterialMap = u_LinearizeTexture < 0;
+
+	convertFromSRGB(diffuse.rgb, linearizeColorMap);
+
+	diffuse.rgb *= var_Color.rgb;
 
 	// Compute normal in world space from normalmap.
 	#if defined(r_normalMapping)
@@ -119,6 +132,8 @@ void main()
 	#if defined(r_specularMapping) || defined(r_physicalMapping)
 		// Compute the material term.
 		vec4 material = texture2D(u_MaterialMap, texCoords);
+
+		convertFromSRGB(material.rgb, linearizeMaterialMap);
 	#elif ( defined(r_realtimeLighting) && r_realtimeLightingRenderer == 1 )\
 		|| defined( USE_DELUXE_MAPPING ) || defined(USE_GRID_DELUXE_MAPPING )
 		// The computeDynamicLights function requires this variable to exist.
@@ -147,17 +162,13 @@ void main()
 	float lightFactor = ColorModulateToLightFactor( u_ColorModulateColorGen );
 	#if defined(USE_LIGHT_MAPPING)
 		// Compute light color from world space lightmap.
-		// When doing vertex lighting with full-range overbright, this reads out
-		// 1<<overbrightBits and serves for the overbright shift for vertex colors.
 		vec3 lightColor = texture2D(u_LightMap, var_TexLight).rgb;
-		lightColor *= lightFactor;
-
+		TransformLightMap(lightColor, lightFactor, linearizeLightMap);
 		color.rgb = vec3(0.0);
 	#else
 		// Compute light color from lightgrid.
 		vec3 ambientColor, lightColor;
-		ReadLightGrid(texture3D(u_LightGrid1, lightGridPos), lightFactor, ambientColor, lightColor);
-
+		ReadLightGrid(texture3D(u_LightGrid1, lightGridPos), lightFactor, linearizeLightMap, ambientColor, lightColor);
 		color.rgb = ambientColor * r_AmbientScale * diffuse.rgb;
 	#endif
 
@@ -214,6 +225,8 @@ void main()
 	#if defined(r_glowMapping)
 		// Blend glow map.
 		vec3 glow = texture2D(u_GlowMap, texCoords).rgb;
+
+		convertFromSRGB(glow, linearizeColorMap);
 
 		color.rgb += glow;
 	#endif

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -110,13 +110,9 @@ void main()
 		return;
 	}
 
-	/* HACK: emulate three-bits bitfield
-	even: no color map linearization (first bit)
-	less than 2: no light map linearization (second bit)
-	positive: no material map linearization (extra bit) */
-	bool linearizeColorMap = bool(u_LinearizeTexture % 2);
-	bool linearizeLightMap = abs(u_LinearizeTexture) > 1;
-	bool linearizeMaterialMap = u_LinearizeTexture < 0;
+	bool linearizeColorMap = ( u_LinearizeTexture & 0x1 ) != 0;
+	bool linearizeLightMap = ( u_LinearizeTexture & 0x2 ) != 0;
+	bool linearizeMaterialMap = ( u_LinearizeTexture & 0x4 ) != 0;
 
 	convertFromSRGB(diffuse.rgb, linearizeColorMap);
 

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -217,9 +217,21 @@ void main()
 
 	// Add Rim Lighting to highlight the edges on model entities.
 	#if defined(r_rimLighting) && defined(USE_MODEL_SURFACE) && defined(USE_GRID_LIGHTING)
+		float mul1, mul2;
+		if ( linearizeLightMap )
+		{
+			mul1 = 0.033; // convertFromSRGB( 0.2 )
+			mul2 = 0.448; // convertFromSRGB( 0.7 )
+		}
+		else
+		{
+			mul1 = 0.2;
+			mul2 = 0.7;
+		}
+
 		float rim = pow(1.0 - clamp(dot(normal, viewDir), 0.0, 1.0), r_RimExponent);
-		vec3 emission = ambientColor * rim * rim * 0.2;
-		color.rgb += 0.7 * emission;
+		vec3 emission = ambientColor * rim * rim * mul1;
+		color.rgb += mul2 * emission;
 	#endif
 
 	#if defined(r_glowMapping)

--- a/src/engine/renderer/glsl_source/skybox_fp.glsl
+++ b/src/engine/renderer/glsl_source/skybox_fp.glsl
@@ -22,6 +22,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 /* skybox_fp.glsl */
 
+#insert colorSpace
+
 #define SKYBOX_GLSL
 
 const float radiusWorld = 4096.0; // Value used by quake 3 skybox code
@@ -77,6 +79,8 @@ void	main()
 		discard;
 		return;
 	}
+
+	convertFromSRGB(color.rgb, u_LinearizeTexture);
 
 	outputColor = color;
 }

--- a/src/engine/renderer/shaders.cpp
+++ b/src/engine/renderer/shaders.cpp
@@ -10,6 +10,7 @@
 #include "blur_vp.glsl.h"
 #include "cameraEffects_fp.glsl.h"
 #include "cameraEffects_vp.glsl.h"
+#include "colorSpace.glsl.h"
 #include "computeLight_fp.glsl.h"
 #include "contrast_fp.glsl.h"
 #include "contrast_vp.glsl.h"
@@ -72,6 +73,7 @@ std::unordered_map<std::string, std::string> shadermap({
 	{ "cameraEffects_fp.glsl", std::string(reinterpret_cast<const char*>(cameraEffects_fp_glsl), sizeof(cameraEffects_fp_glsl)) },
 	{ "cameraEffects_vp.glsl", std::string(reinterpret_cast<const char*>(cameraEffects_vp_glsl), sizeof(cameraEffects_vp_glsl)) },
 	{ "computeLight_fp.glsl", std::string(reinterpret_cast<const char*>(computeLight_fp_glsl), sizeof(computeLight_fp_glsl)) },
+	{ "colorSpace.glsl", std::string(reinterpret_cast<const char*>(colorSpace_glsl), sizeof(colorSpace_glsl)) },
 	{ "contrast_fp.glsl", std::string(reinterpret_cast<const char*>(contrast_fp_glsl), sizeof(contrast_fp_glsl)) },
 	{ "contrast_vp.glsl", std::string(reinterpret_cast<const char*>(contrast_vp_glsl), sizeof(contrast_vp_glsl)) },
 	{ "common.glsl", std::string( reinterpret_cast< const char* >( common_glsl ), sizeof( common_glsl ) ) },

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3048,7 +3048,9 @@ void RB_RenderBloom()
 	GLimp_LogComment( "--- RB_RenderBloom ---\n" );
 
 	if ( ( backEnd.refdef.rdflags & ( RDF_NOWORLDMODEL | RDF_NOBLOOM ) )
-		|| !glConfig2.bloom || backEnd.viewParms.portalLevel > 0 ) {
+		|| !glConfig2.bloom || backEnd.viewParms.portalLevel > 0
+		|| !tr.worldLinearizeTexture )
+	{
 		return;
 	}
 

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -2980,6 +2980,9 @@ void RB_RenderGlobalFog()
 	// go back to the world modelview matrix
 	backEnd.orientation = backEnd.viewParms.world;
 
+	// u_LinearizeTexture
+	gl_fogGlobalShader->SetUniform_LinearizeTexture( tr.worldLinearizeTexture );
+
 	{
 		fog_t *fog;
 
@@ -3327,6 +3330,9 @@ void RB_CameraPostFX()
 
 	// enable shader, set arrays
 	gl_cameraEffectsShader->BindProgram( 0 );
+
+	// u_DelinearizeScreen
+	gl_cameraEffectsShader->SetUniform_DelinearizeScreen( tr.worldLinearizeTexture );
 
 	gl_cameraEffectsShader->SetUniform_ColorModulate( backEnd.viewParms.gradingWeights );
 

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -4162,16 +4162,8 @@ void R_LoadLightGrid( lump_t *l )
 
 			if ( tr.worldLinearizeLightMap )
 			{
-				if ( r_cheapSRGB.Get() )
-				{
-					ambientColor[ j ] = convertFromSRGB( ambientColor[ j ] );
-					directedColor[ j ] = convertFromSRGB( directedColor[ j ] );
-				}
-				else
-				{
-					/* When not cheap, the light grid conversion from sRGB is done
-					in GLSL code after interpolation. */
-				}
+				ambientColor[ j ] = convertFromSRGB( ambientColor[ j ] );
+				directedColor[ j ] = convertFromSRGB( directedColor[ j ] );
 			}
 		}
 

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -3095,15 +3095,6 @@ void R_InitImages()
 	Mappers may port and fix maps by multiplying the lights by 2.5
 	and set the mapOverBrightBits key to 0 in map entities lump.
 
-	It will be possible to assume tr.mapOverBrightBits is 0 when
-	loading maps compiled with sRGB lightmaps as there is no
-	legacy map using sRGB lightmap yet, and then we will be
-	able to avoid the need to explicitly set mapOverBrightBits
-	to 0 in map entities. It will be required to assume that
-	tr.mapOverBrightBits is 0 when loading maps compiled with
-	sRGB lightmaps because otherwise the color shift computation
-	will break the light computation, not only the deluxe one.
-
 	In legacy engines, tr.overbrightBits was non-zero when
 	hardware overbright bits were enabled, zero when disabled.
 	This engine do not implement hardware overbright bit, so

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -3054,59 +3054,6 @@ void R_InitImages()
 	tr.lightmaps.reserve( 128 );
 	tr.deluxemaps.reserve( 128 );
 
-	/* These are the values expected by the rest of the renderer
-	(esp. tr_bsp), used for "gamma correction of the map".
-	Both were set to 0 if we had neither COMPAT_ET nor COMPAT_Q3,
-	it may be interesting to remember.
-
-	Quake 3 and Tremulous values:
-
-	  tr.overbrightBits = 0; // Software implementation.
-	  tr.mapOverBrightBits = 2; // Quake 3 default.
-	  tr.identityLight = 1.0f / ( 1 << tr.overbrightBits );
-
-	Games like Quake 3 and Tremulous require tr.mapOverBrightBits
-	to be set to 2. Because this engine is primarily maintained for
-	Unvanquished and needs to keep compatibility with legacy Tremulous
-	maps, this value is set to 2.
-
-	Games like True Combat: Elite (Wolf:ET mod) or Urban Terror 4
-	(Quake 3 mod) require tr.mapOverBrightBits to be set to 0.
-
-	For some reasons the Wolf:ET engine sets this to 0 by default
-	but the game sets it to 2 (and requires it to be 2 for maps
-	looking as expected).
-
-	The mapOverBrightBits value will be read as map entity key
-	by R_LoadEntities() in tr_bsp, making possible to override
-	the default value and properly render a map with another
-	value than the default one.
-
-	If this key is missing in map entity lump, there is no way
-	to know the required value for mapOverBrightBits when loading
-	a BSP, one may rely on arena files to do some guessing when
-	loading foreign maps and games ported to the Dæmon engine may
-	require to set a different default than what Unvanquished
-	requires.
-
-	Using a non-zero value for tr.mapOverBrightBits turns light
-	non-linear and makes deluxe mapping buggy though.
-
-	Mappers may port and fix maps by multiplying the lights by 2.5
-	and set the mapOverBrightBits key to 0 in map entities lump.
-
-	In legacy engines, tr.overbrightBits was non-zero when
-	hardware overbright bits were enabled, zero when disabled.
-	This engine do not implement hardware overbright bit, so
-	this is always zero, and we can remove it and simplify all
-	the computations making use of it.
-
-	Because tr.overbrightBits is always 0, tr.identityLight is
-	always 1.0f. We can entirely remove it. */
-
-	tr.mapOverBrightBits = r_overbrightDefaultExponent.Get();
-	tr.legacyOverBrightClamping = r_overbrightDefaultClamp.Get();
-
 	// create default texture and white texture
 	R_CreateBuiltinImages();
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -202,6 +202,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_rimExponent;
 
 	Cvar::Cvar<bool> r_highPrecisionRendering("r_highPrecisionRendering", "use high precision frame buffers for rendering and blending", Cvar::NONE, true);
+	Cvar::Cvar<bool> r_cheapSRGB("r_cheapSRGB", "use cheap sRGB computation when converting images", Cvar::NONE, false);
 
 	cvar_t      *r_gamma;
 	cvar_t      *r_lockpvs;
@@ -1288,6 +1289,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		AssertCvarRange( r_rimExponent, 0.5, 8.0, false );
 
 		Cvar::Latch( r_highPrecisionRendering );
+		Cvar::Latch( r_cheapSRGB );
 
 		r_drawBuffer = Cvar_Get( "r_drawBuffer", "GL_BACK", CVAR_CHEAT );
 		r_lockpvs = Cvar_Get( "r_lockpvs", "0", CVAR_CHEAT );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1123,6 +1123,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		bool            dpMaterial;
 
+		int linearizeTexture;
 		// Core renderer (code path for when only OpenGL Core is available, or compatible OpenGL 2).
 		stageRenderer_t colorRenderer;
 
@@ -2730,6 +2731,8 @@ enum class shaderProfilerRenderSubGroupsMode {
 		bool   worldLightMapping;
 		bool   worldDeluxeMapping;
 		bool   worldHDR_RGBE;
+		bool worldLinearizeTexture;
+		bool worldLinearizeLightMap;
 
 		lightMode_t lightMode;
 		lightMode_t worldLight;
@@ -3022,6 +3025,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 	extern cvar_t *r_rimExponent;
 
 	extern Cvar::Cvar<bool> r_highPrecisionRendering;
+	extern Cvar::Cvar<bool> r_cheapSRGB;
 
 	extern cvar_t *r_logFile; // number of frames to emit GL logs
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1207,6 +1207,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		expression_t    deformMagnitudeExp;
 
+		bool specularSRGB;
 		bool        noFog; // used only for shaders that have fog disabled, so we can enable it for individual stages
 
 		bool useMaterialSystem = false;

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -334,6 +334,14 @@ void RE_AddDynamicLightToSceneET( const vec3_t org, float radius, float intensit
 	light->l.color[ 1 ] = g;
 	light->l.color[ 2 ] = b;
 
+	// Linearize dynamic lights.
+	if ( tr.worldLinearizeTexture )
+	{
+		light->l.color[ 0 ] = convertFromSRGB( light->l.color[ 0 ] );
+		light->l.color[ 1 ] = convertFromSRGB( light->l.color[ 1 ] );
+		light->l.color[ 2 ] = convertFromSRGB( light->l.color[ 2 ] );
+	}
+
 	light->l.inverseShadows = (flags & REF_INVERSE_DLIGHT) != 0;
 	light->l.noShadows = !r_realtimeLightingCastShadows->integer && !light->l.inverseShadows;
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2435,6 +2435,11 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 			{
 				rgb = Math::Clamp( RB_EvalExpression( &pStage->rgbExp, 1.0 ), 0.0f, 1.0f );
 
+				if ( tr.worldLinearizeTexture )
+				{
+					rgb = convertFromSRGB ( rgb );
+				}
+
 				tess.svars.color = Color::White * rgb;
 				break;
 			}
@@ -2461,6 +2466,13 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 					red = Math::Clamp( RB_EvalExpression( &pStage->redExp, 1.0 ), 0.0f, 1.0f );
 					green = Math::Clamp( RB_EvalExpression( &pStage->greenExp, 1.0 ), 0.0f, 1.0f );
 					blue = Math::Clamp( RB_EvalExpression( &pStage->blueExp, 1.0 ), 0.0f, 1.0f );
+				}
+
+				if ( tr.worldLinearizeTexture )
+				{
+					red = convertFromSRGB ( red );
+					green = convertFromSRGB ( green );
+					blue = convertFromSRGB ( blue );
 				}
 
 				tess.svars.color.SetRed( red );

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -861,6 +861,9 @@ void Render_generic3D( shaderStage_t *pStage )
 	gl_genericShader->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
 	gl_genericShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
 
+	// u_LinearizeTexture
+	gl_genericShader->SetUniform_LinearizeTexture( pStage->linearizeTexture );
+
 	// u_Bones
 	if ( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning )
 	{
@@ -1033,6 +1036,9 @@ void Render_lightMapping( shaderStage_t *pStage )
 	gl_lightMappingShader->SetUniform_ViewOrigin( viewOrigin );
 
 	gl_lightMappingShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[ glState.stackIndex ] );
+
+	// u_LinearizeTexture
+	gl_lightMappingShader->SetUniform_LinearizeTexture( pStage->linearizeTexture );
 
 	if ( glConfig2.realtimeLighting &&
 	     r_realtimeLightingRenderer.Get() == Util::ordinal( realtimeLightingRenderer_t::TILED ) )
@@ -1961,6 +1967,9 @@ void Render_skybox( shaderStage_t *pStage )
 		GL_BindToTMU( 0, pStage->bundle[TB_COLORMAP].image[0] )
 	);
 
+	// u_LinearizeTexture
+	gl_skyboxShader->SetUniform_LinearizeTexture( pStage->linearizeTexture );
+
 	// u_AlphaThreshold
 	gl_skyboxShader->SetUniform_AlphaTest( GLS_ATEST_NONE );
 
@@ -2268,6 +2277,9 @@ void Render_fog( shaderStage_t* pStage )
 	gl_fogQuake3Shader->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
 
 	gl_fogQuake3Shader->BindProgram( 0 );
+
+	// u_LinearizeTexture
+	gl_fogQuake3Shader->SetUniform_LinearizeTexture( tr.worldLinearizeTexture );
 
 	gl_fogQuake3Shader->SetUniform_FogDistanceVector( fogDistanceVector );
 	gl_fogQuake3Shader->SetUniform_FogDepthVector( fogDepthVector );

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4767,7 +4767,9 @@ static int packLinearizeTexture( bool linearizeColorMap, bool linearizeMaterialM
 	even: no color map linearization (first bit)
 	less than 2: no light map linearization (second bit)
 	positive: no material map linearization (extra bit) */
-	return ( int(linearizeColorMap) + ( 2 * int(linearizeLightMap) ) ) * ( linearizeMaterialMap ? -1 : 1 );
+	return linearizeColorMap << 0
+	     | linearizeLightMap << 1
+	     | linearizeMaterialMap << 2;
 }
 
 /*

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -3233,6 +3233,10 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 		{
 			ParseExpression( text, &stage->deformMagnitudeExp );
 		}
+		else if ( !Q_stricmp( token, "specularSRGB" ) )
+		{
+			stage->specularSRGB = true;
+		}
 		else
 		{
 			Log::Warn("unknown shader stage parameter '%s' in shader '%s'", token, shader.name );
@@ -5326,7 +5330,9 @@ static void FinishStages()
 			case stageType_t::ST_COLLAPSE_DIFFUSEMAP:
 				stage->linearizeTexture = packLinearizeTexture(
 					tr.worldLinearizeTexture,
-					hasMaterialMap && stage->collapseType == collapseType_t::COLLAPSE_PHONG,
+					hasMaterialMap
+						&& stage->collapseType == collapseType_t::COLLAPSE_PHONG
+						&& stage->specularSRGB,
 					tr.worldLinearizeLightMap );
 				break;
 			default:

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4763,10 +4763,6 @@ static bool ParseShader( const char *_text )
 
 static int packLinearizeTexture( bool linearizeColorMap, bool linearizeMaterialMap, bool linearizeLightMap )
 {
-	/* HACK: emulate three-bits bitfield
-	even: no color map linearization (first bit)
-	less than 2: no light map linearization (second bit)
-	positive: no material map linearization (extra bit) */
 	return linearizeColorMap << 0
 	     | linearizeLightMap << 1
 	     | linearizeMaterialMap << 2;

--- a/src/engine/renderer/tr_sky.cpp
+++ b/src/engine/renderer/tr_sky.cpp
@@ -102,6 +102,9 @@ void Tess_StageIteratorSky()
 
 	gl_skyboxShader->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 
+	// u_LinearizeTexture
+	gl_skyboxShader->SetUniform_LinearizeTexture( tr.worldLinearizeTexture );
+
 	gl_skyboxShader->SetRequiredVertexPointers();
 
 	// draw the outer skybox
@@ -160,6 +163,9 @@ void Tess_StageIteratorSky()
 
 		// u_AlphaThreshold
 		gl_skyboxShader->SetUniform_AlphaTest( pStage->stateBits );
+
+		// u_LinearizeTexture
+		gl_skyboxShader->SetUniform_LinearizeTexture( tr.worldLinearizeTexture );
 
 		GL_State( pStage->stateBits );
 


### PR DESCRIPTION
The purpose of this change is to achieve linear blending, this is a continuation of:

- https://github.com/DaemonEngine/Daemon/pull/1034

Some context:

- Everything should be displayed in sRGB space.
- Everything should be computed in linear space.

Textures are in sRGB space, lightmaps are usually in linear space. So the computation for applying a lightmap on a texture and rendering it is:

- `convertToSRGB( convertFromSRGB( texture ) * light )`

Q3map2 has a trick to also store lightmaps in sRGB space, this makes possible to bias the storage and allocate more precision to some wanted values (makes black less banded if I'm right). When this Q3map2 option is used, the computation for applying a lightmap on a texture and rendering it is:

- `convertToSRGB( convertFromSRGB( texture ) * convertFromSRGB( light ) )`

OpenGL provides features to store images while saying if they are in linear or sRGB space, when using those features, OpenGL would automatically convert the colors to linear space when sampling them, and convert them back to sRGB when displaying.

I still want to start with a fully explicit implementation where we do the conversions ourselves, because it makes easier to control what is happening at every step with our current engine design. It's very unlikely that our engine works with graphics card that don't support sRGB image OpenGL formats (even my 23 years old Radeon 2700 Pro supports it if I'm right). Though, our engine design may not makes it easy to use an implicit OpenGL implementation because of its current design:

- When we load a light style light map, we may not know yet it's a lightmap so we may not know yet in which format it is when we need to know it (when uploading it to GPU).
- When we load an image we may not know yet what kind of image it is, for example a normal map is always in linear space, but some legacy shader keywords make possible to load and upload first the image to GPU memory, then tell if it is a normal map or not only after the OpenGL format is already selected.

There can be other shortcomings like that, but also, there can be things that require some in-engine conversions. For example the rgbgen colors are assumed to be in sRGB space, because if people copy the RGB values from a color picker in an image editor like GIMP or Photoshop, those values are in sRGB. So we need to convert those colors back to linear in the C++ engine code.

Migrating to OpenGL sRGB features is something we can postpone for the future, it will reduce the amount of GLSL code and may limit precision loss (so, more performance and less color imprecision), but we don't require that to get a viable product. And we better want to get proper colorspace management as soon as possible.

My effort to achieve proper colorspace management is now 6 years old.

@sweet235 wrote today in chat:

> \<Sweet\> since almost a year, i cannot decide on what specularity to use for the atcshd texture package
> \<Sweet\> because there is always a change coming up

So we better merge this as soon as possible.

Once this is merged, there would not be _strong_ changes to expect. For example if one day we implement HDR rendering, this will not change the colorspace neither the blend computations, it will just add more precision.

This effort is also required (but not enough) to get true PBR.

It is assumed that once this is merged, the light computation formulæ will be stable (except for PBR which is still work-in-progress).
