### PR TITLE
DaemonArchitecture: NUKE x86 revision detection

### DIFF
--- a/cmake/DaemonArchitecture/DaemonArchitecture.cpp
+++ b/cmake/DaemonArchitecture/DaemonArchitecture.cpp
@@ -80,7 +80,10 @@ platform variants we cannot support anyway. */
 #elif defined(Q_PROCESSOR_X86_64)
 	#pragma message("DAEMON_ARCH_amd64")
 
-#elif defined(Q_PROCESSOR_X86_32) && Q_PROCESSOR_X86 >= 6
+#elif defined(Q_PROCESSOR_X86_32)
+	// Assume at least i686. Detecting older revisions would be unlikely to work here
+	// because the revisions are likely configured by flags, but this file is "compiled"
+	// without most command-line flags.
 	#pragma message("DAEMON_ARCH_i686")
 
 /* Devices like:


### PR DESCRIPTION
Always assume i686, instead of trying to use the numeric value of Q_PROCESSOR_X86, which isn't accurate in our build.

For architecture detection the compiler is invoked without any of the flags that we usually pass. So the -march=XXX, etc. flags are not there. This means the architecture revision that the compiler advertises during architecture detection may not be the same as in the real build. You may react, "just do the architecture detection with all flags on", but this would probably lead to chicken-and-egg problems as architecture is used to choose flags. In principle it could be done with two passes of architecture detection but implementing that would obviously be a waste of time.

Fixes #1596.