### PR TITLE
Add more material system debug commands

### DIFF
--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -109,8 +109,6 @@ struct MaterialSurface {
 };
 
 struct Material {
-	uint32_t materialsSSBOOffset = 0;
-
 	uint32_t globalID = 0;
 	uint32_t surfaceCommandBatchOffset = 0;
 	uint32_t surfaceCommandBatchCount = 0;
@@ -316,6 +314,9 @@ struct SurfaceCommandBatch {
 
 class MaterialSystem {
 	public:
+	friend class ListMaterialsCmd;
+	friend class ListMaterialSystemStagesCmd;
+
 	vec3_t worldViewBounds[2];
 
 	uint8_t maxStages = 0;


### PR DESCRIPTION
Adds `/listMaterials` and `/listMaterialSystemStages`, which list some of the info for materials and shader stages used by the material system, like stateBits, GL program ID, buffer offsets and sizes etc.