### PR TITLE
material: fix a maybe uninitialized vec3 use

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -2070,7 +2070,7 @@ void MaterialSystem::RenderMaterial( Material& material, const uint32_t viewID )
 				break;
 			}
 			default:
-				break;
+				ASSERT_UNREACHABLE();
 		}
 
 		if ( material.shaderBinder == BindShaderLightMapping ) {


### PR DESCRIPTION
Fix a maybe uninitialized vec3 use in Material code.

Reported by GCC 14:

```
src/engine/renderer/Material.cpp: In member function ‘void MaterialSystem::RenderMaterial(Material&, uint32_t)’:
src/engine/renderer/Material.cpp:2011:24: warning: ‘color[0]’ may be used uninitialized [-Wmaybe-uninitialized]
 2011 |                 vec3_t color;
      |                        ^~~~~
src/engine/renderer/Material.cpp:2011:24: warning: ‘color[1]’ may be used uninitialized [-Wmaybe-uninitialized]
In file included from src/common/Common.h:35:
In function ‘int VectorCompare(const vec_t*, const vec_t*)’,
    inlined from ‘void GLUniform3f::SetValue(const vec_t*)’ at src/engine/renderer/gl_shader.h:860:21,
    inlined from ‘void u_MaterialColour::SetUniform_MaterialColour(const vec_t*)’ at src/engine/renderer/gl_shader.h:2446:17,
    inlined from ‘void MaterialSystem::RenderMaterial(Material&, uint32_t)’ at src/engine/renderer/Material.cpp:2079:55:
src/engine/qcommon/q_shared.h:653:16: warning: ‘color[2]’ may be used uninitialized [-Wmaybe-uninitialized]
  653 |         return !( v1[ 0 ] != v2[ 0 ] || v1[ 1 ] != v2[ 1 ] || v1[ 2 ] != v2[ 2 ] );
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/engine/renderer/Material.cpp: In member function ‘void MaterialSystem::RenderMaterial(Material&, uint32_t)’:
src/engine/renderer/Material.cpp:2011:24: note: ‘color[2]’ was declared here
 2011 |                 vec3_t color;
      |                        ^~~~~
```