### PR TITLE
Implement staging buffer and use it for the material system

### DIFF
--- a/src.cmake
+++ b/src.cmake
@@ -97,6 +97,8 @@ set(RENDERERLIST
     ${ENGINE_DIR}/renderer/GeometryCache.h
     ${ENGINE_DIR}/renderer/GeometryOptimiser.cpp
     ${ENGINE_DIR}/renderer/GeometryOptimiser.h
+    ${ENGINE_DIR}/renderer/GLMemory.cpp
+    ${ENGINE_DIR}/renderer/GLMemory.h
     ${ENGINE_DIR}/renderer/InternalImage.cpp
     ${ENGINE_DIR}/renderer/InternalImage.h
     ${ENGINE_DIR}/renderer/Material.cpp

--- a/src/engine/renderer/GLMemory.cpp
+++ b/src/engine/renderer/GLMemory.cpp
@@ -1,0 +1,128 @@
+﻿/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2025 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+	* Redistributions of source code must retain the above copyright
+	  notice, this list of conditions and the following disclaimer.
+	* Redistributions in binary form must reproduce the above copyright
+	  notice, this list of conditions and the following disclaimer in the
+	  documentation and/or other materials provided with the distribution.
+	* Neither the name of the Daemon developers nor the
+	  names of its contributors may be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// GLMemory.cpp
+
+#include "common/Common.h"
+
+#include "GLMemory.h"
+
+// 128 MB, should be enough to fit anything in BAR without going overboard
+const GLsizeiptr GLStagingBuffer::SIZE = 128 * 1024 * 1024 / sizeof( uint32_t );
+
+GLStagingBuffer stagingBuffer;
+
+void GLBufferCopy( GLBuffer* src, GLBuffer* dst, GLintptr srcOffset, GLintptr dstOffset, GLsizeiptr size ) {
+	glCopyNamedBufferSubData( src->id, dst->id,
+		srcOffset * sizeof( uint32_t ), dstOffset * sizeof( uint32_t ), size * sizeof( uint32_t ) );
+}
+
+uint32_t* GLStagingBuffer::MapBuffer( const GLsizeiptr size ) {
+	if ( size > SIZE ) {
+		Sys::Drop( "Couldn't map GL staging buffer: size too large (%u/%u)", size, SIZE );
+	}
+
+	if ( pointer + size > SIZE ) {
+		FlushAll();
+
+		GLsync sync = glFenceSync( GL_SYNC_GPU_COMMANDS_COMPLETE, 0 );
+
+		constexpr GLuint64 SYNC_TIMEOUT = 10000000000; // 10 seconds
+		if ( glClientWaitSync( sync, GL_SYNC_FLUSH_COMMANDS_BIT, SYNC_TIMEOUT ) == GL_TIMEOUT_EXPIRED ) {
+			Sys::Drop( "Failed GL staging buffer copy sync" );
+		}
+		glDeleteSync( sync );
+
+		pointer = 0;
+		current = 0;
+		last = 0;
+	}
+
+	uint32_t* ret = buffer.GetData() + pointer;
+	last = pointer;
+	pointer += size;
+
+	return ret;
+}
+
+void GLStagingBuffer::FlushBuffer() {
+	buffer.FlushRange( current, pointer - current );
+
+	GL_CheckErrors();
+
+	current = pointer;
+}
+
+void GLStagingBuffer::QueueStagingCopy( GLBuffer* dst, const GLsizeiptr dstOffset ) {
+	copyQueue[currentCopy].dst = dst;
+	copyQueue[currentCopy].dstOffset = dstOffset;
+	copyQueue[currentCopy].stagingOffset = last;
+	copyQueue[currentCopy].size = pointer - last;
+
+	currentCopy++;
+
+	if ( currentCopy == MAX_COPIES ) {
+		FlushStagingCopyQueue();
+	}
+}
+
+void GLStagingBuffer::FlushStagingCopyQueue() {
+	for ( GLStagingCopy& copy : copyQueue ) {
+		if ( copy.dst ) {
+			GLBufferCopy( &buffer, copy.dst, copy.stagingOffset, copy.dstOffset, copy.size );
+			copy.dst = nullptr;
+		}
+	}
+
+	currentCopy = 0;
+
+	GL_CheckErrors();
+}
+
+void GLStagingBuffer::FlushAll() {
+	FlushBuffer();
+	FlushStagingCopyQueue();
+}
+
+void GLStagingBuffer::InitGLBuffer() {
+	buffer.GenBuffer();
+
+	buffer.BufferStorage( SIZE, 1, nullptr );
+	buffer.MapAll();
+
+	GL_CheckErrors();
+}
+
+void GLStagingBuffer::FreeGLBuffer() {
+	buffer.DelBuffer();
+}

--- a/src/engine/renderer/GeometryCache.h
+++ b/src/engine/renderer/GeometryCache.h
@@ -46,7 +46,6 @@ class GeometryCache {
 	void InitGLBuffers();
 	void FreeGLBuffers();
 
-	void AllocBuffers();
 	void AddMapGeometry( const uint32_t verticesNumber, const uint32_t indicesNumber,
 		const vertexAttributeSpec_t* attrBegin,
 		const vertexAttributeSpec_t* attrEnd,
@@ -59,8 +58,8 @@ class GeometryCache {
 	GLVAO VAO = GLVAO( 0 );
 
 	GLBuffer inputVBO = GLBuffer( "geometryCacheInputVBO", BufferBind::GEOMETRY_CACHE_INPUT_VBO, GL_MAP_WRITE_BIT, GL_MAP_INVALIDATE_RANGE_BIT );
-	GLBuffer VBO = GLBuffer( "geometryCacheVBO", BufferBind::GEOMETRY_CACHE_VBO, GL_MAP_WRITE_BIT, GL_MAP_FLUSH_EXPLICIT_BIT );
-	GLBuffer IBO = GLBuffer( "geometryCacheIBO", BufferBind::GEOMETRY_CACHE_IBO, GL_MAP_WRITE_BIT, GL_MAP_INVALIDATE_RANGE_BIT );
+	GLBuffer VBO = GLBuffer( "geometryCacheVBO", BufferBind::GEOMETRY_CACHE_VBO, 0, 0 );
+	GLBuffer IBO = GLBuffer( "geometryCacheIBO", BufferBind::GEOMETRY_CACHE_IBO, 0, 0 );
 };
 
 extern GeometryCache geometryCache;

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -401,11 +401,9 @@ class MaterialSystem {
 	image_t* depthImage;
 	int depthImageLevels;
 
-	uint32_t totalDrawSurfs;
-	uint32_t totalBatchCount = 0;
-
 	uint32_t surfaceCommandsCount = 0;
 	uint32_t surfaceDescriptorsCount = 0;
+	uint32_t totalBatchCount = 0;
 
 	uint32_t packIDs[3] = { 0, 0, 0 };
 

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -3028,7 +3028,7 @@ GLShader_cull::GLShader_cull() :
 		false, "cull" ),
 	u_Frame( this ),
 	u_ViewID( this ),
-	u_TotalDrawSurfs( this ),
+	u_SurfaceDescriptorsCount( this ),
 	u_SurfaceCommandsOffset( this ),
 	u_Frustum( this ),
 	u_UseFrustumCulling( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -1284,6 +1284,8 @@ class GLBuffer {
 	std::string name;
 	const GLuint64 SYNC_TIMEOUT = 10000000000; // 10 seconds
 
+	GLuint id;
+
 	GLBuffer( const char* newName, const GLuint newBindingPoint, const GLbitfield newFlags, const GLbitfield newMapFlags ) :
 		name( newName ),
 		internalTarget( 0 ),
@@ -1332,6 +1334,8 @@ class GLBuffer {
 		maxAreas = areaCount;
 		glNamedBufferStorage( id, areaSize * areaCount * sizeof( uint32_t ), data, flags );
 		syncs.resize( areaCount );
+
+		GL_CheckErrors();
 	}
 
 	void AreaIncr() {
@@ -1372,6 +1376,10 @@ class GLBuffer {
 		glFlushMappedNamedBufferRange( id, 0, maxAreas * areaSize * sizeof( uint32_t ) );
 	}
 
+	void FlushRange( const GLsizeiptr offset, const GLsizeiptr size ) {
+		glFlushMappedNamedBufferRange( id, offset * sizeof( uint32_t ), size * sizeof( uint32_t ) );
+	}
+
 	uint32_t* MapBufferRange( const GLuint count ) {
 		return MapBufferRange( 0, count );
 	}
@@ -1400,13 +1408,12 @@ class GLBuffer {
 
 	void DelBuffer() {
 		glDeleteBuffers( 1, &id );
+		mapped = false;
 	}
 
 	private:
 	const GLenum internalTarget;
 	const GLuint internalBindingPoint;
-
-	GLuint id;
 
 	bool mapped = false;
 	const GLbitfield flags;

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2764,15 +2764,15 @@ class u_P11 :
 	}
 };
 
-class u_TotalDrawSurfs :
+class u_SurfaceDescriptorsCount :
 	GLUniform1ui {
 	public:
-	u_TotalDrawSurfs( GLShader* shader ) :
-		GLUniform1ui( shader, "u_TotalDrawSurfs", true ) {
+	u_SurfaceDescriptorsCount( GLShader* shader ) :
+		GLUniform1ui( shader, "u_SurfaceDescriptorsCount", true ) {
 	}
 
-	void SetUniform_TotalDrawSurfs( const uint totalDrawSurfs ) {
-		this->SetValue( totalDrawSurfs );
+	void SetUniform_SurfaceDescriptorsCount( const uint SurfaceDescriptorsCount ) {
+		this->SetValue( SurfaceDescriptorsCount );
 	}
 };
 
@@ -4153,7 +4153,7 @@ class GLShader_cull :
 	public GLShader,
 	public u_Frame,
 	public u_ViewID,
-	public u_TotalDrawSurfs,
+	public u_SurfaceDescriptorsCount,
 	public u_SurfaceCommandsOffset,
 	public u_Frustum,
 	public u_UseFrustumCulling,

--- a/src/engine/renderer/glsl_source/cull_cp.glsl
+++ b/src/engine/renderer/glsl_source/cull_cp.glsl
@@ -70,7 +70,7 @@ layout(std430, binding = BIND_PORTAL_SURFACES) restrict buffer portalSurfacesSSB
 
 uniform uint u_Frame;
 uniform uint u_ViewID;
-uniform uint u_TotalDrawSurfs;
+uniform uint u_SurfaceDescriptorsCount;
 uniform uint u_SurfaceCommandsOffset;
 uniform vec4 u_Frustum[6]; // xyz - normal, w - distance
 uniform bool u_UseFrustumCulling;
@@ -198,7 +198,7 @@ void main() {
 	}
 
 	// Regular surfaces
-	if( globalInvocationID >= u_TotalDrawSurfs ) {
+	if( globalInvocationID >= u_SurfaceDescriptorsCount ) {
 		return;
 	}
 	SurfaceDescriptor surface = surfaces[globalInvocationID];

--- a/src/engine/renderer/shaders.cpp
+++ b/src/engine/renderer/shaders.cpp
@@ -72,7 +72,7 @@ std::unordered_map<std::string, std::string> shadermap({
 	{ "depthReduction_cp.glsl", std::string( reinterpret_cast< const char* >( depthReduction_cp_glsl ), sizeof( depthReduction_cp_glsl ) ) },
 	{ "processSurfaces_cp.glsl", std::string( reinterpret_cast< const char* >( processSurfaces_cp_glsl ), sizeof( processSurfaces_cp_glsl ) ) },
 
-	//  Screen-space shaders
+	// Screen-space shaders
 	{ "screenSpace_vp.glsl", std::string( reinterpret_cast< const char* >( screenSpace_vp_glsl ), sizeof( screenSpace_vp_glsl ) ) },
 	{ "blur_fp.glsl", std::string( reinterpret_cast< const char* >( blur_fp_glsl ), sizeof( blur_fp_glsl ) ) },
 	{ "cameraEffects_fp.glsl", std::string( reinterpret_cast< const char* >( cameraEffects_fp_glsl ), sizeof( cameraEffects_fp_glsl ) ) },

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -919,7 +919,7 @@ static void ParseTriangleSurface( dsurface_t* ds, drawVert_t* verts, bspSurface_
 
 	// We may have a nodraw surface, because they might still need to be around for movement clipping
 	if ( s_worldData.shaders[LittleLong( ds->shaderNum )].surfaceFlags & SURF_NODRAW ) {
-		surfaceType_t skipData = surfaceType_t::SF_SKIP;
+		static surfaceType_t skipData = surfaceType_t::SF_SKIP;
 		surf->data = &skipData;
 		return;
 	}

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include "tr_local.h"
 #include "Material.h"
 #include "GeometryCache.h"
+#include "GLMemory.h"
 
 // interleaved data: position, colour, qtangent, texcoord
 // -> struct shaderVertex_t in tr_local.h
@@ -761,6 +762,10 @@ void R_InitVBOs()
 		geometryCache.InitGLBuffers();
 	}
 
+	if ( glConfig2.directStateAccessAvailable && glConfig2.uniformBufferObjectAvailable ) {
+		stagingBuffer.InitGLBuffer();
+	}
+
 	GL_CheckErrors();
 }
 
@@ -831,6 +836,10 @@ void R_ShutdownVBOs()
 
 	if ( glConfig2.usingGeometryCache ) {
 		geometryCache.FreeGLBuffers();
+	}
+
+	if ( glConfig2.directStateAccessAvailable && glConfig2.uniformBufferObjectAvailable ) {
+		stagingBuffer.FreeGLBuffer();
 	}
 
 	tess.verts = tess.vertsBuffer = nullptr;


### PR DESCRIPTION
Adds `GLStagingBuffer` and `GLBufferCopy()`. `GLStagingBuffer` allows setting buffer storage and map flags to 0 on the destination buffers, which pretty much guarantees that they will go into VRAM. The data is uploaded through mapping `stagingBuffer` and doing a copy of the data on the GPU.

The `stagingBuffer` itself should (still depends on the driver) go into the BAR memory (on Nvidia this shows up as `DMA_CACHED` when using `r_glDebugProfile on; r_glDebugMode 7`).

Slightly improves material system performance. Currently this is used for all material system buffers except the portal one (since it requires reading from the GPU), and for the 2 geometry cache buffers that are currently used.

Also fixed `GLBuffer.mapped` state being retained on map change/load.