### PR TITLE
Implement partial overbright clamping like Q3

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -59,19 +59,14 @@ static void ComputeDynamics( shaderStage_t* pStage ) {
 	// TODO: Move color and texMatrices stuff to a compute shader
 	pStage->colorDynamic = false;
 	switch ( pStage->rgbGen ) {
+		case colorGen_t::CGEN_IDENTITY_LIGHTING:
 		case colorGen_t::CGEN_IDENTITY:
 		case colorGen_t::CGEN_ONE_MINUS_VERTEX:
-		default:
-		case colorGen_t::CGEN_IDENTITY_LIGHTING:
-			/* Historically CGEN_IDENTITY_LIGHTING was done this way:
-
-			  tess.svars.color = Color::White * tr.identityLight;
-
-			But tr.identityLight is always 1.0f in Dæmon engine
-			as the as the overbright bit implementation is fully
-			software. */
 		case colorGen_t::CGEN_VERTEX:
 		case colorGen_t::CGEN_CONST:
+		default:
+			break;
+
 		case colorGen_t::CGEN_ENTITY:
 		case colorGen_t::CGEN_ONE_MINUS_ENTITY:
 		{

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2897,6 +2897,7 @@ GLShader_cameraEffects::GLShader_cameraEffects( GLShaderManager *manager ) :
 	GLShader( "cameraEffects", ATTR_POSITION | ATTR_TEXCOORD, manager ),
 	u_ColorMap3D( this ),
 	u_CurrentMap( this ),
+	u_GlobalLightFactor( this ),
 	u_ColorModulate( this ),
 	u_TextureMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3536,6 +3536,21 @@ public:
 	}
 };
 
+class u_GlobalLightFactor :
+	GLUniform1f
+{
+public:
+	u_GlobalLightFactor( GLShader *shader ) :
+		GLUniform1f( shader, "u_GlobalLightFactor" )
+	{
+	}
+
+	void SetUniform_GlobalLightFactor( float value )
+	{
+		this->SetValue( value );
+	}
+};
+
 class GLDeformStage :
 	public u_Time
 {
@@ -4459,6 +4474,7 @@ class GLShader_cameraEffects :
 	public GLShader,
 	public u_ColorMap3D,
 	public u_CurrentMap,
+	public u_GlobalLightFactor,
 	public u_ColorModulate,
 	public u_TextureMatrix,
 	public u_ModelViewProjectionMatrix,

--- a/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
+++ b/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
@@ -29,6 +29,7 @@ uniform sampler3D u_ColorMap3D;
 #endif
 
 uniform vec4      u_ColorModulate;
+uniform float     u_GlobalLightFactor; // 1 / tr.identityLight
 uniform float     u_InverseGamma;
 
 IN(smooth) vec2		var_TexCoords;
@@ -55,6 +56,7 @@ void main()
 	vec2 st = gl_FragCoord.st / r_FBufSize;
 
 	vec4 color = texture2D(u_CurrentMap, st);
+	color *= u_GlobalLightFactor;
 
 	if( u_Tonemap ) {
 		color.rgb = TonemapLottes( color.rgb * u_TonemapExposure );

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -3350,6 +3350,7 @@ void RB_CameraPostFX()
 	// enable shader, set arrays
 	gl_cameraEffectsShader->BindProgram( 0 );
 
+	gl_cameraEffectsShader->SetUniform_GlobalLightFactor( 1.0f / tr.identityLight );
 	gl_cameraEffectsShader->SetUniform_ColorModulate( backEnd.viewParms.gradingWeights );
 
 	gl_cameraEffectsShader->SetUniform_InverseGamma( 1.0 / r_gamma->value );

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -5039,11 +5039,15 @@ void RE_LoadWorldMap( const char *name )
 	// try will not look at the partially loaded version
 	tr.world = nullptr;
 
-	// tr.worldDeluxeMapping will be set by R_LoadLightmaps()
-	tr.worldLightMapping = false;
-	// tr.worldDeluxeMapping will be set by R_LoadEntities()
-	tr.worldDeluxeMapping = false;
-	tr.worldHDR_RGBE = false;
+	// It's probably a mistake if any of these lighting parameters are actually
+	// used before a map is loaded.
+	tr.worldLightMapping = false; // set by R_LoadLightmaps
+	tr.worldDeluxeMapping = false; // set by R_LoadEntities
+	tr.worldHDR_RGBE = false; // set by R_LoadEntities
+	tr.mapOverBrightBits = r_overbrightDefaultExponent.Get(); // maybe set by R_LoadEntities
+	tr.overbrightBits = std::min( tr.mapOverBrightBits, r_overbrightBits.Get() ); // set by RE_LoadWorldMap
+	tr.mapLightFactor = 1.0f; // set by RE_LoadWorldMap
+	tr.identityLight = 1.0f; // set by RE_LoadWorldMap
 
 	s_worldData = {};
 	Q_strncpyz( s_worldData.name, name, sizeof( s_worldData.name ) );
@@ -5131,7 +5135,6 @@ void RE_LoadWorldMap( const char *name )
 	tr.worldLight = tr.lightMode;
 	tr.modelLight = lightMode_t::FULLBRIGHT;
 	tr.modelDeluxe = deluxeMode_t::NONE;
-	tr.mapLightFactor = tr.identityLight = 1.0f;
 
 	// Use fullbright lighting for everything if the world is fullbright.
 	if ( tr.worldLight != lightMode_t::FULLBRIGHT )

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -3054,17 +3054,11 @@ void R_InitImages()
 	tr.lightmaps.reserve( 128 );
 	tr.deluxemaps.reserve( 128 );
 
-	//TODO rewrite WoT with new info :)
-	/* These are the values expected by the rest of the renderer
-	(esp. tr_bsp), used for "gamma correction of the map".
-	Both were set to 0 if we had neither COMPAT_ET nor COMPAT_Q3,
-	it may be interesting to remember.
-
-	Quake 3 and Tremulous values:
-
-	  tr.overbrightBits = 0; // Software implementation.
-	  tr.mapOverBrightBits = 2; // Quake 3 default.
-	  tr.identityLight = 1.0f / ( 1 << tr.overbrightBits );
+	/*
+	**** Map overbright bits ****
+	Lightmaps and vertex light colors are notionally scaled up by a factor of
+	pow(2, tr.mapOverBrightBits). This is a good idea because we would like a bright light
+	to make a texture brighter than its original diffuse image.
 
 	Games like Quake 3 and Tremulous require tr.mapOverBrightBits
 	to be set to 2. Because this engine is primarily maintained for
@@ -3090,29 +3084,41 @@ void R_InitImages()
 	require to set a different default than what Unvanquished
 	requires.
 
-	Using a non-zero value for tr.mapOverBrightBits turns light
-	non-linear and makes deluxe mapping buggy though.
+	**** r_overbrightBits ****
+	Although lightmaps are scaled up by pow(2, tr.overbrightBits), the actual ceiling for lightmap
+	values is pow(2, tr.overbrightBits). tr.overbrightBits may
+	be less than tr.mapOverbrightBits. This is a STUPID configuration because then you are
+	just throwing away 1 or bits of precision from the lightmap. But it was used for many games.
 
-	Mappers may port and fix maps by multiplying the lights by 2.5
-	and set the mapOverBrightBits key to 0 in map entities lump.
+	The excess (tr.mapOverbrightBits - tr.overbrightBits) bits of scaling are done to the lightmap
+	before uploading it. If some component exceeds 1, the color is proportionally downscaled until
+	the max component is 1.
 
-	It will be possible to assume tr.mapOverBrightBits is 0 when
-	loading maps compiled with sRGB lightmaps as there is no
-	legacy map using sRGB lightmap yet, and then we will be
-	able to avoid the need to explicitly set mapOverBrightBits
-	to 0 in map entities. It will be required to assume that
-	tr.mapOverBrightBits is 0 when loading maps compiled with
-	sRGB lightmaps because otherwise the color shift computation
-	will break the light computation, not only the deluxe one.
+	Quake 3 and vanilla Tremulous used these default cvar values:
+	  r_overbrightBits - 1
+	  r_mapOverBrightBits - 2
 
-	In legacy engines, tr.overbrightBits was non-zero when
-	hardware overbright bits were enabled, zero when disabled.
-	This engine do not implement hardware overbright bit, so
-	this is always zero, and we can remove it and simplify all
-	the computations making use of it.
+	So the same as Daemon. But if the game was not running in fullscreen mode or the system was
+	not detected as supporting hardware gamma control, tr.overbrightBit would be set to 0.
+	Tremfusion shipped with r_overbrightBits 0 and r_ignorehwgamma 1, either of which forces
+	tr.overbrightBits to 0, making it the same as the vanilla client's windowed mode.
 
-	Because tr.overbrightBits is always 0, tr.identityLight is
-	always 1.0f. We can entirely remove it. */
+	**** How Quake 3 originally implemented overbright ****
+	When hardware overbright was on (tr.overbrightBits = 1), the color buffer notionally ranged
+	from 0 to 2, rather than 0 to 1. So a buffer with 8-bit colors only had 7 bits of
+	output precision (all values 128+ produced the same output), but the extra bit was useful
+	for intermediate values during blending. The rescaling was effected by using the hardware
+	gamma ramp, which affected the whole monitor (or whole system).
+	Shaders for materials that were not illuminated by any precomputed lighting could use
+	CGEN_IDENTITY_LIGHTING to multiply by tr.identityLight, which would cancel out the
+	rescaling so that the material looked the same regardless of tr.overbrightBits.
+
+	In Daemon tr.identityLight is usually 1, so any distincion between
+	CGEN_IDENTITY/CGEN_IDENTITY_LIGHTING is ignored. But if you set the cvar r_overbrightQ3,
+	which emulates Quake 3's technique of brightening the whole color buffer, it will be used.
+
+	For even more information, see https://github.com/DaemonEngine/Daemon/issues/1542.
+	*/
 
 	// TODO is there any reason to set these before a map is loaded?
 	tr.mapOverBrightBits = r_overbrightDefaultExponent.Get();

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1853,7 +1853,7 @@ image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 		return nullptr;
 	}
 
-	if ( imageParams.bits & IF_LIGHTMAP && tr.legacyOverBrightClamping )
+	if ( imageParams.bits & IF_LIGHTMAP )
 	{
 		R_ProcessLightmap( *pic, width, height, imageParams.bits );
 	}
@@ -3054,6 +3054,7 @@ void R_InitImages()
 	tr.lightmaps.reserve( 128 );
 	tr.deluxemaps.reserve( 128 );
 
+	//TODO rewrite WoT with new info :)
 	/* These are the values expected by the rest of the renderer
 	(esp. tr_bsp), used for "gamma correction of the map".
 	Both were set to 0 if we had neither COMPAT_ET nor COMPAT_Q3,
@@ -3113,8 +3114,9 @@ void R_InitImages()
 	Because tr.overbrightBits is always 0, tr.identityLight is
 	always 1.0f. We can entirely remove it. */
 
+	// TODO is there any reason to set these before a map is loaded?
 	tr.mapOverBrightBits = r_overbrightDefaultExponent.Get();
-	tr.legacyOverBrightClamping = r_overbrightDefaultClamp.Get();
+	tr.overbrightBits = std::min(tr.mapOverBrightBits, r_overbrightBits.Get());
 
 	// create default texture and white texture
 	R_CreateBuiltinImages();

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -3120,10 +3120,6 @@ void R_InitImages()
 	For even more information, see https://github.com/DaemonEngine/Daemon/issues/1542.
 	*/
 
-	// TODO is there any reason to set these before a map is loaded?
-	tr.mapOverBrightBits = r_overbrightDefaultExponent.Get();
-	tr.overbrightBits = std::min(tr.mapOverBrightBits, r_overbrightBits.Get());
-
 	// create default texture and white texture
 	R_CreateBuiltinImages();
 }

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -93,7 +93,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_precomputedLighting;
 	Cvar::Cvar<int> r_overbrightDefaultExponent("r_overbrightDefaultExponent", "default map light color shift (multiply by 2^x)", Cvar::NONE, 2);
 	Cvar::Range<Cvar::Cvar<int>> r_overbrightBits("r_overbrightBits", "clamp lightmap colors to 2^x", Cvar::NONE, 1, 0, 3);
+
+	// also set r_highPrecisionRendering 0 for an even more authentic q3 experience
 	Cvar::Cvar<bool> r_overbrightQ3("r_overbrightQ3", "brighten entire color buffer like Quake 3 (incompatible with newer assets)", Cvar::NONE, false);
+
 	Cvar::Cvar<bool> r_overbrightIgnoreMapSettings("r_overbrightIgnoreMapSettings", "force usage of r_overbrightDefaultClamp / r_overbrightDefaultExponent, ignoring worldspawn", Cvar::NONE, false);
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	Cvar::Cvar<bool> r_colorGrading( "r_colorGrading", "Use color grading", Cvar::NONE, true );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -92,7 +92,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_realtimeLightingCastShadows;
 	cvar_t      *r_precomputedLighting;
 	Cvar::Cvar<int> r_overbrightDefaultExponent("r_overbrightDefaultExponent", "default map light color shift (multiply by 2^x)", Cvar::NONE, 2);
-	Cvar::Cvar<bool> r_overbrightDefaultClamp("r_overbrightDefaultClamp", "clamp lightmap colors to 1 (in absence of map worldspawn value)", Cvar::NONE, false);
+	Cvar::Range<Cvar::Cvar<int>> r_overbrightBits("r_overbrightBits", "clamp lightmap colors to 2^x", Cvar::NONE, 1, 0, 3);
 	Cvar::Cvar<bool> r_overbrightIgnoreMapSettings("r_overbrightIgnoreMapSettings", "force usage of r_overbrightDefaultClamp / r_overbrightDefaultExponent, ignoring worldspawn", Cvar::NONE, false);
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	Cvar::Cvar<bool> r_colorGrading( "r_colorGrading", "Use color grading", Cvar::NONE, true );
@@ -1185,7 +1185,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_realtimeLightingCastShadows = Cvar_Get( "r_realtimeLightingCastShadows", "1", 0 );
 		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_CHEAT | CVAR_LATCH );
 		Cvar::Latch( r_overbrightDefaultExponent );
-		Cvar::Latch( r_overbrightDefaultClamp );
+		Cvar::Latch( r_overbrightBits );
 		Cvar::Latch( r_overbrightIgnoreMapSettings );
 		Cvar::Latch( r_lightMode );
 		Cvar::Latch( r_colorGrading );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -93,6 +93,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	cvar_t      *r_precomputedLighting;
 	Cvar::Cvar<int> r_overbrightDefaultExponent("r_overbrightDefaultExponent", "default map light color shift (multiply by 2^x)", Cvar::NONE, 2);
 	Cvar::Range<Cvar::Cvar<int>> r_overbrightBits("r_overbrightBits", "clamp lightmap colors to 2^x", Cvar::NONE, 1, 0, 3);
+	Cvar::Cvar<bool> r_overbrightQ3("r_overbrightQ3", "brighten entire color buffer like Quake 3 (incompatible with newer assets)", Cvar::NONE, false);
 	Cvar::Cvar<bool> r_overbrightIgnoreMapSettings("r_overbrightIgnoreMapSettings", "force usage of r_overbrightDefaultClamp / r_overbrightDefaultExponent, ignoring worldspawn", Cvar::NONE, false);
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	Cvar::Cvar<bool> r_colorGrading( "r_colorGrading", "Use color grading", Cvar::NONE, true );
@@ -1186,6 +1187,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_precomputedLighting = Cvar_Get( "r_precomputedLighting", "1", CVAR_CHEAT | CVAR_LATCH );
 		Cvar::Latch( r_overbrightDefaultExponent );
 		Cvar::Latch( r_overbrightBits );
+		Cvar::Latch( r_overbrightQ3 );
 		Cvar::Latch( r_overbrightIgnoreMapSettings );
 		Cvar::Latch( r_lightMode );
 		Cvar::Latch( r_colorGrading );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2809,12 +2809,14 @@ enum class shaderProfilerRenderSubGroupsMode {
 
 		viewParms_t    viewParms;
 
-		// r_overbrightDefaultExponent, but can be overridden by mapper using the worldspawn
+		// Brightness scaling: roughly speaking, a lightmap value of x will be interpreted as
+		// min(x * pow(2, mapOverBrightBits), pow(2, overbrightBits))
+		// (but when a component hits the max allowed value, others are scaled down to keep the "same color")
 		int mapOverBrightBits;
-		// pow(2, mapOverbrightBits)
+		// min(r_overbrightBits.Get(), mapOverBrightBits)
+		int overbrightBits;
+		// pow(2, overbrightBits)
 		float mapLightFactor;
-		// May have to be true on some legacy maps: clamp and normalize multiplied colors.
-		bool legacyOverBrightClamping;
 
 		orientationr_t orientation; // for current entity
 
@@ -2938,7 +2940,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 	extern cvar_t *r_realtimeLightingCastShadows;
 	extern cvar_t *r_precomputedLighting;
 	extern Cvar::Cvar<int> r_overbrightDefaultExponent;
-	extern Cvar::Cvar<bool> r_overbrightDefaultClamp;
+	extern Cvar::Range<Cvar::Cvar<int>> r_overbrightBits;
 	extern Cvar::Cvar<bool> r_overbrightIgnoreMapSettings;
 	extern Cvar::Range<Cvar::Cvar<int>> r_lightMode;
 	extern Cvar::Cvar<bool> r_colorGrading;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -825,7 +825,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 	enum class colorGen_t
 	{
 	  CGEN_BAD,
-	  CGEN_IDENTITY_LIGHTING, // Always (1,1,1,1) in Dæmon engine as the overbright bit implementation is fully software.
+	  CGEN_IDENTITY_LIGHTING, // Always (1,1,1,1) in Dæmon engine, unless you set r_overbrightQ3.
 	  CGEN_IDENTITY, // always (1,1,1,1)
 	  CGEN_ENTITY, // grabbed from entity's modulate field
 	  CGEN_ONE_MINUS_ENTITY, // grabbed from 1 - entity.modulate
@@ -2815,8 +2815,10 @@ enum class shaderProfilerRenderSubGroupsMode {
 		int mapOverBrightBits;
 		// min(r_overbrightBits.Get(), mapOverBrightBits)
 		int overbrightBits;
-		// pow(2, overbrightBits)
+		// pow(2, overbrightBits), unless r_overbrightQ3 is on
 		float mapLightFactor;
+		// 1/pow(2, overbrightBits) if r_overbrightQ3 is on
+		float identityLight;
 
 		orientationr_t orientation; // for current entity
 
@@ -2941,6 +2943,7 @@ enum class shaderProfilerRenderSubGroupsMode {
 	extern cvar_t *r_precomputedLighting;
 	extern Cvar::Cvar<int> r_overbrightDefaultExponent;
 	extern Cvar::Range<Cvar::Cvar<int>> r_overbrightBits;
+	extern Cvar::Cvar<bool> r_overbrightQ3;
 	extern Cvar::Cvar<bool> r_overbrightIgnoreMapSettings;
 	extern Cvar::Range<Cvar::Cvar<int>> r_lightMode;
 	extern Cvar::Cvar<bool> r_colorGrading;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2321,21 +2321,15 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 	// rgbGen
 	switch ( pStage->rgbGen )
 	{
+		case colorGen_t::CGEN_IDENTITY_LIGHTING:
+			tess.svars.color = Color::Color(tr.identityLight, tr.identityLight, tr.identityLight);
+			break;
+
 		case colorGen_t::CGEN_IDENTITY:
 		case colorGen_t::CGEN_ONE_MINUS_VERTEX:
 		default:
-		case colorGen_t::CGEN_IDENTITY_LIGHTING:
-			/* Historically CGEN_IDENTITY_LIGHTING was done this way:
-
-			  tess.svars.color = Color::White * tr.identityLight;
-
-			But tr.identityLight is always 1.0f in Dæmon engine
-			as the as the overbright bit implementation is fully
-			software. */
-			{
 				tess.svars.color = Color::White;
 				break;
-			}
 
 		case colorGen_t::CGEN_VERTEX:
 			{

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -846,12 +846,10 @@ void Render_generic3D( shaderStage_t *pStage )
 	colorGen_t rgbGen = SetRgbGen( pStage );
 	alphaGen_t alphaGen = SetAlphaGen( pStage );
 
-	// Here, it's safe to multiply the overbright factor for vertex lighting into the color gen`
-	// since the `generic` fragment shader only takes a single input color. `lightMapping` on the
-	// hand needs to know the real diffuse color, hence the separate u_LightFactor.
 	bool mayUseVertexOverbright = pStage->type == stageType_t::ST_COLORMAP && tess.bspSurface;
 	const bool styleLightMap = pStage->type == stageType_t::ST_STYLELIGHTMAP || pStage->type == stageType_t::ST_STYLECOLORMAP;
-	gl_genericShader->SetUniform_ColorModulateColorGen( rgbGen, alphaGen, mayUseVertexOverbright, styleLightMap );
+	gl_genericShader->SetUniform_ColorModulateColorGen(
+		rgbGen, alphaGen, mayUseVertexOverbright, /*useMapLightFactor=*/ styleLightMap);
 
 	// u_Color
 	gl_genericShader->SetUniform_Color( tess.svars.color );

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4836,7 +4836,7 @@ static void CollapseStages()
 
 		bool rgbGen_identity =
 			stages[ i ].rgbGen == colorGen_t::CGEN_IDENTITY
-			|| stages[ i ].rgbGen == colorGen_t::CGEN_IDENTITY_LIGHTING;
+			|| ( stages[ i ].rgbGen == colorGen_t::CGEN_IDENTITY_LIGHTING && !r_overbrightQ3.Get() );
 
 		bool alphaGen_identity =
 			stages[ i ].alphaGen == alphaGen_t::AGEN_IDENTITY;


### PR DESCRIPTION
Fixes #1542. Adds `r_overbrightBits` which works similar to the one in Quake 3. With the default value of 1, there is one "clamped" bit and one "unclamped" bit of overbright. With map overbright bits = 2 and tr.overbrightBits = 1, A lightmap value of x is treated like `min(x * 4, 2)` except that if some color channel exceeded 2, all the channels are scaled down together.

Comparison of map mxl-school viewpos 1983 -838 353 130 24:

`r_overbrightBits 0` (like old Q3 in non-fullscreen mode, Tremfusion, most versions of Unvanquished until recently): A sickly light. Needs more brightness.

![unvanquished-mxlschool-levelshot](https://github.com/user-attachments/assets/169e73fd-fbf3-4956-964c-7d8922d74063)

`r_overbrightBits 2` (like Unvanquished 0.55+): Too much! Now it's saturated.

![unvanquished-mxlschool-levelshot](https://github.com/user-attachments/assets/c97e21cd-7054-4920-928d-496cd84f859b)

`r_overbrightBits 1` (like full-screen Windows 9x Q3, ioq3 with GL2 renderer, Tremulous 1.1.0): Just right.

![unvanquished-mxlschool-levelshot](https://github.com/user-attachments/assets/626d3699-429d-4512-ac2f-cd91f3d4b793)


Here's a screenshot with ioq3's GL1 renderer for comparison. Also I verified that setting `r_overbrightBits` to 0 or 2 has a similar effect in ioq3's renderers and this PR.

![ob1](https://github.com/user-attachments/assets/24a1e00e-e5e8-4b6f-b306-61d3b41331d7)

Draft PR because:
- Still need to update the code comments explaining this stuff.
- We need to decide if a replacement for `overbrightClamping` in the worldspawn is needed. For now I deleted `r_overbrightDefaultClamp`/`overbrightClamping` since you can do the same clamping by setting `r_overbrightBits 0`, but that doesn't offer a way for a map to force it.
