### PR TITLE
Optionally write source location for logs

### DIFF
--- a/src/common/Log.cpp
+++ b/src/common/Log.cpp
@@ -31,6 +31,16 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Common.h"
 
 namespace Log {
+    Cvar::Cvar<bool> logExtendAll(
+        "logs.writeSrcLocation.all", "Always print source code location for logs", Cvar::NONE, false );
+    Cvar::Cvar<bool> logExtendWarn(
+        "logs.writeSrcLocation.warn", "Print source code location for Warn logs", Cvar::NONE, false );
+    Cvar::Cvar<bool> logExtendNotice(
+        "logs.writeSrcLocation.notice", "Print source code location for Notice logs", Cvar::NONE, false );
+    Cvar::Cvar<bool> logExtendVerbose(
+        "logs.writeSrcLocation.verbose", "Print source code location for Verbose logs", Cvar::NONE, false );
+    Cvar::Cvar<bool> logExtendDebug(
+        "logs.writeSrcLocation.debug", "Print source code location for Debug logs", Cvar::NONE, false );
 
     Logger::Logger(Str::StringRef name, std::string prefix, Level defaultLevel)
         : filterLevel(new Cvar::Cvar<Log::Level>(

--- a/src/common/Log.h
+++ b/src/common/Log.h
@@ -51,6 +51,12 @@ namespace Log {
     // The default filtering level
     const Level DEFAULT_FILTER_LEVEL = Level::WARNING;
 
+    extern Cvar::Cvar<bool> logExtendAll;
+    extern Cvar::Cvar<bool> logExtendWarn;
+    extern Cvar::Cvar<bool> logExtendNotice;
+    extern Cvar::Cvar<bool> logExtendVerbose;
+    extern Cvar::Cvar<bool> logExtendDebug;
+
     /*
      * Loggers are used to group logs by subsystems and allow logs
      * to be filtered by log level by subsystem. They are used like so
@@ -84,16 +90,16 @@ namespace Log {
             Logger(Str::StringRef name, std::string prefix = "", Level defaultLevel = DEFAULT_FILTER_LEVEL);
 
             template<typename ... Args>
-            void Warn(Str::StringRef format, Args&& ... args);
+            void WarnExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
 
             template<typename ... Args>
-            void Notice(Str::StringRef format, Args&& ... args);
+            void NoticeExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
 
             template<typename ... Args>
-            void Verbose(Str::StringRef format, Args&& ... args);
+            void VerboseExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
 
             template<typename ... Args>
-            void Debug(Str::StringRef format, Args&& ... args);
+            void DebugExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
 
             template<typename F>
             void DoWarnCode(F&& code);
@@ -131,16 +137,16 @@ namespace Log {
      */
 
     template<typename ... Args>
-    void Warn(Str::StringRef format, Args&& ... args);
+    void Warn( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
 
     template<typename ... Args>
-    void Notice(Str::StringRef format, Args&& ... args);
+    void Notice( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
 
     template<typename ... Args>
-    void Verbose(Str::StringRef format, Args&& ... args);
+    void Verbose( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
 
     template<typename ... Args>
-    void Debug(Str::StringRef format, Args&& ... args);
+    void Debug( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
 
     /*
      * For messages which are not true log messages, but rather are produced by
@@ -193,31 +199,62 @@ namespace Log {
 
     // Logger
 
+    inline std::string AddSrcLocation( const std::string& message,
+        const char* file, const char* function, const int line,
+        const bool extend ) {
+        if ( logExtendAll.Get() || extend ) {
+            return message + Str::Format( " ^F(%s:%u, %s)",
+                file, line, function );
+        }
+
+        return message;
+    }
+
     template<typename ... Args>
-    void Logger::Warn(Str::StringRef format, Args&& ... args) {
-        if (filterLevel->Get() <= Level::WARNING) {
-            this->Dispatch(Prefix(Str::Format(format, std::forward<Args>(args) ...)), Level::WARNING, format);
+    void Logger::WarnExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
+        if ( filterLevel->Get() <= Level::WARNING ) {
+            this->Dispatch(
+                AddSrcLocation(
+                    Prefix( Str::Format( format, std::forward<Args>( args ) ... ) ),
+                    file, function, line, logExtendWarn.Get()
+                ),
+                Level::WARNING, format );
         }
     }
 
     template<typename ... Args>
-    void Logger::Notice(Str::StringRef format, Args&& ... args) {
-        if (filterLevel->Get() <= Level::NOTICE) {
-            this->Dispatch(Prefix(Str::Format(format, std::forward<Args>(args) ...)), Level::NOTICE, format);
+    void Logger::NoticeExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
+        if ( filterLevel->Get() <= Level::NOTICE ) {
+            this->Dispatch(
+                AddSrcLocation(
+                    Prefix( Str::Format( format, std::forward<Args>( args ) ... ) ),
+                    file, function, line, logExtendNotice.Get()
+                ),
+                Level::NOTICE, format );
         }
     }
 
     template<typename ... Args>
-    void Logger::Verbose(Str::StringRef format, Args&& ... args) {
-        if (filterLevel->Get() <= Level::VERBOSE) {
-            this->Dispatch(Prefix(Str::Format(format, std::forward<Args>(args) ...)), Level::VERBOSE, format);
+    void Logger::VerboseExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
+        if ( filterLevel->Get() <= Level::VERBOSE ) {
+            this->Dispatch(
+                AddSrcLocation(
+                    Prefix( Str::Format( format, std::forward<Args>( args ) ... ) ),
+                    file, function, line, logExtendVerbose.Get()
+                ),
+                Level::VERBOSE, format );
         }
     }
 
     template<typename ... Args>
-    void Logger::Debug(Str::StringRef format, Args&& ... args) {
-        if (filterLevel->Get() <= Level::DEBUG) {
-            this->Dispatch(Prefix(Str::Format(format, std::forward<Args>(args) ...)), Level::DEBUG, format);
+    void Logger::DebugExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
+        if ( filterLevel->Get() <= Level::DEBUG ) {
+            this->Dispatch(
+                AddSrcLocation(
+                    Prefix( Str::Format( format, std::forward<Args>( args ) ... ) ),
+                    file, function, line, logExtendDebug.Get()
+                ),
+                Level::DEBUG, format );
         }
     }
 
@@ -253,24 +290,30 @@ namespace Log {
     extern Logger defaultLogger;
 
     template<typename ... Args>
-    void Warn(Str::StringRef format, Args&& ... args) {
-        defaultLogger.Warn(format, std::forward<Args>(args) ...);
+    void WarnExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
+        defaultLogger.WarnExt( file, function, line, format, std::forward<Args>( args ) ... );
     }
 
     template<typename ... Args>
-    void Notice(Str::StringRef format, Args&& ... args) {
-        defaultLogger.Notice(format, std::forward<Args>(args) ...);
+    void NoticeExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
+        defaultLogger.NoticeExt( file, function, line, format, std::forward<Args>( args ) ... );
     }
 
     template<typename ... Args>
-    void Verbose(Str::StringRef format, Args&& ... args) {
-        defaultLogger.Verbose(format, std::forward<Args>(args) ...);
+    void VerboseExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
+        defaultLogger.VerboseExt( file, function, line, format, std::forward<Args>( args ) ... );
     }
 
     template<typename ... Args>
-    void Debug(Str::StringRef format, Args&& ... args) {
-        defaultLogger.Debug(format, std::forward<Args>(args) ...);
+    void DebugExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
+        defaultLogger.DebugExt( file, function, line, format, std::forward<Args>( args ) ... );
     }
+
+    // Use ##__VA_ARGS__ instead of __VA_ARGS__ because args may be empty. __VA_OPT__( , ) currently doesn't seem to work on MSVC
+    #define Warn( format, ... ) WarnExt( __FILE__, __func__, __LINE__, format, ##__VA_ARGS__ )
+    #define Notice( format, ... ) NoticeExt( __FILE__, __func__, __LINE__, format, ##__VA_ARGS__ )
+    #define Verbose( format, ... ) VerboseExt( __FILE__, __func__, __LINE__, format, ##__VA_ARGS__ )
+    #define Debug( format, ... ) DebugExt( __FILE__, __func__, __LINE__, format, ##__VA_ARGS__ )
 }
 
 namespace Cvar {


### PR DESCRIPTION
Based on #1741 because it adds the cmake option for building with a higher C++ standard.

Adds optional logging of source location with logs, controlled by `logs.writeSrcLocation.*` cvars, to help with debugging.