### PR TITLE
Allow registering shaders multiple times with different RSF_ flags

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -829,7 +829,7 @@ static shader_t* ShaderForShaderNum( int shaderNum ) {
 
 	dshader_t* dsh = &s_worldData.shaders[shaderNum];
 
-	shader_t* shader = R_FindShader( dsh->shader, shaderType_t::SHADER_3D, RSF_DEFAULT );
+	shader_t* shader = R_FindShader( dsh->shader, RSF_3D );
 
 	// If the shader had errors, just use default shader
 	if ( shader->defaultShader ) {
@@ -3271,7 +3271,9 @@ static void R_LoadFogs( lump_t *l, lump_t *brushesLump, lump_t *sidesLump )
 		}
 
 		// get information from the shader for fog parameters
-		shader = R_FindShader( fogs->shader, shaderType_t::SHADER_3D, RSF_DEFAULT );
+		// it says RSF_3D but if there is no shader text found it should probably just error instead
+		// of trying to create an implicit shader from an image...
+		shader = R_FindShader( fogs->shader, RSF_3D );
 
 		out->fogParms = shader->fogParms;
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1051,6 +1051,10 @@ enum class ssaoMode {
 	struct Material;
 	struct MaterialSurface;
 
+	// [implicit only] enable lightmapping, front-side culling, disable (non-BSP) vertex colors, disable blending
+	// TODO(0.56): move to the public RegisterShaderFlags_t interface
+#define RSF_3D ( BIT( 30 ) )
+
 	using stageRenderer_t = void(*)(shaderStage_t *);
 	using stageShaderBuildMarker_t = void(*)(const shaderStage_t*);
 	using surfaceDataUpdater_t = void(*)(uint32_t*, shaderStage_t*, bool, bool, bool);
@@ -1205,16 +1209,10 @@ enum class ssaoMode {
 		float  depthForOpaque;
 	};
 
-	enum class shaderType_t
-	{
-	  SHADER_2D, // surface material: shader is for 2D rendering (like GUI elements)
-	  SHADER_3D,
-	};
-
 	struct shader_t
 	{
 		char         name[ MAX_QPATH ]; // game path, including extension
-		shaderType_t type;
+		int registerFlags; // RSF_
 
 		int          index; // this shader == tr.shaders[index]
 		int          sortedIndex; // this shader == tr.sortedShaders[sortedIndex]
@@ -3103,7 +3101,7 @@ inline bool checkGLErrors()
 	qhandle_t RE_RegisterShader( const char *name, int flags );
 	qhandle_t RE_RegisterShaderFromImage( const char *name, image_t *image );
 
-	shader_t  *R_FindShader( const char *name, shaderType_t type, int flags );
+	shader_t  *R_FindShader( const char *name, int flags );
 	shader_t  *R_GetShaderByHandle( qhandle_t hShader );
 	shader_t  *R_FindShaderByName( const char *name );
 	const char *RE_GetShaderNameFromHandle( qhandle_t shader );

--- a/src/engine/renderer/tr_model_iqm.cpp
+++ b/src/engine/renderer/tr_model_iqm.cpp
@@ -880,8 +880,8 @@ bool R_LoadIQModel( model_t *mod, const void *buffer, int filesize,
 			surface->name = nullptr;
 		}
 
-		surface->shader = R_FindShader( ( char* )IQMPtr(header, header->ofs_text + mesh->material),
-						shaderType_t::SHADER_3D, RSF_DEFAULT );
+		surface->shader = R_FindShader(
+			( char* )IQMPtr(header, header->ofs_text + mesh->material), RSF_3D );
 		if( surface->shader->defaultShader )
 			surface->shader = tr.defaultShader;
 		surface->data = IQModel;

--- a/src/engine/renderer/tr_model_md3.cpp
+++ b/src/engine/renderer/tr_model_md3.cpp
@@ -187,7 +187,7 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 
 		// only consider the first shader
 		md3Shader = ( md3Shader_t * )( ( byte * ) md3Surf + md3Surf->ofsShaders );
-		surf->shader = R_FindShader( md3Shader->name, shaderType_t::SHADER_3D, RSF_DEFAULT );
+		surf->shader = R_FindShader( md3Shader->name, RSF_3D );
 
 		// swap all the triangles
 		surf->numTriangles = md3Surf->numTriangles;

--- a/src/engine/renderer/tr_model_md5.cpp
+++ b/src/engine/renderer/tr_model_md5.cpp
@@ -317,7 +317,7 @@ bool R_LoadMD5( model_t *mod, const char *buffer, const char *modName )
 		// lowercase the surface name so skin compares are faster
 
 		// register the shaders
-		sh = R_FindShader( surf->shader, shaderType_t::SHADER_3D, RSF_DEFAULT );
+		sh = R_FindShader( surf->shader, RSF_3D );
 
 		if ( sh->defaultShader )
 		{

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6374,6 +6374,7 @@ public:
 
 		// Header names
 		std::string num = "num";
+		std::string regFlags = "regFlags";
 		std::string shaderSort = "shaderSort";
 		std::string stageType = "stageType";
 		std::string stageNumber = "stageNumber";
@@ -6384,6 +6385,7 @@ public:
 
 		// Header number sizes
 		numLen = std::max( numLen, num.length() );
+		size_t regFlagsLen = regFlags.length();
 		size_t shaderSortLen = shaderSort.length();
 		size_t stageTypeLen = stageType.length();
 
@@ -6405,6 +6407,7 @@ public:
 		// Print header
 		lineStream << std::left;
 		lineStream << std::setw(numLen) << num << separator;
+		lineStream << std::setw(regFlagsLen) << regFlags << separator;
 		lineStream << std::setw(shaderSortLen) << shaderSort << separator;
 		lineStream << std::setw(stageTypeLen) << stageType << separator;
 		lineStream << stageNumber << ":" << shaderName;
@@ -6427,6 +6430,14 @@ public:
 			{
 				continue;
 			}
+
+			regFlags = {
+				shader->registerFlags & RSF_2D ? '2' : '_',
+				shader->registerFlags & RSF_NOMIP ? 'N' : '_',
+				shader->registerFlags & RSF_FITSCREEN ? 'F' : '_',
+				shader->registerFlags & RSF_SPRITE ? 'S' : '_',
+				shader->registerFlags & RSF_3D ? '3' : '_',
+			};
 
 			if ( !shaderSortName.count( (shaderSort_t) shader->sort ) )
 			{
@@ -6479,6 +6490,7 @@ public:
 
 				lineStream << std::left;
 				lineStream << std::setw(numLen) << i << separator;
+				lineStream << std::setw(regFlagsLen) << regFlags << separator;
 				lineStream << std::setw(shaderSortLen) << shaderSort << separator;
 				lineStream << std::setw(stageTypeLen) << stageType << separator;
 				lineStream << j << ":" << shaderName;

--- a/src/engine/renderer/tr_skin.cpp
+++ b/src/engine/renderer/tr_skin.cpp
@@ -261,7 +261,7 @@ qhandle_t RE_RegisterSkin( const char *name )
 		Q_strncpyz( surf->name, surfName, sizeof( surf->name ) );
 
 		// RB: bspSurface_t does not have ::hash yet
-		surf->shader = R_FindShader( token, shaderType_t::SHADER_3D, RSF_DEFAULT );
+		surf->shader = R_FindShader( token, RSF_3D );
 		skin->numSurfaces++;
 	}
 

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -94,14 +94,29 @@ using bool8_t = uint8_t;
 #define GL_INDEX_TYPE GL_UNSIGNED_INT
 using glIndex_t = unsigned int;
 
-// TODO(0.56): drop RSF_LIGHT_ATTENUATION
+// "[implicit only]" means the flag only has effect if there is no shader text and the
+// shader was auto-generated from an image.
+// TODO(0.56): drop RSF_LIGHT_ATTENUATION, RSF_NOLIGHTSCALE
 enum RegisterShaderFlags_t {
+	// nothing
 	RSF_DEFAULT = BIT( 0 ),
+
+	// [implicit only] alter filter and wrap type
 	RSF_2D = BIT( 1 ),
+
+	// load images without mipmaps
 	RSF_NOMIP = BIT( 2 ),
+
+	// mip images to the screen size when they are larger than the screen
 	RSF_FITSCREEN = BIT( 3 ),
+
+	// nothing
 	RSF_LIGHT_ATTENUATION = BIT( 4 ),
-	RSF_NOLIGHTSCALE = BIT( 5 ), // TODO(0.56): delete, does nothing
+
+	// nothing
+	RSF_NOLIGHTSCALE = BIT( 5 ),
+
+	// when the shader is used on an entity sprite, face view direction instead of viewer
 	RSF_SPRITE = BIT( 6 ),
 };
 


### PR DESCRIPTION
Same idea as #1695 but for q3shaders instead of images.

Stacked on #1699.

It's a draft in case we want to make changes related to distinguishing "2D" vs. "3D" shaders when deciding whether to use sRGB.