### PR TITLE
Require UBO for material system

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2545,7 +2545,8 @@ static void GLimp_InitExtensions()
 		&& glConfig2.shaderDrawParametersAvailable
 		&& glConfig2.shaderImageLoadStoreAvailable
 		&& glConfig2.shadingLanguage420PackAvailable
-		&& glConfig2.SSBOAvailable;
+		&& glConfig2.SSBOAvailable
+		&& glConfig2.uniformBufferObjectAvailable;
 
 	// This requires GLEW 2.2+, so skip if it's a lower version
 #if defined(GLEW_KHR_shader_subgroup)


### PR DESCRIPTION
Uniform buffer objects are required by the staging buffer. Obviously UBO is a very basic feature that we would have  anyway on a system supporting material system.