### PR TITLE
Set APPID the SDL3 way, disable DPI scaling

### DIFF
--- a/src/engine/client/ClientApplication.cpp
+++ b/src/engine/client/ClientApplication.cpp
@@ -80,19 +80,6 @@ class ClientApplication : public Application {
         }
 
         void Initialize() override {
-#if defined(__linux__) && defined(BUILD_GRAPHICAL_CLIENT)
-            // identify the game by its name in certain
-            // volume control / power control applets,
-            // for example, the one found on KDE:
-            // "Unvanquished is currently blocking sleep."
-            // instead of "My SDL application ..."
-            // this feature was introduced in SDL 2.0.22
-            SDL_SetHint("SDL_APP_NAME", PRODUCT_NAME);
-            // SDL_hints.h: #define SDL_HINT_APP_NAME "SDL_APP_NAME"
-            // don't use the macro here, in case
-            // SDL doesn't use current headers.
-#endif
-
             Hunk_Init();
 
             Com_Init();

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1733,6 +1733,10 @@ static rserr_t GLimp_StartDriverAndSetMode( int mode, bool fullscreen, bool bord
 	StartupWMClass variable to PRODUCT_APPID. */
 	SDL_SetAppMetadataProperty( SDL_PROP_APP_METADATA_IDENTIFIER_STRING, PRODUCT_APPID );
 
+	/* Disable DPI scaling.
+	See the SDL wiki page for details: https://wiki.libsdl.org/SDL3/SDL_HINT_VIDEO_WAYLAND_SCALE_TO_DISPLAY */
+	SDL_SetHint( SDL_HINT_VIDEO_WAYLAND_SCALE_TO_DISPLAY, "1" );
+
 	if ( !SDL_WasInit( SDL_INIT_VIDEO ) )
 	{
 		const char *driverName;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -1722,19 +1722,16 @@ GLimp_StartDriverAndSetMode
 */
 static rserr_t GLimp_StartDriverAndSetMode( int mode, bool fullscreen, bool bordered )
 {
-#if !defined(_WIN32) && !defined(__APPLE__)
+	// See the SDL wiki page for details: https://wiki.libsdl.org/SDL3/SDL_SetAppMetadataProperty
+	SDL_SetAppMetadataProperty( SDL_PROP_APP_METADATA_NAME_STRING, PRODUCT_NAME );
+	SDL_SetAppMetadataProperty( SDL_PROP_APP_METADATA_VERSION_STRING, PRODUCT_VERSION );
+	SDL_SetAppMetadataProperty( SDL_PROP_APP_METADATA_TYPE_STRING, "game" );
+
 	/* Let X11 and Wayland desktops (Linux, FreeBSD…) associate the game
 	window with the XDG .desktop file, with the proper name and icon.
 	The .desktop file should have PRODUCT_APPID as base name or set the
 	StartupWMClass variable to PRODUCT_APPID. */
-
-	// SDL2.
-	Sys::SetEnv( "SDL_VIDEO_X11_WMCLASS", PRODUCT_APPID );
-	Sys::SetEnv( "SDL_VIDEO_WAYLAND_WMCLASS", PRODUCT_APPID );
-
-	// SDL3.
-	Sys::SetEnv( "SDL_HINT_APP_ID", PRODUCT_APPID );
-#endif
+	SDL_SetAppMetadataProperty( SDL_PROP_APP_METADATA_IDENTIFIER_STRING, PRODUCT_APPID );
 
 	if ( !SDL_WasInit( SDL_INIT_VIDEO ) )
 	{


### PR DESCRIPTION
- `sdl_glimp: properly set the APPID the SDL3 way, drop the SDL2 setting`

  * Drop the SDL2 way of doing things.
  * The SDL3 environment variable wasn't `SDL_HINT_APP_ID` but `SDL_APP_ID`.
  * For some reasons `SetEnv()` doesn't work (SDL3 bug?)
  * We can use `SDL_SetAppMetadataProperty()` instead, and it works.
  * We can probably don't have to care about being on X11/Wayland or not.
  * Use `SDL_SetAppMetadataProperty()` for other things too.

- `sdl_glimp: disable DPI scaling`