### PR TITLE
Implement some sound priorities

### DIFF
--- a/src/engine/audio/Audio.h
+++ b/src/engine/audio/Audio.h
@@ -43,7 +43,7 @@ namespace Audio {
     void Shutdown();
     void Update();
 
-    void BeginRegistration();
+    void BeginRegistration( const int playerNum );
     sfxHandle_t RegisterSFX(Str::StringRef filename);
     void EndRegistration();
 

--- a/src/engine/audio/AudioPrivate.h
+++ b/src/engine/audio/AudioPrivate.h
@@ -65,6 +65,21 @@ namespace Audio {
 
     constexpr uint32_t MAX_ENTITY_SOUNDS = 4;
 
+    extern int playerClientNum;
+
+    struct entityData_t {
+        Vec3 position;
+        Vec3 velocity;
+        float occlusion;
+    };
+
+    extern entityData_t entities[MAX_GENTITIES];
+
+    enum EmitterPriority {
+        ANY,
+        CLIENT
+    };
+
     // Tweaks the value given by the audio slider
     float SliderToAmplitude(float slider);
 

--- a/src/engine/audio/Emitter.cpp
+++ b/src/engine/audio/Emitter.cpp
@@ -31,14 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AudioPrivate.h"
 
 namespace Audio {
-
-    // Structures to keep the state of entities we were given
-    struct entityData_t {
-        Vec3 position;
-        Vec3 velocity;
-        float occlusion;
-    };
-    static entityData_t entities[MAX_GENTITIES];
+    entityData_t entities[MAX_GENTITIES];
     static int listenerEntity = -1;
 
     struct EntityMultiEmitter {
@@ -311,6 +304,10 @@ namespace Audio {
         Make3D(source, entities[entityNum].position, entities[entityNum].velocity);
     }
 
+    Vec3 EntityEmitter::GetPosition() const {
+        return entities[entityNum].position;
+    }
+
     // Implementation of PositionEmitter
 
     PositionEmitter::PositionEmitter(Vec3 position){
@@ -355,6 +352,10 @@ namespace Audio {
         AL::Source& source = *sound.source;
 
         MakeLocal(source);
+    }
+
+    Vec3 LocalEmitter::GetPosition() const {
+        return Vec3 {};
     }
 
     class TestReverbCmd : public Cmd::StaticCmd {

--- a/src/engine/audio/Emitter.h
+++ b/src/engine/audio/Emitter.h
@@ -64,11 +64,13 @@ namespace Audio {
             void SetupSound(Sound& sound);
 
             // Called each frame before any UpdateSound is called, used to factor computations
-            void virtual Update() = 0;
+            virtual void Update() = 0;
             // Update the Sound's source's spatialization
             virtual void UpdateSound(Sound& sound) = 0;
             // Setup a source for the spatialization of this Emitter
             virtual void InternalSetupSound(Sound& sound) = 0;
+
+            virtual Vec3 GetPosition() const = 0;
     };
 
     // An Emitter that will follow an entity
@@ -80,6 +82,8 @@ namespace Audio {
             void virtual Update() override;
             virtual void UpdateSound(Sound& sound) override;
             virtual void InternalSetupSound(Sound& sound) override;
+
+            Vec3 GetPosition() const override;
 
         private:
             int entityNum;
@@ -95,7 +99,7 @@ namespace Audio {
             virtual void UpdateSound(Sound& sound) override;
             virtual void InternalSetupSound(Sound& sound) override;
 
-            Vec3 GetPosition() const;
+            Vec3 GetPosition() const override;
 
         private:
             Vec3 position;
@@ -110,6 +114,8 @@ namespace Audio {
             void virtual Update() override;
             virtual void UpdateSound(Sound& sound) override;
             virtual void InternalSetupSound(Sound& sound) override;
+
+            Vec3 GetPosition() const override;
     };
 
 }

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -291,7 +291,7 @@ namespace Audio {
 	using UpdateEntityVelocityMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_UPDATEENTITYVELOCITY>, int, Vec3>;
 	using UpdateEntityPositionVelocityMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_UPDATEENTITYPOSITIONVELOCITY>, int, Vec3, Vec3>;
 	using SetReverbMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_SETREVERB>, int, std::string, float>;
-	using BeginRegistrationMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_BEGINREGISTRATION>>;
+	using BeginRegistrationMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_BEGINREGISTRATION>, int>;
 	using EndRegistrationMsg = IPC::Message<IPC::Id<VM::QVM, CG_S_ENDREGISTRATION>>;
 }
 

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -1561,8 +1561,8 @@ void CGameVM::CmdBuffer::HandleCommandBufferSyscall(int major, int minor, Util::
 				break;
 
 			case CG_S_BEGINREGISTRATION:
-				HandleMsg<Audio::BeginRegistrationMsg>(std::move(reader), [this] {
-					Audio::BeginRegistration();
+				HandleMsg<Audio::BeginRegistrationMsg>(std::move(reader), [this] ( const int playerNum ) {
+					Audio::BeginRegistration( playerNum );
 				});
 				break;
 

--- a/src/engine/null/NullAudio.cpp
+++ b/src/engine/null/NullAudio.cpp
@@ -47,7 +47,7 @@ namespace Audio {
     }
 
 
-    void BeginRegistration() {
+    void BeginRegistration( const int ) {
     }
 
     sfxHandle_t RegisterSFX(Str::StringRef) {

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -218,9 +218,9 @@ void trap_S_SetReverb( int slotNum, const char* name, float ratio )
 	cmdBuffer.SendMsg<Audio::SetReverbMsg>(slotNum, name, ratio);
 }
 
-void trap_S_BeginRegistration()
+void trap_S_BeginRegistration( const int playerNum )
 {
-	cmdBuffer.SendMsg<Audio::BeginRegistrationMsg>();
+	cmdBuffer.SendMsg<Audio::BeginRegistrationMsg>( playerNum );
 }
 
 void trap_S_EndRegistration()

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -138,7 +138,7 @@ void            trap_R_SetAltShaderTokens( const char * );
 void            trap_S_UpdateEntityVelocity( int entityNum, const vec3_t velocity );
 void trap_S_UpdateEntityPositionVelocity( int entityNum, const vec3_t position, const vec3_t velocity );
 void            trap_S_SetReverb( int slotNum, const char* presetName, float ratio );
-void            trap_S_BeginRegistration();
+void            trap_S_BeginRegistration( const int playerNum );
 void            trap_S_EndRegistration();
 
 #endif


### PR DESCRIPTION
Requires https://github.com/DaemonEngine/Daemon/pull/1758

Cgame-side pr: https://github.com/Unvanquished/Unvanquished/pull/3408

Use the sound's volume and distance to determine which sounds to replace. Player/bot sounds get a higher priority within `a_clientSoundPriorityMaxDistance` distance, with the multiplier `a_clientSoundPriorityMultiplier`.

This is helpful when there are a lot of sound-emitting entities around (like buildings) which take priority over player/bot sounds. The latter are generally more important.