### PR TITLE
NUKE some unused stuff

### DIFF
--- a/src/engine/renderer/tr_animation.cpp
+++ b/src/engine/renderer/tr_animation.cpp
@@ -540,7 +540,7 @@ qhandle_t RE_RegisterAnimation( const char *name )
 		return 0;
 	}
 
-	if ( Str::IsPrefix( "MD5Version", buffer ) )
+	if ( Str::IsPrefix( MD5_IDENTSTRING, buffer ) )
 	{
 		loaded = R_LoadMD5Anim( anim, buffer.c_str(), name );
 	}

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1725,17 +1725,16 @@ enum class ssaoMode {
 
 		// BSP VBO offset
 		int firstIndex;
+
+		int numVerts;
+
+		int numTriangles;
+		srfTriangle_t* triangles;
 		// ^ Valid in: SF_FACE, SF_GRID, SF_TRIANGLES, SF_VBO_MESH
 
 		cplane_t plane; // Valid in: SF_FACE, SF_TRIANGLES
 
-		int numVerts; // Valid in: SF_FACE, SF_GRID, SF_TRIANGLES, SF_VBO_MESH
 		srfVert_t* verts; // Valid in: SF_FACE, SF_GRID, SF_TRIANGLES
-
-		// v Valid in: SF_FACE, SF_GRID, SF_TRIANGLES
-		int numTriangles;
-		srfTriangle_t* triangles;
-		// ^ Valid in: SF_FACE, SF_GRID, SF_TRIANGLES
 	};
 
 	struct srfGridMesh_t : srfGeneric_t {

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -165,7 +165,6 @@ static inline void halfToFloat( const f16vec4_t in, vec4_t out )
 #define SMP_FRAMES            2
 
 #define MAX_SHADERS           ( 1 << 12 )
-#define SHADERS_MASK          ( MAX_SHADERS - 1 )
 
 #define MAX_SHADER_TABLES     1024
 #define MAX_SHADER_STAGES     16
@@ -353,7 +352,6 @@ enum class ssaoMode {
 	};
 
 #define REF_CUBEMAP_SIZE 32
-#define REF_CUBEMAP_STORE_SIZE 1024
 
 #define REF_COLORGRADE_SLOTS   4
 #define REF_COLORGRADEMAP_SIZE 16
@@ -967,8 +965,6 @@ enum class ssaoMode {
 	};
 
 #define MAX_SHADER_DEFORMS      3
-#define MAX_SHADER_DEFORM_STEPS	4
-#define MAX_SHADER_DEFORM_PARMS ( MAX_SHADER_DEFORMS * MAX_SHADER_DEFORM_STEPS )
 	struct deformStage_t
 	{
 		deform_t   deformation; // vertex coordinate modification type
@@ -1469,23 +1465,12 @@ enum class ssaoMode {
 		shader_t *shader;
 	};
 
-//----(SA) modified
-#define MAX_PART_MODELS 5
-
-	struct skinModel_t
-	{
-		char type[ MAX_QPATH ]; // md3_lower, md3_lbelt, md3_rbelt, etc.
-		char model[ MAX_QPATH ]; // lower.md3, belt1.md3, etc.
-		int  hash;
-	};
-
 	struct skin_t
 	{
 		char          name[ MAX_QPATH ]; // game path, including extension
 		int           numSurfaces;
 		int           numModels;
 		skinSurface_t *surfaces[ MD3_MAX_SURFACES ];
-		skinModel_t   *models[ MAX_PART_MODELS ];
 	};
 
 //----(SA) end
@@ -3170,10 +3155,8 @@ inline bool checkGLErrors()
 	====================================================================
 	*/
 	void GL_Bind( image_t *image );
-	void GL_BindNearestCubeMap( int unit, const vec3_t xyz );
 	void GL_Unbind( image_t *image );
 	GLuint64 BindAnimatedImage( int unit, const textureBundle_t *bundle );
-	void GL_TextureFilter( image_t *image, filterType_t filterType );
 	void GL_BindProgram( ShaderProgramDescriptor* program );
 	GLuint64 GL_BindToTMU( int unit, image_t *image );
 	void GL_BindNullProgram();
@@ -3237,9 +3220,6 @@ inline bool checkGLErrors()
 	void AssertCvarRange( cvar_t *cv, float minVal, float maxVal, bool shouldBeIntegral );
 
 	bool   R_GetModeInfo( int *width, int *height, int mode );
-
-// https://zerowing.idsoftware.com/bugzilla/show_bug.cgi?id=516
-	const void *RB_TakeScreenshotCmd( const void *data );
 
 	void       R_InitSkins();
 	skin_t     *R_GetSkinByHandle( qhandle_t hSkin );
@@ -3670,7 +3650,6 @@ void GLimp_LogComment_( std::string comment );
 	void RE_ClearScene();
 	void RE_AddRefEntityToScene( const refEntity_t *ent );
 
-	void RE_AddPolyToSceneQ3A( qhandle_t hShader, int numVerts, const polyVert_t *verts, int num );
 	void RE_AddPolyToSceneET( qhandle_t hShader, int numVerts, const polyVert_t *verts );
 	void RE_AddPolysToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts, int numPolys );
 
@@ -4003,7 +3982,6 @@ void GLimp_LogComment_( std::string comment );
 
 
 // video stuff
-	const void *RB_TakeVideoFrameCmd( const void *data );
 	void       RE_TakeVideoFrame( int width, int height, byte *captureBuffer, byte *encodeBuffer, bool motionJpeg );
 
 // cubemap reflections stuff

--- a/src/engine/renderer/tr_model.cpp
+++ b/src/engine/renderer/tr_model.cpp
@@ -147,7 +147,7 @@ qhandle_t RE_RegisterModel( const char *name )
 
 		if ( !err )
 		{
-			if ( Str::IsIPrefix( "MD5Version", buffer ) )
+			if ( Str::IsIPrefix( MD5_IDENTSTRING, buffer ) )
 			{
 				loaded = R_LoadMD5( mod, buffer.c_str(), name );
 			}

--- a/src/engine/renderer/tr_skin.cpp
+++ b/src/engine/renderer/tr_skin.cpp
@@ -165,7 +165,6 @@ qhandle_t RE_RegisterSkin( const char *name )
 	qhandle_t     hSkin;
 	skin_t        *skin;
 	skinSurface_t *surf;
-	skinModel_t   *model; //----(SA) added
 	const char    *text_p;
 	const char    *token;
 	char          surfName[ MAX_QPATH ];
@@ -226,7 +225,6 @@ qhandle_t RE_RegisterSkin( const char *name )
 	tr.skins[ hSkin ] = skin;
 	Q_strncpyz( skin->name, name, sizeof( skin->name ) );
 	skin->numSurfaces = 0;
-	skin->numModels = 0; //----(SA) added
 
 //----(SA)  end
 
@@ -253,22 +251,6 @@ qhandle_t RE_RegisterSkin( const char *name )
 
 		if ( !Q_strnicmp( token, "tag_", 4 ) )
 		{
-			continue;
-		}
-
-		if ( !Q_strnicmp( token, "md3_", 4 ) )
-		{
-			// this is specifying a model
-			model = skin->models[ skin->numModels ] = (skinModel_t*) ri.Hunk_Alloc( sizeof( *skin->models[ 0 ] ), ha_pref::h_low );
-			Q_strncpyz( model->type, token, sizeof( model->type ) );
-			model->hash = Com_HashKey( model->type, sizeof( model->type ) );
-
-			// get the model name
-			token = CommaParse( &text_p );
-
-			Q_strncpyz( model->model, token, sizeof( model->model ) );
-
-			skin->numModels++;
 			continue;
 		}
 


### PR DESCRIPTION
`skinModel_t` was only used by Wolf:ET and XreaL, for some stupid back and forth of shader handles through IPC, which we thankfully do not have.

Also fixed some comments on `srfGeneric_t`.