### PR TITLE
Validate BSP vertex input

### DIFF
--- a/src/engine/renderer/GeometryOptimiser.cpp
+++ b/src/engine/renderer/GeometryOptimiser.cpp
@@ -308,11 +308,11 @@ void MergeDuplicateVertices( bspSurface_t** rendererSurfaces, int numSurfaces, s
 	for ( int i = 0; i < numSurfaces; i++ ) {
 		bspSurface_t* surface = rendererSurfaces[i];
 		
-		srfGeneric_t* face = ( srfGeneric_t* ) surface->data;
-		face->firstIndex = idx;
-		for ( srfTriangle_t* triangle = face->triangles; triangle < face->triangles + face->numTriangles; triangle++ ) {
+		srfGeneric_t* srf = ( srfGeneric_t* ) surface->data;
+		srf->firstIndex = idx;
+		for ( srfTriangle_t* triangle = srf->triangles; triangle < srf->triangles + srf->numTriangles; triangle++ ) {
 			for ( int j = 0; j < 3; j++ ) {
-				srfVert_t& vert = face->verts[triangle->indexes[j]];
+				srfVert_t& vert = srf->verts[triangle->indexes[j]];
 				uint32_t index = verts[vert];
 
 				/* There were some crashes due to bad lightmap values in .bsp vertices,

--- a/src/engine/renderer/GeometryOptimiser.cpp
+++ b/src/engine/renderer/GeometryOptimiser.cpp
@@ -315,6 +315,11 @@ void MergeDuplicateVertices( bspSurface_t** rendererSurfaces, int numSurfaces, s
 				srfVert_t& vert = face->verts[triangle->indexes[j]];
 				uint32_t index = verts[vert];
 
+				/* There were some crashes due to bad lightmap values in .bsp vertices,
+				do the check again here just in case some calculation earlier, like patch mesh triangulation,
+				fucks things up again */
+				ValidateVertex( &vert, -1, surface->shader );
+
 				ASSERT_LT( idx, ( uint32_t ) numIndicesIn );
 				if ( !index ) {
 					verts[vert] = vertIdx + 1;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1811,6 +1811,8 @@ enum class ssaoMode {
 
 	extern void ( *rb_surfaceTable[Util::ordinal(surfaceType_t::SF_NUM_SURFACE_TYPES)] )(void * );
 
+	void ValidateVertex( srfVert_t* vertex, int vertexID, shader_t* shader );
+
 	/*
 	==============================================================================
 	BRUSH MODELS - in memory representation


### PR DESCRIPTION
Requires #1652 because it has some other fixes in this area, I didn't test this pr without those.

Apparently, q3map2 sometimes produces garbage values for lightmap uvs in vertices, like nan or just garbage like -1e38 which later turns into inf in patch meshes. Most of these don't use the lightmapping shader, however from my testing some do.

This fixes a crash in `MergeDuplicateVertices()`, which was happening because of these garbages values, since they always compare as false.