### PR TITLE
Fix badly architectured audio file reads

### DIFF
--- a/src/engine/audio/ALObjects.cpp
+++ b/src/engine/audio/ALObjects.cpp
@@ -135,7 +135,7 @@ namespace AL {
 	    ALuint format = Format(audioData.byteDepth, audioData.numberOfChannels);
 
 	    CHECK_AL_ERROR();
-	    alBufferData(alHandle, format, audioData.rawSamples.get(), audioData.size,
+	    alBufferData(alHandle, format, audioData.rawSamples.data(), audioData.rawSamples.size(),
 	                 audioData.sampleRate);
 
 	    return ClearALError();

--- a/src/engine/audio/Audio.cpp
+++ b/src/engine/audio/Audio.cpp
@@ -383,8 +383,10 @@ namespace Audio {
 
         streams[streamNum]->SetGain(volume);
 
-	    AudioData audioData(rate, width, channels, (width * numSamples * channels),
-	                        reinterpret_cast<const char*>(data));
+        AudioData audioData { rate, width, channels };
+        audioData.rawSamples.resize( width * numSamples * channels );
+        memcpy( audioData.rawSamples.data(), data, width * numSamples * channels * sizeof( char ) );
+
 	    AL::Buffer buffer;
 
 	    int feedError = buffer.Feed(audioData);
@@ -506,9 +508,10 @@ namespace Audio {
         int numSamples = AvailableCaptureSamples();
 
         if (numSamples > 0) {
-            uint16_t* buffer = new uint16_t[numSamples];
+            uint16_t* buffer = ( uint16_t* ) Hunk_AllocateTempMemory( numSamples * sizeof( uint16_t ) );
             GetCapturedData(numSamples, buffer);
             StreamData(N_STREAMS - 1, buffer, numSamples, 16000, 2, 1, 1.0, -1);
+            Hunk_FreeTempMemory( buffer );
         }
     }
 

--- a/src/engine/audio/AudioData.h
+++ b/src/engine/audio/AudioData.h
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef AUDIO_DATA_H
 #define AUDIO_DATA_H
 #include <memory>
+#include <vector>
 
 namespace Audio {
 
@@ -39,23 +40,18 @@ struct AudioData {
 	    : sampleRate{0}
 	    , byteDepth{0}
 	    , numberOfChannels{0}
-	    , size{0}
-	    , rawSamples{nullptr}
 	{}
 
-	AudioData(int sampleRate, int byteDepth, int numberOfChannels, int size, const char* rawSamples)
+	AudioData(int sampleRate, int byteDepth, int numberOfChannels )
 	    : sampleRate{sampleRate}
 	    , byteDepth{byteDepth}
 	    , numberOfChannels{numberOfChannels}
-	    , size{size}
-	    , rawSamples{rawSamples}
 	{}
 
 	AudioData(AudioData&& that)
 	    : sampleRate{that.sampleRate}
 	    , byteDepth{that.byteDepth}
 	    , numberOfChannels{that.numberOfChannels}
-	    , size{that.size}
 	    , rawSamples{std::move(that.rawSamples)}
 	{}
 
@@ -64,8 +60,7 @@ struct AudioData {
 	const int sampleRate;
 	const int byteDepth;
 	const int numberOfChannels;
-	const int size;
-	std::unique_ptr<const char[]> rawSamples;
+	std::vector<char> rawSamples;
 };
 } // namespace Audio
 #endif

--- a/src/engine/audio/Sample.cpp
+++ b/src/engine/audio/Sample.cpp
@@ -46,9 +46,9 @@ namespace Audio {
 
     bool Sample::Load() {
         audioLogs.Debug("Loading Sample '%s'", GetName());
-	    auto audioData = LoadSoundCodec(GetName());
+	    AudioData audioData = LoadSoundCodec(GetName());
 
-	    if (audioData.size == 0) {
+	    if ( !audioData.rawSamples.size() ) {
 		    audioLogs.Debug("Couldn't load sound %s, it's empty!", GetName());
             return false;
         }

--- a/src/engine/audio/WavCodec.cpp
+++ b/src/engine/audio/WavCodec.cpp
@@ -108,16 +108,15 @@ AudioData LoadWavCodec(std::string filename)
 
 	int size = PackChars(audioFile, dataOffset + 4, 4);
 
-	if (size <= 0 || sampleRate  <=0 ){
+	if (size <= 0 || sampleRate <= 0 ) {
 		audioLogs.Warn("Error in reading %s.", filename);
 		return AudioData();
 	}
 
-	char* data = new char[size];
+	AudioData out { sampleRate, byteDepth, numChannels };
+	out.rawSamples.assign( audioFile.data() + dataOffset + 8, audioFile.data() + size );
 
-	std::copy_n(audioFile.data() + dataOffset + 8, size, data);
-
-	return AudioData(sampleRate, byteDepth, numChannels, size, data);
+	return out;
 }
 
 } // namespace Audio


### PR DESCRIPTION
Removes most of the reallocations that happen because the file size is not known in advance.

This decreases the load time at start-up by easily 2x, and slightly improves load time for maps.