### PR TITLE
NUKE CMake dependent options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,14 +117,16 @@ if(NOT DAEMON_EXTERNAL_APP)
         option(USE_MUMBLE "Build Daemon with mumblelink sumpport" ON)
     endif()
 
-    cmake_dependent_option(USE_SMP "Compile with support for running the renderer in a separate thread" 1 BUILD_CLIENT 0)
+    option(USE_SMP "Compile with support for running the renderer in a separate thread" ON)
     option(USE_BREAKPAD "Generate Daemon crash dumps (which require Breakpad tools to read)" OFF)
 endif()
 
 option(BUILD_TESTS "Build unit test applications" OFF)
 
 option(USE_LTO "Use link-time optimization for release builds" OFF)
-cmake_dependent_option(USE_SLIM_LTO "Generate slim LTO objects, improves build times" 1 "USE_LTO AND \"${CMAKE_CXX_COMPILER_ID}\" STREQUAL GNU" 0)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL GNU)
+    option(USE_SLIM_LTO "Generate slim LTO objects, improves build times" OFF)
+endif()
 option(USE_HARDENING "Use stack protection and other hardening flags" OFF)
 option(USE_WERROR "Tell the compiler to make the build fail when warnings are present" OFF)
 option(USE_PEDANTIC "Tell the compiler to be pedantic" OFF)


### PR DESCRIPTION
cmake_dependent_option, as implemented in the GUI/TUI, is a pointless misfeature. It could be useful if it, say, showed the option as grayed out and then enabled itself as soon as the dependee changed. But what it actually does is hide the dependent option completely, and not show it until you reconfigure. So it's just a nuisance when you want to use the option: you have to configure multiple times. The goal of hiding options that are not relevant is hopeless anyway since there are always zillions of options that don't affect the current build.

We had just 2 cmake_depend_option's, USE_SMP and USE_SLIM_LTO.

Fixes https://github.com/Unvanquished/Unvanquished/issues/1921.