### PR TITLE
Depth tile cleanup/debugability

### DIFF
--- a/src/engine/renderer/glsl_source/depthtile1_fp.glsl
+++ b/src/engine/renderer/glsl_source/depthtile1_fp.glsl
@@ -115,20 +115,9 @@ void	main()
 
     float maxDepth = max16( depth[0], depth[1], depth[2], depth[3] );
 
-    float avgDepth = dot( depth[0] + depth[1] + depth[2] + depth[3],
-			  vec4( samples ) );
-
-    depth[0] -= avgDepth * mask[0];
-    depth[1] -= avgDepth * mask[1];
-    depth[2] -= avgDepth * mask[2];
-    depth[3] -= avgDepth * mask[3];
-
-    float variance = dot( depth[0], depth[0] ) + dot( depth[1], depth[1] ) +
-      dot( depth[2], depth[2] ) + dot( depth[3], depth[3] );
-    variance *= samples;
-    outputColor = vec4( maxDepth, minDepth, avgDepth, sqrt( variance ) );
+    outputColor = vec4( maxDepth, minDepth, 0.0, 0.0 );
   } else {
     // found just sky pixels
-    outputColor = vec4( 99999.0, 99999.0, 99999.0, 0.0 );
+    outputColor = vec4( 99999.0, 99999.0, 0.0, 0.0 );
   }
 }

--- a/src/engine/renderer/glsl_source/depthtile2_fp.glsl
+++ b/src/engine/renderer/glsl_source/depthtile2_fp.glsl
@@ -47,7 +47,6 @@ void	main()
   vec2 st = gl_FragCoord.st * r_tileStep;
   float x, y;
   vec4 accum = vec4( 0.0, 99999.0, 0.0, 0.0 );
-  float count = 0.0;
 
   for( x = -0.375; x < 0.5; x += 0.25 ) {
     for( y = -0.375; y < 0.5; y += 0.25 ) {
@@ -55,14 +54,8 @@ void	main()
       if( data.y < 99999.0 ) {
 	accum.x = max( accum.x, data.x );
 	accum.y = min( accum.y, data.y );
-	accum.zw += data.zw;
-	count += 1.0;
       }
     }
-  }
-
-  if( count >= 1.0 ) {
-    accum.zw *= 1.0 / count;
   }
 
   outputColor = accum;

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1212,10 +1212,22 @@ void RB_RunVisTests( )
 
 static void RenderDepthTiles()
 {
-	// 1st step
 	GL_State( GLS_DEPTHTEST_DISABLE );
 	GL_Cull( CT_TWO_SIDED );
 
+	if ( !r_depthShaders.Get() )
+	{
+		// put max range so depth-based planes will always pass in lighttile
+		// setting to 99999 worked on my machines but is technically not allowed by the spec
+		// ARB_color_buffer_float lets you set values outside of [0, 1] but we use
+		// a different extension ARB_texture_float to get float color buffer
+		R_BindFBO( tr.depthtile2FBO );
+		glClearColor( /*max*/ 99999.f, /*min*/ 0.0f, 0.0f, 0.0f );
+		glClear( GL_COLOR_BUFFER_BIT );
+		return;
+	}
+
+	// 1st step
 	R_BindFBO( tr.depthtile1FBO );
 	GL_Viewport( 0, 0, tr.depthtile1FBO->width, tr.depthtile1FBO->height );
 	GL_Scissor( 0, 0, tr.depthtile1FBO->width, tr.depthtile1FBO->height );

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2588,7 +2588,7 @@ static void R_CreateDepthRenderImage()
 		imageParams.wrapType = wrapTypeEnum_t::WT_ONE_CLAMP;
 
 		imageParams.bits = IF_NOPICMIP;
-		imageParams.bits |= r_highPrecisionRendering.Get() ? IF_RGBA32F : IF_RGBA16F;
+		imageParams.bits |= r_highPrecisionRendering.Get() ? IF_TWOCOMP32F : IF_TWOCOMP16F;
 
 		tr.depthtile1RenderImage = R_CreateImage( "_depthtile1Render", nullptr, w, h, 1, imageParams );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2688,6 +2688,7 @@ enum
 	extern Cvar::Modified<Cvar::Cvar<std::string>> r_textureMode;
 	extern cvar_t *r_offsetFactor;
 	extern cvar_t *r_offsetUnits;
+	extern Cvar::Cvar<bool> r_depthShaders;
 
 	extern cvar_t *r_physicalMapping;
 	extern cvar_t *r_specularExponentMin;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -753,7 +753,7 @@ void Tess_Begin( void ( *stageIteratorFunc )(),
 
 	GLIMP_LOGCOMMENT( "--- Tess_Begin( surfaceShader = %s, "
 		"skipTangents = %i, lightmapNum = %i, fogNum = %i) ---",
-		tess.surfaceShader->name,
+		tess.surfaceShader ? tess.surfaceShader->name : "NULL",
 		tess.skipTangents, tess.lightmapNum, tess.fogNum );
 }
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -83,9 +83,8 @@ static Cvar::Cvar<float> r_portalDefaultRange(
 	"r_portalDefaultRange", "Default portal range", Cvar::NONE, 1024);
 
 // This can be turned off to debug problems with depth shaders.
-// Almost everything can be rendered correctly without them, except real-time lights
-// (since light tiles are populated using the depth buffer).
-static Cvar::Cvar<bool> r_depthShaders(
+// Things should generally render identically (albeit slower) without them.
+Cvar::Cvar<bool> r_depthShaders(
 	"r_depthShaders", "use depth pre-pass shaders", Cvar::CHEAT, true);
 
 /*

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -475,6 +475,8 @@ void R_BindVBO( VBO_t *vbo )
 		} else {
 			Sys::Drop( "R_BindNullVBO: NULL vbo" );
 		}
+
+		return;
 	}
 
 	GLIMP_LOGCOMMENT( "--- R_BindVBO( %s ) ---", vbo->name );


### PR DESCRIPTION
Remove the unused green and and alpha channel calculations in the depth tiles. Make dynamic lights renderable with `r_depthShaders 0`.