### PR TITLE
Mac: don't vid_restart when toggling full-screen

### DIFF
--- a/src/engine/client/cl_keys.cpp
+++ b/src/engine/client/cl_keys.cpp
@@ -511,7 +511,7 @@ static bool DetectBuiltInShortcut( Keyboard::Key key )
 		if ( key == Key::FromCharacter('f') )
 		{
 			Key_ClearStates();
-			Cmd::BufferCommandText("toggle r_fullscreen; vid_restart");
+			r_fullscreen.Set( !r_fullscreen.Get() );
 			return true;
 		}
 		else if ( key == Key::FromCharacter('q') )


### PR DESCRIPTION
The keyboard shortcut (Command+F) for toggling fullscreen mode unnecessarily issued vid_restart. It works fine without that as can be seen by just setting the cvar r_fullscreen.