### PR TITLE
Fix 2 build system issues with Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,12 +331,11 @@ function(ADD_PRECOMPILED_HEADER Target)
     separate_arguments(Flags)
 
     # Get the per-configuration compile flags
-    foreach(Config Debug Release RelWithDebInfo MinSizeRel)
-        string(TOUPPER ${Config} CONFIG)
-        set(ConfigFlags ${CMAKE_CXX_FLAGS_${CONFIG}})
+    foreach(Config DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+        set(ConfigFlags ${CMAKE_CXX_FLAGS_${Config}})
         separate_arguments(ConfigFlags)
         foreach(Flag ${ConfigFlags})
-            set(Flags ${Flags} $<$<CONFIG:${Config}>:${Flag}>)
+            set(Flags ${Flags} $<${${Config}_GENEXP_COND}:${Flag}>)
         endforeach()
     endforeach()
 

--- a/cmake/DaemonBuildTypeGeneratorExpression.cmake
+++ b/cmake/DaemonBuildTypeGeneratorExpression.cmake
@@ -1,0 +1,44 @@
+# Daemon BSD Source Code
+# Copyright (c) 2025, Daemon Developers
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of the <organization> nor the
+#    names of its contributors may be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Work around https://github.com/DaemonEngine/Daemon/issues/398. The Visual Studio CMake
+# integration, which uses a (single-config) Ninja generator, sets the configuration name
+# to an arbitrary name instead of "Release", "Debug" etc. So then $<CONFIG:Debug> etc.
+# doesn't work since it doesn't correspond to CMAKE_BUILD_TYPE.
+get_property(are_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+if (are_multi_config)
+    set(DEBUG_GENEXP_COND "$<CONFIG:Debug>")
+    set(MINSIZEREL_GENEXP_COND "$<CONFIG:MinSizeRel>")
+    set(RELWITHDEBINFO_GENEXP_COND "$<CONFIG:RelWithDebInfo>")
+    set(RELEASE_GENEXP_COND "$<CONFIG:Release>")
+else()
+    set(DEBUG_GENEXP_COND "0")
+    set(MINSIZEREL_GENEXP_COND "0")
+    set(RELWITHDEBINFO_GENEXP_COND "0")
+    set(RELEASE_GENEXP_COND "0")
+    string(TOUPPER ${CMAKE_BUILD_TYPE} build_type_upper)
+    set(${build_type_upper}_GENEXP_COND "1")
+endif()

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -26,6 +26,7 @@
 
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
+include(DaemonBuildTypeGeneratorExpression)
 
 add_definitions(-DDAEMON_BUILD_${CMAKE_BUILD_TYPE})
 
@@ -554,4 +555,4 @@ endif()
 # is so that it doesn't break the hacky gcc/clang PCH code which reads all the definitions
 # and prefixes "-D" to them.
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS
-             $<$<NOT:$<CONFIG:Debug>>:THIS_IS_NOT_A_>DEBUG_BUILD)
+             $<$<NOT:${DEBUG_GENEXP_COND}>:THIS_IS_NOT_A_>DEBUG_BUILD)

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -49,6 +49,9 @@ else()
     message(STATUS "Disabling compiler custom attributes and operators")
 endif()
 
+option(USE_RECOMMENDED_CXX_STANDARD "Use recommended C++ standard" ON)
+mark_as_advanced(USE_RECOMMENDED_CXX_STANDARD)
+
 # Set flag without checking, optional argument specifies build type
 macro(set_c_flag FLAG)
     if (${ARGC} GREATER 1)
@@ -221,9 +224,6 @@ else()
 			message(FATAL_ERROR "GNU99 is not supported by the compiler")
 		endif()
 	endif()
-
-	option(USE_RECOMMENDED_CXX_STANDARD "Use recommended C++ standard" ON)
-	mark_as_advanced(USE_RECOMMENDED_CXX_STANDARD)
 
 	if (USE_RECOMMENDED_CXX_STANDARD)
 		# PNaCl only defines isascii if __STRICT_ANSI__ is not defined,

--- a/cmake/toolchain-pnacl.cmake
+++ b/cmake/toolchain-pnacl.cmake
@@ -96,17 +96,17 @@ set(NACL ON)
 set(CMAKE_C_FLAGS "")
 set(CMAKE_CXX_FLAGS "")
 
-set(PNACL_TRANSLATE_OPTIONS
-    --allow-llvm-bitcode-input # FIXME: finalize as part of the build process
-    --pnacl-allow-exceptions
-    $<$<CONFIG:None>:-O3>
-    $<$<CONFIG:Release>:-O3>
-    $<$<CONFIG:Debug>:-O0>
-    $<$<CONFIG:RelWithDebInfo>:-O2>
-    $<$<CONFIG:MinSizeRel>:-O2>
-)
-
 function(pnacl_finalize dir module arch)
+    include(DaemonBuildTypeGeneratorExpression)
+
+    set(PNACL_TRANSLATE_OPTIONS
+        --allow-llvm-bitcode-input # FIXME: finalize as part of the build process
+        --pnacl-allow-exceptions
+        $<${RELEASE_GENEXP_COND}:-O3>
+        $<${DEBUG_GENEXP_COND}:-O0>
+        $<${RELWITHDEBINFO_GENEXP_COND}:-O2>
+        $<${MINSIZEREL_GENEXP_COND}:-O2>
+    )
     set(PEXE ${dir}/${module}.pexe)
     set(NEXE ${dir}/${module}-${arch}.nexe)
     set(STRIPPED_NEXE ${dir}/${module}-${arch}-stripped.nexe)


### PR DESCRIPTION
- NaCl builds didn't work due to a mistake with USE_RECOMMENDED_CXX_STANDARD
- #398