### PR TITLE
Add VM syscall for getting local time offset

### DIFF
--- a/src/common/IPC/CommonSyscalls.h
+++ b/src/common/IPC/CommonSyscalls.h
@@ -154,6 +154,7 @@ namespace VM {
     enum EngineMiscMessages {
         CREATE_SHARED_MEMORY,
         CRASH_DUMP,
+        GET_LOCAL_TIME_OFFSET,
     };
 
     // CreateSharedMemoryMsg
@@ -164,6 +165,11 @@ namespace VM {
     // CrashDumpMsg
     using CrashDumpMsg = IPC::SyncMessage<
         IPC::Message<IPC::Id<MISC, CRASH_DUMP>, std::vector<uint8_t>>
+    >;
+    // GetLocalTimeOffsetMsg
+    using GetLocalTimeOffsetMsg = IPC::SyncMessage<
+        IPC::Message<IPC::Id<MISC, EngineMiscMessages::GET_LOCAL_TIME_OFFSET>>,
+        IPC::Reply<int>
     >;
 
     enum VMMiscMessages {

--- a/src/engine/framework/CommonVMServices.cpp
+++ b/src/engine/framework/CommonVMServices.cpp
@@ -59,6 +59,21 @@ namespace VM {
                     Sys::NaclCrashDump(dump, vmName);
                 });
                 break;
+
+            case GET_LOCAL_TIME_OFFSET:
+                IPC::HandleMsg<GetLocalTimeOffsetMsg>(channel, std::move(reader), [this](int& offset) {
+                    time_t epochTime = time(nullptr);
+                    struct tm localDate;
+#ifdef _WIN32
+                    localtime_s(&localDate, &epochTime);
+                    time_t localEpochTime = _mkgmtime(&localDate);
+#else
+                    localtime_r(&epochTime, &localDate);
+                    time_t localEpochTime = timegm(&localDate);
+#endif
+                    offset = static_cast<int>(difftime(localEpochTime, epochTime));
+                });
+                break;
         }
     }
 

--- a/src/shared/CommonProxies.cpp
+++ b/src/shared/CommonProxies.cpp
@@ -435,6 +435,14 @@ namespace VM {
         SendMsg<CrashDumpMsg>(std::vector<uint8_t>{data, data + size});
     }
 
+    // Add this number of seconds to the UTC date/time to get the local date/time.
+    // The current daylight savings time adjustment is included in this.
+    int GetLocalTimeOffset() {
+        int offset;
+        SendMsg<GetLocalTimeOffsetMsg>(offset);
+        return offset;
+    }
+
     void InitializeProxies(int milliseconds) {
         baseTime = Sys::SteadyClock::now() - std::chrono::milliseconds(milliseconds);
         Cmd::InitializeProxy();

--- a/src/shared/CommonProxies.h
+++ b/src/shared/CommonProxies.h
@@ -43,6 +43,7 @@ namespace Cmd {
 namespace VM {
 
     void CrashDump(const uint8_t* data, size_t size);
+    int GetLocalTimeOffset();
     void InitializeProxies(int milliseconds);
     void HandleCommonSyscall(int major, int minor, Util::Reader reader, IPC::Channel& channel);
 


### PR DESCRIPTION
This is needed to get the local time since an NaCl VM can't read the time zone database.

Returns an offset instead of directly returning the local date, in the interests of not doing a trap call every frame.

Companion: https://github.com/Unvanquished/Unvanquished/pull/3328