### PR TITLE
tr_shader: linearize fog colors

### DIFF
--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -3324,6 +3324,12 @@ static void R_LoadFogs( lump_t *l, lump_t *brushesLump, lump_t *sidesLump )
 		out->fogParms = shader->fogParms;
 
 		out->color = Color::Adapt( shader->fogParms.color );
+
+		if ( tr.worldLinearizeTexture )
+		{
+			out->color = out->color.ConvertFromSRGB();
+		}
+
 		out->color *= tr.identityLight;
 
 		out->color.SetAlpha( 1 );


### PR DESCRIPTION
Cherry-pick from #1730:

- https://github.com/DaemonEngine/Daemon/pull/1730

This one shouldn't be controversial.

One discussion possible is that we can do this conversion either in `tr_shader.cpp`, either in `tr_bsp.cpp`.

Fog shaders should be parsed when requested by the BSP code, there is no meaning outside of that, so the behavior should be the same.