### PR TITLE
Add r_materialSeparatePerShader to debug material merging

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1184,6 +1184,11 @@ void MaterialSystem::AddStage( MaterialSurface* surface, shaderStage_t* pStage, 
 			return;
 		}
 
+		if ( r_materialSeparatePerShader.Get() )
+		{
+			continue;
+		}
+
 		if ( pStage->shaderBinder != pStage2->shaderBinder ) {
 			continue;
 		}

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -44,6 +44,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static constexpr uint32_t MAX_DRAWCOMMAND_TEXTURES = 64;
 
+extern Cvar::Cvar<bool> r_materialSeparatePerShader;
+
 struct GLIndirectCommand {
 	GLuint count;
 	GLuint instanceCount;
@@ -155,6 +157,11 @@ struct Material {
 	std::vector<Texture*> textures;
 
 	bool operator==( const Material& other ) {
+		if ( r_materialSeparatePerShader.Get() )
+		{
+			return refStage == other.refStage;
+		}
+
 		return program == other.program && stateBits == other.stateBits
 			&& fog == other.fog && cullType == other.cullType && usePolygonOffset == other.usePolygonOffset;
 	}

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -97,6 +97,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<bool> r_gpuFrustumCulling( "r_gpuFrustumCulling", "Use frustum culling on the GPU for the Material System", Cvar::NONE, true );
 	Cvar::Cvar<bool> r_gpuOcclusionCulling( "r_gpuOcclusionCulling", "Use occlusion culling on the GPU for the Material System", Cvar::NONE, false );
 	Cvar::Cvar<bool> r_materialSystemSkip( "r_materialSystemSkip", "Temporarily skip Material System rendering, using only core renderer instead", Cvar::NONE, false );
+	Cvar::Cvar<bool> r_materialSeparatePerShader("r_materialSeparatePerShader", "generate a material for every q3shader stage (to debug merging)", Cvar::NONE, false);
 	cvar_t      *r_lightStyles;
 	cvar_t      *r_exportTextures;
 	cvar_t      *r_heatHaze;
@@ -1269,7 +1270,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		r_showBspNodes = Cvar_Get( "r_showBspNodes", "0", CVAR_CHEAT );
 		Cvar::Latch( r_showGlobalMaterials );
 		Cvar::Latch( r_materialDebug );
-
+		Cvar::Latch( r_materialSeparatePerShader );
 		Cvar::Latch( r_profilerRenderSubGroups );
 	}
 


### PR DESCRIPTION
This can reveal bugs caused by merging materials that are not really the same.