### PR TITLE
Check that driver matches when loading GLSL cache

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -892,7 +892,6 @@ void GLShaderManager::InitDriverInfo()
 {
 	std::string driverInfo = std::string(glConfig.renderer_string) + glConfig.version_string;
 	_driverVersionHash = Com_BlockChecksum(driverInfo.c_str(), static_cast<int>(driverInfo.size()));
-	_shaderBinaryCacheInvalidated = false;
 }
 
 void GLShaderManager::GenerateBuiltinHeaders() {
@@ -1416,10 +1415,6 @@ bool GLShaderManager::LoadShaderBinary( const std::vector<ShaderEntry>& shaders,
 		return false;
 	}
 
-	if ( _shaderBinaryCacheInvalidated ) {
-		return false;
-	}
-
 	const int start = Sys::Milliseconds();
 
 	std::error_code err;
@@ -1459,14 +1454,7 @@ bool GLShaderManager::LoadShaderBinary( const std::vector<ShaderEntry>& shaders,
 
 	/* Check if the header struct is the correct format
 	and the binary was produced by the same GL driver */
-	if ( shaderHeader.version != GL_SHADER_VERSION /* || shaderHeader.driverVersionHash != _driverVersionHash */ ) {
-		/* These two fields should be the same for all shaders. So if there is a mismatch,
-		don't bother opening any of the remaining files.
-		I've disabled the cache invalidation on driver version change, because we now also cache shader programs that use
-		non-empty deformVertexes. This would mean that after updating the driver, any time you load a new map with
-		deformVertexes, it would cause the rebuild of *all* shaders */
-		Log::Notice( "Invalidating shader binary cache" );
-		_shaderBinaryCacheInvalidated = true;
+	if ( shaderHeader.version != GL_SHADER_VERSION || shaderHeader.driverVersionHash != _driverVersionHash ) {
 		return false;
 	}
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -328,7 +328,6 @@ class GLShaderManager {
 	std::unordered_map<std::string, int> _deformShaderLookup;
 
 	unsigned int _driverVersionHash; // For cache invalidation if hardware changes
-	bool _shaderBinaryCacheInvalidated;
 
 public:
 	GLHeader GLVersionDeclaration;


### PR DESCRIPTION
Commenting out the code that does this was a regression in ab59550f23b41ea80b2443c72c9ce35fce1a7cb4.