### PR TITLE
screenSpace: make it work when GL_EXT_gpu_shader4 is missing

### DIFF
--- a/src/engine/renderer/glsl_source/screenSpace_vp.glsl
+++ b/src/engine/renderer/glsl_source/screenSpace_vp.glsl
@@ -34,8 +34,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /* screenSpace_vp.glsl */
 
+#if defined(HAVE_EXT_gpu_shader4)
 const vec2 vertices[3] = vec2[3] ( vec2( -1.0f, -1.0f ), vec2( 3.0f, -1.0f ), vec2( -1.0f, 3.0f ) );
 
 void main() {
 	gl_Position = vec4( vertices[gl_VertexID], 0.0f, 1.0f );
 }
+#else
+IN vec3 attr_Position;
+
+void main() {
+	gl_Position = vec4( attr_Position, 1.0f );
+}
+#endif

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -531,13 +531,21 @@ void Tess_AddCubeWithNormals( const vec3_t position, const vec3_t minSize, const
 void Tess_InstantScreenSpaceQuad() {
 	GLIMP_LOGCOMMENT( "--- Tess_InstantScreenSpaceQuad ---" );
 
-	tr.skipVBO = true;
-
-	Tess_Begin( Tess_StageIteratorDummy, nullptr, true, -1, 0 );
-	rb_surfaceTable[Util::ordinal( *( tr.genericTriangle->surface ) )]( tr.genericTriangle->surface );
-	Tess_DrawElements();
-
-	tr.skipVBO = false;
+	if ( glConfig2.gpuShader4Available )
+	{
+		tr.skipVBO = true;
+		Tess_Begin( Tess_StageIteratorDummy, nullptr, true, -1, 0 );
+		rb_surfaceTable[Util::ordinal( *( tr.genericTriangle->surface ) )]( tr.genericTriangle->surface );
+		Tess_DrawElements();
+		tr.skipVBO = false;
+	}
+	else
+	{
+		Tess_Begin( Tess_StageIteratorDummy, nullptr, true, -1, 0 );
+		rb_surfaceTable[Util::ordinal( *( tr.genericQuad->surface ) )]( tr.genericQuad->surface );
+		GL_VertexAttribsState( ATTR_POSITION );
+		Tess_DrawElements();
+	}
 
 	GL_CheckErrors();
 
@@ -550,12 +558,15 @@ void Tess_InstantQuad( u_ModelViewProjectionMatrix &shader, const float x, const
 
 	Tess_Begin( Tess_StageIteratorDummy, nullptr, true, -1, 0 );
 
+	/* We don't use x, y, width, height directly to make it compatible
+	with R_InitGenericVBOs() in tr_vbo.cpp.
+	See: https://github.com/DaemonEngine/Daemon/pull/1739 */
 	matrix_t modelViewMatrix;
 	MatrixCopy( matrixIdentity, modelViewMatrix );
-	modelViewMatrix[12] = x;
-	modelViewMatrix[13] = y;
-	modelViewMatrix[0] = width;
-	modelViewMatrix[5] = height;
+	modelViewMatrix[12] = 0.5f * width + x;
+	modelViewMatrix[13] = 0.5f * height + y;
+	modelViewMatrix[0] = 0.5f * width;
+	modelViewMatrix[5] = 0.5f * height;
 	GL_LoadModelViewMatrix( modelViewMatrix );
 	shader.SetUniform_ModelViewProjectionMatrix(
 		glState.modelViewProjectionMatrix[ glState.stackIndex ] );

--- a/src/engine/renderer/tr_vbo.cpp
+++ b/src/engine/renderer/tr_vbo.cpp
@@ -556,24 +556,22 @@ void R_BindNullIBO()
 }
 
 static void R_InitGenericVBOs() {
+	/* Those values are chosen to specify a full-screen rectangle for
+	screen-space shaders without a projection matrix. The values here
+	don't influence the triangle but this is a fallback for when the
+	gl_VertexID-based triangle can't be used (when GL_EXT_gpu_shader4
+	is missing).
+	See: https://github.com/DaemonEngine/Daemon/pull/1739 */
 	// Min and max coordinates of the quad
-	static const vec3_t min = { 0.0f, 0.0f, 0.0f };
+	static const vec3_t min = { -1.0f, -1.0f, 0.0f };
 	static const vec3_t max = { 1.0f, 1.0f, 0.0f };
 	{
 		/*
 			Quad is a static mesh with 4 vertices and 2 triangles
 
-			 z
-			 ^
-			 |     1------2
-			 |   y |      |
-			 |  /  |      |
-			 | /   |      |
-			 |/    0------3
-			 0---------->x
 			   Verts:
-			   0: 0.0 0.0 0.0
-			   1: 0.0 1.0 0.0
+			   0: -1.0 0.0 0.0
+			   1: -1.0 1.0 0.0
 			   2: 1.0 1.0 0.0
 			   3: 1.0 0.0 0.0
 			   Surfs:


### PR DESCRIPTION
WIP: screenSpace: make it work when `GL_EXT_gpu_shader4` is missing

It doesn't work yet, I'm not sure to understand how that works.

The purpose is to slightly modify #1593:

- https://github.com/DaemonEngine/Daemon/pull/1593

Commit 5666be1e1c162d5518a3171c220ff629d1bbaa87 from #1593 brings many improvements, but also makes use of `gl_VertexID`, which is introduced by `EXT_gpu_shader4` if I'm right, making it mandatory.

So I tried to add an alternate code path based on specific parts I read from 5666be1e1c162d5518a3171c220ff629d1bbaa87 that replaced the old code (among many other things), but it's not working yet.

It's now probably very close to have it working so if you have any idea, please share. ☺️