### PR TITLE
cmake/DaemonGame: set FORK value 1 in current scope, as it is used and only used in current scope

### DIFF
--- a/cmake/DaemonGame.cmake
+++ b/cmake/DaemonGame.cmake
@@ -38,6 +38,7 @@ option(BUILD_GAME_NATIVE_DLL "Build the shared library files, mostly useful for 
 # can be loaded by daemon with vm.[sc]game.type 2
 option(BUILD_GAME_NATIVE_EXE "Build native executable, which might be used for better performances by server owners" OFF)
 
+include(ExternalProject)
 include(DaemonBuildInfo)
 include(DaemonPlatform)
 
@@ -173,7 +174,7 @@ function(GAMEMODULE)
 
 	if (NOT FORK)
 		if (BUILD_GAME_NACL)
-			set(FORK 1 PARENT_SCOPE)
+			set(NACL_VMS ON)
 		endif()
 
 		if (BUILD_GAME_NATIVE_DLL)
@@ -185,7 +186,11 @@ function(GAMEMODULE)
 		endif()
 	endif()
 
-	if (FORK EQUAL 1)
+	if (NACL_VMS)
+		if (TARGET nacl-vms)
+			return()
+		endif()
+
 		if (CMAKE_GENERATOR MATCHES "Visual Studio")
 			set(VM_GENERATOR "NMake Makefiles")
 		else()


### PR DESCRIPTION
Fix Unvanquished/Unvanquished#3355:

- https://github.com/Unvanquished/Unvanquished/issues/3355

This is a dormant bug that was already there for a long time (before #1621) , the `set(FORK 1 PARENT_SCOPE)` can already be found in commit de443dc185656d2ca581c848f3ee189351a05833 from https://github.com/Unvanquished/Unvanquished/pull/771 ten years ago.

But because of some luck, the bug wasn't active. Some refactor woke up that bug. I don't know exactly what woken it up and when.

The bug is that the Unvanquished `CMakeLists.txt` calls the `GAMEMODULE()` function, which does `set(FORK 1 PARENT_SCOPE)`, meaning `FORK` is set to `1` in `CMakeLists.txt`, not in `GAMEMODULE()`, and `GAMEMODULE()` test for `FORK` being `1` to add the `nacl-vms` target.

The reason why it worked when both cgame and sgame is built is because it had this side effect:

1. `CMakeLists.txt` calls `GAMEMODULE("sgame")` that sets `FORK` to `1` in `CMakeListst.txt` scope (_not_ in `GAMEMODULE()` scope), then `GAMEMODULE()` doesn't add the `nacl-vms` target because `FORK` isn't set in `GAMEMODULE()` scope.
2. `CMakeLists.txt` calls `GAMEMODULE("cgame")` and `GAMEMODULE()` inherit the `FORK` being previously set to `1` from the `CMakeListst.txt` scope, then `GAMEMODULE()` sets `FORK` to `1` in `CMakeListst.txt` scope again, then `GAMEMODULE()` adds the `nacl-vms` target because `FORK` being `1` was inherited from `CMakeLists.txt` as set by the previous `GAMEMODULE()` call.