### PR TITLE
Allow loading an image multiple times with different params

### DIFF
--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -27,6 +27,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #include <iomanip>
 #include "Material.h"
 
+static Cvar::Cvar<bool> r_allowImageParamMismatch(
+	"r_allowImageParamMismatch", "reuse images when requested with different parameters",
+	Cvar::NONE, false);
+
 int                  gl_filter_min = GL_LINEAR_MIPMAP_NEAREST;
 int                  gl_filter_max = GL_LINEAR;
 
@@ -1813,25 +1817,31 @@ image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 	{
 		if ( !Q_strnicmp( imageName, image->name, sizeof( image->name ) ) )
 		{
-			// The white image can be used with any set of parms, but other mismatches are errors.
-			if ( Q_stricmp( imageName, "_white" ) )
+			if ( imageParams == image->initialParams || r_allowImageParamMismatch.Get() )
 			{
-				unsigned int diff = imageParams.bits ^ image->bits;
-
-				if ( diff & IF_NOPICMIP )
-				{
-					Log::Warn("reused image '%s' with mixed allowPicmip parm for shader", imageName );
-				}
-
-				if ( image->wrapType != imageParams.wrapType )
-				{
-					Log::Warn("reused image '%s' with mixed glWrapType parm for shader", imageName);
-				}
+				return image;
 			}
 
-			return image;
+			// Built-in images can't be reloaded with different parameters, so return them as-is.
+			// For most of the usable ones e.g. _white, parameters wouldn't make a difference anyway.
+			// HACK: detect built-in images by naming convention, though nothing stops users from using such names
+			if ( image->name[ 0 ] == '_' && !strchr( image->name, '/' ) )
+			{
+				return image;
+			}
+
+			Log::Verbose( "image params mismatch for %s: 0x%X %d %d/%d %d %d vs. 0x%X %d %d/%d %d %d",
+				imageName,
+				image->initialParams.bits, Util::ordinal( image->initialParams.filterType ),
+				Util::ordinal( image->initialParams.wrapType.s ), Util::ordinal( image->initialParams.wrapType.t ),
+				image->initialParams.minDimension, image->initialParams.maxDimension,
+				imageParams.bits, Util::ordinal( imageParams.filterType ),
+				Util::ordinal( imageParams.wrapType.s ), Util::ordinal( imageParams.wrapType.t ),
+				imageParams.minDimension, imageParams.maxDimension );
 		}
 	}
+
+	const imageParams_t initialParams = imageParams;
 
 	// Load and create the image.
 	int width = 0, height = 0, numLayers = 0, numMips = 0;
@@ -1859,6 +1869,7 @@ image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 	}
 
 	image_t *image = R_CreateImage( imageName, (const byte **)pic, width, height, numMips, imageParams );
+	image->initialParams = initialParams;
 
 	Z_Free( *pic );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -523,11 +523,19 @@ enum class ssaoMode {
 		wrapType_t wrapType;
 		int minDimension = 0;
 		int maxDimension = 0;
+
+		bool operator==(const imageParams_t &o) const
+		{
+			return o.bits == bits && o.filterType == filterType && o.wrapType == wrapType
+				&& o.minDimension == minDimension && o.maxDimension == maxDimension;
+		}
 	};
 
 	struct image_t
 	{
 		char name[ MAX_QPATH ];
+
+		imageParams_t initialParams; // may not match final values
 
 		GLenum         type;
 		GLuint         texnum; // gl texture binding


### PR DESCRIPTION
E.g. different nopicmip or imageMaxDimension.

Fixes https://github.com/Unvanquished/Unvanquished/issues/2801

This could be useful if an image needs to be loaded with and without sRGB conversion (`IF_` flags are part of the image params).

We have a handful of images in game assets that will be loaded multiple times:

```
image params mismatch for gfx/weapons/tracer/spark: 0x2 0 0/0 128 0 vs. 0x0 0 0/0 0 0
image params mismatch for models/buildables/arm/screen_s: 0x0 0 0/0 128 0 vs. 0x0 0 0/0 16 0
image params mismatch for models/players/human_male/base: 0x0 0 0/0 0 0 vs. 0x0 0 0/0 128 0
```