### PR TITLE
gl_shader: do not require GL_ARB_texture_float in shader

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -417,7 +417,7 @@ static const std::vector<addedExtension_t> fragmentVertexAddedExtensions = {
 	{ glConfig2.gpuShader4Available, 130, "EXT_gpu_shader4" },
 	{ glConfig2.gpuShader5Available, 400, "ARB_gpu_shader5" },
 	{ glConfig2.shadingLanguage420PackAvailable, 420, "ARB_shading_language_420pack" },
-	{ glConfig2.textureFloatAvailable, 130, "ARB_texture_float" },
+	{ glConfig2.textureFloatAvailable, 0, "ARB_texture_float" },
 	{ glConfig2.textureGatherAvailable, 400, "ARB_texture_gather" },
 	{ glConfig2.textureIntegerAvailable, 0, "EXT_texture_integer" },
 	{ glConfig2.textureRGAvailable, 0, "ARB_texture_rg" },


### PR DESCRIPTION
Do not require GL_ARB_texture_float in vertex shader, this is a vertex-only extension.

This is only for convenience, I get this error on both Mesa `radeonsi` and `llvmpipe` drivers when I downgrade the GL/GLSL version to test GLSL 1.20, using `MESA_GL_VERSION_OVERRIDE=2.1 MESA_GLSL_VERSION_OVERRIDE=120` environment variables:

```
Warn: Source for shader program deformVertexes_0:
   0: #version 120 
   1: 
   2: #extension GL_ARB_gpu_shader5 : require
   3: #define HAVE_ARB_gpu_shader5 1
   4: #extension GL_ARB_shading_language_420pack : require
   5: #define HAVE_ARB_shading_language_420pack 1
   6: #extension GL_ARB_texture_float : require
   7: #define HAVE_ARB_texture_float 1
------------------^-------------------
0:7(12): error: extension `GL_ARB_texture_float' unsupported in vertex shader
```

I haven't got this error on actual GL 2.1 / GLSL 1.20 hardware I recently tested (Nvidia, Intel).

There may be other extensions that may be specific to fragment shaders, but they are probably just missing or unused with such GL version so I didn't faced other errors.

While moving other fragment-specific extensions to the fragment-specific list may be better, for “purity” and “just in case” concerns, it is actually not required to make the shaders buildable again on such test bed, so it's not in the scope of this PR.