### PR TITLE
Fix material system uniform SSBO struct packing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -952,7 +952,7 @@ if (BUILD_CLIENT)
         Flags ${WARNINGS}
         Files ${WIN_RC} ${BUILDINFOLIST} ${QCOMMONLIST} ${SERVERLIST} ${CLIENTBASELIST} ${CLIENTLIST}
         Libs ${LIBS_CLIENT} ${LIBS_CLIENTBASE} ${LIBS_ENGINE}
-        Tests ${ENGINETESTLIST}
+        Tests ${CLIENTTESTLIST}
     )
 
     # generate glsl include files

--- a/src.cmake
+++ b/src.cmake
@@ -356,6 +356,10 @@ set(CLIENTLIST
     ${RENDERERLIST}
 )
 
+set(CLIENTTESTLIST ${ENGINETESTLIST}
+    ${ENGINE_DIR}/renderer/gl_shader_test.cpp
+)
+
 set(TTYCLIENTLIST
     ${ENGINE_DIR}/null/NullAudio.cpp
     ${ENGINE_DIR}/null/NullKeyboard.cpp

--- a/src/common/Assert.h
+++ b/src/common/Assert.h
@@ -42,7 +42,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * information to start debugging when the assert fires.
  *
  * In case of name clashes (with for example a testing library), you can define the
- * DAEMON_SKIP_ASSERT_SHORTHANDS to only define the DAEMON_ prefixed macros.
+ * DAEMON_SKIP_ASSERT_SHORTHANDS to only define the DAEMON_ prefixed macros. Avoid using
+ * the shorthands in header files, so that the headers can be included in tests.
  *
  * These asserts feature:
  *     - Logging of the error with file, line and function information.
@@ -157,10 +158,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #define ASSERT_LE DAEMON_ASSERT_LE
     #define ASSERT_GT DAEMON_ASSERT_GT
     #define ASSERT_GE DAEMON_ASSERT_GE
+    #define ASSERT_UNREACHABLE DAEMON_ASSERT_UNREACHABLE
 #endif
 
 // You can put ASSERT_UNREACHABLE() in places that must never be reached.
-#define ASSERT_UNREACHABLE() DAEMON_ASSERT_CALLSITE(false, , false, "Unreachable code hit."); UNREACHABLE();
+#define DAEMON_ASSERT_UNREACHABLE() DAEMON_ASSERT_CALLSITE(false, , false, "Unreachable code hit."); UNREACHABLE();
 
 #ifdef DAEMON_ASSERTS_ENABLED
 // This stuff is so that the ASSERT_cc variants can be used on objects that don't have a

--- a/src/common/Math.h
+++ b/src/common/Math.h
@@ -40,7 +40,7 @@ namespace Math {
     template<typename T> inline WARN_UNUSED_RESULT
     T Clamp(T value, T min, T max)
     {
-        ASSERT_LE(min, max);
+        DAEMON_ASSERT_LE(min, max);
         if (!(value >= min))
             return min;
         if (!(value <= max))

--- a/src/engine/framework/Resource.h
+++ b/src/engine/framework/Resource.h
@@ -61,7 +61,7 @@ namespace Resource {
     class Handle {
         public:
             Handle(std::shared_ptr<T> value, const Manager<T>* manager): value(value), manager(manager) {
-                ASSERT(!!value); // Should not be null
+                DAEMON_ASSERT(!!value); // Should not be null
             }
 
             // Returns a pointer to the resource, or to the default value if the

--- a/src/engine/renderer/GLMemory.h
+++ b/src/engine/renderer/GLMemory.h
@@ -234,7 +234,7 @@ class GLVAO {
 		uint32_t ofs = 0;
 		for ( const vertexAttributeSpec_t* spec = attrBegin; spec < attrEnd; spec++ ) {
 			vboAttributeLayout_t& attr = attrs[spec->attrIndex];
-			ASSERT_NQ( spec->numComponents, 0U );
+			DAEMON_ASSERT_NQ( spec->numComponents, 0U );
 			attr.componentType = spec->componentStorageType;
 			if ( attr.componentType == GL_HALF_FLOAT && !glConfig.halfFloatVertexAvailable ) {
 				attr.componentType = GL_FLOAT;

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1313,7 +1313,7 @@ void MaterialSystem::ProcessStage( MaterialSurface* surface, shaderStage_t* pSta
 
 	material.bspSurface = surface->bspSurface;
 	pStage->materialProcessor( &material, pStage, surface );
-	pStage->paddedSize = material.shader->GetSTD430Size();
+	pStage->paddedSize = material.shader->GetSTD140Size();
 
 	// HACK: Copy the shaderStage_t and MaterialSurface that we need into the material, so we can use it with glsl_restart
 	material.refStage = pStage;

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2128,14 +2128,14 @@ void GLShader::PostProcessUniforms() {
 		GLuint size = _materialSystemUniforms[0]->_std430Size;
 		GLuint components = _materialSystemUniforms[0]->_components;
 		size = components ? PAD( size, 4 ) * components : size;
-		GLuint alignmentConsume = 4 - size % 4;
+		GLuint alignmentConsume = PAD( size, 4 ) - size;
 
 		GLUniform* tmpUniform = _materialSystemUniforms[0];
 		tmp.emplace_back( _materialSystemUniforms[0] );
 		_materialSystemUniforms.erase( _materialSystemUniforms.begin() );
 
 		int uniform;
-		while ( ( alignmentConsume & 3 ) && _materialSystemUniforms.size()
+		while ( alignmentConsume  && _materialSystemUniforms.size()
 			&& ( uniform = FindUniformForAlignment( _materialSystemUniforms, alignmentConsume ) ) != -1 ) {
 			alignmentConsume -= _materialSystemUniforms[uniform]->_std430Size;
 

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1547,6 +1547,7 @@ std::string GLShaderManager::RemoveUniformsFromShaderText( const std::string& sh
 
 void GLShaderManager::GenerateUniformStructDefinesText( const std::vector<GLUniform*>& uniforms,
 	const std::string& definesName, std::string& uniformStruct, std::string& uniformDefines ) {
+	int pad = 0;
 	for ( GLUniform* uniform : uniforms ) {
 		uniformStruct += "	" + ( uniform->_isTexture ? "uvec2" : uniform->_type ) + " " + uniform->_name;
 
@@ -1554,6 +1555,10 @@ void GLShaderManager::GenerateUniformStructDefinesText( const std::vector<GLUnif
 			uniformStruct += "[" + std::to_string( uniform->_components ) + "]";
 		}
 		uniformStruct += ";\n";
+
+		for (int p = uniform->_std430Size - uniform->_std430BaseSize; p--; ) {
+			uniformStruct += "\tfloat _pad" + std::to_string( ++pad ) + ";\n";
+		}
 
 		uniformDefines += "#define ";
 		uniformDefines += uniform->_name;
@@ -2132,6 +2137,7 @@ void GLShader::PostProcessUniforms() {
 			++std430Size;
 			++_materialSystemUniforms.back()->_std430Size;
 		} else {
+			( *iterNext )->_std430Size = ( *iterNext )->_std430BaseSize;
 			std430Size += ( *iterNext )->_std430Size;
 			align = std::max( align, ( *iterNext )->_std430Alignment );
 			_materialSystemUniforms.push_back( *iterNext );

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1545,9 +1545,8 @@ std::string GLShaderManager::RemoveUniformsFromShaderText( const std::string& sh
 	return shaderMain;
 }
 
-void GLShaderManager::GenerateUniformStructDefinesText( const std::vector<GLUniform*>& uniforms, const uint32_t padding,
-	const uint32_t paddingCount, const std::string& definesName,
-	std::string& uniformStruct, std::string& uniformDefines ) {
+void GLShaderManager::GenerateUniformStructDefinesText( const std::vector<GLUniform*>& uniforms,
+	const std::string& definesName, std::string& uniformStruct, std::string& uniformDefines ) {
 	for ( GLUniform* uniform : uniforms ) {
 		uniformStruct += "	" + ( uniform->_isTexture ? "uvec2" : uniform->_type ) + " " + uniform->_name;
 
@@ -1567,12 +1566,6 @@ void GLShaderManager::GenerateUniformStructDefinesText( const std::vector<GLUnif
 		uniformDefines += uniform->_name;
 
 		uniformDefines += "\n";
-	}
-
-	// Array of structs is aligned to the largest member of the struct
-	for ( uint32_t i = 0; i < padding; i++ ) {
-		uniformStruct += "	int uniform_padding" + std::to_string( i + paddingCount );
-		uniformStruct += ";\n";
 	}
 
 	uniformDefines += "\n";
@@ -1637,8 +1630,8 @@ std::string GLShaderManager::ShaderPostProcess( GLShader *shader, const std::str
 
 	std::string materialStruct = "\nstruct Material {\n";
 	std::string materialDefines;
-	GenerateUniformStructDefinesText( shader->_materialSystemUniforms, shader->padding,
-		0, "materials[baseInstance & 0xFFF]", materialStruct, materialDefines );
+	GenerateUniformStructDefinesText( shader->_materialSystemUniforms,
+		"materials[baseInstance & 0xFFF]", materialStruct, materialDefines );
 
 	materialStruct += "};\n\n";
 
@@ -2158,7 +2151,6 @@ void GLShader::PostProcessUniforms() {
 
 		size = PAD( size, 4 );
 		std430Size += size;
-		padding = alignmentConsume;
 	}
 
 	_materialSystemUniforms = tmp;

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -495,7 +495,7 @@ class GLUniformSampler : protected GLUniform {
 		ShaderProgramDescriptor* p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		return p->uniformLocations[_locationIndex];
@@ -574,7 +574,7 @@ protected:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -619,7 +619,7 @@ class GLUniform1ui : protected GLUniform {
 		ShaderProgramDescriptor* p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -663,7 +663,7 @@ class GLUniform1Bool : protected GLUniform {
 		ShaderProgramDescriptor* p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -710,7 +710,7 @@ protected:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -759,7 +759,7 @@ protected:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -794,7 +794,7 @@ protected:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -846,7 +846,7 @@ protected:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -898,7 +898,7 @@ protected:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -947,7 +947,7 @@ protected:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -982,7 +982,7 @@ protected:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -1027,7 +1027,7 @@ class GLUniformMatrix32f : protected GLUniform {
 		ShaderProgramDescriptor* p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -1065,7 +1065,7 @@ protected:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -1099,7 +1099,7 @@ protected:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 
 		if ( _global || !_shader->UseMaterialSystem() ) {
-			ASSERT_EQ( p, glState.currentProgram );
+			DAEMON_ASSERT_EQ( p, glState.currentProgram );
 		}
 
 		if ( _shader->UseMaterialSystem() && !_global ) {
@@ -1155,7 +1155,7 @@ public:
 		ShaderProgramDescriptor *p = _shader->GetProgram();
 		GLuint blockIndex = p->uniformBlockIndexes[_locationIndex];
 
-		ASSERT_EQ( p, glState.currentProgram );
+		DAEMON_ASSERT_EQ( p, glState.currentProgram );
 
 		if( blockIndex != GL_INVALID_INDEX ) {
 			glBindBufferBase( GL_UNIFORM_BUFFER, blockIndex, buffer );
@@ -2795,7 +2795,7 @@ static colorModulation_t ColorModulateColorGen(
 
 	if ( useMapLightFactor )
 	{
-		ASSERT_EQ( vertexOverbright, false );
+		DAEMON_ASSERT_EQ( vertexOverbright, false );
 		colorModulation.lightFactor = tr.mapLightFactor;
 	}
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -186,7 +186,6 @@ private:
 	const bool hasComputeShader;
 
 	GLuint std430Size = 0;
-	uint32_t padding = 0;
 
 	const bool worldShader;
 protected:
@@ -462,8 +461,8 @@ private:
 		ShaderProgramDescriptor* out );
 	void SaveShaderBinary( ShaderProgramDescriptor* descriptor );
 
-	void GenerateUniformStructDefinesText( const std::vector<GLUniform*>& uniforms, const uint32_t padding,
-		const uint32_t paddingCount, const std::string& definesName,
+	void GenerateUniformStructDefinesText(
+		const std::vector<GLUniform*>& uniforms, const std::string& definesName,
 		std::string& uniformStruct, std::string& uniformDefines );
 	std::string RemoveUniformsFromShaderText( const std::string& shaderText, const std::vector<GLUniform*>& uniforms );
 	std::string ShaderPostProcess( GLShader *shader, const std::string& shaderText, const uint32_t offset );

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -317,7 +317,8 @@ class GLUniform {
 	const std::string _type;
 
 	// In multiples of 4 bytes
-	GLuint _std430Size;
+	const GLuint _std430BaseSize;
+	GLuint _std430Size; // includes padding that depends on the other uniforms in the struct
 	const GLuint _std430Alignment;
 
 	const bool _global; // This uniform won't go into the materials UBO if true
@@ -334,6 +335,7 @@ class GLUniform {
 		const bool isTexture = false ) :
 		_name( name ),
 		_type( type ),
+		_std430BaseSize( std430Size ),
 		_std430Size( std430Size ),
 		_std430Alignment( std430Alignment ),
 		_global( global ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -185,7 +185,7 @@ private:
 	const bool hasFragmentShader;
 	const bool hasComputeShader;
 
-	GLuint std430Size = 0;
+	GLuint std140Size = 0;
 
 	const bool worldShader;
 protected:
@@ -300,8 +300,8 @@ public:
 		_vertexAttribs &= ~bit;
 	}
 
-	GLuint GetSTD430Size() const {
-		return std430Size;
+	GLuint GetSTD140Size() const {
+		return std140Size;
 	}
 
 	bool UseMaterialSystem() const {
@@ -317,6 +317,7 @@ class GLUniform {
 	const std::string _type;
 
 	// In multiples of 4 bytes
+	// FIXME: the uniform structs are actually std140 so it would be more relevant to provide std140 info
 	const GLuint _std430BaseSize;
 	GLuint _std430Size; // includes padding that depends on the other uniforms in the struct
 	const GLuint _std430Alignment;
@@ -690,11 +691,6 @@ class GLUniform1Bool : protected GLUniform {
 		return sizeof( int );
 	}
 
-	uint32_t* WriteToBuffer( uint32_t *buffer ) override {
-		memcpy( buffer, &currentValue, sizeof( bool ) );
-		return buffer + _std430Size;
-	}
-
 	private:
 	int currentValue = 0;
 };
@@ -770,11 +766,6 @@ protected:
 		}
 
 		glUniform1fv( p->uniformLocations[ _locationIndex ], numFloats, f );
-	}
-
-	uint32_t* WriteToBuffer( uint32_t* buffer ) override {
-		memcpy( buffer, currentValue.data(), currentValue.size() * sizeof( float ) );
-		return buffer + _components * _std430Size;
 	}
 
 	private:
@@ -1042,11 +1033,6 @@ class GLUniformMatrix32f : protected GLUniform {
 	public:
 	size_t GetSize() override {
 		return 6 * sizeof( float );
-	}
-
-	uint32_t* WriteToBuffer( uint32_t* buffer ) override {
-		memcpy( buffer, currentValue, 6 * sizeof( float ) );
-		return buffer + _std430Size * _components;
 	}
 
 	private:

--- a/src/engine/renderer/gl_shader_test.cpp
+++ b/src/engine/renderer/gl_shader_test.cpp
@@ -122,4 +122,21 @@ TEST(MaterialUniformPackingTest, Vec3Handling)
     EXPECT_EQ(uniforms[3]->_std430Size, 4u);
 }
 
+TEST(MaterialUniformPackingTest, Array)
+{
+    class Shader1 : public MaterialUniformPackingTestShaderBase,
+                    public u_Frustum //vec4[6]
+    {
+    public:
+        Shader1() : u_Frustum(this) {}
+    };
+
+    Shader1 shader1;
+    std::vector<GLUniform*> uniforms = shader1.GetUniforms();
+    EXPECT_EQ(shader1.GetSTD140Size(), 24u);
+    ASSERT_EQ(uniforms.size(), 1);
+    EXPECT_EQ(uniforms[0], Get<u_Frustum>(shader1));
+    EXPECT_EQ(uniforms[0]->_std430Size, 4u);
+}
+
 } // namespace

--- a/src/engine/renderer/gl_shader_test.cpp
+++ b/src/engine/renderer/gl_shader_test.cpp
@@ -73,4 +73,53 @@ TEST(MaterialUniformPackingTest, OneMatrix)
     EXPECT_EQ(uniforms[0]->_std430Size, 16u);
 }
 
+TEST(MaterialUniformPackingTest, TwoFloats)
+{
+    class Shader1 : public MaterialUniformPackingTestShaderBase,
+                    public u_DeformMagnitude, //float
+                    public u_InverseGamma //float
+    {
+    public:
+        Shader1() : u_DeformMagnitude(this), u_InverseGamma(this) {}
+    };
+
+    Shader1 shader1;
+    std::vector<GLUniform*> uniforms = shader1.GetUniforms();
+    EXPECT_EQ(shader1.GetSTD430Size(), 4u);
+    ASSERT_EQ(uniforms.size(), 2);
+    EXPECT_EQ(uniforms[0], Get<u_DeformMagnitude>(shader1));
+    EXPECT_EQ(uniforms[0]->_std430Size, 1u);
+    EXPECT_EQ(uniforms[1], Get<u_InverseGamma>(shader1));
+    EXPECT_EQ(uniforms[1]->_std430Size, 3u);
+}
+
+TEST(MaterialUniformPackingTest, Vec3Handling)
+{
+    class Shader1 : public MaterialUniformPackingTestShaderBase,
+                    public u_DeformMagnitude, //float
+                    public u_SpecularExponent, //vec2
+                    public u_FogColor, //vec3
+                    public u_blurVec //vec3
+    {
+    public:
+        Shader1() : u_DeformMagnitude(this),
+                    u_SpecularExponent(this),
+                    u_FogColor(this),
+                    u_blurVec(this) {}
+    };
+
+    Shader1 shader1;
+    std::vector<GLUniform*> uniforms = shader1.GetUniforms();
+    EXPECT_EQ(shader1.GetSTD430Size(), 12u);
+    ASSERT_EQ(uniforms.size(), 4);
+    EXPECT_EQ(uniforms[0], Get<u_FogColor>(shader1));
+    EXPECT_EQ(uniforms[0]->_std430Size, 3u);
+    EXPECT_EQ(uniforms[1], Get<u_DeformMagnitude>(shader1));
+    EXPECT_EQ(uniforms[1]->_std430Size, 1u);
+    EXPECT_EQ(uniforms[2], Get<u_blurVec>(shader1));
+    EXPECT_EQ(uniforms[2]->_std430Size, 4u);
+    EXPECT_EQ(uniforms[3], Get<u_SpecularExponent>(shader1));
+    EXPECT_EQ(uniforms[3]->_std430Size, 4u);
+}
+
 } // namespace

--- a/src/engine/renderer/gl_shader_test.cpp
+++ b/src/engine/renderer/gl_shader_test.cpp
@@ -67,7 +67,7 @@ TEST(MaterialUniformPackingTest, OneMatrix)
 
     Shader1 shader1;
     std::vector<GLUniform*> uniforms = shader1.GetUniforms();
-    EXPECT_EQ(shader1.GetSTD430Size(), 16u);
+    EXPECT_EQ(shader1.GetSTD140Size(), 16u);
     ASSERT_EQ(uniforms.size(), 1);
     EXPECT_EQ(uniforms[0], Get<u_ModelViewMatrix>(shader1));
     EXPECT_EQ(uniforms[0]->_std430Size, 16u);
@@ -85,7 +85,7 @@ TEST(MaterialUniformPackingTest, TwoFloats)
 
     Shader1 shader1;
     std::vector<GLUniform*> uniforms = shader1.GetUniforms();
-    EXPECT_EQ(shader1.GetSTD430Size(), 4u);
+    EXPECT_EQ(shader1.GetSTD140Size(), 4u);
     ASSERT_EQ(uniforms.size(), 2);
     EXPECT_EQ(uniforms[0], Get<u_DeformMagnitude>(shader1));
     EXPECT_EQ(uniforms[0]->_std430Size, 1u);
@@ -110,7 +110,7 @@ TEST(MaterialUniformPackingTest, Vec3Handling)
 
     Shader1 shader1;
     std::vector<GLUniform*> uniforms = shader1.GetUniforms();
-    EXPECT_EQ(shader1.GetSTD430Size(), 12u);
+    EXPECT_EQ(shader1.GetSTD140Size(), 12u);
     ASSERT_EQ(uniforms.size(), 4);
     EXPECT_EQ(uniforms[0], Get<u_FogColor>(shader1));
     EXPECT_EQ(uniforms[0]->_std430Size, 3u);

--- a/src/engine/renderer/gl_shader_test.cpp
+++ b/src/engine/renderer/gl_shader_test.cpp
@@ -1,0 +1,76 @@
+/*
+===========================================================================
+Daemon BSD Source Code
+Copyright (c) 2025, Daemon Developers
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Daemon developers nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL DAEMON DEVELOPERS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+===========================================================================
+*/
+
+#include <gtest/gtest.h>
+
+#include "common/Common.h"
+
+#include "engine/renderer/gl_shader.h"
+
+namespace {
+
+class MaterialUniformPackingTestShaderBase : public GLShader
+{
+public:
+    MaterialUniformPackingTestShaderBase()
+       : GLShader("MaterialUniformPackingTestShaderBase", 0, true, "", "") {}
+
+    std::vector<GLUniform*> GetUniforms()
+    {
+        PostProcessUniforms();
+        return _materialSystemUniforms;
+    }
+};
+
+template<typename U, typename ShaderT>
+GLUniform* Get(ShaderT& shader)
+{
+   // assume U has a single base class of GLUniform
+   return reinterpret_cast<GLUniform*>(static_cast<U*>(&shader));
+}
+
+TEST(MaterialUniformPackingTest, OneMatrix)
+{
+    class Shader1 : public MaterialUniformPackingTestShaderBase,
+                    public u_ModelViewMatrix //mat4
+    {
+    public:
+        Shader1() : u_ModelViewMatrix(this) {}
+    };
+
+    Shader1 shader1;
+    std::vector<GLUniform*> uniforms = shader1.GetUniforms();
+    EXPECT_EQ(shader1.GetSTD430Size(), 16u);
+    ASSERT_EQ(uniforms.size(), 1);
+    EXPECT_EQ(uniforms[0], Get<u_ModelViewMatrix>(shader1));
+    EXPECT_EQ(uniforms[0]->_std430Size, 16u);
+}
+
+} // namespace

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2255,13 +2255,13 @@ enum
 				z = Math::Clamp( z, 0u, depth - 1 );
 			}
 
-			ASSERT_GE( x, 0u );
-			ASSERT_GE( y, 0u );
-			ASSERT_GE( z, 0u );
+			DAEMON_ASSERT_GE( x, 0u );
+			DAEMON_ASSERT_GE( y, 0u );
+			DAEMON_ASSERT_GE( z, 0u );
 
-			ASSERT_LT( x, width );
-			ASSERT_LT( y, height );
-			ASSERT_LT( z, depth );
+			DAEMON_ASSERT_LT( x, width );
+			DAEMON_ASSERT_LT( y, height );
+			DAEMON_ASSERT_LT( z, depth );
 
 			return grid[z * width * height + y * width + x];
 		}
@@ -2281,9 +2281,9 @@ enum
 				index = Math::Clamp( index, 0u, size - 1 );
 			}
 
-			ASSERT_GE( index, 0U );
+			DAEMON_ASSERT_GE( index, 0U );
 
-			ASSERT_LT( index, size );
+			DAEMON_ASSERT_LT( index, size );
 
 			return grid[index];
 		}

--- a/src/engine/sys/sys_events.h
+++ b/src/engine/sys/sys_events.h
@@ -49,7 +49,7 @@ public:
 
     template<typename T>
     const T& Cast() const {
-        ASSERT_EQ(this->type, T::ClassType());
+        DAEMON_ASSERT_EQ(this->type, T::ClassType());
         return *static_cast<const T*>(this);
     }
 


### PR DESCRIPTION
Fix the code for laying out the std430 struct containing the uniforms for material system GLSL shaders. There is no functional change given the exact sets of uniforms we have on our GLSL shaders right now, but adding a new one could cause things to blow up as demonstrated at https://github.com/DaemonEngine/Daemon/issues/1696#issuecomment-3236089118.

I'm not attempting to run the added unit tests on CI for now as the client test does full client initialization including opening a window. So it wouldn't easily run in a headless environment.