### PR TITLE
Illwieckz/font texture

### DIFF
--- a/src/engine/renderer/tr_font.cpp
+++ b/src/engine/renderer/tr_font.cpp
@@ -419,7 +419,7 @@ static void RE_StoreImage( fontInfo_t *font, int chunk, int page, int from, int 
 	}
 
 
-	Com_sprintf( fileName, sizeof( fileName ), "%s_%i_%i_%i.png", font->name, chunk, page, font->pointSize );
+	Com_sprintf( fileName, sizeof( fileName ), "%s_%i_%i_%i", font->name, chunk, page, font->pointSize );
 
 	image = R_CreateGlyph( fileName, buffer, FONT_SIZE, y );
 

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1509,7 +1509,7 @@ image_t *R_CreateGlyph( const char *name, const byte *pic, int width, int height
 
 	image->uploadWidth = width;
 	image->uploadHeight = height;
-	image->internalFormat = GL_RGBA;
+	image->internalFormat = GL_RGBA8;
 
 	GL_TexImage2D( GL_TEXTURE_2D, 0, image->internalFormat, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, pic, false );
 


### PR DESCRIPTION
- tr_font: no need for file extension
  I did it for log æsthetics, but it fixes `testshader fonts/unifont_0_0_32` as a side effect.
- tr_image: use GL_RGBA8 explicitly for glyphes
  We always use an explicit format as `internalFormat` everywhere else.