### PR TITLE
Some more material system clean-up

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -147,6 +147,7 @@ set(GLSLSOURCELIST
     ${ENGINE_DIR}/renderer/glsl_source/cull_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/depthReduction_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/processSurfaces_cp.glsl
+    ${ENGINE_DIR}/renderer/glsl_source/material_cp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/material_vp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/material_fp.glsl
     ${ENGINE_DIR}/renderer/glsl_source/skybox_vp.glsl

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1604,9 +1604,11 @@ void MaterialSystem::UpdateDynamicSurfaces() {
 
 void MaterialSystem::UpdateFrameData() {
 	atomicCommandCountersBuffer.BindBufferBase( GL_SHADER_STORAGE_BUFFER, Util::ordinal( BufferBind::COMMAND_COUNTERS_STORAGE ) );
+
 	gl_clearSurfacesShader->BindProgram( 0 );
 	gl_clearSurfacesShader->SetUniform_Frame( nextFrame );
 	gl_clearSurfacesShader->DispatchCompute( MAX_VIEWS, 1, 1 );
+
 	atomicCommandCountersBuffer.UnBindBufferBase( GL_SHADER_STORAGE_BUFFER, Util::ordinal( BufferBind::COMMAND_COUNTERS_STORAGE ) );
 
 	GL_CheckErrors();
@@ -1774,11 +1776,8 @@ void MaterialSystem::StartFrame() {
 	if ( !generatedWorldCommandBuffer ) {
 		return;
 	}
+	
 	frames[nextFrame].viewCount = 0;
-
-	// renderedMaterials.clear();
-	// UpdateDynamicSurfaces();
-	// UpdateFrameData();
 }
 
 void MaterialSystem::EndFrame() {
@@ -2059,7 +2058,6 @@ void MaterialSystem::RenderMaterials( const shaderSort_t fromSort, const shaderS
 		renderedMaterials.clear();
 		UpdateDynamicSurfaces();
 		UpdateFrameData();
-		// StartFrame();
 
 		// Make sure compute dispatches from the last frame finished writing to memory
 		glMemoryBarrier( GL_COMMAND_BARRIER_BIT );

--- a/src/engine/renderer/glsl_source/cull_cp.glsl
+++ b/src/engine/renderer/glsl_source/cull_cp.glsl
@@ -35,6 +35,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* cull_cp.glsl */
 
 #insert common_cp
+#insert material_cp
 
 // Keep this to 64 because we don't want extra shared mem etc. to be allocated, and to minimize wasted lanes
 layout (local_size_x = 64, local_size_y = 1, local_size_z = 1) in;

--- a/src/engine/renderer/glsl_source/material_cp.glsl
+++ b/src/engine/renderer/glsl_source/material_cp.glsl
@@ -2,7 +2,7 @@
 ===========================================================================
 
 Daemon BSD Source Code
-Copyright (c) 2024 Daemon Developers
+Copyright (c) 2025 Daemon Developers
 All rights reserved.
 
 This file is part of the Daemon BSD Source Code (Daemon Source Code).
@@ -32,31 +32,41 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ===========================================================================
 */
 
-/* common_cp.glsl */
+/* material_cp.glsl */
 
-/* Common defines */
+struct BoundingSphere {
+	vec3 origin;
+	float radius;
+};
 
-/* Allows accessing each element of a uvec4 array with a singular ID
-Useful to avoid wasting memory due to alignment requirements
-array must be in the form of uvec4 array[] */
+struct SurfaceDescriptor {
+	BoundingSphere boundingSphere;
+	uint surfaceCommandIDs[MAX_SURFACE_COMMANDS];
+};
 
-#define UINT_FROM_UVEC4_ARRAY( array, id ) ( array[id / 4][id % 4] )
-#define UVEC2_FROM_UVEC4_ARRAY( array, id ) ( id % 2 == 0 ? array[id / 2].xy : array[id / 2].zw )
+struct PortalSurface {
+	BoundingSphere boundingSphere;
 
-// Scalar global workgroup ID
-#define GLOBAL_GROUP_ID ( gl_WorkGroupID.z * gl_NumWorkGroups.x * gl_NumWorkGroups.y\
-                        + gl_WorkGroupID.y * gl_NumWorkGroups.x\
-                        + gl_WorkGroupID.x )
-						
-// Scalar global invocation ID
-#define GLOBAL_INVOCATION_ID ( gl_GlobalInvocationID.z * gl_NumWorkGroups.x * gl_WorkGroupSize.x\
-                             * gl_NumWorkGroups.y * gl_WorkGroupSize.y\
-                             + gl_GlobalInvocationID.y * gl_NumWorkGroups.x * gl_WorkGroupSize.x\
-                             + gl_GlobalInvocationID.x )
+	uint drawSurfID;
+	float distance;
+	vec2 padding;
+};
 
-/* Macro combinations for subgroup ops */
+struct GLIndirectCommand {
+	uint count;
+	uint instanceCount;
+	uint firstIndex;
+	int baseVertex;
+	uint baseInstance;
+};
 
-#if defined(HAVE_KHR_shader_subgroup_basic) && defined(HAVE_KHR_shader_subgroup_arithmetic)\
-	&& defined(HAVE_KHR_shader_subgroup_ballot) && defined(HAVE_ARB_shader_atomic_counter_ops)
-	#define SUBGROUP_STREAM_COMPACTION
-#endif
+struct IndirectCompactCommand {
+	uint count;
+	uint firstIndex;
+	uint baseInstance;
+};
+
+struct SurfaceCommand {
+	bool enabled;
+	IndirectCompactCommand drawCommand;
+};

--- a/src/engine/renderer/shaders.cpp
+++ b/src/engine/renderer/shaders.cpp
@@ -51,6 +51,7 @@
 #include "shadowFill_fp.glsl.h"
 #include "shadowFill_vp.glsl.h"
 #include "skybox_fp.glsl.h"
+#include "material_cp.glsl.h"
 #include "material_vp.glsl.h"
 #include "material_fp.glsl.h"
 #include "common.glsl.h"
@@ -101,6 +102,7 @@ std::unordered_map<std::string, std::string> shadermap({
 	{ "lighttile_vp.glsl", std::string(reinterpret_cast<const char*>(lighttile_vp_glsl), sizeof(lighttile_vp_glsl)) },
 	{ "liquid_fp.glsl", std::string(reinterpret_cast<const char*>(liquid_fp_glsl), sizeof(liquid_fp_glsl)) },
 	{ "liquid_vp.glsl", std::string(reinterpret_cast<const char*>(liquid_vp_glsl), sizeof(liquid_vp_glsl)) },
+	{ "material_cp.glsl", std::string( reinterpret_cast< const char* >( material_cp_glsl ), sizeof( material_cp_glsl ) ) },
 	{ "material_vp.glsl", std::string( reinterpret_cast< const char* >( material_vp_glsl ), sizeof( material_vp_glsl ) ) },
 	{ "material_fp.glsl", std::string( reinterpret_cast< const char* >( material_fp_glsl ), sizeof( material_fp_glsl ) ) },
 	{ "motionblur_fp.glsl", std::string(reinterpret_cast<const char*>(motionblur_fp_glsl), sizeof(motionblur_fp_glsl)) },

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -3440,6 +3440,12 @@ static void R_LoadSurfaces( lump_t *surfs, lump_t *verts, lump_t *indexLump )
 			case mapSurfaceType_t::MST_FLARE:
 				Log::Warn( "Surface type not supported: MST_FLARE; firstIndex: %i, numIndexes: %i, shaderNum: %i",
 					in->firstIndex, in->numIndexes, in->shaderNum );
+
+				// We still have to set these because other code will be checking them
+				out->data = ( surfaceType_t* ) ri.Hunk_Alloc( sizeof( surfaceType_t ), ha_pref::h_low );
+				*out->data = surfaceType_t::SF_BAD;
+				out->shader = tr.defaultShader;
+
 				numFlares++;
 				break;
 


### PR DESCRIPTION
These are mostly changes that I picked from #1559.

Previously only the material system used compute shaders at all, but now that other systems will be using them, all this stuff needs to be moved to another shader. Otherwise the other shaders would fail to compile, or all of them would require a bunch of macros to check for it.

Also moved the material system per-frame compute dispatches to `StartFrame()` since they work there now.