### PR TITLE
Fix geometry optimiser

### DIFF
--- a/src/engine/renderer/GeometryOptimiser.cpp
+++ b/src/engine/renderer/GeometryOptimiser.cpp
@@ -377,7 +377,10 @@ std::vector<MaterialSurface> OptimiseMapGeometryMaterial(bspSurface_t** renderer
 		MaterialSurface srf {};
 
 		srf.shader = surface->shader;
+
 		srf.bspSurface = true;
+		srf.skyBrush = surface->skyBrush;
+
 		srf.lightMapNum = surface->lightmapNum;
 		srf.fog = surface->fogIndex;
 		srf.portalNum = surface->portalNum;

--- a/src/engine/renderer/GeometryOptimiser.h
+++ b/src/engine/renderer/GeometryOptimiser.h
@@ -75,12 +75,6 @@ struct MapVertHasher {
 		hash += ( Util::bit_cast<uint32_t, float>( vert.xyz[2] ) << 11 );
 		hash ^= ( Util::bit_cast<uint32_t, float>( vert.xyz[2] ) >> 16 );
 
-		hash += ( Util::bit_cast<uint32_t, float>( vert.st[0] ) << 7 );
-		hash ^= ( Util::bit_cast<uint32_t, float>( vert.st[0] ) >> 12 );
-
-		hash += ( Util::bit_cast<uint32_t, float>( vert.st[1] ) << 13 );
-		hash ^= ( Util::bit_cast<uint32_t, float>( vert.st[1] ) >> 8 );
-
 		return hash;
 	}
 };

--- a/src/engine/renderer/GeometryOptimiser.h
+++ b/src/engine/renderer/GeometryOptimiser.h
@@ -98,7 +98,8 @@ struct MapVertEqual {
 			&& VectorCompareEpsilon( lhs.normal, rhs.normal, 0.0001f )
 			&& CompareEpsilon( lhs.qtangent[0], rhs.qtangent[0] ) && CompareEpsilon( lhs.qtangent[1], rhs.qtangent[1] )
 			&& CompareEpsilon( lhs.qtangent[2], rhs.qtangent[2] ) && CompareEpsilon( lhs.qtangent[3], rhs.qtangent[3] )
-			&& lhs.lightColor.ArrayBytes() == rhs.lightColor.ArrayBytes();
+			&& lhs.lightColor.Red() == rhs.lightColor.Red() && lhs.lightColor.Green() == rhs.lightColor.Green()
+			&& lhs.lightColor.Blue() == rhs.lightColor.Blue() && lhs.lightColor.Alpha() == rhs.lightColor.Alpha();
 	}
 };
 

--- a/src/engine/renderer/GeometryOptimiser.h
+++ b/src/engine/renderer/GeometryOptimiser.h
@@ -68,18 +68,18 @@ struct TriIndex {
 
 struct MapVertHasher {
 	size_t operator()( const srfVert_t& vert ) const {
-		size_t hash = ~( *( ( size_t* ) &vert.xyz[0] ) << 15 );
-		hash ^= ( *( ( size_t* ) &vert.xyz[0] ) >> 10 );
-		hash += ( *( ( size_t* ) &vert.xyz[1] ) << 3 );
-		hash ^= ( *( ( size_t* ) &vert.xyz[1] ) >> 6 );
-		hash += ~( *( ( size_t* ) &vert.xyz[2] ) << 11 );
-		hash ^= ( *( ( size_t* ) &vert.xyz[2] ) >> 16 );
+		uint32_t hash = ~( Util::bit_cast<uint32_t, float>( vert.xyz[0] ) << 15 );
+		hash ^= ( Util::bit_cast<uint32_t, float>( vert.xyz[0] ) >> 10 );
+		hash += ( Util::bit_cast<uint32_t, float>( vert.xyz[1] ) << 3 );
+		hash ^= ( Util::bit_cast<uint32_t, float>( vert.xyz[1] ) >> 6 );
+		hash += ( Util::bit_cast<uint32_t, float>( vert.xyz[2] ) << 11 );
+		hash ^= ( Util::bit_cast<uint32_t, float>( vert.xyz[2] ) >> 16 );
 
-		hash ^= ( *( ( size_t* ) &vert.st[0] ) << 7 );
-		hash += ( *( ( size_t* ) &vert.st[0] ) >> 12 );
+		hash += ( Util::bit_cast<uint32_t, float>( vert.st[0] ) << 7 );
+		hash ^= ( Util::bit_cast<uint32_t, float>( vert.st[0] ) >> 12 );
 
-		hash ^= ( *( ( size_t* ) &vert.st[1] ) << 13 );
-		hash += ( *( ( size_t* ) &vert.st[1] ) >> 8 );
+		hash += ( Util::bit_cast<uint32_t, float>( vert.st[1] ) << 13 );
+		hash ^= ( Util::bit_cast<uint32_t, float>( vert.st[1] ) >> 8 );
 
 		return hash;
 	}

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -638,6 +638,10 @@ void MaterialSystem::GenerateWorldCommandBuffer( std::vector<MaterialSurface>& s
 	}
 
 	for ( MaterialSurface& surface : surfaces ) {
+		if ( surface.skyBrush ) {
+			continue;
+		}
+
 		SurfaceDescriptor surfaceDescriptor;
 		VectorCopy( surface.origin, surfaceDescriptor.boundingSphere.origin );
 		surfaceDescriptor.boundingSphere.radius = surface.radius;
@@ -1328,6 +1332,10 @@ void MaterialSystem::GenerateMaterial( MaterialSurface* surface ) {
 
 	uint32_t stage = 0;
 	uint32_t previousMaterialID = 0;
+
+	if ( surface->skyBrush ) {
+		return;
+	}
 	
 	if ( surface->shader->depthShader ) {
 		uint32_t unused;

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -77,7 +77,10 @@ struct DrawCommand {
 struct MaterialSurface {
 	shader_t* shader;
 	surfaceType_t* surface;
+
 	bool bspSurface;
+	bool skyBrush;
+
 	int16_t lightMapNum;
 	int fog;
 	int portalNum = -1;

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -2538,7 +2538,7 @@ static void R_CreateWorldVBO() {
 		// HACK: portals: don't use VBO because when adding a portal we have to read back the verts CPU-side
 		// Autosprite: don't use VBO because verts are rewritten each time based on view origin
 		if ( surface->shader->isPortal || surface->shader->autoSpriteMode != 0 ) {
-			if( glConfig2.usingMaterialSystem && surface->shader->autoSpriteMode ) {
+			if( glConfig2.usingMaterialSystem ) {
 				materialSystem.autospriteSurfaces.push_back( surface );
 			}
 
@@ -2548,10 +2548,15 @@ static void R_CreateWorldVBO() {
 			continue;
 		}
 
-		if ( glConfig2.usingMaterialSystem && surface->shader->isSky
-			&& std::find( materialSystem.skyShaders.begin(), materialSystem.skyShaders.end(), surface->shader )
-			== materialSystem.skyShaders.end() ) {
-			materialSystem.skyShaders.emplace_back( surface->shader );
+		if ( glConfig2.usingMaterialSystem && surface->shader->isSky ) {
+			if ( std::find( materialSystem.skyShaders.begin(), materialSystem.skyShaders.end(), surface->shader )
+				== materialSystem.skyShaders.end() ) {
+				materialSystem.skyShaders.emplace_back( surface->shader );
+			}
+
+			/* Sky brushes are currently not used by the material system,
+			but they still have to go into the VBO for the core renderer */
+			surface->skyBrush = true;
 		}
 
 		if ( *surface->data == surfaceType_t::SF_FACE || *surface->data == surfaceType_t::SF_GRID

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1830,6 +1830,7 @@ enum class ssaoMode {
 
 		bool renderable = false;
 		bool BSPModel = false;
+		bool skyBrush = false;
 
 		surfaceType_t   *data; // any of srf*_t
 	};


### PR DESCRIPTION
Fixes #1651

I opted for making the hash not use uv's instead, as it didn't seem to have much of any effect on the loading time, but resulted in merging a few more vertices. 

Also fixed sky brushes being added as surfaces to the material system.