### PR TITLE
Get rid of a bunch of duplicate code in map loading and srf*_t

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1016,19 +1016,13 @@ static int MergeInteractionBounds( const matrix_t lightViewProjectionMatrix, int
 			}
 		}
 
-		if ( *surface == surfaceType_t::SF_FACE || *surface == surfaceType_t::SF_GRID || *surface == surfaceType_t::SF_TRIANGLES )
+		if ( *surface == surfaceType_t::SF_FACE || *surface == surfaceType_t::SF_GRID || *surface == surfaceType_t::SF_TRIANGLES
+			|| *surface == surfaceType_t::SF_VBO_MESH )
 		{
 			srfGeneric_t *gen = ( srfGeneric_t * ) surface;
 
 			VectorCopy( gen->bounds[ 0 ], worldBounds[ 0 ] );
 			VectorCopy( gen->bounds[ 1 ], worldBounds[ 1 ] );
-		}
-		else if ( *surface == surfaceType_t::SF_VBO_MESH )
-		{
-			srfVBOMesh_t *srf = ( srfVBOMesh_t * ) surface;
-
-			VectorCopy( srf->bounds[ 0 ], worldBounds[ 0 ] );
-			VectorCopy( srf->bounds[ 1 ], worldBounds[ 1 ] );
 		}
 		else if ( *surface == surfaceType_t::SF_MDV )
 		{

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -2605,7 +2605,7 @@ static void R_CreateWorldVBO()
 		if ( *surface->data == surfaceType_t::SF_FACE || *surface->data == surfaceType_t::SF_GRID
 			|| *surface->data == surfaceType_t::SF_TRIANGLES )
 		{
-			srfSurfaceFace_t* srf = ( srfSurfaceFace_t * ) surface->data;
+			srfGeneric_t* srf = ( srfGeneric_t* ) surface->data;
 
 			numVerts += srf->numVerts;
 			numTriangles += srf->numTriangles;

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -1238,9 +1238,7 @@ static void ParseMesh( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf )
 ParseTriSurf
 ===============
 */
-static void ParseTriSurf( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf, int *indexes )
-{
-	srfTriangles_t       *cv;
+static void ParseTriSurf( dsurface_t* ds, drawVert_t* verts, bspSurface_t* surf, int* indexes ) {
 	srfTriangle_t        *tri;
 	int                  i, j;
 	int                  numVerts, numTriangles;
@@ -1281,14 +1279,14 @@ static void ParseTriSurf( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf,
 	numVerts = LittleLong( ds->numVerts );
 	numTriangles = LittleLong( ds->numIndexes ) / 3;
 
-	cv = (srfTriangles_t*) ri.Hunk_Alloc( sizeof( *cv ), ha_pref::h_low );
+	srfGeneric_t* cv = ( srfGeneric_t* ) ri.Hunk_Alloc( sizeof( *cv ), ha_pref::h_low );
 	cv->surfaceType = surfaceType_t::SF_TRIANGLES;
 
 	cv->numTriangles = numTriangles;
 	cv->triangles = (srfTriangle_t*) ri.Hunk_Alloc( numTriangles * sizeof( cv->triangles[ 0 ] ), ha_pref::h_low );
 
 	cv->numVerts = numVerts;
-	cv->verts = (srfVert_t*) ri.Hunk_Alloc( numVerts * sizeof( cv->verts[ 0 ] ), ha_pref::h_low );
+	cv->verts = ( srfVert_t* ) ri.Hunk_Alloc( numVerts * sizeof( cv->verts[ 0 ] ), ha_pref::h_low );
 
 	surf->data = ( surfaceType_t * ) cv;
 
@@ -2865,7 +2863,7 @@ static void R_CreateWorldVBO()
 		}
 		else if ( *surface->data == surfaceType_t::SF_TRIANGLES )
 		{
-			srfTriangles_t *tri = ( srfTriangles_t * ) surface->data;
+			srfGeneric_t* tri = ( srfGeneric_t* ) surface->data;
 
 			numVerts += tri->numVerts;
 			numTriangles += tri->numTriangles;
@@ -3042,7 +3040,7 @@ static void R_CreateWorldVBO()
 		}
 		else if ( *surface->data == surfaceType_t::SF_TRIANGLES )
 		{
-			srfTriangles_t *srf = ( srfTriangles_t * ) surface->data;
+			srfGeneric_t* srf = ( srfGeneric_t* ) surface->data;
 
 			srf->firstIndex = vboNumIndexes;
 			surfVerts = srf->verts;
@@ -3183,7 +3181,7 @@ static void R_CreateWorldVBO()
 			}
 			else if ( *surf1->data == surfaceType_t::SF_TRIANGLES )
 			{
-				srfTriangles_t *tris = ( srfTriangles_t * ) surf1->data;
+				srfGeneric_t* tris = ( srfGeneric_t* ) surf1->data;
 				firstIndex = tris->firstIndex;
 			}
 			else if ( *surf1->data == surfaceType_t::SF_GRID )
@@ -3213,7 +3211,7 @@ static void R_CreateWorldVBO()
 				}
 				else if ( *surf2->data == surfaceType_t::SF_TRIANGLES )
 				{
-					srfTriangles_t *tris = ( srfTriangles_t * ) surf2->data;
+					srfGeneric_t* tris = ( srfGeneric_t* ) surf2->data;
 					surfIndexes += tris->numTriangles * 3;
 					surfVerts += tris->numVerts;
 					BoundsAdd( bounds[ 0 ], bounds[ 1 ], tris->bounds[ 0 ], tris->bounds[ 1 ] );
@@ -3295,7 +3293,7 @@ static void R_CreateWorldVBO()
 		}
 		else if ( *surface->data == surfaceType_t::SF_TRIANGLES )
 		{
-			srfTriangles_t *srf = ( srfTriangles_t * ) surface->data;
+			srfGeneric_t* srf = ( srfGeneric_t* ) surface->data;
 			srf->vbo = s_worldData.vbo;
 			srf->ibo = s_worldData.ibo;
 		}

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -931,8 +931,9 @@ static void ParseTriangleSurface( dsurface_t* ds, drawVert_t* verts, bspSurface_
 		for ( int j = 0; j < 3; j++ ) {
 			tri->indexes[ j ] = LittleLong( indexes[ i * 3 + j ] );
 
-			if ( tri->indexes[ j ] < 0 || tri->indexes[ j ] >= cv->numVerts ) {
-				Sys::Drop( "Bad index in face surface" );
+			if ( tri->indexes[j] < 0 || tri->indexes[j] >= cv->numVerts ) {
+				Sys::Drop( "Index out of range in surface: %i not in [0, %i] (index in BSP: %i, surface: indexes: %i-%i, shader: %s)",
+					tri->indexes[j], cv->numVerts, i * 3 + j, ds->firstIndex, ds->firstIndex + ds->numIndexes, surf->shader->name );
 			}
 		}
 	}
@@ -1113,7 +1114,8 @@ static void ParseMesh( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf )
 
 	if ( width < 0 || width > MAX_PATCH_SIZE || height < 0 || height > MAX_PATCH_SIZE )
 	{
-		Sys::Drop( "ParseMesh: bad size" );
+		Sys::Drop( "ParseMesh: bad size: width: %i (range: [0, %i]), height: %i (range: [0, %i]), surface: firstVertex: %i,"
+		" shader: %s", width, MAX_PATCH_SIZE, height, MAX_PATCH_SIZE, ds->firstVert, surf->shader->name );
 	}
 
 	verts += LittleLong( ds->firstVert );

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -1080,6 +1080,15 @@ static void ParseTriSurf( dsurface_t* ds, drawVert_t* verts, bspSurface_t* surf,
 
 	srfGeneric_t* surface = ( srfGeneric_t* ) surf->data;
 	surface->surfaceType = surfaceType_t::SF_TRIANGLES;
+
+	plane_t plane;
+	srfVert_t* v1 = surface->verts + surface->triangles[0].indexes[0];
+	srfVert_t* v2 = surface->verts + surface->triangles[0].indexes[1];
+	srfVert_t* v3 = surface->verts + surface->triangles[0].indexes[2];
+
+	PlaneFromPoints( plane, v1->xyz, v2->xyz, v3->xyz );
+	VectorCopy( plane.normal, surface->plane.normal );
+	surface->plane.dist = plane.dist;
 }
 
 static void ParseMesh( dsurface_t *ds, drawVert_t *verts, bspSurface_t *surf )

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -800,18 +800,6 @@ static void FinishGenericSurface( dsurface_t *ds, srfGeneric_t *gen, vec3_t pt )
 {
 	// set bounding sphere
 	SphereFromBounds( gen->bounds[ 0 ], gen->bounds[ 1 ], gen->origin, &gen->radius );
-
-	if ( gen->surfaceType == surfaceType_t::SF_FACE )
-	{
-		srfSurfaceFace_t *srf = ( srfSurfaceFace_t * )gen;
-		// take the plane normal from the lightmap vector and classify it
-		srf->plane.normal[ 0 ] = LittleFloat( ds->lightmapVecs[ 2 ][ 0 ] );
-		srf->plane.normal[ 1 ] = LittleFloat( ds->lightmapVecs[ 2 ][ 1 ] );
-		srf->plane.normal[ 2 ] = LittleFloat( ds->lightmapVecs[ 2 ][ 2 ] );
-		srf->plane.dist = DotProduct( pt, srf->plane.normal );
-		SetPlaneSignbits( &srf->plane );
-		srf->plane.type = PlaneTypeForNormal( srf->plane.normal );
-	}
 }
 
 // Generate the skybox mesh and add it to world

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -875,6 +875,7 @@ static void ParseTriangleSurface( dsurface_t* ds, drawVert_t* verts, bspSurface_
 	}
 
 	srfGeneric_t* cv = ( srfGeneric_t* ) ri.Hunk_Alloc( sizeof( *cv ), ha_pref::h_low );
+	cv->surfaceType = surfaceType_t::SF_BAD; // Will be set later by ParseFace() or ParseTriSurf()
 
 	cv->numTriangles = LittleLong( ds->numIndexes ) / 3;
 	cv->triangles = ( srfTriangle_t* ) ri.Hunk_Alloc( cv->numTriangles * sizeof( cv->triangles[ 0 ] ), ha_pref::h_low );
@@ -1023,6 +1024,10 @@ static void ParseFace( dsurface_t* ds, drawVert_t* verts, bspSurface_t* surf, in
 	ParseTriangleSurface( ds, verts, surf, indexes );
 
 	srfGeneric_t* surface = ( srfGeneric_t* ) surf->data;
+	if ( surface->surfaceType == surfaceType_t::SF_SKIP ) {
+		return;
+	}
+
 	surface->surfaceType = surfaceType_t::SF_FACE;
 
 	// take the plane information from the lightmap vector
@@ -1039,6 +1044,10 @@ static void ParseTriSurf( dsurface_t* ds, drawVert_t* verts, bspSurface_t* surf,
 	ParseTriangleSurface( ds, verts, surf, indexes );
 
 	srfGeneric_t* surface = ( srfGeneric_t* ) surf->data;
+	if ( surface->surfaceType == surfaceType_t::SF_SKIP ) {
+		return;
+	}
+
 	surface->surfaceType = surfaceType_t::SF_TRIANGLES;
 
 	plane_t plane;

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -2847,26 +2847,13 @@ static void R_CreateWorldVBO()
 			continue;
 		}
 
-		if ( *surface->data == surfaceType_t::SF_FACE )
+		if ( *surface->data == surfaceType_t::SF_FACE || *surface->data == surfaceType_t::SF_GRID
+			|| *surface->data == surfaceType_t::SF_TRIANGLES )
 		{
-			srfSurfaceFace_t *face = ( srfSurfaceFace_t * ) surface->data;
+			srfSurfaceFace_t* srf = ( srfSurfaceFace_t * ) surface->data;
 
-			numVerts += face->numVerts;
-			numTriangles += face->numTriangles;
-		}
-		else if ( *surface->data == surfaceType_t::SF_GRID )
-		{
-			srfGridMesh_t *grid = ( srfGridMesh_t * ) surface->data;
-
-			numVerts += grid->numVerts;
-			numTriangles += grid->numTriangles;
-		}
-		else if ( *surface->data == surfaceType_t::SF_TRIANGLES )
-		{
-			srfGeneric_t* tri = ( srfGeneric_t* ) surface->data;
-
-			numVerts += tri->numVerts;
-			numTriangles += tri->numTriangles;
+			numVerts += srf->numVerts;
+			numTriangles += srf->numTriangles;
 		}
 		else
 		{
@@ -3018,27 +3005,8 @@ static void R_CreateWorldVBO()
 		int numSurfVerts;
 		const srfTriangle_t *surfTriangle, *surfTriangleEnd;
 
-		if ( *surface->data == surfaceType_t::SF_FACE )
-		{
-			srfSurfaceFace_t *srf = ( srfSurfaceFace_t * ) surface->data;
-
-			srf->firstIndex = vboNumIndexes;
-			surfVerts = srf->verts;
-			numSurfVerts = srf->numVerts;
-			surfTriangle = srf->triangles;
-			surfTriangleEnd = surfTriangle + srf->numTriangles;
-		}
-		else if ( *surface->data == surfaceType_t::SF_GRID )
-		{
-			srfGridMesh_t *srf = ( srfGridMesh_t * ) surface->data;
-
-			srf->firstIndex = vboNumIndexes;
-			surfVerts = srf->verts;
-			numSurfVerts = srf->numVerts;
-			surfTriangle = srf->triangles;
-			surfTriangleEnd = surfTriangle + srf->numTriangles;
-		}
-		else if ( *surface->data == surfaceType_t::SF_TRIANGLES )
+		if ( *surface->data == surfaceType_t::SF_FACE || *surface->data == surfaceType_t::SF_GRID
+			|| *surface->data == surfaceType_t::SF_TRIANGLES )
 		{
 			srfGeneric_t* srf = ( srfGeneric_t* ) surface->data;
 
@@ -3174,20 +3142,11 @@ static void R_CreateWorldVBO()
 
 			oldViewCount = surf1->viewCount;
 
-			if ( *surf1->data == surfaceType_t::SF_FACE )
+			if ( *surf1->data == surfaceType_t::SF_FACE || *surf1->data == surfaceType_t::SF_TRIANGLES
+				|| *surf1->data == surfaceType_t::SF_GRID )
 			{
-				srfSurfaceFace_t *face = ( srfSurfaceFace_t * ) surf1->data;
+				srfGeneric_t* face = ( srfGeneric_t* ) surf1->data;
 				firstIndex = face->firstIndex;
-			}
-			else if ( *surf1->data == surfaceType_t::SF_TRIANGLES )
-			{
-				srfGeneric_t* tris = ( srfGeneric_t* ) surf1->data;
-				firstIndex = tris->firstIndex;
-			}
-			else if ( *surf1->data == surfaceType_t::SF_GRID )
-			{
-				srfGridMesh_t *grid = ( srfGridMesh_t * ) surf1->data;
-				firstIndex = grid->firstIndex;
 			}
 
 			// count verts and indexes and add bounds for the merged surface
@@ -3202,26 +3161,13 @@ static void R_CreateWorldVBO()
 					break;
 				}
 
-				if ( *surf2->data == surfaceType_t::SF_FACE )
+				if ( *surf2->data == surfaceType_t::SF_FACE || *surf2->data == surfaceType_t::SF_TRIANGLES
+					|| *surf2->data == surfaceType_t::SF_GRID )
 				{
-					srfSurfaceFace_t *face = ( srfSurfaceFace_t * ) surf2->data;
-					surfIndexes += face->numTriangles * 3;
-					surfVerts += face->numVerts;
-					BoundsAdd( bounds[ 0 ], bounds[ 1 ], face->bounds[ 0 ], face->bounds[ 1 ] );
-				}
-				else if ( *surf2->data == surfaceType_t::SF_TRIANGLES )
-				{
-					srfGeneric_t* tris = ( srfGeneric_t* ) surf2->data;
-					surfIndexes += tris->numTriangles * 3;
-					surfVerts += tris->numVerts;
-					BoundsAdd( bounds[ 0 ], bounds[ 1 ], tris->bounds[ 0 ], tris->bounds[ 1 ] );
-				}
-				else if ( *surf2->data == surfaceType_t::SF_GRID )
-				{
-					srfGridMesh_t *grid = ( srfGridMesh_t * ) surf2->data;
-					surfIndexes += grid->numTriangles * 3;
-					surfVerts += grid->numVerts;
-					BoundsAdd( bounds[ 0 ], bounds[ 1 ], grid->bounds[ 0 ], grid->bounds[ 1 ] );
+					srfGeneric_t* srf = ( srfGeneric_t* ) surf2->data;
+					surfIndexes += srf->numTriangles * 3;
+					surfVerts += srf->numVerts;
+					BoundsAdd( bounds[ 0 ], bounds[ 1 ], srf->bounds[ 0 ], srf->bounds[ 1 ] );
 				}
 			}
 
@@ -3279,19 +3225,8 @@ static void R_CreateWorldVBO()
 	{
 		surface = surfaces[ k ];
 
-		if ( *surface->data == surfaceType_t::SF_FACE )
-		{
-			srfSurfaceFace_t *srf = ( srfSurfaceFace_t * ) surface->data;
-			srf->vbo = s_worldData.vbo;
-			srf->ibo = s_worldData.ibo;
-		}
-		else if ( *surface->data == surfaceType_t::SF_GRID )
-		{
-			srfGridMesh_t *srf = ( srfGridMesh_t * ) surface->data;
-			srf->vbo = s_worldData.vbo;
-			srf->ibo = s_worldData.ibo;
-		}
-		else if ( *surface->data == surfaceType_t::SF_TRIANGLES )
+		if ( *surface->data == surfaceType_t::SF_FACE || *surface->data == surfaceType_t::SF_GRID
+			|| *surface->data == surfaceType_t::SF_TRIANGLES )
 		{
 			srfGeneric_t* srf = ( srfGeneric_t* ) surface->data;
 			srf->vbo = s_worldData.vbo;

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -2911,8 +2911,8 @@ static void R_CreateWorldVBO()
 			if ( *surf1->data == surfaceType_t::SF_FACE || *surf1->data == surfaceType_t::SF_TRIANGLES
 				|| *surf1->data == surfaceType_t::SF_GRID )
 			{
-				srfGeneric_t* face = ( srfGeneric_t* ) surf1->data;
-				firstIndex = face->firstIndex;
+				srfGeneric_t* srf = ( srfGeneric_t* ) surf1->data;
+				firstIndex = srf->firstIndex;
 			}
 
 			// count verts and indexes and add bounds for the merged surface

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1742,6 +1742,8 @@ enum class ssaoMode {
 		vec3_t origin;
 		float radius;
 
+		cplane_t plane;
+
 		int numVerts;
 		srfVert_t* verts;
 
@@ -1772,7 +1774,6 @@ enum class ssaoMode {
 	};
 
 	struct srfSurfaceFace_t : srfGeneric_t {
-		cplane_t plane;
 	};
 
 	struct srfVBOMesh_t : srfGeneric_t {

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1735,6 +1735,7 @@ enum class ssaoMode {
 
 // ydnar: plain map drawsurfaces must match this header
 	struct srfGeneric_t {
+		// v Valid in: SF_FACE, SF_GRID, SF_TRIANGLES, SF_VBO_MESH
 		surfaceType_t surfaceType;
 
 		// Culling information
@@ -1742,20 +1743,23 @@ enum class ssaoMode {
 		vec3_t origin;
 		float radius;
 
-		cplane_t plane;
-
-		int numVerts;
-		srfVert_t* verts;
-
-		int numTriangles;
-		srfTriangle_t* triangles;
-
 		// Static render data
 		VBO_t* vbo;
 		IBO_t* ibo;
 
 		// BSP VBO offset
 		int firstIndex;
+		// ^ Valid in: SF_FACE, SF_GRID, SF_TRIANGLES, SF_VBO_MESH
+
+		cplane_t plane; // Valid in: SF_FACE, SF_TRIANGLES
+
+		int numVerts; // Valid in: SF_FACE, SF_GRID, SF_TRIANGLES, SF_VBO_MESH
+		srfVert_t* verts; // Valid in: SF_FACE, SF_GRID, SF_TRIANGLES
+
+		// v Valid in: SF_FACE, SF_GRID, SF_TRIANGLES
+		int numTriangles;
+		srfTriangle_t* triangles;
+		// ^ Valid in: SF_FACE, SF_GRID, SF_TRIANGLES
 	};
 
 	struct srfGridMesh_t : srfGeneric_t {

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1775,10 +1775,6 @@ enum class ssaoMode {
 		cplane_t plane;
 	};
 
-// misc_models in maps are turned into direct geometry by q3map
-	struct srfTriangles_t : srfGeneric_t {
-	};
-
 	struct srfVBOMesh_t : srfGeneric_t {
 		struct shader_t *shader; // FIXME move this to somewhere else
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1773,9 +1773,6 @@ enum class ssaoMode {
 		float* heightLodError;
 	};
 
-	struct srfSurfaceFace_t : srfGeneric_t {
-	};
-
 	struct srfVBOMesh_t : srfGeneric_t {
 		struct shader_t *shader; // FIXME move this to somewhere else
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1734,97 +1734,59 @@ enum class ssaoMode {
 	};
 
 // ydnar: plain map drawsurfaces must match this header
-	struct srfGeneric_t
-	{
+	struct srfGeneric_t {
 		surfaceType_t surfaceType;
 
-		// culling information
-		vec3_t   bounds[ 2 ];
-		vec3_t   origin;
-		float    radius;
+		// Culling information
+		vec3_t bounds[2];
+		vec3_t origin;
+		float radius;
+
+		int numVerts;
+		srfVert_t* verts;
+
+		int numTriangles;
+		srfTriangle_t* triangles;
+
+		// Static render data
+		VBO_t* vbo;
+		IBO_t* ibo;
+
+		// BSP VBO offset
+		int firstIndex;
 	};
 
-	struct srfGridMesh_t : srfGeneric_t
-	{
+	struct srfGridMesh_t : srfGeneric_t {
 		// lod information, which may be different
 		// than the culling information to allow for
 		// groups of curves that LOD as a unit
 		vec3_t lodOrigin;
-		float  lodRadius;
-		int    lodFixed;
-		int    lodStitched;
+		float lodRadius;
+		int lodFixed;
+		int lodStitched;
 
 		// triangle definitions
-		int           width, height;
-		float         *widthLodError;
-		float         *heightLodError;
-
-		int           numTriangles;
-		srfTriangle_t *triangles;
-
-		int           numVerts;
-		srfVert_t     *verts;
-
-		// BSP VBO offset
-		int firstIndex;
-
-		// static render data
-		VBO_t *vbo; // points to bsp model VBO
-		IBO_t *ibo;
+		int width, height;
+		float* widthLodError;
+		float* heightLodError;
 	};
 
-	struct srfSurfaceFace_t : srfGeneric_t
-	{
-		cplane_t     plane;
-
-		// triangle definitions
-		int           numTriangles;
-		srfTriangle_t *triangles;
-
-		int           numVerts;
-		srfVert_t     *verts;
-
-		// BSP VBO offset
-		int firstIndex;
-
-		// static render data
-		VBO_t *vbo; // points to bsp model VBO
-		IBO_t *ibo;
+	struct srfSurfaceFace_t : srfGeneric_t {
+		cplane_t plane;
 	};
 
 // misc_models in maps are turned into direct geometry by q3map
-	struct srfTriangles_t : srfGeneric_t
-	{
-		// triangle definitions
-		int           numTriangles;
-		srfTriangle_t *triangles;
-
-		int           numVerts;
-		srfVert_t     *verts;
-
-		// BSP VBO offset
-		int firstIndex;
-
-		// static render data
-		VBO_t *vbo; // points to bsp model VBO
-		IBO_t *ibo;
+	struct srfTriangles_t : srfGeneric_t {
 	};
 
-	struct srfVBOMesh_t : srfGeneric_t
-	{
+	struct srfVBOMesh_t : srfGeneric_t {
 		struct shader_t *shader; // FIXME move this to somewhere else
 
-		int             lightmapNum; // FIXME get rid of this by merging all lightmaps at level load
-		int             fogIndex;
+		int lightmapNum; // FIXME get rid of this by merging all lightmaps at level load
+		int fogIndex;
 
 		// backEnd stats
-		int firstIndex;
 		int numIndexes;
-		int numVerts;
-
-		// static render data
-		VBO_t *vbo;
-		IBO_t *ibo;
 	};
 
 	struct srfVBOMD5Mesh_t

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1701,8 +1701,6 @@ enum class ssaoMode {
 		interaction_t *next;
 	};
 
-#define MAX_FACE_POINTS 64
-
 #define MAX_PATCH_SIZE  64 // max dimensions of a patch mesh in map file
 #define MAX_GRID_SIZE   65 // max dimensions of a grid mesh in memory
 

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1205,7 +1205,6 @@ R_PlaneForSurface
 */
 void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane ) {
 	srfPoly_t *poly;
-	srfVert_t *v1, *v2, *v3;
 
 	if ( !surfType )
 	{
@@ -1218,19 +1217,9 @@ void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane ) {
 	switch ( *surfType )
 	{
 		case surfaceType_t::SF_FACE:
-		{
-			*plane = ( ( srfSurfaceFace_t* ) surfType )->plane;
-			return;
-		}
 		case surfaceType_t::SF_TRIANGLES:
 		{
-			srfGeneric_t* tri = ( srfGeneric_t* ) surfType;
-			v1 = tri->verts + tri->triangles[0].indexes[0];
-			v2 = tri->verts + tri->triangles[0].indexes[1];
-			v3 = tri->verts + tri->triangles[0].indexes[2];
-			PlaneFromPoints( plane4, v1->xyz, v2->xyz, v3->xyz );
-			VectorCopy( plane4.normal, plane->normal );
-			plane->dist = plane4.dist;
+			*plane = ( ( srfSurfaceFace_t* ) surfType )->plane;
 			return;
 		}
 		case surfaceType_t::SF_POLY:

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1219,7 +1219,7 @@ void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane ) {
 		case surfaceType_t::SF_FACE:
 		case surfaceType_t::SF_TRIANGLES:
 		{
-			*plane = ( ( srfSurfaceFace_t* ) surfType )->plane;
+			*plane = ( ( srfGeneric_t* ) surfType )->plane;
 			return;
 		}
 		case surfaceType_t::SF_POLY:

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1203,11 +1203,9 @@ void R_MirrorPoint( vec3_t in, orientation_t *surface, orientation_t *camera, ve
 R_PlaneForSurface
 =============
 */
-void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane )
-{
-	srfTriangles_t *tri;
-	srfPoly_t      *poly;
-	srfVert_t      *v1, *v2, *v3;
+void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane ) {
+	srfPoly_t *poly;
+	srfVert_t *v1, *v2, *v3;
 
 	if ( !surfType )
 	{
@@ -1220,26 +1218,29 @@ void R_PlaneForSurface( surfaceType_t *surfType, cplane_t *plane )
 	switch ( *surfType )
 	{
 		case surfaceType_t::SF_FACE:
-			*plane = ( ( srfSurfaceFace_t * ) surfType )->plane;
+		{
+			*plane = ( ( srfSurfaceFace_t* ) surfType )->plane;
 			return;
-
+		}
 		case surfaceType_t::SF_TRIANGLES:
-			tri = ( srfTriangles_t * ) surfType;
-			v1 = tri->verts + tri->triangles[ 0 ].indexes[ 0 ];
-			v2 = tri->verts + tri->triangles[ 0 ].indexes[ 1 ];
-			v3 = tri->verts + tri->triangles[ 0 ].indexes[ 2 ];
+		{
+			srfGeneric_t* tri = ( srfGeneric_t* ) surfType;
+			v1 = tri->verts + tri->triangles[0].indexes[0];
+			v2 = tri->verts + tri->triangles[0].indexes[1];
+			v3 = tri->verts + tri->triangles[0].indexes[2];
 			PlaneFromPoints( plane4, v1->xyz, v2->xyz, v3->xyz );
 			VectorCopy( plane4.normal, plane->normal );
 			plane->dist = plane4.dist;
 			return;
-
+		}
 		case surfaceType_t::SF_POLY:
-			poly = ( srfPoly_t * ) surfType;
-			PlaneFromPoints( plane4, poly->verts[ 0 ].xyz, poly->verts[ 1 ].xyz, poly->verts[ 2 ].xyz );
+		{
+			poly = ( srfPoly_t* ) surfType;
+			PlaneFromPoints( plane4, poly->verts[0].xyz, poly->verts[1].xyz, poly->verts[2].xyz );
 			VectorCopy( plane4.normal, plane->normal );
 			plane->dist = plane4.dist;
 			return;
-
+		}
 		default:
 			memset( plane, 0, sizeof( *plane ) );
 			plane->normal[ 0 ] = 1;

--- a/src/engine/renderer/tr_marks.cpp
+++ b/src/engine/renderer/tr_marks.cpp
@@ -199,13 +199,13 @@ void R_BoxSurfaces_r( bspNode_t *node, vec3_t mins, vec3_t maxs, surfaceType_t *
 		else if ( * ( surf->data ) == surfaceType_t::SF_FACE )
 		{
 			// the face plane should go through the box
-			s = BoxOnPlaneSide( mins, maxs, & ( ( srfSurfaceFace_t * ) surf->data )->plane );
+			s = BoxOnPlaneSide( mins, maxs, & ( ( srfGeneric_t* ) surf->data )->plane );
 
 			if ( s == 1 || s == 2 )
 			{
 				surf->viewCount = tr.viewCountNoReset;
 			}
-			else if ( DotProduct( ( ( srfSurfaceFace_t * ) surf->data )->plane.normal, dir ) > -0.5 )
+			else if ( DotProduct( ( ( srfGeneric_t* ) surf->data )->plane.normal, dir ) > -0.5 )
 			{
 				// don't add faces that make sharp angles with the projection direction
 				surf->viewCount = tr.viewCountNoReset;
@@ -301,7 +301,6 @@ int R_MarkFragments( int numPoints, const vec3_t *points, const vec3_t projectio
 	vec3_t           clipPoints[ 2 ][ MAX_VERTS_ON_POLY ];
 	int              numClipPoints;
 	float            *v;
-	srfSurfaceFace_t *face;
 	srfGridMesh_t    *cv;
 	srfVert_t        *dv;
 	srfTriangle_t    *tri;
@@ -450,7 +449,7 @@ int R_MarkFragments( int numPoints, const vec3_t *points, const vec3_t projectio
 		}
 		else if ( *surfaces[ i ] == surfaceType_t::SF_FACE )
 		{
-			face = ( srfSurfaceFace_t * ) surfaces[ i ];
+			srfGeneric_t* face = ( srfGeneric_t* ) surfaces[i];
 
 			// check the normal of this face
 			if ( DotProduct( face->plane.normal, projectionDir ) > -0.5 )

--- a/src/engine/renderer/tr_marks.cpp
+++ b/src/engine/renderer/tr_marks.cpp
@@ -303,7 +303,6 @@ int R_MarkFragments( int numPoints, const vec3_t *points, const vec3_t projectio
 	float            *v;
 	srfSurfaceFace_t *face;
 	srfGridMesh_t    *cv;
-	srfTriangles_t   *trisurf;
 	srfVert_t        *dv;
 	srfTriangle_t    *tri;
 	vec3_t           normal;
@@ -481,7 +480,7 @@ int R_MarkFragments( int numPoints, const vec3_t *points, const vec3_t projectio
 		}
 		else if ( *surfaces[ i ] == surfaceType_t::SF_TRIANGLES && !r_noMarksOnTrisurfs->integer )
 		{
-			trisurf = ( srfTriangles_t * ) surfaces[ i ];
+			srfGeneric_t* trisurf = ( srfGeneric_t* ) surfaces[ i ];
 
 			for ( k = 0, tri = trisurf->triangles; k < trisurf->numTriangles; k++, tri++ )
 			{

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -778,7 +778,7 @@ static void Tess_SurfaceGrid( srfGridMesh_t *srf )
 Tess_SurfaceTriangles
 =============
 */
-static void Tess_SurfaceTriangles( srfTriangles_t *srf )
+static void Tess_SurfaceTriangles( srfGeneric_t* srf )
 {
 	GLIMP_LOGCOMMENT( "--- Tess_SurfaceTriangles ---" );
 

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -748,7 +748,7 @@ static void Tess_SurfacePolychain( srfPoly_t *p )
 Tess_SurfaceFace
 ==============
 */
-static void Tess_SurfaceFace( srfSurfaceFace_t *srf )
+static void Tess_SurfaceFace( srfGeneric_t* srf )
 {
 	GLIMP_LOGCOMMENT( "--- Tess_SurfaceFace ---" );
 

--- a/src/engine/renderer/tr_world.cpp
+++ b/src/engine/renderer/tr_world.cpp
@@ -62,12 +62,12 @@ static bool R_CullSurface( surfaceType_t *surface, shader_t *shader, int planeBi
 	}
 
 	// get generic surface
-	gen = ( srfGeneric_t * ) surface;
+	gen = ( srfGeneric_t* ) surface;
 
 	// plane cull
 	if ( *surface == surfaceType_t::SF_FACE && r_facePlaneCull->integer )
 	{
-		srfSurfaceFace_t *srf = ( srfSurfaceFace_t * )gen;
+		srfGeneric_t* srf = ( srfGeneric_t* ) gen;
 		d = DotProduct( tr.orientation.viewOrigin, srf->plane.normal ) - srf->plane.dist;
 
 		// don't cull exactly on the plane, because there are levels of rounding
@@ -167,7 +167,7 @@ static bool R_CullLightSurface( surfaceType_t *surface, shader_t *shader, trRefL
 	// plane cull
 	if ( *surface == surfaceType_t::SF_FACE && r_facePlaneCull->integer )
 	{
-		srfSurfaceFace_t *srf = ( srfSurfaceFace_t * )gen;
+		srfGeneric_t* srf = ( srfGeneric_t* ) gen;
 		if ( light->l.rlType == refLightType_t::RL_DIRECTIONAL )
 		{
 			d = DotProduct( tr.sunDirection, srf->plane.normal );


### PR DESCRIPTION
I've run into a bunch of duplicate code while making some improvements to map processing, any improvements to which required to add more such duplication, while the code underneath is the exact same.

This pr NUKES `srfTriangles_t` and `srfSurface_t`, and moves all the common information between them, `srfGridMesh_t`, and `srfVBOMesh_t `, into `srfGeneric_t`.

The common parts of `ParseFace()` and `ParseTriSurf()` are moved into a new `ParseTriangleSurface()`, which is all of it except the plane calculation. The comment about `.lwo` models in `ParseTriSurf()` is irrelevant, because we don't support those.

`ParseTriangleSurface()` and `ParseMesh()` now use `SphereFromBounds()` instead of `FinishGenericSurface()`, because the only difference between the 2 was just duplicated code.