### PR TITLE
Material and u_Lights buffer clean-up

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -78,6 +78,7 @@ set(COMMONTESTLIST
 )
 
 set(RENDERERLIST
+    ${ENGINE_DIR}/renderer/BufferBind.h
     ${ENGINE_DIR}/renderer/DetectGLVendors.cpp
     ${ENGINE_DIR}/renderer/DetectGLVendors.h
     ${ENGINE_DIR}/renderer/gl_shader.cpp

--- a/src/engine/renderer/BufferBind.h
+++ b/src/engine/renderer/BufferBind.h
@@ -1,0 +1,70 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2025 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// BufferBind.h
+
+#ifndef BUFFERBIND_H
+#define BUFFERBIND_H
+
+namespace BufferBind {
+	enum : uint32_t {
+		// UBO
+		MATERIALS = 0,
+		TEX_DATA = 1,
+		LIGHTMAP_DATA = 2,
+		LIGHTS = 3,
+
+		SURFACE_BATCHES = 4,
+
+		// SSBO
+		SURFACE_DESCRIPTORS = 0,
+		SURFACE_COMMANDS = 1,
+		CULLED_COMMANDS = 2,
+		PORTAL_SURFACES = 4,
+
+		GEOMETRY_CACHE_INPUT_VBO = 5,
+		GEOMETRY_CACHE_VBO = 6,
+
+		COMMAND_COUNTERS_STORAGE = 9,
+		TEX_DATA_STORAGE = 11,
+
+		DEBUG = 10,
+		
+		// Atomic
+		COMMAND_COUNTERS_ATOMIC = 0,
+		
+		UNUSED = INT32_MAX
+	};
+};
+
+#endif // BUFFERBIND_H

--- a/src/engine/renderer/GeometryOptimiser.cpp
+++ b/src/engine/renderer/GeometryOptimiser.cpp
@@ -716,6 +716,8 @@ std::vector<MaterialSurface> OptimiseMapGeometryMaterial( world_t* world, bspSur
 	materialSystem.GeneratePortalBoundingSpheres();
 	materialSystem.GenerateWorldCommandBuffer( processedMaterialSurfaces );
 
+	materialSystem.BindBuffers();
+
 	vertexAttributeSpec_t attrs[] {
 		{ ATTR_INDEX_POSITION, GL_FLOAT, GL_FLOAT, &vertices[0].xyz, 3, sizeof( *vertices ), 0 },
 		{ ATTR_INDEX_COLOR, GL_UNSIGNED_BYTE, GL_UNSIGNED_BYTE, &vertices[0].lightColor, 4, sizeof( *vertices ), ATTR_OPTION_NORMALIZE },

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -730,11 +730,6 @@ void MaterialSystem::BindBuffers() {
 	texDataBuffer.BindBufferBase( texDataBufferType, texDataBindingPoint );
 	lightMapDataUBO.BindBufferBase();
 
-	if ( glConfig2.realtimeLighting ) {
-		// UBOs are actually completely independent of shaders since we set the binding points explicitly here
-		gl_lightMappingShaderMaterial->SetUniformBlock_Lights( tr.dlightUBO );
-	}
-
 	culledCommandsBuffer.BindBuffer( GL_DRAW_INDIRECT_BUFFER );
 	atomicCommandCountersBuffer.BindBuffer( GL_PARAMETER_BUFFER_ARB );
 

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -306,21 +306,23 @@ struct SurfaceCommandBatch {
 	uint32_t materialIDs[2] { 0, 0 };
 };
 
-enum class BufferBind {
-	MATERIALS = 1, // LightTile UBO uses binding point 0, so avoid it here
-	TEX_DATA = 6,
-	LIGHTMAP_DATA = 2,
-	SURFACE_DESCRIPTORS = 0,
-	SURFACE_COMMANDS = 1,
-	CULLED_COMMANDS = 2,
-	SURFACE_BATCHES = 3,
-	COMMAND_COUNTERS_ATOMIC = 0,
-	COMMAND_COUNTERS_STORAGE = 4, // Avoid needlessly rebinding buffers
-	PORTAL_SURFACES = 5,
-	GEOMETRY_CACHE_INPUT_VBO = 6,
-	GEOMETRY_CACHE_VBO = 7,
-	DEBUG = 10,
-	UNUSED = INT32_MAX
+namespace BufferBind {
+	enum : uint32_t {
+		MATERIALS = 1, // LightTile UBO uses binding point 0, so avoid it here
+		TEX_DATA = 6,
+		LIGHTMAP_DATA = 2,
+		SURFACE_DESCRIPTORS = 0,
+		SURFACE_COMMANDS = 1,
+		CULLED_COMMANDS = 2,
+		SURFACE_BATCHES = 3,
+		COMMAND_COUNTERS_ATOMIC = 0,
+		COMMAND_COUNTERS_STORAGE = 4, // Avoid needlessly rebinding buffers
+		PORTAL_SURFACES = 5,
+		GEOMETRY_CACHE_INPUT_VBO = 6,
+		GEOMETRY_CACHE_VBO = 7,
+		DEBUG = 10,
+		UNUSED = INT32_MAX
+	};
 };
 
 class MaterialSystem {

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -364,6 +364,8 @@ class MaterialSystem {
 	void InitGLBuffers();
 	void FreeGLBuffers();
 
+	void BindBuffers();
+
 	uint32_t GetTexDataSize() const {
 		return texData.size();
 	}

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -306,26 +306,6 @@ struct SurfaceCommandBatch {
 	uint32_t materialIDs[2] { 0, 0 };
 };
 
-namespace BufferBind {
-	enum : uint32_t {
-		MATERIALS = 1,
-		TEX_DATA = 6,
-		LIGHTMAP_DATA = 2,
-		LIGHTS = 0,
-		SURFACE_DESCRIPTORS = 0,
-		SURFACE_COMMANDS = 1,
-		CULLED_COMMANDS = 2,
-		SURFACE_BATCHES = 3,
-		COMMAND_COUNTERS_ATOMIC = 0,
-		COMMAND_COUNTERS_STORAGE = 4, // Avoid needlessly rebinding buffers
-		PORTAL_SURFACES = 5,
-		GEOMETRY_CACHE_INPUT_VBO = 6,
-		GEOMETRY_CACHE_VBO = 7,
-		DEBUG = 10,
-		UNUSED = INT32_MAX
-	};
-};
-
 class MaterialSystem {
 	public:
 	vec3_t worldViewBounds[2];
@@ -431,6 +411,7 @@ class MaterialSystem {
 	std::vector<shaderStage_t*> dynamicStages;
 
 	GLenum texDataBufferType;
+	GLuint texDataBindingPoint;
 	std::vector<TextureData> texData;
 	std::vector<TextureData> dynamicTexData;
 

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -308,9 +308,10 @@ struct SurfaceCommandBatch {
 
 namespace BufferBind {
 	enum : uint32_t {
-		MATERIALS = 1, // LightTile UBO uses binding point 0, so avoid it here
+		MATERIALS = 1,
 		TEX_DATA = 6,
 		LIGHTMAP_DATA = 2,
+		LIGHTS = 0,
 		SURFACE_DESCRIPTORS = 0,
 		SURFACE_COMMANDS = 1,
 		CULLED_COMMANDS = 2,

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -584,6 +584,7 @@ static std::string GenVertexHeader() {
 	if ( glConfig2.usingMaterialSystem ) {
 		AddDefine( str, "BIND_MATERIALS", BufferBind::MATERIALS );
 		AddDefine( str, "BIND_TEX_DATA", BufferBind::TEX_DATA );
+		AddDefine( str, "BIND_TEX_DATA_STORAGE", BufferBind::TEX_DATA_STORAGE );
 		AddDefine( str, "BIND_LIGHTMAP_DATA", BufferBind::LIGHTMAP_DATA );
 	}
 
@@ -628,6 +629,7 @@ static std::string GenFragmentHeader() {
 	if ( glConfig2.usingMaterialSystem ) {
 		AddDefine( str, "BIND_MATERIALS", BufferBind::MATERIALS );
 		AddDefine( str, "BIND_TEX_DATA", BufferBind::TEX_DATA );
+		AddDefine( str, "BIND_TEX_DATA_STORAGE", BufferBind::TEX_DATA_STORAGE );
 		AddDefine( str, "BIND_LIGHTMAP_DATA", BufferBind::LIGHTMAP_DATA );
 	}
 

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -286,7 +286,7 @@ void GLShaderManager::UpdateShaderProgramUniformLocations( GLShader* shader, Sha
 		uniform->UpdateShaderProgramUniformLocation( shaderProgram );
 	}
 
-	if( glConfig2.uniformBufferObjectAvailable ) {
+	if( glConfig2.uniformBufferObjectAvailable && !glConfig2.shadingLanguage420PackAvailable ) {
 		// create buffer for storing uniform block indexes
 		shaderProgram->uniformBlockIndexes = ( GLuint* ) Z_Malloc( sizeof( GLuint ) * numUniformBlocks );
 
@@ -416,6 +416,7 @@ struct addedExtension_t {
 static const std::vector<addedExtension_t> fragmentVertexAddedExtensions = {
 	{ glConfig2.gpuShader4Available, 130, "EXT_gpu_shader4" },
 	{ glConfig2.gpuShader5Available, 400, "ARB_gpu_shader5" },
+	{ glConfig2.shadingLanguage420PackAvailable, 420, "ARB_shading_language_420pack" },
 	{ glConfig2.textureFloatAvailable, 130, "ARB_texture_float" },
 	{ glConfig2.textureGatherAvailable, 400, "ARB_texture_gather" },
 	{ glConfig2.textureIntegerAvailable, 0, "EXT_texture_integer" },
@@ -618,6 +619,10 @@ static std::string GenFragmentHeader() {
 		str += "IN(flat) int in_baseInstance;\n";
 		str += "#define drawID in_drawID\n";
 		str += "#define baseInstance in_baseInstance\n\n";
+	}
+
+	if ( glConfig2.shadingLanguage420PackAvailable ) {
+		AddDefine( str, "BIND_LIGHTS", BufferBind::LIGHTS );
 	}
 
 	if ( glConfig2.usingMaterialSystem ) {

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1181,6 +1181,10 @@ void GLShaderManager::BuildAll( const bool buildOnlyMarked ) {
 		cacheLoadCount, cacheLoadTime, cacheSaveCount, cacheSaveTime );
 }
 
+void GLShaderManager::BindBuffers() {
+	glBindBufferBase( GL_UNIFORM_BUFFER, BufferBind::LIGHTS, tr.dlightUBO );
+}
+
 std::string GLShaderManager::ProcessInserts( const std::string& shaderText ) const {
 	std::string out;
 	std::istringstream shaderTextStream( shaderText );

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -303,6 +303,10 @@ static inline void AddDefine( std::string& defines, const std::string& define, i
 	defines += Str::Format("#ifndef %s\n#define %s %d\n#endif\n", define, define, value);
 }
 
+static inline void AddDefine( std::string& defines, const std::string& define, uint32_t value ) {
+	defines += Str::Format( "#ifndef %s\n#define %s %d\n#endif\n", define, define, value );
+}
+
 // Epsilon for float is 5.96e-08, so exponential notation with 8 decimal places should give exact values.
 
 static inline void AddDefine( std::string& defines, const std::string& define, float value )
@@ -577,9 +581,9 @@ static std::string GenVertexHeader() {
 	}
 
 	if ( glConfig2.usingMaterialSystem ) {
-		AddDefine( str, "BIND_MATERIALS", Util::ordinal( BufferBind::MATERIALS ) );
-		AddDefine( str, "BIND_TEX_DATA", Util::ordinal( BufferBind::TEX_DATA ) );
-		AddDefine( str, "BIND_LIGHTMAP_DATA", Util::ordinal( BufferBind::LIGHTMAP_DATA ) );
+		AddDefine( str, "BIND_MATERIALS", BufferBind::MATERIALS );
+		AddDefine( str, "BIND_TEX_DATA", BufferBind::TEX_DATA );
+		AddDefine( str, "BIND_LIGHTMAP_DATA", BufferBind::LIGHTMAP_DATA );
 	}
 
 	return str;
@@ -617,9 +621,9 @@ static std::string GenFragmentHeader() {
 	}
 
 	if ( glConfig2.usingMaterialSystem ) {
-		AddDefine( str, "BIND_MATERIALS", Util::ordinal( BufferBind::MATERIALS ) );
-		AddDefine( str, "BIND_TEX_DATA", Util::ordinal( BufferBind::TEX_DATA ) );
-		AddDefine( str, "BIND_LIGHTMAP_DATA", Util::ordinal( BufferBind::LIGHTMAP_DATA ) );
+		AddDefine( str, "BIND_MATERIALS", BufferBind::MATERIALS );
+		AddDefine( str, "BIND_TEX_DATA", BufferBind::TEX_DATA );
+		AddDefine( str, "BIND_LIGHTMAP_DATA", BufferBind::LIGHTMAP_DATA );
 	}
 
 	return str;
@@ -636,15 +640,15 @@ static std::string GenComputeHeader() {
 		AddDefine( str, "MAX_SURFACE_COMMAND_BATCHES", MAX_SURFACE_COMMAND_BATCHES );
 		AddDefine( str, "MAX_COMMAND_COUNTERS", MAX_COMMAND_COUNTERS );
 
-		AddDefine( str, "BIND_SURFACE_DESCRIPTORS", Util::ordinal( BufferBind::SURFACE_DESCRIPTORS ) );
-		AddDefine( str, "BIND_SURFACE_COMMANDS", Util::ordinal( BufferBind::SURFACE_COMMANDS ) );
-		AddDefine( str, "BIND_CULLED_COMMANDS", Util::ordinal( BufferBind::CULLED_COMMANDS ) );
-		AddDefine( str, "BIND_SURFACE_BATCHES", Util::ordinal( BufferBind::SURFACE_BATCHES ) );
-		AddDefine( str, "BIND_COMMAND_COUNTERS_ATOMIC", Util::ordinal( BufferBind::COMMAND_COUNTERS_ATOMIC ) );
-		AddDefine( str, "BIND_COMMAND_COUNTERS_STORAGE", Util::ordinal( BufferBind::COMMAND_COUNTERS_STORAGE ) );
-		AddDefine( str, "BIND_PORTAL_SURFACES", Util::ordinal( BufferBind::PORTAL_SURFACES ) );
+		AddDefine( str, "BIND_SURFACE_DESCRIPTORS", BufferBind::SURFACE_DESCRIPTORS );
+		AddDefine( str, "BIND_SURFACE_COMMANDS", BufferBind::SURFACE_COMMANDS );
+		AddDefine( str, "BIND_CULLED_COMMANDS", BufferBind::CULLED_COMMANDS );
+		AddDefine( str, "BIND_SURFACE_BATCHES", BufferBind::SURFACE_BATCHES );
+		AddDefine( str, "BIND_COMMAND_COUNTERS_ATOMIC", BufferBind::COMMAND_COUNTERS_ATOMIC );
+		AddDefine( str, "BIND_COMMAND_COUNTERS_STORAGE", BufferBind::COMMAND_COUNTERS_STORAGE );
+		AddDefine( str, "BIND_PORTAL_SURFACES", BufferBind::PORTAL_SURFACES );
 
-		AddDefine( str, "BIND_DEBUG", Util::ordinal( BufferBind::DEBUG ) );
+		AddDefine( str, "BIND_DEBUG", BufferBind::DEBUG );
 	}
 
 	if ( glConfig2.usingBindlessTextures ) {
@@ -1510,19 +1514,19 @@ std::string GLShaderManager::ShaderPostProcess( GLShader *shader, const std::str
 	// 6 kb for materials
 	const uint32_t count = ( 4096 + 2048 ) / shader->GetPaddedSize();
 	std::string materialBlock = "layout(std140, binding = "
-		                        + std::to_string( Util::ordinal( BufferBind::MATERIALS ) )
+		                        + std::to_string( BufferBind::MATERIALS )
 		                        + ") uniform materialsUBO {\n"
 	                            "	Material materials[" + std::to_string( count ) + "]; \n"
 	                            "};\n\n";
 
 	std::string texBuf = glConfig2.maxUniformBlockSize >= MIN_MATERIAL_UBO_SIZE ?
 		"layout(std140, binding = "
-		+ std::to_string( Util::ordinal( BufferBind::TEX_DATA ) )
+		+ std::to_string( BufferBind::TEX_DATA )
 		+ ") uniform texDataUBO {\n"
 		"	TexData texData[" + std::to_string( MAX_TEX_BUNDLES ) + "]; \n"
 		"};\n\n"
 		: "layout(std430, binding = "
-		+ std::to_string( Util::ordinal( BufferBind::TEX_DATA ) )
+		+ std::to_string( BufferBind::TEX_DATA )
 		+ ") restrict readonly buffer texDataSSBO {\n"
 		"	TexData texData[];\n"
 		"};\n\n";

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1231,12 +1231,13 @@ class GLUniformBlock
 protected:
 	GLShader   *_shader;
 	std::string _name;
-	size_t      _locationIndex;
+	size_t      _locationIndex; // Only valid if GL_ARB_shading_language_420pack is not available
+	const GLuint bindingPoint; // Only valid if GL_ARB_shading_language_420pack is available
 
-	GLUniformBlock( GLShader *shader, const char *name ) :
+	GLUniformBlock( GLShader *shader, const char *name, const GLuint newBindingPoint = 0 ) :
 		_shader( shader ),
 		_name( name ),
-		_locationIndex( 0 )
+		bindingPoint( newBindingPoint )
 	{
 		_shader->RegisterUniformBlock( this );
 	}
@@ -1258,10 +1259,15 @@ public:
 	}
 
 	void SetBuffer( GLuint buffer ) {
-		ShaderProgramDescriptor *p = _shader->GetProgram();
-		GLuint blockIndex = p->uniformBlockIndexes[ _locationIndex ];
+		if ( glConfig2.shadingLanguage420PackAvailable ) {
+			glBindBufferBase( GL_UNIFORM_BUFFER, bindingPoint, buffer );
+			return;
+		}
 
-		ASSERT_EQ(p, glState.currentProgram);
+		ShaderProgramDescriptor *p = _shader->GetProgram();
+		GLuint blockIndex = p->uniformBlockIndexes[_locationIndex];
+
+		ASSERT_EQ( p, glState.currentProgram );
 
 		if( blockIndex != GL_INVALID_INDEX ) {
 			glBindBufferBase( GL_UNIFORM_BUFFER, blockIndex, buffer );

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -368,6 +368,8 @@ public:
 	bool BuildPermutation( GLShader* shader, int macroIndex, int deformIndex, const bool buildOneShader );
 	void BuildAll( const bool buildOnlyMarked );
 	void FreeAll();
+
+	void BindBuffers();
 private:
 	struct InfoLogEntry {
 		int line;
@@ -1261,7 +1263,6 @@ public:
 
 	void SetBuffer( GLuint buffer ) {
 		if ( glConfig2.shadingLanguage420PackAvailable ) {
-			glBindBufferBase( GL_UNIFORM_BUFFER, bindingPoint, buffer );
 			return;
 		}
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #define GL_SHADER_H
 
 #include "tr_local.h"
+#include "BufferBind.h"
 #include <stdexcept>
 
 #define USE_UNIFORM_FIREWALL 1
@@ -1234,7 +1235,7 @@ protected:
 	size_t      _locationIndex; // Only valid if GL_ARB_shading_language_420pack is not available
 	const GLuint bindingPoint; // Only valid if GL_ARB_shading_language_420pack is available
 
-	GLUniformBlock( GLShader *shader, const char *name, const GLuint newBindingPoint = 0 ) :
+	GLUniformBlock( GLShader *shader, const char *name, const GLuint newBindingPoint ) :
 		_shader( shader ),
 		_name( name ),
 		bindingPoint( newBindingPoint )
@@ -3605,7 +3606,7 @@ class u_Lights :
 {
  public:
 	u_Lights( GLShader *shader ) :
-		GLUniformBlock( shader, "u_Lights" )
+		GLUniformBlock( shader, "u_Lights", BufferBind::LIGHTS )
 	{
 	}
 

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -153,7 +153,11 @@ struct Light {
 	float angle;
 };
 
+#if defined( HAVE_ARB_shading_language_420pack )
+layout(std140, binding = BIND_LIGHTS) uniform u_Lights {
+#else
 layout(std140) uniform u_Lights {
+#endif
 	Light lights[MAX_REF_LIGHTS];
 };
 

--- a/src/engine/renderer/glsl_source/lighttile_fp.glsl
+++ b/src/engine/renderer/glsl_source/lighttile_fp.glsl
@@ -45,7 +45,11 @@ struct Light {
 	float angle;
 };
 
+#if defined( HAVE_ARB_shading_language_420pack )
+layout(std140, binding = BIND_LIGHTS) uniform u_Lights {
+#else
 layout(std140) uniform u_Lights {
+#endif
 	Light lights[MAX_REF_LIGHTS];
 };
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1540,6 +1540,10 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			GLSL_FinishGPUShaders();
 		}
 
+		if ( glConfig2.shadingLanguage420PackAvailable ) {
+			gl_shaderManager.BindBuffers();
+		}
+
 		/* TODO: Move this into a loading step and don't render it to the screen
 		For now though do it here to avoid the ugly square rendering appearing on top of the loading screen */
 		if ( glConfig2.reflectionMappingAvailable ) {


### PR DESCRIPTION
Re-arrange the buffer IDs so they make more sense when debugging, get rid of the requirement to not use bind 0 in `BufferBind` by using explicit binding for the `u_Lights` UBO, and also make that work in the core renderer.

Also removed the calls to bind/unbind buffers every frame (and even more often), reducing the amount of API calls.