### PR TITLE
Fix cursor not rendering right in main menu

### DIFF
--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -2320,7 +2320,14 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 	switch ( pStage->rgbGen )
 	{
 		case colorGen_t::CGEN_IDENTITY_LIGHTING:
-			tess.svars.color = Color::Color(tr.identityLight, tr.identityLight, tr.identityLight);
+			if ( backEnd.projection2D )
+			{
+				tess.svars.color = Color::White;
+			}
+			else
+			{
+				tess.svars.color = Color::Color(tr.identityLight, tr.identityLight, tr.identityLight);
+			}
 			break;
 
 		case colorGen_t::CGEN_IDENTITY:


### PR DESCRIPTION
Some 2D shaders are automatically assigned CGEN_IDENTITY_LIGHTING. This causes a bug of the cursor being black in the main menu (where tr.identityLighting is 0) and the wrong color if r_overbrightQ3 is used while in a map. Fix by making it behave as CGEN_IDENTITY during 2D rendering.

Fixes #1590.