### PR TITLE
Fix mistake when setting linker flags

### DIFF
--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -147,7 +147,7 @@ macro(try_linker_flag PROP FLAG)
     check_C_compiler_flag(${FLAG} FLAG_${PROP})
     set(CMAKE_REQUIRED_FLAGS "")
     if (FLAG_${PROP})
-        set_exe_linker_flag(${FLAG} ${ARGN})
+        set_linker_flag(${FLAG} ${ARGN})
     endif()
 endmacro()
 
@@ -158,7 +158,7 @@ macro(try_exe_linker_flag PROP FLAG)
 	set(CMAKE_REQUIRED_FLAGS "")
 
 	if (FLAG_${PROP})
-		set_linker_flag(${FLAG} ${ARGN})
+		set_exe_linker_flag(${FLAG} ${ARGN})
 	endif()
 endmacro()
 

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -395,11 +395,13 @@ else()
 		try_c_cxx_flag(WSTACK_PROTECTOR "-Wstack-protector")
 
 		if (NOT NACL OR (NACL AND GAME_PIE))
-			try_c_cxx_flag(FPIE "-fPIC")
+			try_c_cxx_flag(FPIC "-fPIC")
 
+			# The -pie flag requires -fPIC:
+			# > ld: error: relocation R_X86_64_64 cannot be used against local symbol; recompile with -fPIC
 			# This flag isn't used on macOS:
 			# > clang: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
-			if (NOT APPLE)
+			if (FLAG_FPIC AND NOT APPLE)
 				try_exe_linker_flag(LINKER_PIE "-pie")
 			endif()
 		endif()


### PR DESCRIPTION
There was a stupid mistake inverting between executable-linker-flags and everythng-linker-flags.

Fixes #1573:

- https://github.com/DaemonEngine/Daemon/issues/1573

I verified that even after fixing this maCOS still complains about `-pie` not being used on executables so I kept the macOS test to disable `-pie`:

```
[100%] Linking CXX executable daemonded
clang++: warning: argument unused during compilation: '-pie' [-Wunused-command-line-argument]
```