### PR TITLE
Fix a crash with r_noportals

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -332,11 +332,9 @@ static void GLSL_InitGPUShadersOrError()
 		gl_shaderManager.load( gl_contrastShader );
 	}
 
-	if ( !r_noportals->integer || r_liquidMapping->integer )
-	{
-		// portal process effect
-		gl_shaderManager.load( gl_portalShader );
-	}
+	
+	// portal process effect
+	gl_shaderManager.load( gl_portalShader );
 
 	// camera post process effect
 	gl_shaderManager.load( gl_cameraEffectsShader );


### PR DESCRIPTION
`r_noportals` is non-latch, so loading a map with `r_noportals 1` that uses alphaGen portals, then setting `r_noportals 0` will result in a crash. This can be observed on e. g. map `pulse` with the camera screens.

Fix this by always loading the portal shader.