### PR TITLE
NUKE some unused stuff from srfVBOMesh_t

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -2950,8 +2950,6 @@ static void R_CreateWorldVBO()
 			vboSurf->numVerts = surfVerts;
 			vboSurf->firstIndex = firstIndex;
 
-			vboSurf->shader = surf1->shader;
-			vboSurf->fogIndex = surf1->fogIndex;
 			vboSurf->lightmapNum = surf1->lightmapNum;
 			vboSurf->vbo = s_worldData.vbo;
 			vboSurf->ibo = s_worldData.ibo;

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -788,7 +788,7 @@ static void FinishSkybox() {
 	surface = ( srfVBOMesh_t* ) ri.Hunk_Alloc( sizeof( *surface ), ha_pref::h_low );
 	surface->surfaceType = surfaceType_t::SF_VBO_MESH;
 	surface->numVerts = 8;
-	surface->numIndexes = 36;
+	surface->numTriangles = 12;
 	surface->firstIndex = 0;
 
 	vec3_t verts[ 8 ] {
@@ -813,7 +813,7 @@ static void FinishSkybox() {
 							  2, 7, 6,  2, 3, 7,   // Right
 							  3, 4, 7,  3, 0, 4 }; // Back
 
-	surface->ibo = R_CreateStaticIBO( "skybox_IBO", indexes, surface->numIndexes );
+	surface->ibo = R_CreateStaticIBO( "skybox_IBO", indexes, surface->numTriangles * 3 );
 	skybox->surface = ( surfaceType_t* ) surface;
 
 	tr.skybox = skybox;
@@ -2946,7 +2946,7 @@ static void R_CreateWorldVBO()
 			*vboSurf = {};
 			vboSurf->surfaceType = surfaceType_t::SF_VBO_MESH;
 
-			vboSurf->numIndexes = surfIndexes;
+			vboSurf->numTriangles = surfIndexes / 3;
 			vboSurf->numVerts = surfVerts;
 			vboSurf->firstIndex = firstIndex;
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1779,9 +1779,6 @@ enum class ssaoMode {
 
 	struct srfVBOMesh_t : srfGeneric_t {
 		int lightmapNum; // FIXME get rid of this by merging all lightmaps at level load
-
-		// backEnd stats
-		int numIndexes;
 	};
 
 	struct srfVBOMD5Mesh_t

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1778,10 +1778,7 @@ enum class ssaoMode {
 	};
 
 	struct srfVBOMesh_t : srfGeneric_t {
-		struct shader_t *shader; // FIXME move this to somewhere else
-
 		int lightmapNum; // FIXME get rid of this by merging all lightmaps at level load
-		int fogIndex;
 
 		// backEnd stats
 		int numIndexes;

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1371,7 +1371,7 @@ static void Tess_SurfaceVBOMesh( srfVBOMesh_t *srf )
 {
 	GLIMP_LOGCOMMENT( "--- Tess_SurfaceVBOMesh ---" );
 
-	Tess_SurfaceVBO( srf->vbo, srf->ibo, srf->numIndexes, srf->firstIndex );
+	Tess_SurfaceVBO( srf->vbo, srf->ibo, srf->numTriangles * 3, srf->firstIndex );
 }
 
 /*

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -601,7 +601,7 @@ static void R_InitGenericVBOs() {
 		surface = ( srfVBOMesh_t* ) ri.Hunk_Alloc( sizeof( *surface ), ha_pref::h_low );
 		surface->surfaceType = surfaceType_t::SF_VBO_MESH;
 		surface->numVerts = 4;
-		surface->numIndexes = 6;
+		surface->numTriangles = 2;
 		surface->firstIndex = 0;
 
 		vec3_t verts[4] = {
@@ -628,7 +628,7 @@ static void R_InitGenericVBOs() {
 
 		glIndex_t indexes[6] = { 0, 2, 1,  0, 3, 2 }; // Front
 
-		surface->ibo = R_CreateStaticIBO( "genericQuad_IBO", indexes, surface->numIndexes );
+		surface->ibo = R_CreateStaticIBO( "genericQuad_IBO", indexes, surface->numTriangles * 3 );
 		genericQuad->surface = ( surfaceType_t* ) surface;
 
 		tr.genericQuad = genericQuad;
@@ -641,14 +641,14 @@ static void R_InitGenericVBOs() {
 		srfVBOMesh_t* surface = ( srfVBOMesh_t* ) ri.Hunk_Alloc( sizeof( *surface ), ha_pref::h_low );
 		surface->surfaceType = surfaceType_t::SF_VBO_MESH;
 		surface->numVerts = 0;
-		surface->numIndexes = 3;
+		surface->numTriangles = 1;
 		surface->firstIndex = 0;
 
 		surface->vbo = nullptr;
 
 		glIndex_t indexes[6] = { 0, 2, 1 }; // Front
 
-		surface->ibo = R_CreateStaticIBO( "genericTriangle_IBO", indexes, surface->numIndexes );
+		surface->ibo = R_CreateStaticIBO( "genericTriangle_IBO", indexes, surface->numTriangles * 3 );
 		genericTriangle->surface = ( surfaceType_t* ) surface;
 
 		tr.genericTriangle = genericTriangle;


### PR DESCRIPTION
NUKE unused `shader` and `fogIndex`, use `srfGeneric_t::numTriangles` instead of `srfVBOMesh_t::numIndexes`, to avoid duplication.