### PR TITLE
Workaround for atomic ops on AMD

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -506,6 +506,20 @@ static std::string GenCompatHeader() {
 		str += "#define unpackUnorm4x8( value ) ( ( vec4( value, value >> 8, value >> 16, value >> 24 ) & 0xFF ) / 255.0f )\n";
 	}
 
+	/* Driver bug: Adrenaline/OGLP drivers fail to recognise the ARB function versions when they return a 4.6 context
+	and the shaders get #version 460 core, so add #define's for them here */
+	if ( glConfig2.driverVendor == glDriverVendor_t::ATI && glConfig2.shaderAtomicCounterOpsAvailable ) {
+		str += "#define atomicCounterAddARB atomicCounterAdd\n";
+		str += "#define atomicCounterSubtractARB atomicCounterSubtract\n";
+		str += "#define atomicCounterMinARB atomicCounterMin\n";
+		str += "#define atomicCounterMaxARB atomicCounterMax\n";
+		str += "#define atomicCounterAndARB atomicCounterAnd\n";
+		str += "#define atomicCounterOrARB atomicCounterOr\n";
+		str += "#define atomicCounterXorARB atomicCounterXor\n";
+		str += "#define atomicCounterExchangeARB atomicCounterExchange\n";
+		str += "#define atomicCounterAndARB atomicCounterAnd\n";
+	}
+
 	return str;
 }
 


### PR DESCRIPTION
Fixes one of the issues in #1535.

Adrenaline/OGLP drivers erroneously disregard the ARB extension functionality (which has different naming than the core one) with `#version 460 core`, which is the one we end up using on such drivers, because it's the context version that the driver provides.