### PR TITLE
Improve lazy shader loading

### DIFF
--- a/src/engine/renderer/GeometryOptimiser.cpp
+++ b/src/engine/renderer/GeometryOptimiser.cpp
@@ -451,6 +451,7 @@ std::vector<MaterialSurface> OptimiseMapGeometryMaterial(bspSurface_t** renderer
 	// std::unordered_map<TriEdge, TriIndex> triEdges;
 
 	vec3_t worldBounds[2] = {};
+	materialSystem.buildOneShader = false;
 	for ( int i = 0; i < numSurfaces; i++ ) {
 		bspSurface_t* surface = rendererSurfaces[i];
 
@@ -485,6 +486,8 @@ std::vector<MaterialSurface> OptimiseMapGeometryMaterial(bspSurface_t** renderer
 
 		materialSurfaces.emplace_back( srf );
 	}
+
+	materialSystem.buildOneShader = true;
 
 	materialSystem.GenerateWorldMaterialsBuffer();
 	materialSystem.GeneratePortalBoundingSpheres();

--- a/src/engine/renderer/GeometryOptimiser.cpp
+++ b/src/engine/renderer/GeometryOptimiser.cpp
@@ -129,9 +129,6 @@ void MarkShaderBuild( const shader_t* shader, const int lightMapNum, const bool 
 
 	tess.vboVertexSkinning = vertexSkinning;
 	tess.vboVertexAnimation = vertexAnimation;
-	/* Fuck knows why there are 2 different ways of setting the vertex animation global (through tess and through glState),
-	but that's what we have */
-	glState.vertexAttribsInterpolation = vertexAnimation ? 1.0f : 0.0f;
 
 	for ( const shaderStage_t* pStage = shader->stages; pStage < shader->lastStage; pStage++ ) {
 		pStage->shaderBuildMarker( pStage );
@@ -142,7 +139,6 @@ void MarkShaderBuild( const shader_t* shader, const int lightMapNum, const bool 
 
 	tess.vboVertexSkinning = false;
 	tess.vboVertexAnimation = false;
-	glState.vertexAttribsInterpolation = 0.0f;
 }
 
 static void CoreResetSurfaceViewCounts( bspSurface_t** rendererSurfaces, int numSurfaces ) {

--- a/src/engine/renderer/GeometryOptimiser.cpp
+++ b/src/engine/renderer/GeometryOptimiser.cpp
@@ -73,6 +73,78 @@ static int LeafSurfaceCompare( const void* a, const void* b ) {
 	return 0;
 }
 
+void MarkShaderBuildNONE( const shaderStage_t* ) {
+	ASSERT_UNREACHABLE();
+}
+
+void MarkShaderBuildNOP( const shaderStage_t* ) {
+}
+
+void MarkShaderBuildGeneric3D( const shaderStage_t* pStage ) {
+	ProcessShaderGeneric3D( pStage );
+	gl_genericShader->MarkProgramForBuilding( pStage->deformIndex );
+}
+
+void MarkShaderBuildLightMapping( const shaderStage_t* pStage ) {
+	ProcessShaderLightMapping( pStage );
+	gl_lightMappingShader->MarkProgramForBuilding( pStage->deformIndex );
+}
+
+void MarkShaderBuildReflection( const shaderStage_t* pStage ) {
+	ProcessShaderReflection( pStage );
+	gl_reflectionShader->MarkProgramForBuilding( pStage->deformIndex );
+}
+
+void MarkShaderBuildSkybox( const shaderStage_t* pStage ) {
+	gl_skyboxShader->MarkProgramForBuilding( pStage->deformIndex );
+}
+
+void MarkShaderBuildScreen( const shaderStage_t* pStage ) {
+	gl_screenShader->MarkProgramForBuilding( pStage->deformIndex );
+}
+
+void MarkShaderBuildPortal( const shaderStage_t* pStage ) {
+	gl_portalShader->MarkProgramForBuilding( pStage->deformIndex );
+}
+
+void MarkShaderBuildHeatHaze( const shaderStage_t* pStage ) {
+	ProcessShaderHeatHaze( pStage );
+	gl_heatHazeShader->MarkProgramForBuilding( pStage->deformIndex );
+}
+
+void MarkShaderBuildLiquid( const shaderStage_t* pStage ) {
+	ProcessShaderLiquid( pStage );
+	gl_liquidShader->MarkProgramForBuilding( pStage->deformIndex );
+}
+
+void MarkShaderBuildFog( const shaderStage_t* pStage ) {
+	ProcessShaderFog( pStage );
+	gl_fogQuake3Shader->MarkProgramForBuilding( 0 );
+}
+
+void MarkShaderBuild( const shader_t* shader, const int lightMapNum, const bool bspSurface,
+	const bool vertexSkinning, const bool vertexAnimation ) {
+	tess.bspSurface = bspSurface;
+	tess.lightmapNum = lightMapNum;
+
+	tess.vboVertexSkinning = vertexSkinning;
+	tess.vboVertexAnimation = vertexAnimation;
+	/* Fuck knows why there are 2 different ways of setting the vertex animation global (through tess and through glState),
+	but that's what we have */
+	glState.vertexAttribsInterpolation = vertexAnimation ? 1.0f : 0.0f;
+
+	for ( const shaderStage_t* pStage = shader->stages; pStage < shader->lastStage; pStage++ ) {
+		pStage->shaderBuildMarker( pStage );
+	}
+
+	tess.bspSurface = false;
+	tess.lightmapNum = -1;
+
+	tess.vboVertexSkinning = false;
+	tess.vboVertexAnimation = false;
+	glState.vertexAttribsInterpolation = 0.0f;
+}
+
 static void CoreResetSurfaceViewCounts( bspSurface_t** rendererSurfaces, int numSurfaces ) {
 	for ( int i = 0; i < numSurfaces; i++ ) {
 		bspSurface_t* surface = rendererSurfaces[i];
@@ -145,6 +217,14 @@ void OptimiseMapGeometryCore( world_t* world, bspSurface_t** rendererSurfaces, i
 	}
 
 	qsort( rendererSurfaces, numSurfaces, sizeof( bspSurface_t* ), LeafSurfaceCompare );
+
+	if ( r_lazyShaders.Get() == 1 ) {
+		for ( int i = 0; i < numSurfaces; i++ ) {
+			bspSurface_t* surface = rendererSurfaces[i];
+
+			MarkShaderBuild( surface->shader, surface->lightmapNum, true, false, false );
+		}
+	}
 }
 
 static void SphereFromBounds( vec3_t mins, vec3_t maxs, vec3_t origin, float* radius ) {

--- a/src/engine/renderer/GeometryOptimiser.h
+++ b/src/engine/renderer/GeometryOptimiser.h
@@ -97,6 +97,25 @@ struct MapVertEqual {
 	}
 };
 
+void MarkShaderBuildNONE( const shaderStage_t* );
+void MarkShaderBuildNOP( const shaderStage_t* );
+void MarkShaderBuildGeneric3D( const shaderStage_t* pStage );
+void MarkShaderBuildLightMapping( const shaderStage_t* pStage );
+void MarkShaderBuildReflection( const shaderStage_t* pStage );
+void MarkShaderBuildSkybox( const shaderStage_t* pStage );
+void MarkShaderBuildScreen( const shaderStage_t* pStage );
+void MarkShaderBuildPortal( const shaderStage_t* pStage );
+void MarkShaderBuildHeatHaze( const shaderStage_t* pStage );
+void MarkShaderBuildLiquid( const shaderStage_t* pStage );
+void MarkShaderBuildFog( const shaderStage_t* pStage );
+
+void MarkShaderBuildIQM( const IQModel_t* model );
+void MarkShaderBuildMDV( const mdvModel_t* model );
+void MarkShaderBuildMD5( const md5Model_t* model );
+
+void MarkShaderBuild( const shader_t* shader, const int lightMapNum, const bool bspSurface,
+	const bool vertexSkinning, const bool vertexAnimation );
+
 void OptimiseMapGeometryCore( world_t* world, bspSurface_t** rendererSurfaces, int numSurfaces );
 void MergeLeafSurfacesCore( world_t* world, bspSurface_t** rendererSurfaces, int numSurfaces );
 void MergeDuplicateVertices( bspSurface_t** rendererSurfaces, int numSurfaces, srfVert_t* vertices, int numVerticesIn,

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1027,8 +1027,6 @@ void ProcessMaterialLightMapping( Material* material, shaderStage_t* pStage, Mat
 	bool enableGridLighting = ( lightMode == lightMode_t::GRID );
 	bool enableGridDeluxeMapping = ( deluxeMode == deluxeMode_t::GRID );
 
-	DAEMON_ASSERT( !( enableDeluxeMapping && enableGridDeluxeMapping ) );
-
 	material->enableDeluxeMapping = enableDeluxeMapping;
 	material->enableGridLighting = enableGridLighting;
 	material->enableGridDeluxeMapping = enableGridDeluxeMapping;

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1011,7 +1011,7 @@ void ProcessMaterialGeneric3D( Material* material, shaderStage_t* pStage, Materi
 	material->hasDepthFade = hasDepthFade;
 	gl_genericShaderMaterial->SetDepthFade( hasDepthFade );
 
-	material->program = gl_genericShaderMaterial->GetProgram( pStage->deformIndex );
+	material->program = gl_genericShaderMaterial->GetProgram( pStage->deformIndex, materialSystem.buildOneShader );
 }
 
 void ProcessMaterialLightMapping( Material* material, shaderStage_t* pStage, MaterialSurface* surface ) {
@@ -1053,7 +1053,7 @@ void ProcessMaterialLightMapping( Material* material, shaderStage_t* pStage, Mat
 
 	gl_lightMappingShaderMaterial->SetPhysicalShading( pStage->enablePhysicalMapping );
 
-	material->program = gl_lightMappingShaderMaterial->GetProgram( pStage->deformIndex );
+	material->program = gl_lightMappingShaderMaterial->GetProgram( pStage->deformIndex, materialSystem.buildOneShader );
 }
 
 void ProcessMaterialReflection( Material* material, shaderStage_t* pStage, MaterialSurface* /* surface */ ) {
@@ -1067,7 +1067,7 @@ void ProcessMaterialReflection( Material* material, shaderStage_t* pStage, Mater
 
 	gl_reflectionShaderMaterial->SetReliefMapping( pStage->enableReliefMapping );
 
-	material->program = gl_reflectionShaderMaterial->GetProgram( pStage->deformIndex );
+	material->program = gl_reflectionShaderMaterial->GetProgram( pStage->deformIndex, materialSystem.buildOneShader );
 }
 
 void ProcessMaterialSkybox( Material* material, shaderStage_t* pStage, MaterialSurface* /* surface */ ) {
@@ -1075,7 +1075,7 @@ void ProcessMaterialSkybox( Material* material, shaderStage_t* pStage, MaterialS
 
 	material->deformIndex = pStage->deformIndex;
 
-	material->program = gl_skyboxShaderMaterial->GetProgram( pStage->deformIndex );
+	material->program = gl_skyboxShaderMaterial->GetProgram( pStage->deformIndex, materialSystem.buildOneShader );
 }
 
 void ProcessMaterialScreen( Material* material, shaderStage_t* pStage, MaterialSurface* /* surface */ ) {
@@ -1083,7 +1083,7 @@ void ProcessMaterialScreen( Material* material, shaderStage_t* pStage, MaterialS
 
 	material->deformIndex = pStage->deformIndex;
 
-	material->program = gl_screenShaderMaterial->GetProgram( pStage->deformIndex );
+	material->program = gl_screenShaderMaterial->GetProgram( pStage->deformIndex, materialSystem.buildOneShader );
 }
 
 void ProcessMaterialHeatHaze( Material* material, shaderStage_t* pStage, MaterialSurface* ) {
@@ -1091,7 +1091,7 @@ void ProcessMaterialHeatHaze( Material* material, shaderStage_t* pStage, Materia
 
 	material->deformIndex = pStage->deformIndex;
 
-	material->program = gl_heatHazeShaderMaterial->GetProgram( pStage->deformIndex );
+	material->program = gl_heatHazeShaderMaterial->GetProgram( pStage->deformIndex, materialSystem.buildOneShader );
 }
 
 void ProcessMaterialLiquid( Material* material, shaderStage_t* pStage, MaterialSurface* surface ) {
@@ -1115,14 +1115,14 @@ void ProcessMaterialLiquid( Material* material, shaderStage_t* pStage, MaterialS
 
 	gl_liquidShaderMaterial->SetGridLighting( lightMode == lightMode_t::GRID );
 
-	material->program = gl_liquidShaderMaterial->GetProgram( pStage->deformIndex );
+	material->program = gl_liquidShaderMaterial->GetProgram( pStage->deformIndex, materialSystem.buildOneShader );
 }
 
 void ProcessMaterialFog( Material* material, shaderStage_t* pStage, MaterialSurface* surface ) {
 	material->shader = gl_fogQuake3ShaderMaterial;
 	material->fog = surface->fog;
 
-	material->program = gl_fogQuake3ShaderMaterial->GetProgram( pStage->deformIndex );
+	material->program = gl_fogQuake3ShaderMaterial->GetProgram( pStage->deformIndex, materialSystem.buildOneShader );
 }
 
 void MaterialSystem::AddStage( MaterialSurface* surface, shaderStage_t* pStage, uint32_t stage,
@@ -1741,6 +1741,8 @@ void MaterialSystem::Free() {
 			portalView.count = 0;
 		}
 	}
+
+	buildOneShader = true;
 
 	totalDrawSurfs = 0;
 

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -339,6 +339,8 @@ class MaterialSystem {
 	uint32_t totalPortals;
 	std::vector<shader_t*> skyShaders;
 
+	bool buildOneShader = true;
+
 	std::vector<Material*> renderedMaterials;
 
 	/* MaterialPack is an abstraction to match a range of materials with the 3 different calls to RB_RenderDrawSurfaces()

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2353,14 +2353,14 @@ void GLShader::MarkProgramForBuilding( int deformIndex ) {
 	shaderProgramsToBuild[index] = true;
 }
 
-GLuint GLShader::GetProgram( int deformIndex ) {
+GLuint GLShader::GetProgram( int deformIndex, const bool buildOneShader ) {
 	int macroIndex = SelectProgram();
 	size_t index = macroIndex + ( size_t( deformIndex ) << _compileMacros.size() );
 
 	// program may not be loaded yet because the shader manager hasn't yet gotten to it
 	// so try to load it now
 	if ( index >= shaderPrograms.size() || !shaderPrograms[index].id ) {
-		gl_shaderManager.BuildPermutation( this, macroIndex, deformIndex, true );
+		gl_shaderManager.BuildPermutation( this, macroIndex, deformIndex, buildOneShader );
 	}
 
 	// program is still not loaded

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -186,7 +186,7 @@ protected:
 	int SelectProgram();
 public:
 	void MarkProgramForBuilding( int deformIndex );
-	GLuint GetProgram( int deformIndex );
+	GLuint GetProgram( int deformIndex, const bool buildOneShader );
 	void BindProgram( int deformIndex );
 	void DispatchCompute( const GLuint globalWorkgroupX, const GLuint globalWorkgroupY, const GLuint globalWorkgroupZ );
 	void DispatchComputeIndirect( const GLintptr indirectBuffer );

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -108,6 +108,7 @@ protected:
 	uint32_t _vertexAttribs = 0; // can be set by uniforms
 
 	std::vector<ShaderProgramDescriptor> shaderPrograms;
+	std::vector<bool> shaderProgramsToBuild;
 
 	std::vector<int> vertexShaderDescriptors;
 	std::vector<int> fragmentShaderDescriptors;
@@ -184,6 +185,7 @@ protected:
 	virtual void SetShaderProgramUniforms( ShaderProgramDescriptor* /*shaderProgram*/ ) { };
 	int SelectProgram();
 public:
+	void MarkProgramForBuilding( int deformIndex );
 	GLuint GetProgram( int deformIndex );
 	void BindProgram( int deformIndex );
 	void DispatchCompute( const GLuint globalWorkgroupX, const GLuint globalWorkgroupY, const GLuint globalWorkgroupZ );
@@ -365,7 +367,7 @@ public:
 	int GetDeformShaderIndex( deformStage_t *deforms, int numDeforms );
 
 	bool BuildPermutation( GLShader* shader, int macroIndex, int deformIndex );
-	void BuildAll();
+	void BuildAll( const bool buildOnlyMarked );
 	void FreeAll();
 private:
 	struct InfoLogEntry {

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -366,7 +366,7 @@ public:
 
 	int GetDeformShaderIndex( deformStage_t *deforms, int numDeforms );
 
-	bool BuildPermutation( GLShader* shader, int macroIndex, int deformIndex );
+	bool BuildPermutation( GLShader* shader, int macroIndex, int deformIndex, const bool buildOneShader );
 	void BuildAll( const bool buildOnlyMarked );
 	void FreeAll();
 private:

--- a/src/engine/renderer/tr_animation.cpp
+++ b/src/engine/renderer/tr_animation.cpp
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 // tr_animation.c
 #include "tr_local.h"
+#include "GeometryOptimiser.h"
 
 /*
 ===========================================================================
@@ -1552,4 +1553,18 @@ int RE_AnimFrameRate( qhandle_t hAnim )
 	}
 
 	return 0;
+}
+
+void MarkShaderBuildMD5( const md5Model_t* model ) {
+	for ( int i = 0; i < model->numSurfaces; i++ ) {
+		md5Surface_t* surface = &model->surfaces[i];
+
+		shader_t* defaultModelShader = R_GetShaderByHandle( surface->shaderIndex );
+		MarkShaderBuild( defaultModelShader, -1, false, true, false );
+
+		for ( int j = 0; j < MAX_ALTSHADERS; j++ ) {
+			shader_t* shader = R_GetShaderByHandle( defaultModelShader->altShader[j].index );
+			MarkShaderBuild( shader, -1, false, true, false );
+		}
+	}
 }

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -677,7 +677,7 @@ void GL_VertexAttribPointers( uint32_t attribBits )
 
 		if ( ( attribBits & bit ) != 0 &&
 		     ( !( glState.vertexAttribPointersSet & bit ) ||
-		       glState.vertexAttribsInterpolation >= 0 ||
+		       tess.vboVertexAnimation ||
 		       glState.currentVBO == tess.vbo ) )
 		{
 			const vboAttributeLayout_t *layout = &glState.currentVBO->attribs[ i ];

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1091,11 +1091,13 @@ enum class ssaoMode {
 	  COLLAPSE_REFLECTIONMAP,
 	};
 
+	struct shader_t;
 	struct shaderStage_t;
 	struct Material;
 	struct MaterialSurface;
 
 	using stageRenderer_t = void(*)(shaderStage_t *);
+	using stageShaderBuildMarker_t = void(*)(const shaderStage_t*);
 	using surfaceDataUpdater_t = void(*)(uint32_t*, shaderStage_t*, bool, bool, bool);
 	using stageShaderBinder_t = void(*)(Material*);
 	using stageMaterialProcessor_t = void(*)(Material*, shaderStage_t*, MaterialSurface*);
@@ -1119,6 +1121,7 @@ enum class ssaoMode {
 
 		// Core renderer (code path for when only OpenGL Core is available, or compatible OpenGL 2).
 		stageRenderer_t colorRenderer;
+		stageShaderBuildMarker_t shaderBuildMarker;
 
 		// Material renderer (code path for advanced OpenGL techniques like bindless textures).
 		surfaceDataUpdater_t surfaceDataUpdater;
@@ -3487,6 +3490,15 @@ void GLimp_LogComment_( std::string comment );
 	void Tess_UpdateVBOs();
 
 	void RB_ShowImages();
+
+	void ProcessShaderNONE( const shaderStage_t* );
+	void ProcessShaderNOP( const shaderStage_t* );
+	void ProcessShaderGeneric3D( const shaderStage_t* pStage );
+	void ProcessShaderLightMapping( const shaderStage_t* pStage );
+	void ProcessShaderReflection( const shaderStage_t* pStage );
+	void ProcessShaderHeatHaze( const shaderStage_t* );
+	void ProcessShaderLiquid( const shaderStage_t* pStage );
+	void ProcessShaderFog( const shaderStage_t* );
 
 	void Render_NONE( shaderStage_t *pStage );
 	void Render_NOP( shaderStage_t *pStage );

--- a/src/engine/renderer/tr_mesh.cpp
+++ b/src/engine/renderer/tr_mesh.cpp
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 // tr_mesh.c -- triangle model functions
 #include "tr_local.h"
+#include "GeometryOptimiser.h"
 
 /*
 =============
@@ -465,6 +466,23 @@ void R_AddMDVInteractions( trRefEntity_t *ent, trRefLight_t *light, interactionT
 			{
 				R_AddLightInteraction( light, ( surfaceType_t * ) mdvSurface, shader, cubeSideBits, iaType );
 				tr.pc.c_dlightSurfaces++;
+			}
+		}
+	}
+}
+
+void MarkShaderBuildMDV( const mdvModel_t* model ) {
+	for ( int i = 0; i < model->numVBOSurfaces; i++ ) {
+		srfVBOMDVMesh_t* surface = model->vboSurfaces[i];
+		MarkShaderBuild( surface->mdvSurface->shader, -1, false, false, true );
+
+		for ( int j = 0; j < tr.numSkins; j++ ) {
+			skin_t* skin = tr.skins[j];
+			for ( int k = 0; k < skin->numSurfaces; k++ ) {
+				// the names have both been lowercased
+				if ( !strcmp( skin->surfaces[k]->name, surface->mdvSurface->name ) ) {
+					MarkShaderBuild( skin->surfaces[k]->shader, -1, false, false, true );
+				}
 			}
 		}
 	}

--- a/src/engine/renderer/tr_model_iqm.cpp
+++ b/src/engine/renderer/tr_model_iqm.cpp
@@ -33,6 +33,7 @@ Maryland 20850 USA.
 */
 
 #include "tr_local.h"
+#include "GeometryOptimiser.h"
 
 /* Flags -O2, -O3 and -0s produce SIGBUS in R_LoadIQModel() on armhf,
 see https://github.com/DaemonEngine/Daemon/issues/736 */
@@ -1054,5 +1055,16 @@ void R_AddIQMSurfaces( trRefEntity_t *ent ) {
 		}
 
 		surface++;
+	}
+}
+
+void MarkShaderBuildIQM( const IQModel_t* model ) {
+	for ( srfIQModel_t* surface = model->surfaces; surface < model->surfaces + model->num_surfaces; surface++ ) {
+		MarkShaderBuild( surface->shader, -1, false, true, false );
+
+		for ( int i = 0; i < MAX_ALTSHADERS; i++ ) {
+			shader_t* shader = R_GetShaderByHandle( surface->shader->altShader[i].index );
+			MarkShaderBuild( shader, -1, false, true, false );
+		}
 	}
 }

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -876,12 +876,12 @@ void ProcessShaderReflection( const shaderStage_t* pStage ) {
 	gl_reflectionShader->SetReliefMapping( pStage->enableReliefMapping );
 
 	gl_reflectionShader->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
-	gl_reflectionShader->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
+	gl_reflectionShader->SetVertexAnimation( tess.vboVertexAnimation );
 }
 
 void ProcessShaderHeatHaze( const shaderStage_t* ) {
 	gl_heatHazeShader->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
-	gl_heatHazeShader->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
+	gl_heatHazeShader->SetVertexAnimation( tess.vboVertexAnimation );
 }
 
 void ProcessShaderLiquid( const shaderStage_t* pStage ) {
@@ -900,7 +900,7 @@ void ProcessShaderLiquid( const shaderStage_t* pStage ) {
 
 void ProcessShaderFog( const shaderStage_t* ) {
 	gl_heatHazeShader->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
-	gl_heatHazeShader->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
+	gl_heatHazeShader->SetVertexAnimation( tess.vboVertexAnimation );
 }
 
 void Render_NONE( shaderStage_t * )
@@ -1300,7 +1300,7 @@ static void Render_shadowFill( shaderStage_t *pStage )
 	GL_State( stateBits );
 
 	gl_shadowFillShader->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
-	gl_shadowFillShader->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
+	gl_shadowFillShader->SetVertexAnimation( tess.vboVertexAnimation );
 
 	gl_shadowFillShader->SetMacro_LIGHT_DIRECTIONAL( backEnd.currentLight->l.rlType == refLightType_t::RL_DIRECTIONAL );
 
@@ -1374,7 +1374,7 @@ static void Render_forwardLighting_DBS_omni( shaderStage_t *pStage,
 
 	// choose right shader program ----------------------------------
 	gl_forwardLightingShader_omniXYZ->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
-	gl_forwardLightingShader_omniXYZ->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
+	gl_forwardLightingShader_omniXYZ->SetVertexAnimation( tess.vboVertexAnimation );
 
 	gl_forwardLightingShader_omniXYZ->SetHeightMapInNormalMap( pStage->hasHeightMapInNormalMap );
 
@@ -1549,7 +1549,7 @@ static void Render_forwardLighting_DBS_proj( shaderStage_t *pStage,
 
 	// choose right shader program ----------------------------------
 	gl_forwardLightingShader_projXYZ->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
-	gl_forwardLightingShader_projXYZ->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
+	gl_forwardLightingShader_projXYZ->SetVertexAnimation( tess.vboVertexAnimation );
 
 	gl_forwardLightingShader_projXYZ->SetHeightMapInNormalMap( pStage->hasHeightMapInNormalMap );
 
@@ -1725,7 +1725,7 @@ static void Render_forwardLighting_DBS_directional( shaderStage_t *pStage, trRef
 
 	// choose right shader program ----------------------------------
 	gl_forwardLightingShader_directionalSun->SetVertexSkinning( glConfig2.vboVertexSkinningAvailable && tess.vboVertexSkinning );
-	gl_forwardLightingShader_directionalSun->SetVertexAnimation( glState.vertexAttribsInterpolation > 0 );
+	gl_forwardLightingShader_directionalSun->SetVertexAnimation( tess.vboVertexAnimation );
 
 	gl_forwardLightingShader_directionalSun->SetHeightMapInNormalMap( pStage->hasHeightMapInNormalMap );
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -207,6 +207,8 @@ void GLSL_InitWorldShaders() {
 	// Material system shaders that are always loaded if material system is available
 	if ( glConfig2.usingMaterialSystem ) {
 		gl_shaderManager.LoadShader( gl_cullShader );
+
+		gl_cullShader->MarkProgramForBuilding( 0 );
 	}
 }
 
@@ -240,6 +242,10 @@ static void GLSL_InitGPUShadersOrError()
 		gl_shaderManager.LoadShader( gl_clearSurfacesShader );
 		gl_shaderManager.LoadShader( gl_processSurfacesShader );
 		gl_shaderManager.LoadShader( gl_depthReductionShader );
+
+		gl_clearSurfacesShader->MarkProgramForBuilding( 0 );
+		gl_processSurfacesShader->MarkProgramForBuilding( 0 );
+		gl_depthReductionShader->MarkProgramForBuilding( 0 );
 	}
 
 	if ( tr.world ) // this only happens with /glsl_restart
@@ -267,6 +273,10 @@ static void GLSL_InitGPUShadersOrError()
 			gl_shaderManager.LoadShader( gl_depthtile1Shader );
 			gl_shaderManager.LoadShader( gl_depthtile2Shader );
 			gl_shaderManager.LoadShader( gl_lighttileShader );
+
+			gl_depthtile1Shader->MarkProgramForBuilding( 0 );
+			gl_depthtile2Shader->MarkProgramForBuilding( 0 );
+			gl_lighttileShader->MarkProgramForBuilding( 0 );
 			DAEMON_FALLTHROUGH;
 		default:
 			/* Dynamic shadowing code also needs this shader.
@@ -302,9 +312,13 @@ static void GLSL_InitGPUShadersOrError()
 		// skybox drawing for abitrary polygons
 		gl_shaderManager.LoadShader( gl_skyboxShader );
 
+		gl_skyboxShader->MarkProgramForBuilding( 0 );
+
 		if ( glConfig2.usingMaterialSystem )
 		{
 			gl_shaderManager.LoadShader( gl_skyboxShaderMaterial );
+
+			gl_skyboxShaderMaterial->MarkProgramForBuilding( 0 );
 		}
 	}
 
@@ -320,6 +334,8 @@ static void GLSL_InitGPUShadersOrError()
 
 		// global fog post process effect
 		gl_shaderManager.LoadShader( gl_fogGlobalShader );
+
+		gl_fogGlobalShader->MarkProgramForBuilding( 0 );
 	}
 
 	if ( r_heatHaze->integer )
@@ -338,26 +354,38 @@ static void GLSL_InitGPUShadersOrError()
 		// screen post process effect
 		gl_shaderManager.LoadShader( gl_screenShader );
 
+		gl_screenShader->MarkProgramForBuilding( 0 );
+
 		if ( glConfig2.usingMaterialSystem )
 		{
 			gl_shaderManager.LoadShader( gl_screenShaderMaterial );
+
+			gl_screenShaderMaterial->MarkProgramForBuilding( 0 );
 		}
 
 		// LDR bright pass filter
 		gl_shaderManager.LoadShader( gl_contrastShader );
+
+		gl_contrastShader->MarkProgramForBuilding( 0 );
 	}
 
 	
 	// portal process effect
 	gl_shaderManager.LoadShader( gl_portalShader );
 
+	gl_portalShader->MarkProgramForBuilding( 0 );
+
 	// camera post process effect
 	gl_shaderManager.LoadShader( gl_cameraEffectsShader );
+
+	gl_cameraEffectsShader->MarkProgramForBuilding( 0 );
 
 	if ( glConfig2.bloom || glConfig2.shadowMapping )
 	{
 		// gaussian blur
 		gl_shaderManager.LoadShader( gl_blurShader );
+
+		gl_blurShader->MarkProgramForBuilding( 0 );
 	}
 
 	if ( glConfig2.shadowMapping )
@@ -382,16 +410,22 @@ static void GLSL_InitGPUShadersOrError()
 	if ( glConfig2.motionBlur )
 	{
 		gl_shaderManager.LoadShader( gl_motionblurShader );
+
+		gl_motionblurShader->MarkProgramForBuilding( 0 );
 	}
 
 	if ( glConfig2.ssao )
 	{
 		gl_shaderManager.LoadShader( gl_ssaoShader );
+
+		gl_ssaoShader->MarkProgramForBuilding( 0 );
 	}
 
 	if ( r_FXAA->integer != 0 )
 	{
 		gl_shaderManager.LoadShader( gl_fxaaShader );
+
+		gl_fxaaShader->MarkProgramForBuilding( 0 );
 	}
 
 	if ( r_lazyShaders.Get() == 0 )

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -846,8 +846,6 @@ void ProcessShaderLightMapping( const shaderStage_t* pStage ) {
 	bool enableGridLighting = ( lightMode == lightMode_t::GRID );
 	bool enableGridDeluxeMapping = ( deluxeMode == deluxeMode_t::GRID );
 
-	DAEMON_ASSERT( !( enableDeluxeMapping && enableGridDeluxeMapping ) );
-
 	// Not implemented yet in PBR code.
 	bool enableReflectiveSpecular =
 		pStage->enableSpecularMapping && glConfig2.reflectionMapping
@@ -1058,11 +1056,8 @@ void Render_lightMapping( shaderStage_t *pStage )
 		stateBits &= ~( GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS | GLS_ATEST_BITS );
 	}
 
-	bool enableDeluxeMapping = ( deluxeMode == deluxeMode_t::MAP );
 	bool enableGridLighting = ( lightMode == lightMode_t::GRID );
 	bool enableGridDeluxeMapping = ( deluxeMode == deluxeMode_t::GRID );
-
-	DAEMON_ASSERT( !( enableDeluxeMapping && enableGridDeluxeMapping ) );
 
 	// Not implemented yet in PBR code.
 	bool enableReflectiveSpecular =


### PR DESCRIPTION
Implements #1294

Previously, when `r_lazyShaders 1` was used, it would simply load all of the possible shaders with the current graphics settings, and without deform shaders.

With this change, it will instead mark shaders that are used for BSP and model surfaces for building, which will be done in `RE_EndRegistration()`. Skins are also loaded (the variants with skeletal animation are always loaded because we don't know if an MD5 model will need them later).

This *greatly* reduces the amount of shaders built, and allows building deform shaders at map load. For example, on plat23 with pretty much all shader stuff enabled (except liquid shaders and static reflections), including material system, it went down from 433 shaders built at map load to just 28. I did know that a bunch of the shaders were unused, but this is still a surprising amount less.

Also made it so when a shader is loaded outside of `BuildAll()` (i. e. in `BindProgram()` or `GetProgram()`), the engine will print information about that.

From my testing, there are only a few shaders that this system doesn't get at map load, I'll see if I can make those load at the start as well in a different pr.