### PR TITLE
report game version in userinfo

### DIFF
--- a/src/engine/qcommon/common.cpp
+++ b/src/engine/qcommon/common.cpp
@@ -572,7 +572,7 @@ void Com_Init()
 #endif
 
 	s = va( "%s %s %s %s", Q3_VERSION, PLATFORM_STRING, DAEMON_ARCH_STRING, __DATE__ );
-	com_version = Cvar_Get( "version", s, CVAR_ROM | CVAR_SERVERINFO );
+	com_version = Cvar_Get( "version", s, CVAR_ROM | CVAR_SERVERINFO | CVAR_USERINFO );
 
 	Cmd_AddCommand( "in_restart", Com_In_Restart_f );
 


### PR DESCRIPTION
I believe it would be beneficial to report the game version in the userinfo, this will help server admins troubleshoot issues when players are reporting problems with the game. There will be a separate PR for the `/versions` command in `sg_admin.cpp` which will allow admins to view this information.

Some Tremulous clients had this feature, I am simply bringing that here (notably Tremfusion did this).

I also believe we should be reporting the build short commit hash in the version string, which will allow server admins to understand which exact build a player is using, but I believe that should be done in another PR. 

CC: @illwieckz and @VReaperV 