### PR TITLE
cmake: make possible to build both game and engine against the engine Freetype submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -778,16 +778,20 @@ endif()
 option(PREFER_EXTERNAL_LIBS "Tries to use system libs where possible." ON)
 
 macro(prefer_package LIB_NAME LIB_CMAKE)
-    if (PREFER_EXTERNAL_LIBS AND NOT NACL)
-        find_package(${LIB_NAME})
+    if (NOT ${LIB_NAME}_FOUND)
+        if (PREFER_EXTERNAL_LIBS AND NOT NACL)
+            find_package(${LIB_NAME})
+
+            if (NOT ${LIB_NAME}_FOUND)
+                message(WARNING "PREFER_EXTERNAL_LIBS is enabled but external ${LIB_NAME} is not found, falling back to vendored ${LIB_NAME}.")
+            endif()
+        endif()
 
         if (NOT ${LIB_NAME}_FOUND)
-            message(WARNING "PREFER_EXTERNAL_LIBS is enabled but external ${LIB_NAME} is not found, falling back to vendored ${LIB_NAME}.")
-        endif()
-    endif()
+            include(${LIB_CMAKE})
 
-    if (NOT ${LIB_NAME}_FOUND)
-        include(${LIB_CMAKE})
+            set(${LIB_NAME}_FOUND ON)
+        endif()
     endif()
 endmacro()
 
@@ -817,7 +821,6 @@ if (BUILD_CLIENT)
     set(LIBS_CLIENT ${LIBS_CLIENT} ${PNG_LIBRARIES})
 
     prefer_package(Freetype ${DAEMON_DIR}/freetype.cmake)
-
     include_directories(${FREETYPE_INCLUDE_DIRS})
     set(LIBS_CLIENT ${LIBS_CLIENT} ${FREETYPE_LIBRARIES})
 

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -381,6 +381,8 @@ else()
 		# Don't set _FORTIFY_SOURCE in debug builds.
 	endif()
 
+	try_c_cxx_flag(FPIC "-fPIC")
+
 	if (USE_HARDENING)
 		# PNaCl accepts the flags but does not define __stack_chk_guard and __stack_chk_fail.
 		if (NOT NACL)
@@ -395,8 +397,6 @@ else()
 		try_c_cxx_flag(WSTACK_PROTECTOR "-Wstack-protector")
 
 		if (NOT NACL OR (NACL AND GAME_PIE))
-			try_c_cxx_flag(FPIC "-fPIC")
-
 			# The -pie flag requires -fPIC:
 			# > ld: error: relocation R_X86_64_64 cannot be used against local symbol; recompile with -fPIC
 			# This flag isn't used on macOS:

--- a/freetype.cmake
+++ b/freetype.cmake
@@ -2,24 +2,33 @@ set(FREETYPE_DIR ${DAEMON_DIR}/libs/freetype)
 set(FREETYPE_INCLUDE_DIRS ${FREETYPE_DIR}/include)
 set(FREETYPE_LIBRARIES freetype)
 
-option(FT_DISABLE_BROTLI "Disable Brotli" ON)
-option(FT_DISABLE_BZIP2 "Disable bzip2" ON)
-option(FT_DISABLE_HARFBUZZ "Disable HarfBuzz" ON)
-option(FT_DISABLE_PNG "Disable PNG" ON)
-
 if (PREFER_EXTERNAL_LIBS AND NOT NACL)
 	set(FREETYPE_INTERNAL_ZLIB OFF)
 else()
 	set(FREETYPE_INTERNAL_ZLIB ON)
 endif()
 
-set(FT_DISABLE_ZLIB ${FREETYPE_INTERNAL_ZLIB} CACHE BOOL "Disable external zlib" FORCE)
+if (NOT FREETYPE_INTERNAL_ZLIB)
+	find_package(ZLIB REQUIRED)
+	set(FREETYPE_LIBRARIES ${FREETYPE_LIBRARIES} ${ZLIB_LIBRARIES})
+endif()
 
-add_subdirectory(${FREETYPE_DIR})
+# Do not re-add the target if already set to be built.
+# For example both the engine and a native game may request Freetype
+# to be built, but we need to only build once for both.
+if (NOT TARGET freetype)
+	option(FT_DISABLE_BROTLI "Disable Brotli" ON)
+	option(FT_DISABLE_BZIP2 "Disable bzip2" ON)
+	option(FT_DISABLE_HARFBUZZ "Disable HarfBuzz" ON)
+	option(FT_DISABLE_PNG "Disable PNG" ON)
+	set(FT_DISABLE_ZLIB ${FREETYPE_INTERNAL_ZLIB} CACHE BOOL "Disable external zlib" FORCE)
 
-mark_as_advanced(FT_DISABLE_BROTLI)
-mark_as_advanced(FT_DISABLE_BZIP2)
-mark_as_advanced(FT_DISABLE_HARFBUZZ)
-mark_as_advanced(FT_DISABLE_PNG)
-mark_as_advanced(FT_DISABLE_ZLIB)
-mark_as_advanced(FT_ENABLE_ERROR_STRINGS)
+	add_subdirectory(${FREETYPE_DIR})
+
+	mark_as_advanced(FT_DISABLE_BROTLI)
+	mark_as_advanced(FT_DISABLE_BZIP2)
+	mark_as_advanced(FT_DISABLE_HARFBUZZ)
+	mark_as_advanced(FT_DISABLE_PNG)
+	mark_as_advanced(FT_DISABLE_ZLIB)
+	mark_as_advanced(FT_ENABLE_ERROR_STRINGS)
+endif()

--- a/freetype.cmake
+++ b/freetype.cmake
@@ -2,10 +2,14 @@ set(FREETYPE_DIR ${DAEMON_DIR}/libs/freetype)
 set(FREETYPE_INCLUDE_DIRS ${FREETYPE_DIR}/include)
 set(FREETYPE_LIBRARIES freetype)
 
-if (PREFER_EXTERNAL_LIBS AND NOT NACL)
-	set(FREETYPE_INTERNAL_ZLIB OFF)
-else()
+if (NACL)
+	# Using Freetype's own zlib prevents the need for a zlib submodule when building the nexe cgame.
 	set(FREETYPE_INTERNAL_ZLIB ON)
+else()
+	# Even if we can build an engine with Freetype using its internal zlib, we better rely on the
+	# external zlib even if PREFER_EXTERNAL_LIBS is OFF, because then it will avoid zlib duplication
+	# and share the same zlib between Freetype and the libpng.
+	set(FREETYPE_INTERNAL_ZLIB OFF)
 endif()
 
 if (NOT FREETYPE_INTERNAL_ZLIB)


### PR DESCRIPTION
Make possible to build both game and engine against the engine Freetype submodule.

Extracted from #1585:

- https://github.com/DaemonEngine/Daemon/pull/1585

Without the controversial change about default building.

See also:

- https://github.com/Unvanquished/Unvanquished/pull/3353