### PR TITLE
engine: load worldspawn separately from other map data

### DIFF
--- a/src/dummygame/cgame.cpp
+++ b/src/dummygame/cgame.cpp
@@ -155,7 +155,8 @@ public:
 			// the renderer starts (though there is no way to get it back later)
 			refdef.gradingWeights[0] = 1.0f;
 
-			trap_R_LoadWorldMap(("maps/" + args.Argv(2) + ".bsp").c_str());
+			trap_R_LoadWorldSpawn(("maps/" + args.Argv(2)).c_str());
+			trap_R_LoadWorldData();
 
 			// This is done by EndRegistration but there is no way to invoke that
 			bool reflection;

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -159,7 +159,8 @@ enum cgameImport_t
   CG_R_GETSHADERNAMEFROMHANDLE,
   CG_R_SCISSOR_ENABLE,
   CG_R_SCISSOR_SET,
-  CG_R_LOADWORLDMAP,
+  CG_R_LOADWORLDSPAWN,
+  CG_R_LOADWORLDDATA,
   CG_R_REGISTERMODEL,
   CG_R_REGISTERSKIN,
   CG_R_REGISTERSHADER,
@@ -301,8 +302,16 @@ namespace Render {
 		IPC::Message<IPC::Id<VM::QVM, CG_R_GETSHADERNAMEFROMHANDLE>, int>,
 		IPC::Reply<std::string>
 	>;
-	// TODO is it really async?
-	using LoadWorldMapMsg = IPC::Message<IPC::Id<VM::QVM, CG_R_LOADWORLDMAP>, std::string>;
+	// It better be sync even if it doesn't return anything.
+	using LoadWorldSpawnMsg = IPC::SyncMessage<
+		IPC::Message<IPC::Id<VM::QVM, CG_R_LOADWORLDSPAWN>, std::string>,
+		IPC::Reply<bool>
+	>;
+	// It better be sync even if it doesn't return anything.
+	using LoadWorldDataMsg = IPC::SyncMessage<
+		IPC::Message<IPC::Id<VM::QVM, CG_R_LOADWORLDDATA>>,
+		IPC::Reply<bool>
+	>;
 	using RegisterModelMsg = IPC::SyncMessage<
 		IPC::Message<IPC::Id<VM::QVM, CG_R_REGISTERMODEL>, std::string>,
 		IPC::Reply<int>

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1185,10 +1185,18 @@ void CGameVM::QVMSyscall(int syscallNum, Util::Reader& reader, IPC::Channel& cha
 			});
 			break;
 
-		case CG_R_LOADWORLDMAP:
-			IPC::HandleMsg<Render::LoadWorldMapMsg>(channel, std::move(reader), [this] (const std::string& mapName) {
+		case CG_R_LOADWORLDSPAWN:
+			IPC::HandleMsg<Render::LoadWorldSpawnMsg>(channel, std::move(reader), [this] (const std::string& mapName, bool &done) {
 				re.SetWorldVisData(CM_ClusterPVS(-1));
-				re.LoadWorld(mapName.c_str());
+				re.LoadWorldSpawn(mapName);
+				done = true;
+			});
+			break;
+
+		case CG_R_LOADWORLDDATA:
+			IPC::HandleMsg<Render::LoadWorldDataMsg>(channel, std::move(reader), [this] (bool &done) {
+				re.LoadWorldData();
+				done = true;
 			});
 			break;
 

--- a/src/engine/null/null_renderer.cpp
+++ b/src/engine/null/null_renderer.cpp
@@ -75,7 +75,8 @@ void RE_GlyphChar( fontInfo_t *font, int, glyphInfo_t *glyph )
 	RE_Glyph( font, nullptr, glyph );
 }
 void RE_UnregisterFont( fontInfo_t* ) { }
-void RE_LoadWorldMap( const char * ) { }
+void RE_LoadWorldSpawn( const std::string ) { }
+void RE_LoadWorldData() { }
 void RE_SetWorldVisData( const byte * ) { }
 void RE_EndRegistration() { }
 void RE_ClearScene() { }
@@ -208,7 +209,8 @@ refexport_t    *GetRefAPI( int, refimport_t* )
     re.Glyph = RE_Glyph;
     re.GlyphChar = RE_GlyphChar;
     re.UnregisterFont = RE_UnregisterFont;
-    re.LoadWorld = RE_LoadWorldMap;
+    re.LoadWorldSpawn = RE_LoadWorldSpawn;
+    re.LoadWorldData = RE_LoadWorldData;
     re.SetWorldVisData = RE_SetWorldVisData;
     re.EndRegistration = RE_EndRegistration;
 

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1591,7 +1591,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		re.RegisterSkin = RE_RegisterSkin;
 		re.RegisterShader = RE_RegisterShader;
 
-		re.LoadWorld = RE_LoadWorldMap;
+		re.LoadWorldSpawn = RE_LoadWorldSpawn;
+		re.LoadWorldData = RE_LoadWorldData;
 		re.SetWorldVisData = RE_SetWorldVisData;
 		re.EndRegistration = RE_EndRegistration;
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3033,7 +3033,8 @@ inline bool checkGLErrors()
 
 	void      RE_BeginFrame();
 	bool  RE_BeginRegistration( glconfig_t *glconfig, glconfig2_t *glconfig2 );
-	void      RE_LoadWorldMap( const char *mapname );
+	void RE_LoadWorldSpawn( const std::string worldName );
+	void RE_LoadWorldData();
 	void      RE_SetWorldVisData( const byte *vis );
 	qhandle_t RE_RegisterModel( const char *name );
 	qhandle_t RE_RegisterSkin( const char *name );

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -184,7 +184,8 @@ struct refexport_t
 	void   ( *Glyph )( fontInfo_t *font, const char *str, glyphInfo_t *glyph );
 	void   ( *GlyphChar )( fontInfo_t *font, int ch, glyphInfo_t *glyph );
 
-	void ( *LoadWorld )( const char *name );
+	void ( *LoadWorldSpawn )( std::string worldName );
+	void ( *LoadWorldData )();
 
 	// the vis data is a large enough block of data that we go to the trouble
 	// of sharing it with the clipmodel subsystem

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -257,9 +257,16 @@ void trap_R_ScissorSet( int x, int y, int w, int h )
 	cmdBuffer.SendMsg<Render::ScissorSetMsg>(x, y, w, h);
 }
 
-void trap_R_LoadWorldMap( const char *mapname )
+void trap_R_LoadWorldSpawn( std::string worldName )
 {
-	VM::SendMsg<Render::LoadWorldMapMsg>(mapname);
+	bool done;
+	VM::SendMsg<Render::LoadWorldSpawnMsg>(worldName, done);
+}
+
+void trap_R_LoadWorldData()
+{
+	bool done;
+	VM::SendMsg<Render::LoadWorldDataMsg>(done);
 }
 
 qhandle_t trap_R_RegisterModel( const char *name )

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -60,7 +60,8 @@ void            trap_S_UpdateEntityPosition( int entityNum, const vec3_t origin 
 void            trap_S_Respatialize( int entityNum, const vec3_t origin, vec3_t axis[ 3 ], int inwater );
 sfxHandle_t     trap_S_RegisterSound( const char *sample, bool compressed );
 void            trap_S_StartBackgroundTrack( const char *intro, const char *loop );
-void            trap_R_LoadWorldMap( const char *mapname );
+void trap_R_LoadWorldSpawn( std::string worldName );
+void trap_R_LoadWorldData();
 qhandle_t       trap_R_RegisterModel( const char *name );
 qhandle_t       trap_R_RegisterSkin( const char *name );
 qhandle_t       trap_R_RegisterShader( const char *name, int flags );


### PR DESCRIPTION
Make possible to load the worldspawn separately from other map data.

It's related to me trying to implement native sRGB support:

- https://github.com/DaemonEngine/Daemon/pull/1687

I'm afraid we have to know if the rendering should use sRGB/linear conversions before rendering anything else from the UI, including the map loading menu itself.

Because right now, at the time we know the map requires sRGB/linerar conversion, the UI is already created.

I'm not sure what I'm doing is right, but this is the problem I attempt to solve.

See on client side:

- https://github.com/Unvanquished/Unvanquished/pull/3390