### PR TITLE
Move entityType_t in gamelogic

### DIFF
--- a/src/engine/qcommon/q_shared.cpp
+++ b/src/engine/qcommon/q_shared.cpp
@@ -288,45 +288,6 @@ int Com_HashKey( char *string, int maxlen )
 /*
 ============================================================================
 
-q_shared.h-enum to name conversion
-
-============================================================================
-*/
-
-const char *Com_EntityTypeName(entityType_t entityType)
-{
-	switch (entityType)
-	{
-	case entityType_t::ET_GENERAL:          return "GENERAL";
-	case entityType_t::ET_PLAYER:           return "PLAYER";
-	case entityType_t::ET_ITEM:             return "ITEM";
-	case entityType_t::ET_BUILDABLE:        return "BUILDABLE";
-	case entityType_t::ET_LOCATION:         return "LOCATION";
-	case entityType_t::ET_MISSILE:          return "MISSILE";
-	case entityType_t::ET_MOVER:            return "MOVER";
-	case entityType_t::ET_PORTAL:           return "PORTAL";
-	case entityType_t::ET_SPEAKER:          return "SPEAKER";
-	case entityType_t::ET_PUSHER:           return "PUSHER";
-	case entityType_t::ET_TELEPORTER:       return "TELEPORTER";
-	case entityType_t::ET_INVISIBLE:        return "INVISIBLE";
-	case entityType_t::ET_FIRE:             return "FIRE";
-	case entityType_t::ET_CORPSE:           return "CORPSE";
-	case entityType_t::ET_PARTICLE_SYSTEM:  return "PARTICLE_SYSTEM";
-	case entityType_t::ET_ANIMMAPOBJ:       return "ANIMMAPOBJ";
-	case entityType_t::ET_MODELDOOR:        return "MODELDOOR";
-	case entityType_t::ET_LIGHTFLARE:       return "LIGHTFLARE";
-	case entityType_t::ET_LEV2_ZAP_CHAIN:   return "LEV2_ZAP_CHAIN";
-	case entityType_t::ET_BEACON:   	return "BEACON";
-	default:
-		if(entityType >= entityType_t::ET_EVENTS)
-			return "EVENT";
-		return nullptr;
-	}
-}
-
-/*
-============================================================================
-
 PARSING
 
 ============================================================================

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -2086,56 +2086,10 @@ union OpaquePlayerState {
 //----(SA)  removed
 	};
 
-// entityState_t is the information conveyed from the server
-// in an update message about entities that the client will
-// need to render in some way
-// Different eTypes may use the information in different ways
-// The messages are delta compressed, so it doesn't really matter if
-// the structure size is fairly large
-//
-// NOTE: all fields in here must be 32 bits (or those within sub-structures)
-//
-// You can use Com_EntityTypeName to get a String representation of this enum
-	enum class entityType_t
-	{
-		ET_GENERAL,
-		ET_PLAYER,
-		ET_ITEM,
-
-		ET_BUILDABLE,       // buildable type
-
-		ET_LOCATION,
-
-		ET_MISSILE,
-		ET_MOVER,
-		ET_UNUSED,
-		ET_PORTAL,
-		ET_SPEAKER,
-		ET_PUSHER,
-		ET_TELEPORTER,
-		ET_INVISIBLE,
-		ET_FIRE,
-
-		ET_CORPSE,
-		ET_PARTICLE_SYSTEM,
-		ET_ANIMMAPOBJ,
-		ET_MODELDOOR,
-		ET_LIGHTFLARE,
-		ET_LEV2_ZAP_CHAIN,
-
-		ET_BEACON,
-
-		ET_EVENTS       // any of the EV_* events can be added freestanding
-		// by setting eType to ET_EVENTS + eventNum
-		// this avoids having to set eFlags and eventNum
-	};
-
-	const char *Com_EntityTypeName(entityType_t entityType);
-
 	struct entityState_t
 	{
 		int          number; // entity index
-		entityType_t eType; // entityType_t
+		int eType; // entityType_t
 		int          eFlags;
 
 		trajectory_t pos; // for calculating position


### PR DESCRIPTION
Gamelogic-side pr: https://github.com/Unvanquished/Unvanquished/pull/3359

Patch shared by freem, this moves `entityType_t` to gamelogic, since the engine doesn't need to know about it.

This should be fine to merge into master, since the ABI is still the same and merge conflicts from this change are unlikely.