### PR TITLE
generate a DaemonBuildInfo.cpp file instead of using compiler definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ if (NOT (BUILD_CLIENT OR BUILD_TTY_CLIENT OR BUILD_SERVER OR BUILD_DUMMY_APP))
     message(NOTICE "You can safely ignore the following reported architecture, it is not used.")
     message(NOTICE "You can safely ignore the following reported compilers, they are unused.")
 endif()
-include(DaemonPlatform)
 
 if (Daemon_OUT)
     set(CMAKE_CURRENT_BINARY_DIR ${Daemon_OUT})
@@ -85,6 +84,9 @@ if (Daemon_OUT)
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${Daemon_OUT})
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${Daemon_OUT})
 endif()
+
+include(DaemonBuildInfo)
+include(DaemonPlatform)
 
 ################################################################################
 # Configuration options
@@ -605,8 +607,9 @@ if (BUILD_CLIENT)
         message(STATUS "Found OpenGL ABI: ${OpenGL_selected_ABI}")
         message(STATUS "Found OpenGL library: ${OpenGL_selected_LIBRARY}")
 
-        add_definitions("-DDAEMON_OpenGL_ABI=${OpenGL_selected_ABI}")
-        add_definitions("-DDAEMON_OpenGL_ABI_${OpenGL_selected_ABI}")
+        daemon_add_buildinfo("char*" "DAEMON_OPENGL_ABI_STRING" "\"${OpenGL_selected_ABI}\"")
+        add_definitions("-DDAEMON_OPENGL_ABI_${OpenGL_selected_ABI}")
+        add_definitions("-DDAEMON_OPENGL_ABI")
     endif()
 endif()
 
@@ -655,7 +658,8 @@ endif()
 
 if (BUILD_CLIENT OR BUILD_TTY_CLIENT OR BUILD_SERVER OR BUILD_DUMMY_APP)
     if (NACL_RUNTIME_PATH)
-        add_definitions("-DNACL_RUNTIME_PATH=${NACL_RUNTIME_PATH}")
+        daemon_add_buildinfo("char*" "DAEMON_NACL_RUNTIME_PATH_STRING" "\"${NACL_RUNTIME_PATH}\"")
+        add_definitions("-DDAEMON_NACL_RUNTIME_PATH")
     endif()
 
     # FindLocale
@@ -888,8 +892,10 @@ function(AddApplication)
     ADD_PRECOMPILED_HEADER(${A_Target}-objects)
 endfunction()
 
+daemon_write_buildinfo()
+
 if (NOT NACL)
-    add_library(engine-lib EXCLUDE_FROM_ALL ${PCH_FILE} ${COMMONLIST} ${ENGINELIST})
+    add_library(engine-lib EXCLUDE_FROM_ALL ${PCH_FILE} ${BUILDINFOLIST} ${COMMONLIST} ${ENGINELIST})
     target_link_libraries(engine-lib ${LIBS_BASE} ${LIBS_ENGINE_BASE})
     set_property(TARGET engine-lib APPEND PROPERTY COMPILE_DEFINITIONS BUILD_ENGINE)
     set_property(TARGET engine-lib APPEND PROPERTY INCLUDE_DIRECTORIES ${ENGINE_DIR} ${MOUNT_DIR} ${LIB_DIR})
@@ -923,7 +929,7 @@ if (BUILD_CLIENT)
         ApplicationMain ${ENGINE_DIR}/client/ClientApplication.cpp
         Definitions ${Definitions}
         Flags ${WARNINGS}
-        Files ${WIN_RC} ${QCOMMONLIST} ${SERVERLIST} ${CLIENTBASELIST} ${CLIENTLIST}
+        Files ${WIN_RC} ${BUILDINFOLIST} ${QCOMMONLIST} ${SERVERLIST} ${CLIENTBASELIST} ${CLIENTLIST}
         Libs ${LIBS_CLIENT} ${LIBS_CLIENTBASE} ${LIBS_ENGINE}
         Tests ${ENGINETESTLIST}
     )
@@ -954,7 +960,7 @@ if (BUILD_SERVER)
         ApplicationMain ${ENGINE_DIR}/server/ServerApplication.cpp
         Definitions BUILD_ENGINE BUILD_SERVER
         Flags ${WARNINGS}
-        Files ${WIN_RC} ${QCOMMONLIST} ${SERVERLIST} ${DEDSERVERLIST}
+        Files ${WIN_RC} ${BUILDINFOLIST} ${QCOMMONLIST} ${SERVERLIST} ${DEDSERVERLIST}
         Libs ${LIBS_ENGINE}
         Tests ${ENGINETESTLIST}
     )
@@ -967,7 +973,7 @@ if (BUILD_TTY_CLIENT)
         ApplicationMain ${ENGINE_DIR}/client/ClientApplication.cpp
         Definitions BUILD_ENGINE BUILD_TTY_CLIENT
         Flags ${WARNINGS}
-        Files ${WIN_RC} ${QCOMMONLIST} ${SERVERLIST} ${CLIENTBASELIST} ${TTYCLIENTLIST}
+        Files ${WIN_RC} ${BUILDINFOLIST} ${QCOMMONLIST} ${SERVERLIST} ${CLIENTBASELIST} ${TTYCLIENTLIST}
         Libs ${LIBS_CLIENTBASE} ${LIBS_ENGINE}
         Tests ${ENGINETESTLIST}
     )

--- a/cmake/DaemonArchitecture.cmake
+++ b/cmake/DaemonArchitecture.cmake
@@ -69,9 +69,7 @@ message(STATUS "Detected architecture: ${ARCH}")
 add_definitions(-D${ARCH_DEFINE})
 
 # This string can be modified without breaking compatibility.
-# Quotes cannot be part of the define as support for them is not reliable.
-# See: https://cmake.org/cmake/help/latest/prop_dir/COMPILE_DEFINITIONS.html
-add_definitions(-DARCH_STRING=${ARCH})
+daemon_add_buildinfo("char*" "DAEMON_ARCH_STRING" "\"${ARCH}\"")
 
 # Modifying NACL_ARCH breaks engine compatibility with nexe game binaries
 # since NACL_ARCH contributes to the nexe file name.
@@ -91,8 +89,7 @@ elseif(APPLE)
 	endif()
 endif()
 
-# Quotes cannot be part of the define as support for them is not reliable.
-add_definitions(-DNACL_ARCH_STRING=${NACL_ARCH})
+daemon_add_buildinfo("char*" "DAEMON_NACL_ARCH_STRING" "\"${NACL_ARCH}\"")
 
 option(USE_ARCH_INTRINSICS "Enable custom code using intrinsics functions or asm declarations" ON)
 mark_as_advanced(USE_ARCH_INTRINSICS)

--- a/cmake/DaemonBuildInfo.cmake
+++ b/cmake/DaemonBuildInfo.cmake
@@ -1,0 +1,29 @@
+set(DAEMON_BUILDINFO_HEADER "// Automatically generated, do not modify!\n")
+set(DAEMON_BUILDINFO_CPP "${DAEMON_BUILDINFO_HEADER}")
+set(DAEMON_BUILDINFO_H "${DAEMON_BUILDINFO_HEADER}")
+
+macro(daemon_add_buildinfo TYPE NAME VALUE)
+	set(DAEMON_BUILDINFO_CPP "${DAEMON_BUILDINFO_CPP}const ${TYPE} ${NAME}=${VALUE};\n")
+	set(DAEMON_BUILDINFO_H "${DAEMON_BUILDINFO_H}extern const ${TYPE} ${NAME};\n")
+endmacro()
+
+set(DAEMON_BUILDINFO_DIR "${CMAKE_CURRENT_BINARY_DIR}/DaemonBuildInfo")
+set(DAEMON_BUILDINFO_CPP_FILE "${DAEMON_BUILDINFO_DIR}/DaemonBuildInfo.cpp")
+set(DAEMON_BUILDINFO_H_FILE "${DAEMON_BUILDINFO_DIR}/DaemonBuildInfo.h")
+
+file(MAKE_DIRECTORY "${DAEMON_BUILDINFO_DIR}")
+include_directories("${DAEMON_BUILDINFO_DIR}")
+
+set(BUILDINFOLIST "${DAEMON_BUILDINFO_CPP_FILE}" "${DAEMON_BUILDINFO_H_FILE}")
+
+macro(daemon_write_buildinfo)
+	foreach(kind CPP H)
+		if (EXISTS "${DAEMON_BUILDINFO_${kind}_FILE}")
+			file(READ "${DAEMON_BUILDINFO_${kind}_FILE}" DAEMON_BUILDINFO_${kind}_READ)
+		endif()
+
+		if (NOT "${DAEMON_BUILDINFO_${kind}}" STREQUAL "${DAEMON_BUILDINFO_${kind}_READ}")
+			file(WRITE "${DAEMON_BUILDINFO_${kind}_FILE}" "${DAEMON_BUILDINFO_${kind}}")
+		endif()
+	endforeach()
+endmacro()

--- a/cmake/DaemonCompiler.cmake
+++ b/cmake/DaemonCompiler.cmake
@@ -237,10 +237,5 @@ foreach(lang C;CXX)
 	set(${compiler_var_name} ON)
 	add_definitions(-D${compiler_var_name}=1)
 
-	# Preprocessor definitions containing '#' may not be passed on the compiler
-	# command line because many compilers do not support it.
-	string(REGEX REPLACE "\#" "~" DAEMON_DEFINE_${lang}_COMPILER_STRING "${DAEMON_${lang}_COMPILER_STRING}")
-
-	# Quotes cannot be part of the define as support for them is not reliable.
-	add_definitions(-DDAEMON_${lang}_COMPILER_STRING=${DAEMON_DEFINE_${lang}_COMPILER_STRING})
+	daemon_add_buildinfo("char*" "DAEMON_${lang}_COMPILER_STRING" "\"${DAEMON_${lang}_COMPILER_STRING}\"")
 endforeach()

--- a/cmake/DaemonGame.cmake
+++ b/cmake/DaemonGame.cmake
@@ -38,6 +38,7 @@ option(BUILD_GAME_NATIVE_DLL "Build the shared library files, mostly useful for 
 # can be loaded by daemon with vm.[sc]game.type 2
 option(BUILD_GAME_NATIVE_EXE "Build native executable, which might be used for better performances by server owners" OFF)
 
+include(DaemonBuildInfo)
 include(DaemonPlatform)
 
 # Do not report unused native compiler if native vms are not built.
@@ -109,9 +110,11 @@ function(GAMEMODULE)
     set(multiValueArgs DEFINITIONS FLAGS FILES LIBS)
     cmake_parse_arguments(GAMEMODULE "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
+	daemon_write_buildinfo()
+
     if (NOT NACL)
         if (BUILD_GAME_NATIVE_DLL)
-            add_library(${GAMEMODULE_NAME}-native-dll MODULE ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${COMMONLIST})
+            add_library(${GAMEMODULE_NAME}-native-dll MODULE ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${BUILDINFOLIST} ${COMMONLIST})
             target_link_libraries(${GAMEMODULE_NAME}-native-dll ${GAMEMODULE_LIBS} ${LIBS_BASE})
             set_target_properties(${GAMEMODULE_NAME}-native-dll PROPERTIES
                 PREFIX ""
@@ -123,7 +126,7 @@ function(GAMEMODULE)
         endif()
 
         if (BUILD_GAME_NATIVE_EXE)
-            add_executable(${GAMEMODULE_NAME}-native-exe ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${COMMONLIST})
+            add_executable(${GAMEMODULE_NAME}-native-exe ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${BUILDINFOLIST} ${COMMONLIST})
             target_link_libraries(${GAMEMODULE_NAME}-native-exe ${GAMEMODULE_LIBS} ${LIBS_BASE})
             set_target_properties(${GAMEMODULE_NAME}-native-exe PROPERTIES
                 COMPILE_DEFINITIONS "VM_NAME=${GAMEMODULE_NAME};${GAMEMODULE_DEFINITIONS};BUILD_VM"
@@ -247,7 +250,7 @@ function(GAMEMODULE)
             endif()
         endif()
 
-        add_executable(${GAMEMODULE_NAME}-nacl ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${COMMONLIST})
+        add_executable(${GAMEMODULE_NAME}-nacl ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${BUILDINFOLIST} ${COMMONLIST})
         target_link_libraries(${GAMEMODULE_NAME}-nacl ${GAMEMODULE_LIBS} ${LIBS_BASE})
         # PLATFORM_EXE_SUFFIX is .pexe when building with PNaCl
         # as translating to .nexe is a separate task.

--- a/src/common/Defs.h
+++ b/src/common/Defs.h
@@ -31,6 +31,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef COMMON_DEFS_H_
 #define COMMON_DEFS_H_
 
+#include "DaemonBuildInfo.h"
+
 #define PRODUCT_NAME        "Unvanquished"
 /** Case, No spaces */
 #define PRODUCT_NAME_UPPER  "UNVANQUISHED"

--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -837,7 +837,7 @@ static void Init(int argc, char** argv)
 #endif
 
 	// Print a banner and a copy of the command-line arguments
-	Log::Notice(Q3_VERSION " " PLATFORM_STRING " " XSTRING(ARCH_STRING) " (" XSTRING(DAEMON_CXX_COMPILER_STRING) ") " __DATE__);
+	Log::Notice("%s %s %s (%s) %s", Q3_VERSION, PLATFORM_STRING, DAEMON_ARCH_STRING, DAEMON_CXX_COMPILER_STRING, __DATE__);
 
 	std::string argsString = "cmdline:";
 	for (int i = 1; i < argc; i++) {

--- a/src/engine/framework/VirtualMachine.cpp
+++ b/src/engine/framework/VirtualMachine.cpp
@@ -234,8 +234,8 @@ static std::pair<Sys::OSHandle, IPC::Socket> InternalLoadModule(std::pair<IPC::S
 static std::pair<Sys::OSHandle, IPC::Socket> CreateNaClVM(std::pair<IPC::Socket, IPC::Socket> pair, Str::StringRef name, bool debug, bool extract, int debugLoader) {
 	CheckMinAddressSysctlTooLarge();
 	const std::string& libPath = FS::GetLibPath();
-#ifdef NACL_RUNTIME_PATH
-	const char* naclPath = XSTRING(NACL_RUNTIME_PATH);
+#ifdef DAEMON_NACL_RUNTIME_PATH
+	const char* naclPath = DAEMON_NACL_RUNTIME_PATH_STRING;
 #else
 	const std::string& naclPath = libPath;
 #endif
@@ -254,7 +254,9 @@ static std::pair<Sys::OSHandle, IPC::Socket> CreateNaClVM(std::pair<IPC::Socket,
 #endif
 
 	// Extract the nexe from the pak so that nacl_loader can load it
-	module = win32Force64Bit ? name + "-amd64.nexe" : name + "-" XSTRING(NACL_ARCH_STRING) ".nexe";
+	module = win32Force64Bit
+		? name + "-amd64.nexe"
+		: Str::Format("%s-%s.nexe", name, DAEMON_NACL_ARCH_STRING);
 	if (extract) {
 		try {
 			FS::File out = FS::HomePath::OpenWrite(module);
@@ -272,7 +274,9 @@ static std::pair<Sys::OSHandle, IPC::Socket> CreateNaClVM(std::pair<IPC::Socket,
 
 	// Generate command line
 	Q_snprintf(rootSocketRedir, sizeof(rootSocketRedir), "%d:%d", ROOT_SOCKET_FD, (int)(intptr_t)pair.second.GetHandle());
-	irt = FS::Path::Build(naclPath, win32Force64Bit ? "irt_core-amd64.nexe" : "irt_core-" XSTRING(NACL_ARCH_STRING) ".nexe");
+	irt = FS::Path::Build(naclPath, win32Force64Bit
+		? "irt_core-amd64.nexe"
+		: Str::Format("irt_core-%s.nexe", DAEMON_NACL_ARCH_STRING));
 	nacl_loader = FS::Path::Build(naclPath, win32Force64Bit ? "nacl_loader-amd64" EXE_EXT : "nacl_loader" EXE_EXT);
 
 	if (!FS::RawPath::FileExists(modulePath)) {

--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -571,7 +571,7 @@ void Com_Init()
 	Cmd_AddCommand( "writebindings", Com_WriteBindings_f );
 #endif
 
-	s = va( "%s %s %s %s", Q3_VERSION, PLATFORM_STRING, XSTRING(ARCH_STRING), __DATE__ );
+	s = va( "%s %s %s %s", Q3_VERSION, PLATFORM_STRING, DAEMON_ARCH_STRING, __DATE__ );
 	com_version = Cvar_Get( "version", s, CVAR_ROM | CVAR_SERVERINFO );
 
 	Cmd_AddCommand( "in_restart", Com_In_Restart_f );

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -931,7 +931,7 @@ static bool GLimp_CreateContext( const glConfiguration &configuration )
 			"Please report the bug and tell us what is your operating system,\n"
 			"OpenGL driver, graphic card, and if you built the game yourself.\n\n"
 
-#if defined(DAEMON_OpenGL_ABI_GLVND)
+#if defined(DAEMON_OPENGL_ABI_GLVND)
 			"This engine was built with the \"GLVND\" OpenGL ABI,\n"
 			"try to reconfigure the build with the \"LEGACY\" one:\n\n"
 			"  cmake -DOpenGL_GL_PREFERENCE=LEGACY\n\n"
@@ -1750,8 +1750,8 @@ static rserr_t GLimp_StartDriverAndSetMode( int mode, bool fullscreen, bool bord
 		Sys::Error( "SDL_GetNumVideoDisplays failed: %s\n", SDL_GetError() );
 	}
 
-#if defined(DAEMON_OpenGL_ABI)
-	logger.Notice( "Using OpenGL ABI \"%s\"", XSTRING(DAEMON_OpenGL_ABI) );
+#if defined(DAEMON_OPENGL_ABI)
+	logger.Notice( "Using OpenGL ABI \"%s\"", DAEMON_OPENGL_ABI_STRING );
 #endif
 
 	AssertCvarRange( r_displayIndex, 0, numDisplays - 1, true );


### PR DESCRIPTION
Generate a builtin.cpp file instead of using compiler definitions.

It produces those kind of files:

- `builtin/builtin.cpp`

```c++
// Automatically generated, do not modify!
const char* DAEMON_ARCH_STRING="amd64";
const char* DAEMON_NACL_ARCH_STRING="amd64";
const char* DAEMON_C_COMPILER_STRING="GCC_13.3.0:x86_64-linux-gnu-gcc";
const char* DAEMON_CXX_COMPILER_STRING="GCC_13.3.0:x86_64-linux-gnu-g++";
const char* DAEMON_OPENGL_ABI_STRING="LEGACY";
```

- `builtin/builtin.h`

```c++
// Automatically generated, do not modify!
extern const char* DAEMON_ARCH_STRING;
extern const char* DAEMON_NACL_ARCH_STRING;
extern const char* DAEMON_C_COMPILER_STRING;
extern const char* DAEMON_CXX_COMPILER_STRING;
extern const char* DAEMON_OPENGL_ABI_STRING;
```

Needed by:

- https://github.com/Unvanquished/Unvanquished/pull/3317

Fixes:

- https://github.com/DaemonEngine/Daemon/issues/1551

Would have fixed (if a workaround wasn't already implemented):

- https://github.com/DaemonEngine/Daemon/pull/1497
- https://github.com/DaemonEngine/Daemon/pull/1500