### PR TITLE
NUKE glconfig_t, use WindowConfig instead

### DIFF
--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -510,7 +510,7 @@ using CGameStaticInitMsg = IPC::SyncMessage<
 	IPC::Message<IPC::Id<VM::QVM, CG_STATIC_INIT>, int>
 >;
 using CGameInitMsg = IPC::SyncMessage<
-	IPC::Message<IPC::Id<VM::QVM, CG_INIT>, int, int, glconfig_t, GameStateCSs>
+	IPC::Message<IPC::Id<VM::QVM, CG_INIT>, int, int, WindowConfig, GameStateCSs>
 >;
 using CGameShutdownMsg = IPC::SyncMessage<
 	IPC::Message<IPC::Id<VM::QVM, CG_SHUTDOWN>>
@@ -540,7 +540,7 @@ using CGameFocusEventMsg = IPC::SyncMessage<
 
 //TODO Check all rocket calls
 using CGameRocketInitMsg = IPC::SyncMessage<
-	IPC::Message<IPC::Id<VM::QVM, CG_ROCKET_VM_INIT>, glconfig_t>
+	IPC::Message<IPC::Id<VM::QVM, CG_ROCKET_VM_INIT>, WindowConfig>
 >;
 using CGameRocketFrameMsg = IPC::SyncMessage<
 	IPC::Message<IPC::Id<VM::QVM, CG_ROCKET_FRAME>, cgClientState_t>

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -956,15 +956,7 @@ void CGameVM::CGameStaticInit()
 
 void CGameVM::CGameInit(int serverMessageNum, int clientNum)
 {
-	glconfig_t glConfig;
-	memset( &glConfig, 0, sizeof( glconfig_t ) );
-	glConfig.displayAspect = cls.windowConfig.displayAspect;
-	glConfig.displayWidth = cls.windowConfig.displayWidth;
-	glConfig.displayHeight = cls.windowConfig.displayHeight;
-	glConfig.vidWidth = cls.windowConfig.vidWidth;
-	glConfig.vidHeight = cls.windowConfig.vidHeight;
-
-	this->SendMsg<CGameInitMsg>(serverMessageNum, clientNum, glConfig, cl.gameState);
+	this->SendMsg<CGameInitMsg>(serverMessageNum, clientNum, cls.windowConfig, cl.gameState);
 	NetcodeTable psTable;
 	size_t psSize;
 	this->SendMsg<VM::GetNetcodeTablesMsg>(psTable, psSize);
@@ -1028,15 +1020,7 @@ void CGameVM::CGameTextInputEvent(int c)
 
 void CGameVM::CGameRocketInit()
 {
-	glconfig_t glConfig;
-	memset( &glConfig, 0, sizeof( glconfig_t ) );
-	glConfig.displayAspect = cls.windowConfig.displayAspect;
-	glConfig.displayWidth = cls.windowConfig.displayWidth;
-	glConfig.displayHeight = cls.windowConfig.displayHeight;
-	glConfig.vidWidth = cls.windowConfig.vidWidth;
-	glConfig.vidHeight = cls.windowConfig.vidHeight;
-
-	this->SendMsg<CGameRocketInitMsg>( glConfig );
+	this->SendMsg<CGameRocketInitMsg>( cls.windowConfig );
 }
 
 void CGameVM::CGameRocketFrame()

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -170,12 +170,6 @@ struct GLConfig
 	bool motionBlur;
 };
 
-struct WindowConfig {
-	float displayAspect;
-	int displayWidth, displayHeight; // the entire monitor (the one indicated by displayIndex)
-	int vidWidth, vidHeight; // what the game is using
-};
-
 //
 // these are the functions exported by the refresh module
 //
@@ -192,8 +186,8 @@ struct refexport_t
 	// if necessary.
 	//
 	// BeginRegistration makes any existing media pointers invalid
-	// and returns the current gl configuration, including screen width
-	// and height, which can be used by the client to intelligently
+	// and returns the current window configuration, including screen and display width
+	// and height, and aspect ratio, which can be used by the client to intelligently
 	// size display elements. Returns false if the renderer couldn't
 	// be initialized.
 	bool( *BeginRegistration )( WindowConfig* windowCfg );

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -273,30 +273,13 @@ enum class glHardwareType_t
 
 /**
  * Contains variables specific to the OpenGL configuration
- * being run right now.  These are constant once the OpenGL
+ * being run right now. These are constant once the OpenGL
  * subsystem is initialized.
  */
-struct glconfig_t
-{
-	char                 renderer_string[ MAX_STRING_CHARS ];
-	char                 vendor_string[ MAX_STRING_CHARS ];
-	char                 version_string[ MAX_STRING_CHARS ];
-
-	int                  maxTextureSize; // queried from GL
-
-	int colorBits;
-
-	glDriverType_t       driverType;
-	glHardwareType_t     hardwareType;
-
-	textureCompression_t textureCompression;
-
-	int displayIndex;
+struct WindowConfig {
 	float displayAspect;
 	int displayWidth, displayHeight; // the entire monitor (the one indicated by displayIndex)
 	int vidWidth, vidHeight; // what the game is using
-
-	bool8_t smpActive; // dual processor
 };
 
 #pragma pop_macro("bool")


### PR DESCRIPTION
Cgame-side pr: https://github.com/Unvanquished/Unvanquished/pull/3405

Fixes #517

Move the stuff actually used by cgame (window and display sizes and display aspect) to `WindowConfig`. Merge the rest with `glconfig2_t` into `GLConfig`.

I've noticed this issue earlier when adding things to `glconfig2` and when working on daemon-vulkan: `RE_BeginRegistration()` uses `glconfig_t* glConfigOut, glconfig2_t glConfig2Out` as its parameters, even though it only needs the window and display sizes from the first one and nothing else.