### PR TITLE
sdl_glimp: set `APPID` as `WMCLASS` on Linux

### DIFF
--- a/src/common/Defs.h
+++ b/src/common/Defs.h
@@ -37,6 +37,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /** No case, No spaces */
 #define PRODUCT_NAME_LOWER  "unvanquished"
 
+#define PRODUCT_APPID "net.unvanquished.Unvanquished"
+
 #define PRODUCT_VERSION     "0.55.4"
 
 /** Default base package */

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1703,6 +1703,20 @@ static rserr_t GLimp_StartDriverAndSetMode( int mode, bool fullscreen, bool bord
 {
 	int numDisplays;
 
+#if !defined(_WIN32) && !defined(__APPLE__)
+	/* Let X11 and Wayland desktops (Linux, FreeBSD…) associate the game
+	window with the XDG .desktop file, with the proper name and icon.
+	The .desktop file should have PRODUCT_APPID as base name or set the
+	StartupWMClass variable to PRODUCT_APPID. */
+
+	// SDL2.
+	Sys::SetEnv( "SDL_VIDEO_X11_WMCLASS", PRODUCT_APPID );
+	Sys::SetEnv( "SDL_VIDEO_WAYLAND_WMCLASS", PRODUCT_APPID );
+
+	// SDL3.
+	Sys::SetEnv( "SDL_HINT_APP_ID", PRODUCT_APPID );
+#endif
+
 	if ( !SDL_WasInit( SDL_INIT_VIDEO ) )
 	{
 		const char *driverName;


### PR DESCRIPTION
Let X11 and Wayland desktops (Linux, FreeBSD…) display the game name on the game windows instead of the engine binary name. This also makes possible to display the correct icon if that `WMCLASS` is also set in the `net.unvanquished.Unvanquished.desktop` file.