### PR TITLE
Renderer: Avoid a DSA function with VAOs

### DIFF
--- a/src/engine/renderer/GLMemory.h
+++ b/src/engine/renderer/GLMemory.h
@@ -275,11 +275,6 @@ class GLVAO {
 		glVertexArrayElementBuffer( id, buffer.id );
 	}
 
-	// For compatibility with IBO_t
-	void SetIndexBuffer( const GLuint bufferID ) {
-		glVertexArrayElementBuffer( id, bufferID );
-	}
-
 	void GenVAO() {
 		glGenVertexArrays( 1, &id );
 	}

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -456,7 +456,7 @@ void SetupVAOBuffers( VBO_t* VBO, const IBO_t* IBO, const uint32_t stateBits,
 	GL_VertexAttribsState( stateBits, true );
 
 	if ( IBO ) {
-		VAO->SetIndexBuffer( IBO->indexesVBO );
+		glBindBuffer( GL_ELEMENT_ARRAY_BUFFER, IBO->indexesVBO );
 	}
 
 	GL_BindVAO( backEnd.defaultVAO );


### PR DESCRIPTION
Use the old method to bind the IBO to the VAO instead of glVertexArrayElementBuffer. Fixes #1729.