### PR TITLE
Fix /listmaps with pak prefix + /map bug with invalid names

### DIFF
--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -2842,8 +2842,11 @@ std::set<std::string> GetAvailableMaps(bool allowLegacyPaks)
 				FS::PakPath::LoadPakPrefix(pak, "maps/", ignored);
 			}
 		} else {
-			if (Str::IsPrefix(pakPrefix, pak.name) && pak.name.size() > pakPrefix.size()) {
-				maps.insert(pak.name.substr(pakPrefix.size()));
+			std::string basename = FS::Path::BaseName(pak.name);
+			if (Str::IsPrefix(pakPrefix, basename) && basename.size() > pakPrefix.size()
+			    && FS::FindPak(basename) != nullptr) {
+				// FS::FindPak checked that the pak can be loaded via its base name respecting fs_pakprefixes.
+				maps.insert(basename.substr(pakPrefix.size()));
 			}
 		}
 	}

--- a/src/engine/server/sv_ccmds.cpp
+++ b/src/engine/server/sv_ccmds.cpp
@@ -51,7 +51,7 @@ class MapCmd: public Cmd::StaticCmd {
         }
 
         void Run(const Cmd::Args& args) const override {
-            if (args.Argc() < 2) {
+            if (args.Argc() < 2 || args.Argv(1).empty()) {
                 PrintUsage(args, "<mapname> (layoutname)", "loads a new map");
                 return;
             }
@@ -64,6 +64,12 @@ class MapCmd: public Cmd::StaticCmd {
             }
 
             const std::string& mapName = args.Argv(1);
+
+            if (mapName.find_first_of("/\\") != mapName.npos) {
+                Print("Map name '%s' must not contain directory separators", mapName);
+                return;
+            }
+
             // For non-legacy paks, a map named "foo" must be in the pak "map-foo"
             std::string pakName;
 


### PR DESCRIPTION
1. fix `listmaps` commands not respecting `fs_pakprefixes`
2. fix the server dropping in https://github.com/Unvanquished/Unvanquished/issues/3080