### PR TITLE
cmake: refactor game build configuration to reuse the same code in parent build or subproject build and mutualize code between vm type build

### DIFF
--- a/cmake/DaemonGame.cmake
+++ b/cmake/DaemonGame.cmake
@@ -106,173 +106,170 @@ endif()
 
 daemon_write_buildinfo("Game")
 
+function(buildGameModule module_slug)
+	set(module_target "${GAMEMODULE_NAME}-${module_slug}")
+
+	set(module_target_args "${module_target}" ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${BUILDINFOLIST} ${COMMONLIST})
+
+	if (module_slug STREQUAL "native-dll")
+		add_library(${module_target_args})
+		set_target_properties(${module_target} PROPERTIES
+			PREFIX ""
+			COMPILE_DEFINITIONS "BUILD_VM_IN_PROCESS")
+	else()
+		add_executable(${module_target_args})
+	endif()
+
+	set_target_properties(${module_target} PROPERTIES
+		COMPILE_DEFINITIONS "VM_NAME=${GAMEMODULE_NAME};${GAMEMODULE_DEFINITIONS};BUILD_VM"
+		COMPILE_OPTIONS "${GAMEMODULE_FLAGS}"
+		FOLDER ${GAMEMODULE_NAME}
+	)
+
+	if (module_slug STREQUAL "nacl")
+		set_target_properties(${module_target} PROPERTIES
+			OUTPUT_NAME "${GAMEMODULE_NAME}"
+			SUFFIX "${PLATFORM_EXE_SUFFIX}")
+	endif()
+
+	target_link_libraries(${module_target} ${GAMEMODULE_LIBS} ${LIBS_BASE})
+
+	ADD_PRECOMPILED_HEADER(${module_target})
+endfunction()
+
+function(gameSubProject)
+	ExternalProject_Add(${VMS_PROJECT}
+		SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+		BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${VMS_PROJECT}
+		CMAKE_GENERATOR ${VM_GENERATOR}
+		CMAKE_ARGS
+			-DFORK=2
+			-DDAEMON_DIR=${Daemon_SOURCE_DIR}
+			-DDEPS_DIR=${DEPS_DIR}
+			-DBUILD_CLIENT=OFF
+			-DBUILD_TTY_CLIENT=OFF
+			-DBUILD_SERVER=OFF
+			${ARGV}
+			${INHERITED_OPTION_ARGS}
+		INSTALL_COMMAND ""
+	)
+
+	# Force the rescan and rebuild of the subproject.
+	ExternalProject_Add_Step(${VMS_PROJECT} forcebuild
+		COMMAND ${CMAKE_COMMAND} -E remove
+			${CMAKE_CURRENT_BINARY_DIR}/${VMS_PROJECT}-prefix/src/${VMS_PROJECT}-stamp/${VMS_PROJECT}-configure
+		COMMENT "Forcing build step for '${VMS_PROJECT}'"
+		DEPENDEES build
+		ALWAYS 1
+	)
+endfunction()
+
 function(GAMEMODULE)
-    # ParseArguments setup
-    set(oneValueArgs NAME)
-    set(multiValueArgs DEFINITIONS FLAGS FILES LIBS)
-    cmake_parse_arguments(GAMEMODULE "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+	# ParseArguments setup
+	set(oneValueArgs NAME)
+	set(multiValueArgs DEFINITIONS FLAGS FILES LIBS)
+	cmake_parse_arguments(GAMEMODULE "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    if (NOT NACL)
-        if (BUILD_GAME_NATIVE_DLL)
-            add_library(${GAMEMODULE_NAME}-native-dll MODULE ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${BUILDINFOLIST} ${COMMONLIST})
-            target_link_libraries(${GAMEMODULE_NAME}-native-dll ${GAMEMODULE_LIBS} ${LIBS_BASE})
-            set_target_properties(${GAMEMODULE_NAME}-native-dll PROPERTIES
-                PREFIX ""
-                COMPILE_DEFINITIONS "VM_NAME=${GAMEMODULE_NAME};${GAMEMODULE_DEFINITIONS};BUILD_VM;BUILD_VM_IN_PROCESS"
-                COMPILE_OPTIONS "${GAMEMODULE_FLAGS}"
-                FOLDER ${GAMEMODULE_NAME}
-            )
-            ADD_PRECOMPILED_HEADER(${GAMEMODULE_NAME}-native-dll)
-        endif()
+	if (NOT FORK)
+		if (BUILD_GAME_NACL)
+			set(FORK 1 PARENT_SCOPE)
+		endif()
 
-        if (BUILD_GAME_NATIVE_EXE)
-            add_executable(${GAMEMODULE_NAME}-native-exe ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${BUILDINFOLIST} ${COMMONLIST})
-            target_link_libraries(${GAMEMODULE_NAME}-native-exe ${GAMEMODULE_LIBS} ${LIBS_BASE})
-            set_target_properties(${GAMEMODULE_NAME}-native-exe PROPERTIES
-                COMPILE_DEFINITIONS "VM_NAME=${GAMEMODULE_NAME};${GAMEMODULE_DEFINITIONS};BUILD_VM"
-                COMPILE_OPTIONS "${GAMEMODULE_FLAGS}"
-                FOLDER ${GAMEMODULE_NAME}
-            )
-            ADD_PRECOMPILED_HEADER(${GAMEMODULE_NAME}-native-exe)
-        endif()
+		if (BUILD_GAME_NATIVE_DLL)
+			buildGameModule("native-dll")
+		endif()
 
-        if (NOT FORK AND BUILD_GAME_NACL)
-            if (CMAKE_GENERATOR MATCHES "Visual Studio")
-                set(VM_GENERATOR "NMake Makefiles")
-            else()
-                set(VM_GENERATOR ${CMAKE_GENERATOR})
-            endif()
+		if (BUILD_GAME_NATIVE_EXE)
+			buildGameModule("native-exe")
+		endif()
+	endif()
 
-            set(FORK 1 PARENT_SCOPE)
-            include(ExternalProject)
-            set(inherited_option_args)
+	if (FORK EQUAL 1)
+		if (CMAKE_GENERATOR MATCHES "Visual Studio")
+			set(VM_GENERATOR "NMake Makefiles")
+		else()
+			set(VM_GENERATOR ${CMAKE_GENERATOR})
+		endif()
 
-            foreach(inherited_option ${NACL_VM_INHERITED_OPTIONS})
-                set(inherited_option_args ${inherited_option_args}
-                    "-D${inherited_option}=${${inherited_option}}")
-            endforeach(inherited_option)
+		include(ExternalProject)
+		set(INHERITED_OPTION_ARGS)
 
-            if (USE_NACL_SAIGO)
-                add_custom_target(nacl-vms ALL)
-                unset(NACL_VMS_PROJECTS)
+		foreach(inherited_option ${NACL_VM_INHERITED_OPTIONS})
+			set(INHERITED_OPTION_ARGS ${INHERITED_OPTION_ARGS}
+				"-D${inherited_option}=${${inherited_option}}")
+		endforeach(inherited_option)
 
-                foreach(NACL_TARGET ${NACL_TARGETS})
-                    if (NACL_TARGET STREQUAL "i686")
-                        set(SAIGO_ARCH "i686")
-                    elseif (NACL_TARGET STREQUAL "amd64")
-                        set(SAIGO_ARCH "x86_64")
-                    elseif (NACL_TARGET STREQUAL "armhf")
-                        set(SAIGO_ARCH "arm")
-                    else()
-                        message(FATAL_ERROR "Unknown NaCl architecture ${NACL_TARGET}")
-                    endif()
+		if (BUILD_GAME_NACL)
+			if (USE_NACL_SAIGO)
+				add_custom_target(nacl-vms ALL)
+				unset(VMS_PROJECTS)
 
-                    set(NACL_VMS_PROJECT nacl-vms-${NACL_TARGET})
-                    list(APPEND NACL_VMS_PROJECTS ${NACL_VMS_PROJECT})
-                    add_dependencies(nacl-vms ${NACL_VMS_PROJECT})
+				foreach(NACL_TARGET ${NACL_TARGETS})
+					if (NACL_TARGET STREQUAL "i686")
+						set(SAIGO_ARCH "i686")
+					elseif (NACL_TARGET STREQUAL "amd64")
+						set(SAIGO_ARCH "x86_64")
+					elseif (NACL_TARGET STREQUAL "armhf")
+						set(SAIGO_ARCH "arm")
+					else()
+						message(FATAL_ERROR "Unknown NaCl architecture ${NACL_TARGET}")
+					endif()
 
-                    ExternalProject_Add(${NACL_VMS_PROJECT}
-                        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                        BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${NACL_VMS_PROJECT}
-                        CMAKE_GENERATOR ${VM_GENERATOR}
-                        CMAKE_ARGS
-                            -DFORK=2
-                            -DCMAKE_TOOLCHAIN_FILE=${Daemon_SOURCE_DIR}/cmake/toolchain-saigo.cmake
-                            -DDAEMON_DIR=${Daemon_SOURCE_DIR}
-                            -DDEPS_DIR=${DEPS_DIR}
-                            -DBUILD_GAME_NACL=ON
-                            -DUSE_NACL_SAIGO=ON
-                            -DNACL_TARGET=${NACL_TARGET}
-                            -DSAIGO_ARCH=${SAIGO_ARCH}
-                            -DBUILD_GAME_NATIVE_DLL=OFF
-                            -DBUILD_GAME_NATIVE_EXE=OFF
-                            -DBUILD_CLIENT=OFF
-                            -DBUILD_TTY_CLIENT=OFF
-                            -DBUILD_SERVER=OFF
-                            ${inherited_option_args}
-                        INSTALL_COMMAND ""
-                    )
+					set(VMS_PROJECT nacl-vms-${NACL_TARGET})
+					list(APPEND VMS_PROJECTS ${VMS_PROJECT})
+					add_dependencies(nacl-vms ${VMS_PROJECT})
 
-                    # Force the rescan and rebuild of the subproject.
-                    ExternalProject_Add_Step(${NACL_VMS_PROJECT} forcebuild
-                        COMMAND ${CMAKE_COMMAND} -E remove
-                            ${CMAKE_CURRENT_BINARY_DIR}/${NACL_VMS_PROJECT}-prefix/src/${NACL_VMS_PROJECT}-stamp/${NACL_VMS_PROJECT}-configure
-                        COMMENT "Forcing build step for '${NACL_VMS_PROJECT}'"
-                        DEPENDEES build
-                        ALWAYS 1
-                    )
-                endforeach()
-            else()
-                set(NACL_VMS_PROJECT nacl-vms)
-                set(NACL_VMS_PROJECTS ${NACL_VMS_PROJECT})
+					gameSubProject(
+						-DCMAKE_TOOLCHAIN_FILE=${Daemon_SOURCE_DIR}/cmake/toolchain-saigo.cmake
+						-DBUILD_GAME_NACL=ON
+						-DBUILD_GAME_NATIVE_DLL=OFF
+						-DBUILD_GAME_NATIVE_EXE=OFF
+						-DUSE_NACL_SAIGO=ON
+						-DSAIGO_ARCH=${SAIGO_ARCH}
+						-DNACL_TARGET=${NACL_TARGET}
+					)
+				endforeach()
+			else()
+				set(VMS_PROJECT nacl-vms)
+				set(VMS_PROJECTS ${VMS_PROJECT})
 
-                # Workaround a bug where CMake ExternalProject lists-as-args are cut on first “;”
-                string(REPLACE ";" "," NACL_TARGETS_STRING "${NACL_TARGETS}")
+				# Workaround a bug where CMake ExternalProject lists-as-args are cut on first “;”
+				string(REPLACE ";" "," NACL_TARGETS_STRING "${NACL_TARGETS}")
 
-                ExternalProject_Add(${NACL_VMS_PROJECT}
-                    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
-                    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/${NACL_VMS_PROJECT}
-                    CMAKE_GENERATOR ${VM_GENERATOR}
-                    CMAKE_ARGS
-                        -DFORK=2
-                        -DCMAKE_TOOLCHAIN_FILE=${Daemon_SOURCE_DIR}/cmake/toolchain-pnacl.cmake
-                        -DDAEMON_DIR=${Daemon_SOURCE_DIR}
-                        -DDEPS_DIR=${DEPS_DIR}
-                        -DBUILD_GAME_NACL=ON
-                        -DNACL_TARGETS_STRING=${NACL_TARGETS_STRING}
-                        -DBUILD_GAME_NATIVE_DLL=OFF
-                        -DBUILD_GAME_NATIVE_EXE=OFF
-                        -DBUILD_CLIENT=OFF
-                        -DBUILD_TTY_CLIENT=OFF
-                        -DBUILD_SERVER=OFF
-                        ${inherited_option_args}
-                    INSTALL_COMMAND ""
-                )
+				gameSubProject(
+					-DCMAKE_TOOLCHAIN_FILE=${Daemon_SOURCE_DIR}/cmake/toolchain-pnacl.cmake
+					-DBUILD_GAME_NACL=ON
+					-DBUILD_GAME_NATIVE_DLL=OFF
+					-DBUILD_GAME_NATIVE_EXE=OFF
+					-DNACL_TARGETS_STRING=${NACL_TARGETS_STRING}
+				)
+			endif()
+		endif()
 
-                # Force the rescan and rebuild of the subproject.
-                ExternalProject_Add_Step(${NACL_VMS_PROJECT} forcebuild
-                    COMMAND ${CMAKE_COMMAND} -E remove
-                        ${CMAKE_CURRENT_BINARY_DIR}/${NACL_VMS_PROJECT}-prefix/src/${NACL_VMS_PROJECT}-stamp/${NACL_VMS_PROJECT}-configure
-                    COMMENT "Forcing build step for '${NACL_VMS_PROJECT}'"
-                    DEPENDEES build
-                    ALWAYS 1
-                )
-            endif()
-            set(NACL_VMS_PROJECTS ${NACL_VMS_PROJECTS} PARENT_SCOPE)
-        endif()
-    else()
-        if (FORK EQUAL 2)
-            if(USE_NACL_SAIGO)
-                set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-            else()
-                # Put the .nexe and .pexe files in the same directory as the engine
-                set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/..)
-            endif()
-        endif()
+		set(VMS_PROJECTS ${VMS_PROJECTS} PARENT_SCOPE)
+	elseif (FORK EQUAL 2)
+		if (BUILD_GAME_NACL)
+			if (USE_NACL_SAIGO)
+				set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+			else()
+				# Put the .nexe and .pexe files in the same directory as the engine.
+				set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/..)
+			endif()
 
-        add_executable(${GAMEMODULE_NAME}-nacl ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${BUILDINFOLIST} ${COMMONLIST})
-        target_link_libraries(${GAMEMODULE_NAME}-nacl ${GAMEMODULE_LIBS} ${LIBS_BASE})
-        # PLATFORM_EXE_SUFFIX is .pexe when building with PNaCl
-        # as translating to .nexe is a separate task.
-        set_target_properties(${GAMEMODULE_NAME}-nacl PROPERTIES
-            OUTPUT_NAME ${GAMEMODULE_NAME}${PLATFORM_EXE_SUFFIX}
-            COMPILE_DEFINITIONS "VM_NAME=${GAMEMODULE_NAME};${GAMEMODULE_DEFINITIONS};BUILD_VM"
-            COMPILE_OPTIONS "${GAMEMODULE_FLAGS}"
-            FOLDER ${GAMEMODULE_NAME}
-        )
-        ADD_PRECOMPILED_HEADER(${GAMEMODULE_NAME}-nacl)
+			buildGameModule("nacl")
 
-        # Revert a workaround for a bug where CMake ExternalProject lists-as-args are cut on first “;”
-        string(REPLACE "," ";" NACL_TARGETS "${NACL_TARGETS_STRING}")
+			if (USE_NACL_SAIGO)
+				# Finalize NaCl executables for supported architectures.
+				saigo_finalize(${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/.. ${GAMEMODULE_NAME} ${NACL_TARGET})
+			else()
+				# Revert a workaround for a bug where CMake ExternalProject lists-as-args are cut on first “;”
+				string(REPLACE "," ";" NACL_TARGETS "${NACL_TARGETS_STRING}")
 
-        if (USE_NACL_SAIGO)
-            # Finalize NaCl executables for supported architectures.
-            saigo_finalize(${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/.. ${GAMEMODULE_NAME} ${NACL_TARGET})
-        else()
-            # Generate NaCl executables for supported architectures.
-            foreach(NACL_TARGET ${NACL_TARGETS})
-                pnacl_finalize(${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${GAMEMODULE_NAME} ${NACL_TARGET})
-            endforeach()
-        endif()
-    endif()
+				# Generate NaCl executables for supported architectures.
+				foreach(NACL_TARGET ${NACL_TARGETS})
+					pnacl_finalize(${CMAKE_RUNTIME_OUTPUT_DIRECTORY} ${GAMEMODULE_NAME} ${NACL_TARGET})
+				endforeach()
+			endif()
+		endif()
+	endif()
 endfunction()


### PR DESCRIPTION
Refactor game build configuration to reuse the same code in parent build or subproject build and mutualize code between vm type build.

Extracted from:

- https://github.com/DaemonEngine/Daemon/pull/1484

This one brings nothing new, it just refactors the code in a better way so it makes future changes easier.

Amont various things,

- it makes building vm subproject independent from NaCl
- it deduplicates and mutualises the code to avoid maintaining multiple copy-paste