### PR TITLE
crypto: only include gmp.h on MSVC to disable the warning, add a comment explaining why

### DIFF
--- a/src/engine/qcommon/crypto.h
+++ b/src/engine/qcommon/crypto.h
@@ -27,10 +27,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "q_shared.h"
 #include "qcommon.h"
 
+/* The Nettle headers include the GMP header, this disables the warning
+on GMP alone, not the whole Nettle. We don't use GMP directly ourselves. */
+#if defined(_MSC_VER)
 #pragma warning(push)
 #pragma warning(disable : 4146) // "unary minus operator applied to unsigned type, result still unsigned"
 #include <gmp.h>
 #pragma warning(pop)
+#endif
 
 #include <nettle/bignum.h>
 #include <nettle/rsa.h>


### PR DESCRIPTION
Only include gmp.h on MSVC to disable the warning, add a comment explaining why.

----
_Former comment:_

Do not include `gmp.h`, It is unused.

We need to link against GMP because we link against Nettle that requires it, but it looks like ourselves never use any symbol from GMP directly.

Imported from #1433:

- https://github.com/DaemonEngine/Daemon/pull/1433

When testing #1433 I was able to rebuild every engine binaries and NaCl VMs in Docker with this commit, I also built dll VM locally fine.