### PR TITLE
Add some support for C++17-23

### DIFF
--- a/src/common/CPPStandard.h
+++ b/src/common/CPPStandard.h
@@ -1,0 +1,90 @@
+/*
+===========================================================================
+
+Daemon BSD Source Code
+Copyright (c) 2025 Daemon Developers
+All rights reserved.
+
+This file is part of the Daemon BSD Source Code (Daemon Source Code).
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Daemon developers nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+===========================================================================
+*/
+// CPPStandard.h
+
+#ifndef CPPSTANDARD_H
+#define CPPSTANDARD_H
+
+#undef CPP_AGGREGATE
+#undef CPP_CONCEPTS
+#undef CPP_CONSTEVAL
+#undef CPP_CONSTEXPR
+#undef CPP_CTAD
+#undef CPP_DESIGNATED_INIT
+#undef CPP_INVOKE_RESULT
+#undef CPP_ATOMIC_WAIT_NOTIFY
+#undef CPP_SOURCE_LOCATION
+#undef CPP_STACKTRACE
+
+#if defined( __cpp_aggregate_bases ) && defined ( __cpp_aggregate_nsdmi ) && defined ( __cpp_aggregate_paren_init )
+    #define CPP_AGGREGATE
+#endif
+
+#if __cpp_concepts >= 201907L
+    #define CPP_CONCEPTS
+#endif
+
+#if __cpp_consteval >= 201811L
+    #define CPP_CONSTEVAL
+#endif
+
+#if __cpp_constexpr >= 202110L && __cpp_if_constexpr >= 201606L
+    #define CPP_CONSTEXPR
+#endif
+
+#if __cpp_deduction_guides >= 201907L
+    #define CPP_CTAD
+#endif
+
+#if __cpp_designated_initializers >= 201707L
+    #define CPP_DESIGNATED_INIT
+#endif
+
+#if __cpp_lib_is_invocable >= 201703L
+    #define CPP_INVOKE_RESULT
+#endif
+
+#if __cpp_lib_atomic_wait >= 201907L
+    #define CPP_ATOMIC_WAIT_NOTIFY
+#endif
+
+#if __cpp_lib_source_location >= 201907L
+    #define CPP_SOURCE_LOCATION
+#endif
+
+#if __cpp_lib_stacktrace >= 202011L
+    #define CPP_STACKTRACE
+#endif
+
+#endif // CPPSTANDARD_H

--- a/src/common/math/Vector.h
+++ b/src/common/math/Vector.h
@@ -26,6 +26,9 @@ along with Daemon Source Code.  If not, see <http://www.gnu.org/licenses/>.
 #define COMMON_VECTOR_H_
 
 #include <ostream>
+#include <type_traits>
+
+template<typename Func, typename... Args> using resultof_t = decltype( std::declval<Func>()( std::declval<Args...> ) );
 
 namespace Math {
 
@@ -87,9 +90,9 @@ namespace Math {
 		void Store(Type* ptr) const;
 
 		// Apply a function on all elements of the vector
-		template<typename Func> Vector<Dimension, typename std::result_of<Func(Type)>::type> Apply(Func func) const;
-		template<typename Func, typename Type2> Vector<Dimension, typename std::result_of<Func(Type, Type2)>::type> Apply2(Func func, Vector<Dimension, Type2> other) const;
-		template<typename Func, typename Type2, typename Type3> Vector<Dimension, typename std::result_of<Func(Type, Type2, Type3)>::type> Apply3(Func func, Vector<Dimension, Type2> other1, Vector<Dimension, Type3> other2) const;
+		template<typename Func> Vector<Dimension, resultof_t<Func, Type>> Apply(Func func) const;
+		template<typename Func, typename Type2> Vector<Dimension, resultof_t<Func, Type, Type2>> Apply2(Func func, Vector<Dimension, Type2> other) const;
+		template<typename Func, typename Type2, typename Type3> Vector<Dimension, resultof_t<Func, Type, Type2, Type3>> Apply3(Func func, Vector<Dimension, Type2> other1, Vector<Dimension, Type3> other2) const;
 
 		// Reduce the elements of the vector to a single value
 		template<typename Func> Type Reduce(Type init, Func func);
@@ -843,25 +846,25 @@ namespace Math {
 
 	// VectorBase::Apply/Apply2/Apply3
 	template<size_t Dimension, typename Type> template<typename Func>
-	Vector<Dimension, typename std::result_of<Func(Type)>::type> VectorBase<Dimension, Type>::Apply(Func func) const
+	Vector<Dimension, resultof_t<Func, Type>> VectorBase<Dimension, Type>::Apply(Func func) const
 	{
-		Vector<Dimension, typename std::result_of<Func(Type)>::type> out;
+		Vector<Dimension, resultof_t<Func, Type>> out;
 		for (size_t i = 0; i < Dimension; i++)
 			out.data[i] = func(data[i]);
 		return out;
 	}
 	template<size_t Dimension, typename Type> template<typename Func, typename Type2>
-	Vector<Dimension, typename std::result_of<Func(Type, Type2)>::type> VectorBase<Dimension, Type>::Apply2(Func func, Vector<Dimension, Type2> other) const
+	Vector<Dimension, resultof_t<Func, Type, Type2>> VectorBase<Dimension, Type>::Apply2(Func func, Vector<Dimension, Type2> other) const
 	{
-		Vector<Dimension, typename std::result_of<Func(Type, Type2)>::type> out;
+		Vector<Dimension, resultof_t<Func(Type, Type2)>> out;
 		for (size_t i = 0; i < Dimension; i++)
 			out.data[i] = func(data[i], other.data[i]);
 		return out;
 	}
 	template<size_t Dimension, typename Type> template<typename Func, typename Type2, typename Type3>
-	Vector<Dimension, typename std::result_of<Func(Type, Type2, Type3)>::type> VectorBase<Dimension, Type>::Apply3(Func func, Vector<Dimension, Type2> other1, Vector<Dimension, Type3> other2) const
+	Vector<Dimension, resultof_t<Func, Type, Type2, Type3>> VectorBase<Dimension, Type>::Apply3(Func func, Vector<Dimension, Type2> other1, Vector<Dimension, Type3> other2) const
 	{
-		Vector<Dimension, typename std::result_of<Func(Type, Type2, Type3)>::type> out;
+		Vector<Dimension, resultof_t<Func, Type, Type2, Type3>> out;
 		for (size_t i = 0; i < Dimension; i++)
 			out.data[i] = func(data[i], other1.data[i], other2.data[i]);
 		return out;


### PR DESCRIPTION
Add `CPPStandard.h` for checking C++ features support by version, replace deprecated `std::result_of` on >= C++17. Use the `/Zc:__cplusplus` for MSVC CI so it will get the correct version in `CPPStandard`.