### PR TITLE
Fix looping sounds

### DIFF
--- a/src/engine/audio/Audio.cpp
+++ b/src/engine/audio/Audio.cpp
@@ -194,10 +194,10 @@ namespace Audio {
         }
 
         for (int i = 0; i < MAX_GENTITIES; i++) {
-            auto& loop = entityLoops[i];
+            entityLoop_t& loop = entityLoops[i];
             if (loop.sound and not loop.addedThisFrame) {
                 // The loop wasn't added this frame, that means it has to be removed.
-                loop.sound->SetSoundGain( 0 );
+                loop.sound->soundGain = 0;
             } else if (loop.oldSfx != loop.newSfx) {
                 // The last sfx added in the frame is not the current one being played
                 // To mimic the previous sound system's behavior we sart playing the new one.
@@ -341,7 +341,7 @@ namespace Audio {
 
         StopMusic();
         music = std::make_shared<LoopingSound>(loopingSample, leadingSample);
-        music->SetVolumeModifier(musicVolume);
+        music->volumeModifier = &musicVolume;
         AddSound(GetLocalEmitter(), music, 1);
     }
 
@@ -379,7 +379,7 @@ namespace Audio {
             }
         }
 
-        streams[streamNum]->SetGain(volume);
+        streams[streamNum]->soundGain = volume;
 
 	    AudioData audioData(rate, width, channels, (width * numSamples * channels),
 	                        reinterpret_cast<const char*>(data));

--- a/src/engine/audio/Audio.cpp
+++ b/src/engine/audio/Audio.cpp
@@ -197,9 +197,7 @@ namespace Audio {
             auto& loop = entityLoops[i];
             if (loop.sound and not loop.addedThisFrame) {
                 // The loop wasn't added this frame, that means it has to be removed.
-                loop.sound->FadeOutAndDie();
-                loop = {false, nullptr, -1, -1};
-
+                loop.sound->SetSoundGain( 0 );
             } else if (loop.oldSfx != loop.newSfx) {
                 // The last sfx added in the frame is not the current one being played
                 // To mimic the previous sound system's behavior we sart playing the new one.

--- a/src/engine/audio/Audio.h
+++ b/src/engine/audio/Audio.h
@@ -50,7 +50,7 @@ namespace Audio {
     void StartSound(int entityNum, Vec3 origin, sfxHandle_t sfx);
     void StartLocalSound(int entityNum);
 
-    void AddEntityLoopingSound(int entityNum, sfxHandle_t sfx);
+    void AddEntityLoopingSound(int entityNum, sfxHandle_t sfx, bool persistent);
     void ClearAllLoopingSounds();
     void ClearLoopingSoundsForEntity(int entityNum);
 

--- a/src/engine/audio/Emitter.cpp
+++ b/src/engine/audio/Emitter.cpp
@@ -261,7 +261,7 @@ namespace Audio {
     Emitter::~Emitter() = default;
 
     void Emitter::SetupSound(Sound& sound) {
-        sound.GetSource().SetReferenceDistance(120.0f);
+        sound.source->SetReferenceDistance(120.0f);
         InternalSetupSound(sound);
         UpdateSound(sound);
     }
@@ -278,7 +278,7 @@ namespace Audio {
     }
 
     void EntityEmitter::UpdateSound(Sound& sound) {
-        AL::Source& source = sound.GetSource();
+        AL::Source& source = *sound.source;
 
         if (entityNum == listenerEntity) {
             MakeLocal(source);
@@ -288,7 +288,7 @@ namespace Audio {
     }
 
     void EntityEmitter::InternalSetupSound(Sound& sound) {
-        AL::Source& source = sound.GetSource();
+        AL::Source& source = *sound.source;
 
         Make3D(source, entities[entityNum].position, entities[entityNum].velocity);
     }
@@ -306,13 +306,13 @@ namespace Audio {
     }
 
     void PositionEmitter::UpdateSound(Sound& sound) {
-        AL::Source& source = sound.GetSource();
+        AL::Source& source = *sound.source;
 
         Make3D(source, position, origin);
     }
 
     void PositionEmitter::InternalSetupSound(Sound& sound) {
-        AL::Source& source = sound.GetSource();
+        AL::Source& source = *sound.source;
 
         Make3D(source, position, origin);
     }
@@ -334,7 +334,7 @@ namespace Audio {
     }
 
     void LocalEmitter::InternalSetupSound(Sound& sound) {
-        AL::Source& source = sound.GetSource();
+        AL::Source& source = *sound.source;
 
         MakeLocal(source);
     }

--- a/src/engine/audio/Sound.h
+++ b/src/engine/audio/Sound.h
@@ -54,29 +54,24 @@ namespace Audio {
     //TODO sound.mute
     class Sound {
         public:
+            float positionalGain;
+            float soundGain;
+            float currentGain;
+
+            bool playing;
+            const Cvar::Range<Cvar::Cvar<float>>* volumeModifier;
+
+            AL::Source* source;
+            std::shared_ptr<Emitter> emitter;
+
             Sound();
             virtual ~Sound();
 
             void Play();
             // Stop the source and marks the sound for deletion.
             void Stop();
-            bool IsStopped();
-
-            // The is attenuated because of its inherent porperties and because of its position.
-            // Each attenuation can be set separately.
-            void SetPositionalGain(float gain);
-            void SetSoundGain(float gain);
-            float GetCurrentGain();
-
-            // sfx vs. music
-            void SetVolumeModifier(const Cvar::Range<Cvar::Cvar<float>>& volumeMod);
-            float GetVolumeModifier() const;
-
-            void SetEmitter(std::shared_ptr<Emitter> emitter);
-            std::shared_ptr<Emitter> GetEmitter();
 
             void AcquireSource(AL::Source& source);
-            AL::Source& GetSource();
 
             // Used to setup a source for a specific kind of sound and to start the sound.
             virtual void SetupSource(AL::Source& source) = 0;
@@ -85,16 +80,6 @@ namespace Audio {
             void Update();
             // Called each frame, after emitters have been updated.
             virtual void InternalUpdate() = 0;
-
-        private:
-            float positionalGain;
-            float soundGain;
-            float currentGain;
-
-            bool playing;
-            std::shared_ptr<Emitter> emitter;
-            const Cvar::Range<Cvar::Cvar<float>>* volumeModifier;
-            AL::Source* source;
     };
 
     // A sound that is played once.
@@ -139,7 +124,6 @@ namespace Audio {
             virtual void InternalUpdate() override;
 
             void AppendBuffer(AL::Buffer buffer);
-            void SetGain(float gain);
     };
 
 }

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -282,7 +282,7 @@ namespace Audio {
 	using StartSoundMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_STARTSOUND>, bool, Vec3, int, int>;
 	using StartLocalSoundMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_STARTLOCALSOUND>, int>;
 	using ClearLoopingSoundsMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_CLEARLOOPINGSOUNDS>>;
-	using AddLoopingSoundMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_ADDLOOPINGSOUND>, int, int>;
+	using AddLoopingSoundMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_ADDLOOPINGSOUND>, int, int, bool>;
 	using StopLoopingSoundMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_STOPLOOPINGSOUND>, int>;
 	using UpdateEntityPositionMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_UPDATEENTITYPOSITION>, int, Vec3>;
 	using RespatializeMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_RESPATIALIZE>, int, std::array<Vec3, 3>>;

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1506,8 +1506,8 @@ void CGameVM::CmdBuffer::HandleCommandBufferSyscall(int major, int minor, Util::
 				break;
 
 			case CG_S_ADDLOOPINGSOUND:
-				HandleMsg<Audio::AddLoopingSoundMsg>(std::move(reader), [this] (int entityNum, int sfx) {
-					Audio::AddEntityLoopingSound(entityNum, sfx);
+				HandleMsg<Audio::AddLoopingSoundMsg>(std::move(reader), [this] (int entityNum, int sfx, bool persistent) {
+					Audio::AddEntityLoopingSound(entityNum, sfx, persistent);
 				});
 				break;
 

--- a/src/engine/null/NullAudio.cpp
+++ b/src/engine/null/NullAudio.cpp
@@ -65,7 +65,7 @@ namespace Audio {
     }
 
 
-    void AddEntityLoopingSound(int, sfxHandle_t) {
+    void AddEntityLoopingSound(int, sfxHandle_t, bool) {
     }
 
     void ClearAllLoopingSounds() {

--- a/src/engine/server/sg_api.h
+++ b/src/engine/server/sg_api.h
@@ -44,6 +44,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define SVF_SELF_PORTAL_EXCLUSIVE 0x00010000
 #define SVF_RIGID_BODY            0x00020000 // ignored by the engine
 #define SVF_CLIENTS_IN_RANGE      0x00040000 // clients within range
+#define SVF_BROADCAST_ONCE        0x00040000 // broadcasted to newly connecting clients, and once to connected clients when spawned
 
 #define MAX_ENT_CLUSTERS  16
 

--- a/src/engine/server/sv_snapshot.cpp
+++ b/src/engine/server/sv_snapshot.cpp
@@ -341,7 +341,7 @@ static void SV_AddEntToSnapshot( svEntity_t *svEnt, sharedEntity_t *gEnt,
 SV_AddEntitiesVisibleFromPoint
 ===============
 */
-static void SV_AddEntitiesVisibleFromPoint( vec3_t origin, clientSnapshot_t *frame,
+static void SV_AddEntitiesVisibleFromPoint( client_t* client, vec3_t origin, clientSnapshot_t *frame,
 //                                  snapshotEntityNumbers_t *eNums, bool portal, clientSnapshot_t *oldframe, bool localClient ) {
 //                                  snapshotEntityNumbers_t *eNums, bool portal ) {
     snapshotEntityNumbers_t *eNums /*, bool portal, bool localClient */ )
@@ -379,7 +379,7 @@ static void SV_AddEntitiesVisibleFromPoint( vec3_t origin, clientSnapshot_t *fra
 
 	if ( playerEnt->r.svFlags & SVF_SELF_PORTAL )
 	{
-		SV_AddEntitiesVisibleFromPoint( playerEnt->s.origin2, frame, eNums );
+		SV_AddEntitiesVisibleFromPoint( client, playerEnt->s.origin2, frame, eNums );
 	}
 
 	for ( e = 0; e < sv.num_entities; e++ )
@@ -458,6 +458,11 @@ static void SV_AddEntitiesVisibleFromPoint( vec3_t origin, clientSnapshot_t *fra
 		// broadcast entities are always sent
 		if ( ent->r.svFlags & SVF_BROADCAST )
 		{
+			SV_AddEntToSnapshot( svEnt, ent, eNums );
+			continue;
+		}
+
+		if ( ( ent->r.svFlags & SVF_BROADCAST_ONCE ) && !client->reliableAcknowledge ) {
 			SV_AddEntToSnapshot( svEnt, ent, eNums );
 			continue;
 		}
@@ -637,7 +642,7 @@ static void SV_AddEntitiesVisibleFromPoint( vec3_t origin, clientSnapshot_t *fra
 			}
 
 //          SV_AddEntitiesVisibleFromPoint( ent->s.origin2, frame, eNums, true, oldframe, localClient );
-			SV_AddEntitiesVisibleFromPoint( ent->s.origin2, frame, eNums /*, true, localClient */ );
+			SV_AddEntitiesVisibleFromPoint( client, ent->s.origin2, frame, eNums /*, true, localClient */ );
 		}
 
 		continue;
@@ -720,7 +725,7 @@ static void SV_BuildClientSnapshot( client_t *client )
 
 	// add all the entities directly visible to the eye, which
 	// may include portal entities that merge other viewpoints
-	SV_AddEntitiesVisibleFromPoint( org, frame, &entityNumbers /*, false, client->netchan.remoteAddress.type == NA_LOOPBACK */ );
+	SV_AddEntitiesVisibleFromPoint( client, org, frame, &entityNumbers /*, false, client->netchan.remoteAddress.type == NA_LOOPBACK */ );
 
 	// if there were portals visible, there may be out of order entities
 	// in the list which will need to be resorted for the delta compression

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -153,7 +153,7 @@ void trap_S_ClearLoopingSounds( bool )
 	cmdBuffer.SendMsg<Audio::ClearLoopingSoundsMsg>();
 }
 
-void trap_S_AddLoopingSound( int entityNum, const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx )
+void trap_S_AddLoopingSound( int entityNum, const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx, bool persistent )
 {
 	if (origin) {
 		trap_S_UpdateEntityPosition(entityNum, origin);
@@ -161,12 +161,7 @@ void trap_S_AddLoopingSound( int entityNum, const vec3_t origin, const vec3_t ve
 	if (velocity) {
 		trap_S_UpdateEntityVelocity(entityNum, velocity);
 	}
-	cmdBuffer.SendMsg<Audio::AddLoopingSoundMsg>(entityNum, sfx);
-}
-
-void trap_S_AddRealLoopingSound( int entityNum, const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx )
-{
-	trap_S_AddLoopingSound(entityNum, origin, velocity, sfx);
+	cmdBuffer.SendMsg<Audio::AddLoopingSoundMsg>( entityNum, sfx, persistent );
 }
 
 void trap_S_StopLoopingSound( int entityNum )

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -53,8 +53,8 @@ void trap_CM_BatchMarkFragments(
 void            trap_S_StartSound( vec3_t origin, int entityNum, soundChannel_t entchannel, sfxHandle_t sfx );
 void            trap_S_StartLocalSound( sfxHandle_t sfx, soundChannel_t channelNum );
 void            trap_S_ClearLoopingSounds( bool killall );
-void            trap_S_AddLoopingSound( int entityNum, const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx );
-void            trap_S_AddRealLoopingSound( int entityNum, const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx );
+void            trap_S_AddLoopingSound( int entityNum, const vec3_t origin, const vec3_t velocity, sfxHandle_t sfx,
+                                        bool persistent = false );
 void            trap_S_StopLoopingSound( int entityNum );
 void            trap_S_UpdateEntityPosition( int entityNum, const vec3_t origin );
 void            trap_S_Respatialize( int entityNum, const vec3_t origin, vec3_t axis[ 3 ], int inwater );


### PR DESCRIPTION
Cgame-side pr: 

Fixes the magical quantum looping sound emitters that change their state when you stop observing them.

The effect can be very easily heard on the map spacetracks where the elevator music restarts whenever the speaker goes out of view without this fix.

Also removed a layer of useless functions in the surrounding code.

Added an `SVF_BROADCAST_ONCE` so the speakers aren't magically paused until they come into view (this also fixes the elevator music on the different floors of `spacetracks` being desynced).