### PR TITLE
Update googletest submodule to v1.16.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -844,6 +844,7 @@ endif()
 
 if (BUILD_TESTS)
     set(BUILD_GMOCK ON)
+    set(GTEST_HAS_ABSL OFF)
     set(INSTALL_GTEST OFF)
     set(gtest_force_shared_crt ON)
     add_subdirectory(${LIB_DIR}/googletest EXCLUDE_FROM_ALL)


### PR DESCRIPTION
That's the last release compatible with C++14.

This fixes some CMake warnings about gtest's minimum version being too old and about CMP0077.