### PR TITLE
cmake: make sure the dll game is built as module, not as static library

### DIFF
--- a/cmake/DaemonGame.cmake
+++ b/cmake/DaemonGame.cmake
@@ -109,15 +109,14 @@ daemon_write_buildinfo("Game")
 function(buildGameModule module_slug)
 	set(module_target "${GAMEMODULE_NAME}-${module_slug}")
 
-	set(module_target_args "${module_target}" ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${BUILDINFOLIST} ${COMMONLIST})
+	set(module_target_args ${PCH_FILE} ${GAMEMODULE_FILES} ${SHAREDLIST_${GAMEMODULE_NAME}} ${SHAREDLIST} ${BUILDINFOLIST} ${COMMONLIST})
 
 	if (module_slug STREQUAL "native-dll")
-		add_library(${module_target_args})
-		set_target_properties(${module_target} PROPERTIES
-			PREFIX ""
-			COMPILE_DEFINITIONS "BUILD_VM_IN_PROCESS")
+		add_library("${module_target}" MODULE ${module_target_args})
+		set_target_properties(${module_target} PROPERTIES PREFIX "")
+		set(GAMEMODULE_DEFINITIONS "${GAMEMODULE_DEFINITIONS};BUILD_VM_IN_PROCESS")
 	else()
-		add_executable(${module_target_args})
+		add_executable("${module_target}" ${module_target_args})
 	endif()
 
 	set_target_properties(${module_target} PROPERTIES


### PR DESCRIPTION
Make sure the dll game is built as module, not as static library.

Fixup for:

- https://github.com/DaemonEngine/Daemon/pull/1555

This wasn't caught by the CI, but a bug in #1555 made the dll game being compiled to `cgame-native-dll.a` instead of `cgame-native-dll.so`. Also, this hid another bug where CMake would overwrite `COMPILE_DEFINITIONS` and then lose the `BUILD_VM_IN_PROCESS` definition.