### PR TITLE
Fix SSAO + material system on AMD

### DIFF
--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1535,6 +1535,13 @@ void RB_RenderSSAO()
 
 	GLIMP_LOGCOMMENT( "--- RB_RenderSSAO ---" );
 
+	// Assume depth is dirty since we just rendered depth pass and everything opaque
+	if ( glConfig2.textureBarrierAvailable )
+	{
+		glTextureBarrier();
+		backEnd.dirtyDepthBuffer = false;
+	}
+
 	GL_State( GLS_DEPTHTEST_DISABLE | GLS_SRCBLEND_DST_COLOR | GLS_DSTBLEND_ZERO );
 	GL_Cull( cullType_t::CT_TWO_SIDED );
 


### PR DESCRIPTION
Fixes #1616. Same trick as #1704 for fixing depth fade - insert a texture barrier so that reading the depth texture is valid.

Some depth-writing stuff such as polygonOffset decals and alpha-tested textures is rendered after SSAO is done, so in general we need to do the texture barrier twice (if SSAO is on).