### PR TITLE
Fix --help output not appearing through a pipe

### DIFF
--- a/src/engine/framework/System.cpp
+++ b/src/engine/framework/System.cpp
@@ -739,9 +739,11 @@ static void ParseCmdline(int argc, char** argv, cmdlineArgs_t& cmdlineArgs)
 				"Nothing is read and executed after -connect option and the following URI.\n"
 				"If another instance is already running, commands will be forwarded to it.\n"
 			);
+			FS::FlushAll();
 			OSExit(0);
 		} else if (!strcmp(argv[i], "--version") || !strcmp(argv[i], "-version") || !strcmp(argv[i], "-v")) {
 			printf(PRODUCT_NAME " " PRODUCT_VERSION "\n");
+			FS::FlushAll();
 			OSExit(0);
 		} else if (!strcmp(argv[i], "-set")) {
 			if (i >= argc - 2) {


### PR DESCRIPTION
On *nix using a pipe makes the output fully buffered, as opposed to a TTY where the default is line buffering. We did a fast shutdown without flushing so the output could be lost.

Fixes #631.