### PR TITLE
Implement Lottes HDR->LDR tonemapper

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2910,6 +2910,9 @@ GLShader_cameraEffects::GLShader_cameraEffects( GLShaderManager *manager ) :
 	u_ColorModulate( this ),
 	u_TextureMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
+	u_Tonemap( this ),
+	u_TonemapParms( this ),
+	u_TonemapExposure( this ),
 	u_InverseGamma( this )
 {
 }

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3811,7 +3811,7 @@ class u_TonemapParms :
 	GLUniform4f {
 	public:
 	u_TonemapParms( GLShader* shader ) :
-		GLUniform4f( shader, "u_TonemapParms" ) {
+		GLUniform4f( shader, "u_TonemapParms", true ) {
 	}
 
 	void SetUniform_TonemapParms( vec4_t tonemapParms ) {

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3795,6 +3795,42 @@ public:
 	}
 };
 
+class u_Tonemap :
+	GLUniform1Bool {
+	public:
+	u_Tonemap( GLShader* shader ) :
+		GLUniform1Bool( shader, "u_Tonemap", true ) {
+	}
+
+	void SetUniform_Tonemap( bool tonemap ) {
+		this->SetValue( tonemap );
+	}
+};
+
+class u_TonemapParms :
+	GLUniform4f {
+	public:
+	u_TonemapParms( GLShader* shader ) :
+		GLUniform4f( shader, "u_TonemapParms" ) {
+	}
+
+	void SetUniform_TonemapParms( vec4_t tonemapParms ) {
+		this->SetValue( tonemapParms );
+	}
+};
+
+class u_TonemapExposure :
+	GLUniform1f {
+	public:
+	u_TonemapExposure( GLShader* shader ) :
+		GLUniform1f( shader, "u_TonemapExposure", true ) {
+	}
+
+	void SetUniform_TonemapExposure( float tonemapExposure ) {
+		this->SetValue( tonemapExposure );
+	}
+};
+
 class u_LightGridOrigin :
 	GLUniform3f
 {
@@ -4427,6 +4463,9 @@ class GLShader_cameraEffects :
 	public u_ColorModulate,
 	public u_TextureMatrix,
 	public u_ModelViewProjectionMatrix,
+	public u_Tonemap,
+	public u_TonemapParms,
+	public u_TonemapExposure,
 	public u_InverseGamma
 {
 public:

--- a/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
+++ b/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
@@ -58,9 +58,8 @@ void main()
 
 	if( u_Tonemap ) {
 		color.rgb = TonemapLottes( color.rgb * u_TonemapExposure );
-	} else {
-		color.rgb = clamp( color.rgb, vec3( 0.0f ), vec3( 1.0f ) );
 	}
+	color.rgb = clamp( color.rgb, vec3( 0.0f ), vec3( 1.0f ) );
 
 #if defined(r_colorGrading)
 	// apply color grading

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3302,6 +3302,35 @@ void RB_FXAA()
 	GL_CheckErrors();
 }
 
+static void ComputeTonemapParams( const float contrast, const float highlightsCompressionSpeed,
+	const float HDRMax,
+	const float darkAreaPointHDR, const float darkAreaPointLDR,
+	float& shoulderClip, float& highlightsCompression ) {
+	// Lottes 2016, "Advanced Techniques and Optimization of HDR Color Pipelines"
+	/* a: contrast
+	d: highlightsCompressionSpeed
+	b: shoulderClip
+	c: highlightsCompression
+	hdrMax: HDRMax
+	midIn: darkAreaPointHDR
+	midOut: darkAreaPointLDR */
+
+	shoulderClip =
+		( -pow( darkAreaPointHDR, contrast ) + pow( HDRMax, contrast ) * darkAreaPointLDR )
+		/
+		( ( pow( HDRMax, contrast * highlightsCompressionSpeed )
+			- pow( darkAreaPointHDR, contrast * highlightsCompressionSpeed )
+		) * darkAreaPointLDR );
+	highlightsCompression =
+		( pow( HDRMax, contrast * highlightsCompressionSpeed ) * pow( darkAreaPointHDR, contrast )
+			- pow( HDRMax, contrast ) * pow( darkAreaPointHDR, contrast * highlightsCompressionSpeed ) * darkAreaPointLDR
+		)
+		/
+		( ( pow( HDRMax, contrast * highlightsCompressionSpeed )
+			- pow( darkAreaPointHDR, contrast * highlightsCompressionSpeed )
+		) * darkAreaPointLDR );
+}
+
 void RB_CameraPostFX()
 {
 	matrix_t ortho;
@@ -3331,6 +3360,15 @@ void RB_CameraPostFX()
 	gl_cameraEffectsShader->SetUniform_ColorModulate( backEnd.viewParms.gradingWeights );
 
 	gl_cameraEffectsShader->SetUniform_InverseGamma( 1.0 / r_gamma->value );
+
+	if ( r_highPrecisionRendering.Get() ) {
+		vec4_t tonemapParms { r_tonemapContrast.Get(), r_tonemapHighlightsCompressionSpeed.Get() };
+		ComputeTonemapParams( tonemapParms[0], tonemapParms[1], r_tonemapHDRMax.Get(),
+			r_tonemapDarkAreaPointHDR.Get(), r_tonemapDarkAreaPointLDR.Get(), tonemapParms[2], tonemapParms[3] );
+		gl_cameraEffectsShader->SetUniform_TonemapParms( tonemapParms );
+		gl_cameraEffectsShader->SetUniform_TonemapExposure( r_tonemapExposure.Get() );
+	}
+	gl_cameraEffectsShader->SetUniform_Tonemap( r_highPrecisionRendering.Get() && r_tonemap.Get() );
 
 	// This shader is run last, so let it render to screen instead of
 	// tr.mainFBO

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3361,14 +3361,15 @@ void RB_CameraPostFX()
 
 	gl_cameraEffectsShader->SetUniform_InverseGamma( 1.0 / r_gamma->value );
 
-	if ( r_highPrecisionRendering.Get() ) {
+	const bool tonemap = r_tonemap.Get() && r_highPrecisionRendering.Get() && glConfig2.textureFloatAvailable;
+	if ( tonemap ) {
 		vec4_t tonemapParms { r_tonemapContrast.Get(), r_tonemapHighlightsCompressionSpeed.Get() };
 		ComputeTonemapParams( tonemapParms[0], tonemapParms[1], r_tonemapHDRMax.Get(),
 			r_tonemapDarkAreaPointHDR.Get(), r_tonemapDarkAreaPointLDR.Get(), tonemapParms[2], tonemapParms[3] );
 		gl_cameraEffectsShader->SetUniform_TonemapParms( tonemapParms );
 		gl_cameraEffectsShader->SetUniform_TonemapExposure( r_tonemapExposure.Get() );
 	}
-	gl_cameraEffectsShader->SetUniform_Tonemap( r_highPrecisionRendering.Get() && r_tonemap.Get() );
+	gl_cameraEffectsShader->SetUniform_Tonemap( tonemap );
 
 	// This shader is run last, so let it render to screen instead of
 	// tr.mainFBO

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3316,18 +3316,18 @@ static void ComputeTonemapParams( const float contrast, const float highlightsCo
 	midOut: darkAreaPointLDR */
 
 	shoulderClip =
-		( -pow( darkAreaPointHDR, contrast ) + pow( HDRMax, contrast ) * darkAreaPointLDR )
+		( -powf( darkAreaPointHDR, contrast ) + powf( HDRMax, contrast ) * darkAreaPointLDR )
 		/
-		( ( pow( HDRMax, contrast * highlightsCompressionSpeed )
-			- pow( darkAreaPointHDR, contrast * highlightsCompressionSpeed )
+		( ( powf( HDRMax, contrast * highlightsCompressionSpeed )
+			- powf( darkAreaPointHDR, contrast * highlightsCompressionSpeed )
 		) * darkAreaPointLDR );
 	highlightsCompression =
-		( pow( HDRMax, contrast * highlightsCompressionSpeed ) * pow( darkAreaPointHDR, contrast )
-			- pow( HDRMax, contrast ) * pow( darkAreaPointHDR, contrast * highlightsCompressionSpeed ) * darkAreaPointLDR
+		( powf( HDRMax, contrast * highlightsCompressionSpeed ) * powf( darkAreaPointHDR, contrast )
+			- powf( HDRMax, contrast ) * powf( darkAreaPointHDR, contrast * highlightsCompressionSpeed ) * darkAreaPointLDR
 		)
 		/
-		( ( pow( HDRMax, contrast * highlightsCompressionSpeed )
-			- pow( darkAreaPointHDR, contrast * highlightsCompressionSpeed )
+		( ( powf( HDRMax, contrast * highlightsCompressionSpeed )
+			- powf( darkAreaPointHDR, contrast * highlightsCompressionSpeed )
 		) * darkAreaPointLDR );
 }
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -204,6 +204,23 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<bool> r_highPrecisionRendering("r_highPrecisionRendering", "use high precision frame buffers for rendering and blending", Cvar::NONE, true);
 
 	cvar_t      *r_gamma;
+
+	Cvar::Cvar<bool> r_tonemap( "r_tonemap", "Use  HDR->LDR tonemapping", Cvar::NONE, true );
+	Cvar::Cvar<float> r_tonemapExposure( "r_tonemapExposure", "Tonemap exposure", Cvar::NONE, 1.0f );
+	Cvar::Range<Cvar::Cvar<float>> r_tonemapContrast( "r_tonemapContrast", "Makes dark areas light up faster",
+		Cvar::NONE, 1.6f, 1.0f, 10.0f );
+	Cvar::Range<Cvar::Cvar<float>> r_tonemapHighlightsCompressionSpeed( "r_tonemapHighlightsCompressionSpeed",
+		"Highlights saturation",
+		Cvar::NONE, 0.977f, 0.0f, 10.0f );
+	Cvar::Range<Cvar::Cvar<float>> r_tonemapHDRMax( "r_tonemapHDRMax", "HDR white point",
+		Cvar::NONE, 8.0f, 1.0f, 128.0f );
+	Cvar::Range<Cvar::Cvar<float>> r_tonemapDarkAreaPointHDR( "r_tonemapDarkAreaPointHDR",
+		"Cut-off for dark area light-up",
+		Cvar::NONE, 0.18f, 0.0f, 1.0f );
+	Cvar::Range<Cvar::Cvar<float>> r_tonemapDarkAreaPointLDR( "r_tonemapDarkAreaPointLDR",
+		"Convert to this brightness at dark area cut-off",
+		Cvar::NONE, 0.268f, 0.0f, 1.0f );
+
 	cvar_t      *r_lockpvs;
 	cvar_t      *r_noportals;
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2985,6 +2985,14 @@ enum class shaderProfilerRenderSubGroupsMode {
 	extern cvar_t *r_mode; // video mode
 	extern cvar_t *r_gamma;
 
+	extern Cvar::Cvar<bool> r_tonemap;
+	extern Cvar::Cvar<float> r_tonemapExposure;
+	extern Cvar::Range<Cvar::Cvar<float>> r_tonemapContrast;
+	extern Cvar::Range<Cvar::Cvar<float>> r_tonemapHighlightsCompressionSpeed;
+	extern Cvar::Range<Cvar::Cvar<float>> r_tonemapHDRMax;
+	extern Cvar::Range<Cvar::Cvar<float>> r_tonemapDarkAreaPointHDR;
+	extern Cvar::Range<Cvar::Cvar<float>> r_tonemapDarkAreaPointLDR;
+
 	extern cvar_t *r_nobind; // turns off binding to appropriate textures
 	extern cvar_t *r_singleShader; // make most world faces use default shader
 	extern cvar_t *r_picMip; // controls picmip values


### PR DESCRIPTION
## Background
Ever since #1050, we've had some major changes to lighting thanks to fixing the bug that was affecting how strong the lights were on any map (see #1050 and related pr for the explanation).

#1050 added the option of using int16 render targets. This was done in order to avoid clamping shader output to the `[0.0, 1.0]` range before blending it. And then later #1406 changed it to an fp16 framebuffer to avoid colour clamping in multi-stage shaders. This all requires `r_highPrecisionRendering on`.

One of the side-effects of the whole overbright fix is that some lights became brighter than what the 8-bit framebuffer could hold. Coincidentally, the change to 16-bit framebuffers - in particular the fp16 ones, because int framebuffers still get clamped to `[0.0, 1.0]` - is part of the solution to lights exceeding the `[0.0, 1.0]` range - and part of a proper HDR implementation.

However, doing only that is only good enough for operations that take place *before* presenting the final image to the screen: i. e. rendering all the map and entity surfaces etc, and blending them together. As the final step we were just doing `clamp( color, 0.0f, 1.0f )` in the shader, which obviously creates some pretty bad effects for bright lights:
![unvanquished_2025-02-11_211352_000](https://github.com/user-attachments/assets/23bc6921-a8ed-4f1a-8340-6d80f2477682)
Which gets even worse when `r_bloom` is enabled:
![unvanquished_2025-02-11_211357_000](https://github.com/user-attachments/assets/2bff4891-bddf-45fd-8b63-a5856b4303ea)
Here are 2 more examples using the `test-pbr` map:
Bloom off:
![unvanquished_2025-02-11_211945_000](https://github.com/user-attachments/assets/f4a83dc3-68bb-4edc-b231-46274ae71fe8)
Bloom on:
![unvanquished_2025-02-11_211949_000](https://github.com/user-attachments/assets/328a4a45-9b96-4705-8a35-aa957a77d88e)
We get some very whitened out areas, in which we lose details due to that.

## HDR->LDR conversion
The basic cause of this is that monitors generally display colours only in the `[0.0, 1.0]` range - i. e. the Low Dynamic Range (LDR). The range dynamicity here refers to how far away the highest value can be from the lowest one. As a result of this, on non-HDR monitors the input will first be converted to LDR - in OpenGL this is always done when rendering to the default framebuffer (i. e. one that's provided by the OS), and consists of clamping the values to the `[0.0, 1.0]` range. It's the same thing as we were doing manually and, of course, does not produce good results if the input colours can actually go over that range.

So the default - linear - mapping is basically just:
```
y = x, x < 1.0
y = 1.0, x >= 1.0
```

The other problem is that we lose details in dark regions too, because they're always mapped to some low range.

## Tonemapping operators
In order to solve this, different HDR->LDR mappings exist. They, of course, cannot fully capture all the details across the whole range - but they sure make the end result look way better than either clamping the colours or doing everything in LDR.

There are [many](https://filmicworlds.com/blog/filmic-tonemapping-with-piecewise-power-curves/) [different](https://filmicworlds.com/blog/filmic-tonemapping-operators/) [tonemapping](https://dev.epicgames.com/documentation/en-us/unreal-engine/color-grading-and-the-filmic-tonemapper-in-unreal-engine) [operators](https://gpuopen.com/wp-content/uploads/2016/03/GdcVdrLottes.pdf), and here's also a comparison of a few them displayed as the HDR->LDR mapping curves that someone made on shadertoy:
https://www.shadertoy.com/view/llXyWr

All of them have different trade-offs, because, again, there's no 1:1 HDR->LDR mapping, and we could probably try different algorithms for months on end, which I'm not inclined to do, so I just chose one - Lottes tonemapper (https://gpuopen.com/wp-content/uploads/2016/03/GdcVdrLottes.pdf), because it's easy to implement and gives good results.

I won't go into details about how the formula is derived and why, because there are a lot of them, but they all can be found in the above paper. However, like with most  tonemapping operators (a notable exception is the Reinhard tonemapper, which just does `color /= color + 1.0` - this results in a very bleak output and still a lack of details in dark areas; some variations of this tonemapper exist, but they're not as good as other tonemappers), the mapping looks like this (image from https://filmicworlds.com/blog/filmic-tonemapping-with-piecewise-power-curves/):
![image](https://github.com/user-attachments/assets/1957e4d1-7a5e-4b49-bc39-a463848015f8)

The curve mainly has the form `a * x ^ b`. The "toe" section is the dark area, where colours are mapped to exponentially brighter ones. "Linear" section, if it exists, just does a 1:1 mapping. While "shoulder" *decreases* the brightness of colours in that area - this is what fixes the problem of lights going over the `[0.0, 1.0]` range, and just improves the look of it in general - these are also referred to as `highlights`.

## Settings
The tonemapper currently provides 5 different settings that can be changed:
`r_tonemap`: enable/disable tonemapper
`r_tonemapExposure`: similar to an exposure setting on a camera - all colours will be premultiplied by it; this is the first thing to try to increase brightness in dark areas
`r_tonemapContrast`: again similar to a contrast setting on a camera - changes the contrast between light and dark areas
`r_tonemapHighlightsCompressionSpeed`: this is how fast the light will tend to approach `1.0` in the highlights area
`r_tonemapHDRMax`: this is the "white point" for HDR - how far up a light value can go. Setting this too high will dim the output a bit, but setting it lower than the maximum colour value in input will result. If you see yellow spots appearing in lights, then this value should be set higher
`r_tonemapDarkAreaPointHDR`: this is the `HDR` input cut-off for the dark area - any value below this will be processed as "toe"
`r_tonemapDarkAreaPointLDR`: this is the `LDR` output that corresponds to the previous value - the highest values in "toe" will be mapped to this
All of these settings can be changed at runtime, restarts or anything like that are not required at all.

(images from the paper with this tonemapper linked above)
`r_tonemapContrast`:
![image](https://github.com/user-attachments/assets/9a9c0cc0-8b3e-4ca0-8f3b-2b6744463575)
`r_tonemapHighlightsCompressionSpeed`:
![image](https://github.com/user-attachments/assets/b14aa7a0-531e-47b9-9c9f-e6c3903b3e38)
`r_tonemapHDRMax` (this is actually for `shoulderClip` and is computed in code, but it does depend on `r_tonemapHDRMax`):
![image](https://github.com/user-attachments/assets/43c815b7-bb3a-4afe-ab4b-21a98f378f1e)
`r_tonemapDarkAreaPointHDR` and `r_tonemapDarkAreaPointLDR`:
![image](https://github.com/user-attachments/assets/164a9962-4556-41b4-958e-9c6030104293)

I've also put together this graph where different inputs can be changed to produce a different HDR->LDR mapping:
https://www.desmos.com/calculator/4jujpbdntp

## Output with tonemapper enabled
Let's revisit the areas on previous screenshots, where the lights became too bright, but this time with the tonemapper enabled:
![unvanquished_2025-02-11_211402_000](https://github.com/user-attachments/assets/bcde5b49-b42a-4887-9fcf-95ce47419a60)
And here's the difference with a slider (both with bloom on):
https://imgsli.com/MzQ4MjY5

Different tonemapper settings on the `test-pbr` map:
![unvanquished_2025-02-11_212003_000](https://github.com/user-attachments/assets/a6c60300-7e99-48c8-8a8b-7965dfb9997f)
![unvanquished_2025-02-11_212027_000](https://github.com/user-attachments/assets/7167f85a-f4ef-4bd1-9d7e-297bb9df4d4b)
![unvanquished_2025-02-11_212054_000](https://github.com/user-attachments/assets/7ce74c20-c983-4f1c-9015-9ab92d33b0d3)
![unvanquished_2025-02-11_212316_000](https://github.com/user-attachments/assets/5d14611d-b3fe-4ae3-a038-00e478cb1a60)

With a slider:
https://imgsli.com/MzQ4Mjcw
Different tonemapper settings:
https://imgsli.com/MzQ4Mjcy
https://imgsli.com/MzQ4Mjc0

By mapping the HDR values to LDR properly, we are able to keep details in highly-lit areas *and* add more details to areas that were previously dark:
`r_overbrightDefaultClamp on; r_bloomBlur 1`:
![unvanquished_2025-02-11_201832_000](https://github.com/user-attachments/assets/84a16c92-035c-4690-9aa8-0609921289e2)
`r_overbrightDefaultClamp off; r_bloomBlur 1`:
![unvanquished_2025-02-11_201902_000](https://github.com/user-attachments/assets/5bf0717a-4641-4d5b-9c4a-ed79be2dd25c)
`r_overbrightDefaultClamp off; r_bloomBlur 1; r_tonemap on` (increased exposure):
![unvanquished_2025-02-11_201922_000](https://github.com/user-attachments/assets/81d004e9-4a86-428e-9712-1ba5751b8304)

With a slider:
https://imgsli.com/MzQ4Mjc1