### PR TITLE
Don't print some network information on startup

### DIFF
--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -151,7 +151,6 @@ CGameVM            cgvm;
 refexport_t        re;
 
 void        CL_CheckForResend();
-void        CL_ShowIP_f();
 
 #if defined(USE_MUMBLE)
 static void CL_UpdateMumble()
@@ -2400,7 +2399,6 @@ void CL_Init()
 
 	Cmd_AddCommand( "ping", CL_Ping_f );
 	Cmd_AddCommand( "serverstatus", CL_ServerStatus_f );
-	Cmd_AddCommand( "showip", CL_ShowIP_f );
 
 	Cmd_AddCommand( "updatescreen", SCR_UpdateScreen );
 	// done.
@@ -2476,7 +2474,6 @@ void CL_Shutdown()
 	Cmd_RemoveCommand( "globalservers" );
 	Cmd_RemoveCommand( "ping" );
 	Cmd_RemoveCommand( "serverstatus" );
-	Cmd_RemoveCommand( "showip" );
 
 	CL_ClearKeyBinding();
 	CL_ClearInput();
@@ -2494,16 +2491,6 @@ void CL_Shutdown()
 
 	Log::Debug( "-----------------------" );
 
-}
-
-/*
-==================
-CL_ShowIP_f
-==================
-*/
-void CL_ShowIP_f()
-{
-	Sys_ShowIP();
 }
 
 /*

--- a/src/engine/qcommon/net_ip.cpp
+++ b/src/engine/qcommon/net_ip.cpp
@@ -170,6 +170,8 @@ struct nip_localaddr_t
 	struct sockaddr_storage netmask;
 };
 
+// Used to get local IP list. Saved here just to ensure /showip shows the same one that we used
+static char hostname[ 256 ];
 // Used for Sys_IsLANAddress
 static nip_localaddr_t localIP[ MAX_IPS ];
 static int             numIP;
@@ -895,6 +897,8 @@ public:
 
 	void Run( const Cmd::Args & ) const override
 	{
+		Print( "Hostname: %s", hostname );
+
 		int  i;
 		char addrbuf[ NET_ADDR_STR_MAX_LEN ];
 
@@ -1516,19 +1520,17 @@ static void NET_GetLocalAddress()
 #else
 static void NET_GetLocalAddress()
 {
-	char            hostname[ 256 ];
 	struct addrinfo hint;
 
 	struct addrinfo *res = nullptr;
 
 	numIP = 0;
 
-	if ( gethostname( hostname, 256 ) == SOCKET_ERROR )
+	if ( gethostname( hostname, sizeof( hostname ) ) == SOCKET_ERROR )
 	{
+		*hostname = '\0';
 		return;
 	}
-
-	Log::Notice( "Hostname: %s", hostname );
 
 	memset( &hint, 0, sizeof( hint ) );
 

--- a/src/engine/qcommon/net_ip.cpp
+++ b/src/engine/qcommon/net_ip.cpp
@@ -1507,8 +1507,6 @@ static void NET_GetLocalAddress()
 		}
 
 		freeifaddrs( ifap );
-
-		Sys_ShowIP();
 	}
 }
 
@@ -1564,8 +1562,6 @@ static void NET_GetLocalAddress()
 				NET_AddLocalAddress( "", search->ai_addr, ( struct sockaddr * ) &mask6 );
 			}
 		}
-
-		Sys_ShowIP();
 	}
 
 	if ( res )

--- a/src/engine/qcommon/net_ip.cpp
+++ b/src/engine/qcommon/net_ip.cpp
@@ -170,6 +170,7 @@ struct nip_localaddr_t
 	struct sockaddr_storage netmask;
 };
 
+// Used for Sys_IsLANAddress
 static nip_localaddr_t localIP[ MAX_IPS ];
 static int             numIP;
 
@@ -887,30 +888,32 @@ bool Sys_IsLANAddress( const netadr_t& adr )
 	return false;
 }
 
-/*
-==================
-Sys_ShowIP
-==================
-*/
-void Sys_ShowIP()
+class ShowIPCommand : public Cmd::StaticCmd
 {
-	int  i;
-	char addrbuf[ NET_ADDR_STR_MAX_LEN ];
+public:
+	ShowIPCommand() : StaticCmd("showip", Cmd::SERVER, "show addresses of network interfaces") {}
 
-	for ( i = 0; i < numIP; i++ )
+	void Run( const Cmd::Args & ) const override
 	{
-		Sys_SockaddrToString( addrbuf, sizeof( addrbuf ), ( struct sockaddr * ) &localIP[ i ].addr );
+		int  i;
+		char addrbuf[ NET_ADDR_STR_MAX_LEN ];
 
-		if ( localIP[ i ].type == netadrtype_t::NA_IP )
+		for ( i = 0; i < numIP; i++ )
 		{
-			Log::Notice( "IP: %s", addrbuf );
-		}
-		else if ( localIP[ i ].type == netadrtype_t::NA_IP6 )
-		{
-			Log::Notice( "IP6: %s", addrbuf );
+			Sys_SockaddrToString( addrbuf, sizeof( addrbuf ), ( struct sockaddr * ) &localIP[ i ].addr );
+
+			if ( localIP[ i ].type == netadrtype_t::NA_IP )
+			{
+				Print( "IP: %s", addrbuf );
+			}
+			else if ( localIP[ i ].type == netadrtype_t::NA_IP6 )
+			{
+				Print( "IP6: %s", addrbuf );
+			}
 		}
 	}
-}
+};
+static ShowIPCommand showipRegistration;
 
 //=============================================================================
 

--- a/src/engine/qcommon/sys.h
+++ b/src/engine/qcommon/sys.h
@@ -43,6 +43,5 @@ bool Sys_GetPacket(netadr_t *net_from, msg_t *net_message);
 bool Sys_StringToAdr(const char *s, netadr_t *a, netadrtype_t family);
 
 bool Sys_IsLANAddress(const netadr_t& adr);
-void Sys_ShowIP();
 
 #endif // ENGINE_QCOMMON_SYS_H_


### PR DESCRIPTION
Don't print the hostname and network addresses that may make people worry about posting logs with confidential information. Instead the `showip` command can be used. Make the command available for all engines.

Fixes https://github.com/Unvanquished/Unvanquished/issues/1573.