### PR TITLE
Fix some bugs from address sanitizer 

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -2593,21 +2593,20 @@ might still appear at that side.
 int R_TryStitchingPatch( int grid1num )
 {
 	int           j, numstitches;
-	srfGridMesh_t *grid1, *grid2;
 
 	numstitches = 0;
-	grid1 = ( srfGridMesh_t * ) s_worldData.surfaces[ grid1num ].data;
 
 	for ( j = 0; j < s_worldData.numSurfaces; j++ )
 	{
-		//
-		grid2 = ( srfGridMesh_t * ) s_worldData.surfaces[ j ].data;
+		srfGridMesh_t *grid2 = ( srfGridMesh_t * ) s_worldData.surfaces[ j ].data;
 
 		// if this surface is not a grid
 		if ( grid2->surfaceType != surfaceType_t::SF_GRID )
 		{
 			continue;
 		}
+
+		srfGridMesh_t *grid1 = ( srfGridMesh_t * ) s_worldData.surfaces[ grid1num ].data;
 
 		// grids in the same LOD group should have the exact same lod radius
 		if ( grid1->lodRadius != grid2->lodRadius )

--- a/src/engine/renderer/tr_light.cpp
+++ b/src/engine/renderer/tr_light.cpp
@@ -135,17 +135,17 @@ float R_InterpolateLightGrid( world_t *w, int from[3], int to[3],
 
 	for( x = from[ 0 ], xFactor = factors[ 0 ]; x <= to[ 0 ];
 	     x++, xFactor++ ) {
-		if( x < 0 || x > w->lightGridBounds[ 0 ] )
+		if( x < 0 || x >= w->lightGridBounds[ 0 ] )
 			continue;
 
 		for( y = from[ 1 ], yFactor = factors[ 1 ]; y <= to[ 1 ];
 		     y++, yFactor++ ) {
-			if( y < 0 || y > w->lightGridBounds[ 1 ] )
+			if( y < 0 || y >= w->lightGridBounds[ 1 ] )
 				continue;
 
 			for( z = from[ 2 ], zFactor = factors[ 2 ]; z <= to[ 2 ];
 			     z++, zFactor++ ) {
-				if( z < 0 || z > w->lightGridBounds[ 2 ] )
+				if( z < 0 || z >= w->lightGridBounds[ 2 ] )
 					continue;
 
 				gp1 = w->lightGridData1 + x * gridStep[ 0 ] + y * gridStep[ 1 ] + z * gridStep[ 2 ];

--- a/src/engine/server/sv_init.cpp
+++ b/src/engine/server/sv_init.cpp
@@ -108,7 +108,7 @@ static void SendConfigStringToClient( int cs, client_t *cl )
 
 		*out++ = c;
 
-		if ( !*in )
+		if ( !c )
 		{
 			break;
 		}


### PR DESCRIPTION
The out-of-bounds light grid read one led to visibly different lighting on Nano. This map tends to read on the edges of the grid due to its very large cell size: the light grid is only 3x4x2 for the whole map.