### PR TITLE
NUKE RDF_SKYBOXPORTAL usages

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -2980,10 +2980,6 @@ static void R_LoadNodesAndLeafs( lump_t *nodeLump, lump_t *leafLump )
 	s_worldData.numnodes = numNodes + numLeafs;
 	s_worldData.numDecisionNodes = numNodes;
 
-	// ydnar: skybox optimization
-	s_worldData.numSkyNodes = 0;
-	s_worldData.skyNodes = (bspNode_t**) ri.Hunk_Alloc( WORLD_MAX_SKY_NODES * sizeof( *s_worldData.skyNodes ), ha_pref::h_low );
-
 	// load nodes
 	for ( i = 0; i < numNodes; i++, in++, out++ )
 	{

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1890,9 +1890,6 @@ enum class ssaoMode {
 		vec3_t maxs;
 	};
 
-// ydnar: optimization
-#define WORLD_MAX_SKY_NODES 32
-
 	struct world_t
 	{
 		char          name[ MAX_QPATH ]; // ie: maps/tim_dm2.bsp
@@ -1912,9 +1909,6 @@ enum class ssaoMode {
 		int           numnodes; // includes leafs
 		int           numDecisionNodes;
 		bspNode_t     *nodes;
-
-		int           numSkyNodes;
-		bspNode_t     **skyNodes; // ydnar: don't walk the entire bsp when rendering sky
 
 		int numPortals;
 		AABB *portals;

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -541,7 +541,7 @@ void RE_RenderScene( const refdef_t *fd )
 	// will force a reset of the visible leafs even if the view hasn't moved
 	tr.refdef.areamaskModified = false;
 
-	if ( !( tr.refdef.rdflags & RDF_NOWORLDMODEL ) && !( ( tr.refdef.rdflags & RDF_SKYBOXPORTAL ) && tr.world->numSkyNodes > 0 ) )
+	if ( !( tr.refdef.rdflags & RDF_NOWORLDMODEL ) )
 	{
 		int areaDiff;
 		int i;


### PR DESCRIPTION
This is half of a feature from Wolf:ET, but we don't have the sgame/cgame counterpart, and none of the maps made for Unvanquished/Tremulous appear to use it. This was done in Wolf:ET by using a `misc_skyportal` entity on the map, parsing it in sgame and sending the result through configstrings. Daemon/Unvanquished never actually sets `RDF_SKYBOXPORTAL`.

We have maps that use background-in-a-box (`freeway`, `covid` etc.), but they use a different mechanism and keep working correctly with this change.