### PR TITLE
Fix some fog bugs

### DIFF
--- a/src/engine/renderer/GeometryOptimiser.cpp
+++ b/src/engine/renderer/GeometryOptimiser.cpp
@@ -570,7 +570,7 @@ std::vector<MaterialSurface> OptimiseMapGeometryMaterial( world_t* world, bspSur
 		VectorCopy( ( ( srfGeneric_t* ) surface->data )->origin, srf.origin );
 		srf.radius = ( ( srfGeneric_t* ) surface->data )->radius;
 
-		materialSystem.GenerateMaterial( &srf );
+		materialSystem.GenerateMaterial( &srf, world->globalFog );
 
 		static const float MAX_NORMAL_SURFACE_DISTANCE = 65536.0f * sqrtf( 2.0f );
 		if ( VectorLength( ( ( srfGeneric_t* ) surface->data )->bounds[0] ) > MAX_NORMAL_SURFACE_DISTANCE

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1481,7 +1481,7 @@ void MaterialSystem::ProcessStage( MaterialSurface* surface, shaderStage_t* pSta
 /* This will only generate a material itself
 A material represents a distinct global OpenGL state (e. g. blend function, depth test, depth write etc.)
 Materials can have a dependency on other materials to make sure that consecutive stages are rendered in the proper order */
-void MaterialSystem::GenerateMaterial( MaterialSurface* surface ) {
+void MaterialSystem::GenerateMaterial( MaterialSurface* surface, int globalFog ) {
 	uint32_t stage = 0;
 	uint32_t previousMaterialID = 0;
 
@@ -1502,7 +1502,7 @@ void MaterialSystem::GenerateMaterial( MaterialSurface* surface ) {
 		surface->stages++;
 	}
 
-	if ( !surface->shader->noFog && surface->fog >= 1 ) {
+	if ( !surface->shader->noFog && surface->fog >= 1 && surface->fog != globalFog ) {
 		uint32_t unused;
 		ProcessStage( surface, surface->shader->fogShader->stages, surface->shader->fogShader, packIDs, stage, unused, true );
 

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1106,12 +1106,9 @@ void BindShaderFog( Material* material ) {
 	float eyeT;
 	vec4_t fogDepthVector;
 	if ( fog->hasSurface ) {
-		fogDepthVector[0] = fog->surface[0] * backEnd.orientation.axis[0][0] +
-			fog->surface[1] * backEnd.orientation.axis[0][1] + fog->surface[2] * backEnd.orientation.axis[0][2];
-		fogDepthVector[1] = fog->surface[0] * backEnd.orientation.axis[1][0] +
-			fog->surface[1] * backEnd.orientation.axis[1][1] + fog->surface[2] * backEnd.orientation.axis[1][2];
-		fogDepthVector[2] = fog->surface[0] * backEnd.orientation.axis[2][0] +
-			fog->surface[1] * backEnd.orientation.axis[2][1] + fog->surface[2] * backEnd.orientation.axis[2][2];
+		fogDepthVector[0] = DotProduct( fog->surface, backEnd.orientation.axis[ 0 ] );
+		fogDepthVector[1] = DotProduct( fog->surface, backEnd.orientation.axis[ 1 ] );
+		fogDepthVector[2] = DotProduct( fog->surface, backEnd.orientation.axis[ 2 ] );
 		fogDepthVector[3] = -fog->surface[3] + DotProduct( backEnd.orientation.origin, fog->surface );
 
 		eyeT = DotProduct( backEnd.orientation.viewOrigin, fogDepthVector ) + fogDepthVector[3];

--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -1091,12 +1091,8 @@ void BindShaderFog( Material* material ) {
 
 	// all fogging distance is based on world Z units
 	vec4_t fogDistanceVector;
-	vec3_t local;
-	VectorSubtract( backEnd.orientation.origin, backEnd.viewParms.orientation.origin, local );
-	fogDistanceVector[0] = -backEnd.orientation.modelViewMatrix[2];
-	fogDistanceVector[1] = -backEnd.orientation.modelViewMatrix[6];
-	fogDistanceVector[2] = -backEnd.orientation.modelViewMatrix[10];
-	fogDistanceVector[3] = DotProduct( local, backEnd.viewParms.orientation.axis[0] );
+	VectorCopy( backEnd.viewParms.orientation.axis[ 0 ], fogDistanceVector );
+	fogDistanceVector[ 3 ] = -DotProduct( fogDistanceVector, backEnd.viewParms.orientation.origin );
 
 	// scale the fog vectors based on the fog's thickness
 	VectorScale( fogDistanceVector, fog->tcScale, fogDistanceVector );
@@ -1106,12 +1102,9 @@ void BindShaderFog( Material* material ) {
 	float eyeT;
 	vec4_t fogDepthVector;
 	if ( fog->hasSurface ) {
-		fogDepthVector[0] = DotProduct( fog->surface, backEnd.orientation.axis[ 0 ] );
-		fogDepthVector[1] = DotProduct( fog->surface, backEnd.orientation.axis[ 1 ] );
-		fogDepthVector[2] = DotProduct( fog->surface, backEnd.orientation.axis[ 2 ] );
-		fogDepthVector[3] = -fog->surface[3] + DotProduct( backEnd.orientation.origin, fog->surface );
-
-		eyeT = DotProduct( backEnd.orientation.viewOrigin, fogDepthVector ) + fogDepthVector[3];
+		VectorCopy( fog->surface, fogDepthVector );
+		fogDepthVector[ 3 ] = -fog->surface[ 3 ];
+		eyeT = DotProduct( backEnd.viewParms.orientation.origin, fogDepthVector ) + fogDepthVector[ 3 ];
 	} else {
 		Vector4Set( fogDepthVector, 0, 0, 0, 1 );
 		eyeT = 1; // non-surface fog always has eye inside

--- a/src/engine/renderer/Material.h
+++ b/src/engine/renderer/Material.h
@@ -384,7 +384,7 @@ class MaterialSystem {
 		const bool mayUseVertexOverbright, const bool vertexLit, const bool fullbright );
 	void ProcessStage( MaterialSurface* surface, shaderStage_t* pStage, shader_t* shader, uint32_t* packIDs, uint32_t& stage,
 		uint32_t& previousMaterialID, bool skipStageSync = false );
-	void GenerateMaterial( MaterialSurface* surface );
+	void GenerateMaterial( MaterialSurface* surface, int globalFog );
 	void GenerateWorldMaterialsBuffer();
 	void GenerateWorldCommandBuffer( std::vector<MaterialSurface>& surfaces );
 	void GeneratePortalBoundingSpheres();

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2636,7 +2636,8 @@ GLShader_fogGlobal::GLShader_fogGlobal() :
 	u_UnprojectMatrix( this ),
 	u_Color_Float( this ),
 	u_Color_Uint( this ),
-	u_FogDistanceVector( this )
+	u_ViewOrigin( this ),
+	u_FogDensity( this )
 {
 }
 

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3481,7 +3481,8 @@ class GLShader_fogGlobal :
 	public u_UnprojectMatrix,
 	public u_Color_Float,
 	public u_Color_Uint,
-	public u_FogDistanceVector
+	public u_ViewOrigin,
+	public u_FogDensity
 {
 public:
 	GLShader_fogGlobal();

--- a/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
@@ -29,7 +29,8 @@ uniform sampler2D	u_DepthMap;
 
 uniform colorPack u_Color;
 
-uniform vec4		u_FogDistanceVector;
+uniform vec3 u_ViewOrigin;
+uniform float u_FogDensity;
 uniform mat4		u_UnprojectMatrix;
 
 DECLARE_OUTPUT(vec4)
@@ -45,7 +46,7 @@ void	main()
 	P.xyz /= P.w;
 
 	// calculate the length in fog (t is always 1 if eye is in fog)
-	st.s = dot(P.xyz, u_FogDistanceVector.xyz) + u_FogDistanceVector.w;
+	st.s = distance(u_ViewOrigin, P.xyz) * u_FogDensity;
 	st.t = 1.0;
 
 	vec4 color = texture2D(u_ColorMap, st);

--- a/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogGlobal_fp.glsl
@@ -32,11 +32,7 @@ uniform colorPack u_Color;
 uniform vec4		u_FogDistanceVector;
 uniform mat4		u_UnprojectMatrix;
 
-#if __VERSION__ > 120
-out vec4 outputColor;
-#else
-#define outputColor gl_FragColor
-#endif
+DECLARE_OUTPUT(vec4)
 
 void	main()
 {
@@ -48,9 +44,8 @@ void	main()
 	vec4 P = u_UnprojectMatrix * vec4(gl_FragCoord.xy, depth, 1.0);
 	P.xyz /= P.w;
 
-	// calculate the length in fog (t is always 0 if eye is in fog)
+	// calculate the length in fog (t is always 1 if eye is in fog)
 	st.s = dot(P.xyz, u_FogDistanceVector.xyz) + u_FogDistanceVector.w;
-	// st.s = vertexDistanceToCamera;
 	st.t = 1.0;
 
 	vec4 color = texture2D(u_ColorMap, st);

--- a/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogQuake3_fp.glsl
@@ -26,7 +26,6 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 uniform sampler2D u_FogMap;
 
-IN(smooth) vec3		var_Position;
 IN(smooth) vec2		var_TexCoords;
 IN(smooth) vec4		var_Color;
 
@@ -41,8 +40,4 @@ void	main()
 	color *= var_Color;
 
 	outputColor = color;
-
-#if 0
-	outputColor = vec4(vec3(1.0, 0.0, 0.0), color.a);
-#endif
 }

--- a/src/engine/renderer/glsl_source/fogQuake3_vp.glsl
+++ b/src/engine/renderer/glsl_source/fogQuake3_vp.glsl
@@ -34,11 +34,14 @@ uniform colorPack u_ColorGlobal;
 uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
-uniform vec4		u_FogDistanceVector;
-uniform vec4		u_FogDepthVector;
+uniform vec4		u_FogDistanceVector; // view axis in model coordinates, scaled by fog density
+uniform vec4		u_FogDepthVector; // fog plane in model coordinates
 uniform float		u_FogEyeT;
 
 OUT(smooth) vec3	var_Position;
+
+// var_TexCoords.s is distance from viewer to vertex dotted with view axis
+// var_TexCoords.t is the fraction of the viewer-to-vertex ray which is inside fog
 OUT(smooth) vec2	var_TexCoords;
 OUT(smooth) vec4	var_Color;
 

--- a/src/engine/renderer/glsl_source/fogQuake3_vp.glsl
+++ b/src/engine/renderer/glsl_source/fogQuake3_vp.glsl
@@ -34,11 +34,9 @@ uniform colorPack u_ColorGlobal;
 uniform mat4		u_ModelMatrix;
 uniform mat4		u_ModelViewProjectionMatrix;
 
-uniform vec4		u_FogDistanceVector; // view axis in model coordinates, scaled by fog density
-uniform vec4		u_FogDepthVector; // fog plane in model coordinates
+uniform vec4		u_FogDistanceVector; // view axis, scaled by fog density
+uniform vec4		u_FogDepthVector; // fog plane
 uniform float		u_FogEyeT;
-
-OUT(smooth) vec3	var_Position;
 
 // var_TexCoords.s is distance from viewer to vertex dotted with view axis
 // var_TexCoords.t is the fraction of the viewer-to-vertex ray which is inside fog
@@ -74,7 +72,8 @@ void main()
 	gl_Position = u_ModelViewProjectionMatrix * position;
 
 	// transform position into world space
-	var_Position = (u_ModelMatrix * position).xyz;
+	position = u_ModelMatrix * position;
+	position.xyz /= position.w;
 
 	// calculate the length in fog
 	float s = dot(position.xyz, u_FogDistanceVector.xyz) + u_FogDistanceVector.w;

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1377,20 +1377,8 @@ void RB_RenderGlobalFog()
 
 		GL_State( GLS_DEPTHTEST_DISABLE | GLS_SRCBLEND_SRC_ALPHA | GLS_DSTBLEND_ONE_MINUS_SRC_ALPHA );
 
-		// all fogging distance is based on world Z units
-		vec4_t fogDistanceVector;
-		vec3_t local;
-		VectorSubtract( backEnd.orientation.origin, backEnd.viewParms.orientation.origin, local );
-		fogDistanceVector[ 0 ] = -backEnd.orientation.modelViewMatrix[ 2 ];
-		fogDistanceVector[ 1 ] = -backEnd.orientation.modelViewMatrix[ 6 ];
-		fogDistanceVector[ 2 ] = -backEnd.orientation.modelViewMatrix[ 10 ];
-		fogDistanceVector[ 3 ] = DotProduct( local, backEnd.viewParms.orientation.axis[ 0 ] );
-
-		// scale the fog vectors based on the fog's thickness
-		VectorScale( fogDistanceVector, fog->tcScale, fogDistanceVector );
-		fogDistanceVector[ 3 ] *= fog->tcScale;
-
-		gl_fogGlobalShader->SetUniform_FogDistanceVector( fogDistanceVector );
+		gl_fogGlobalShader->SetUniform_FogDensity( fog->tcScale );
+		gl_fogGlobalShader->SetUniform_ViewOrigin( backEnd.viewParms.orientation.origin );
 		SetUniform_Color( gl_fogGlobalShader, fog->color );
 	}
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1597,12 +1597,8 @@ void Render_fog( shaderStage_t* pStage )
 
 	// all fogging distance is based on world Z units
 	vec4_t fogDistanceVector;
-	vec3_t local;
-	VectorSubtract( backEnd.orientation.origin, backEnd.viewParms.orientation.origin, local );
-	fogDistanceVector[ 0 ] = -backEnd.orientation.modelViewMatrix[ 2 ];
-	fogDistanceVector[ 1 ] = -backEnd.orientation.modelViewMatrix[ 6 ];
-	fogDistanceVector[ 2 ] = -backEnd.orientation.modelViewMatrix[ 10 ];
-	fogDistanceVector[ 3 ] = DotProduct( local, backEnd.viewParms.orientation.axis[ 0 ] );
+	VectorCopy( backEnd.viewParms.orientation.axis[ 0 ], fogDistanceVector );
+	fogDistanceVector[ 3 ] = -DotProduct( fogDistanceVector, backEnd.viewParms.orientation.origin );
 
 	// scale the fog vectors based on the fog's thickness
 	VectorScale( fogDistanceVector, fog->tcScale, fogDistanceVector );
@@ -1613,12 +1609,9 @@ void Render_fog( shaderStage_t* pStage )
 	vec4_t fogDepthVector;
 	if ( fog->hasSurface )
 	{
-		fogDepthVector[ 0 ] = DotProduct( fog->surface, backEnd.orientation.axis[ 0 ] );
-		fogDepthVector[ 1 ] = DotProduct( fog->surface, backEnd.orientation.axis[ 1 ] );
-		fogDepthVector[ 2 ] = DotProduct( fog->surface, backEnd.orientation.axis[ 2 ] );
-		fogDepthVector[ 3 ] = -fog->surface[ 3 ] + DotProduct( backEnd.orientation.origin, fog->surface );
-
-		eyeT = DotProduct( backEnd.orientation.viewOrigin, fogDepthVector ) + fogDepthVector[ 3 ];
+		VectorCopy( fog->surface, fogDepthVector );
+		fogDepthVector[ 3 ] = -fog->surface[ 3 ];
+		eyeT = DotProduct( backEnd.viewParms.orientation.origin, fogDepthVector ) + fogDepthVector[ 3 ];
 	}
 	else
 	{

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1613,12 +1613,9 @@ void Render_fog( shaderStage_t* pStage )
 	vec4_t fogDepthVector;
 	if ( fog->hasSurface )
 	{
-		fogDepthVector[ 0 ] = fog->surface[ 0 ] * backEnd.orientation.axis[ 0 ][ 0 ] +
-		                      fog->surface[ 1 ] * backEnd.orientation.axis[ 0 ][ 1 ] + fog->surface[ 2 ] * backEnd.orientation.axis[ 0 ][ 2 ];
-		fogDepthVector[ 1 ] = fog->surface[ 0 ] * backEnd.orientation.axis[ 1 ][ 0 ] +
-		                      fog->surface[ 1 ] * backEnd.orientation.axis[ 1 ][ 1 ] + fog->surface[ 2 ] * backEnd.orientation.axis[ 1 ][ 2 ];
-		fogDepthVector[ 2 ] = fog->surface[ 0 ] * backEnd.orientation.axis[ 2 ][ 0 ] +
-		                      fog->surface[ 1 ] * backEnd.orientation.axis[ 2 ][ 1 ] + fog->surface[ 2 ] * backEnd.orientation.axis[ 2 ][ 2 ];
+		fogDepthVector[ 0 ] = DotProduct( fog->surface, backEnd.orientation.axis[ 0 ] );
+		fogDepthVector[ 1 ] = DotProduct( fog->surface, backEnd.orientation.axis[ 1 ] );
+		fogDepthVector[ 2 ] = DotProduct( fog->surface, backEnd.orientation.axis[ 2 ] );
 		fogDepthVector[ 3 ] = -fog->surface[ 3 ] + DotProduct( backEnd.orientation.origin, fog->surface );
 
 		eyeT = DotProduct( backEnd.orientation.viewOrigin, fogDepthVector ) + fogDepthVector[ 3 ];


### PR DESCRIPTION
- Don't draw global fog twice in material system (like #1740 but for material system)
- Make fog distance for global fog be the real distance from viewer to vertex, not the distance dotted with the view axis. Non-global fog has this issue too but I will fix it in a later PR. Here's two screenshots from master using increased FOV to exaggerate the effect:

![unvanquished_2025-09-10_004722_000](https://github.com/user-attachments/assets/c0ef4cbc-7b70-43ae-ac28-20404fe63157)

![unvanquished_2025-09-10_004723_000](https://github.com/user-attachments/assets/7ad2835f-1cfe-4f83-b468-20f4b7b9dd4d)


- Fix wrong fog for models that use `nonNormalizedAxes` scaling. The issue is pretty subtle with our player models, so here's a before/after with a 3x scaled repeater.

![unvanquished-atcshd-fog-buildables](https://github.com/user-attachments/assets/2cedfa32-b27a-43e5-a980-9338af3d6d49)
![unvanquished-atcshd-fog-buildables](https://github.com/user-attachments/assets/fca0e062-4123-4032-b00e-b874018a389b)