### PR TITLE
Fix some FS allocations/copies

### DIFF
--- a/src/engine/framework/CommonVMServices.cpp
+++ b/src/engine/framework/CommonVMServices.cpp
@@ -273,9 +273,11 @@ namespace VM {
             case QVM_COMMON_FS_READ:
                 IPC::HandleMsg<FSReadMsg>(channel, std::move(reader), [this](int handle, int len, std::string& res, int& ret) {
                     FS_CheckOwnership(handle, fileOwnership);
-                    std::unique_ptr<char[]> buffer(new char[len]);
-                    ret = FS_Read(buffer.get(), len, handle);
-                    res.assign(buffer.get(), ret >= 0 ? ret : 0);
+                    res.resize( len );
+                    ret = FS_Read( &res[0], len, handle );
+
+                    res.resize( ret );
+                    res.shrink_to_fit();
                 });
                 break;
 
@@ -315,17 +317,15 @@ namespace VM {
 
             case QVM_COMMON_FS_GET_FILE_LIST:
                 IPC::HandleMsg<FSGetFileListMsg>(channel, std::move(reader), [this](const std::string& path, std::string extension, int len, int& intRes, std::string& res) {
-                    std::unique_ptr<char[]> buffer(new char[len]);
-                    intRes = FS_GetFileList(path.c_str(), extension.c_str(), buffer.get(), len);
-                    res.assign(buffer.get(), len);
+                    res.resize( len );
+                    intRes = FS_GetFileList(path.c_str(), extension.c_str(), &res[0], len);
                 });
                 break;
 
             case QVM_COMMON_FS_GET_FILE_LIST_RECURSIVE:
                 IPC::HandleMsg<FSGetFileListRecursiveMsg>(channel, std::move(reader), [this](const std::string& path, std::string extension, int len, int& intRes, std::string& res) {
-                    std::unique_ptr<char[]> buffer(new char[len]);
-                    intRes = FS_GetFileListRecursive(path.c_str(), extension.c_str(), buffer.get(), len);
-                    res.assign(buffer.get(), len);
+                    res.resize( len );
+                    intRes = FS_GetFileListRecursive(path.c_str(), extension.c_str(), &res[0], len);
                 });
                 break;
 

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -267,6 +267,7 @@ int FS_FCloseFile(fileHandle_t handle)
 	handleTable[handle].isOpen = false;
 	if (handleTable[handle].isPakFile) {
 		handleTable[handle].fileData.clear();
+		handleTable[handle].fileData.shrink_to_fit();
 		return 0;
 	} else {
 		try {


### PR DESCRIPTION
Use `shrink_to_fit()` after clearing strings holding a pak file after it is closed. This was a source of ever-growing memory usage, since `handleTable[handle].fileData.clear()` doesn't actually deallocate, so eventually all the storage in `handleTable` grows to some stupid size. Which was made worse by the fact that the same large dpk would get loaded into different slots.

Also removed some useless allocations + copies in `QVM_COMMON_FS_*`.

All in all, this reduced the memory usage by 2-3x when running `daemonded` and loading different maps.