### PR TITLE
Fix looping sounds

### DIFF
--- a/src/engine/audio/Audio.cpp
+++ b/src/engine/audio/Audio.cpp
@@ -194,10 +194,10 @@ namespace Audio {
         }
 
         for (int i = 0; i < MAX_GENTITIES; i++) {
-            auto& loop = entityLoops[i];
+            entityLoop_t& loop = entityLoops[i];
             if (loop.sound and not loop.addedThisFrame) {
                 // The loop wasn't added this frame, that means it has to be removed.
-                loop.sound->SetSoundGain( 0 );
+                loop.sound->soundGain = 0;
             } else if (loop.oldSfx != loop.newSfx) {
                 // The last sfx added in the frame is not the current one being played
                 // To mimic the previous sound system's behavior we sart playing the new one.
@@ -341,7 +341,7 @@ namespace Audio {
 
         StopMusic();
         music = std::make_shared<LoopingSound>(loopingSample, leadingSample);
-        music->SetVolumeModifier(musicVolume);
+        music->volumeModifier = &musicVolume;
         AddSound(GetLocalEmitter(), music, 1);
     }
 
@@ -379,7 +379,7 @@ namespace Audio {
             }
         }
 
-        streams[streamNum]->SetGain(volume);
+        streams[streamNum]->soundGain = volume;
 
 	    AudioData audioData(rate, width, channels, (width * numSamples * channels),
 	                        reinterpret_cast<const char*>(data));

--- a/src/engine/audio/Emitter.cpp
+++ b/src/engine/audio/Emitter.cpp
@@ -261,7 +261,7 @@ namespace Audio {
     Emitter::~Emitter() = default;
 
     void Emitter::SetupSound(Sound& sound) {
-        sound.GetSource().SetReferenceDistance(120.0f);
+        sound.source->SetReferenceDistance(120.0f);
         InternalSetupSound(sound);
         UpdateSound(sound);
     }
@@ -278,7 +278,7 @@ namespace Audio {
     }
 
     void EntityEmitter::UpdateSound(Sound& sound) {
-        AL::Source& source = sound.GetSource();
+        AL::Source& source = *sound.source;
 
         if (entityNum == listenerEntity) {
             MakeLocal(source);
@@ -288,7 +288,7 @@ namespace Audio {
     }
 
     void EntityEmitter::InternalSetupSound(Sound& sound) {
-        AL::Source& source = sound.GetSource();
+        AL::Source& source = *sound.source;
 
         Make3D(source, entities[entityNum].position, entities[entityNum].velocity);
     }
@@ -306,13 +306,13 @@ namespace Audio {
     }
 
     void PositionEmitter::UpdateSound(Sound& sound) {
-        AL::Source& source = sound.GetSource();
+        AL::Source& source = *sound.source;
 
         Make3D(source, position, origin);
     }
 
     void PositionEmitter::InternalSetupSound(Sound& sound) {
-        AL::Source& source = sound.GetSource();
+        AL::Source& source = *sound.source;
 
         Make3D(source, position, origin);
     }
@@ -334,7 +334,7 @@ namespace Audio {
     }
 
     void LocalEmitter::InternalSetupSound(Sound& sound) {
-        AL::Source& source = sound.GetSource();
+        AL::Source& source = *sound.source;
 
         MakeLocal(source);
     }

--- a/src/engine/audio/Sound.h
+++ b/src/engine/audio/Sound.h
@@ -54,29 +54,24 @@ namespace Audio {
     //TODO sound.mute
     class Sound {
         public:
+            float positionalGain;
+            float soundGain;
+            float currentGain;
+
+            bool playing;
+            const Cvar::Range<Cvar::Cvar<float>>* volumeModifier;
+
+            AL::Source* source;
+            std::shared_ptr<Emitter> emitter;
+
             Sound();
             virtual ~Sound();
 
             void Play();
             // Stop the source and marks the sound for deletion.
             void Stop();
-            bool IsStopped();
-
-            // The is attenuated because of its inherent porperties and because of its position.
-            // Each attenuation can be set separately.
-            void SetPositionalGain(float gain);
-            void SetSoundGain(float gain);
-            float GetCurrentGain();
-
-            // sfx vs. music
-            void SetVolumeModifier(const Cvar::Range<Cvar::Cvar<float>>& volumeMod);
-            float GetVolumeModifier() const;
-
-            void SetEmitter(std::shared_ptr<Emitter> emitter);
-            std::shared_ptr<Emitter> GetEmitter();
 
             void AcquireSource(AL::Source& source);
-            AL::Source& GetSource();
 
             // Used to setup a source for a specific kind of sound and to start the sound.
             virtual void SetupSource(AL::Source& source) = 0;
@@ -85,16 +80,6 @@ namespace Audio {
             void Update();
             // Called each frame, after emitters have been updated.
             virtual void InternalUpdate() = 0;
-
-        private:
-            float positionalGain;
-            float soundGain;
-            float currentGain;
-
-            bool playing;
-            std::shared_ptr<Emitter> emitter;
-            const Cvar::Range<Cvar::Cvar<float>>* volumeModifier;
-            AL::Source* source;
     };
 
     // A sound that is played once.
@@ -139,7 +124,6 @@ namespace Audio {
             virtual void InternalUpdate() override;
 
             void AppendBuffer(AL::Buffer buffer);
-            void SetGain(float gain);
     };
 
 }


### PR DESCRIPTION
Fixes the magical quantum looping sound emitters that change their state when you stop observing them.

The effect can be very easily heard on the map `spacetracks` where the elevator music restarts whenever the speaker goes out of view without this fix.

Also removed a layer of useless functions in the surrounding code.