### PR TITLE
tr_shader: fix “flags & RSF_2D”

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6169,7 +6169,7 @@ shader_t       *R_FindShader( const char *name, shaderType_t type, int flags )
 
 	Log::Debug( "loading '%s' image as shader", fileName );
 
-	if( bits & RSF_2D )
+	if ( flags & RSF_2D )
 	{
 		imageParams_t imageParams = {};
 		imageParams.bits = bits;


### PR DESCRIPTION
Something wrong I noticed while reading the code, because `bits` is set to `IF_NONE`, this test was always false, and then I noticed `RSF_2D` is expected to be stored in `flags`…