### PR TITLE
Do not assume shaders without a stage is fog

### DIFF
--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4735,10 +4735,10 @@ static bool ParseShader( const char *_text )
 		}
 	}
 
-	// ignore shaders that don't have any stages, unless it is a sky or fog
+	// Make shaders without stages that are not fog and not sky as blend (they are fully transparent).
 	if ( s == 0 && !shader.forceOpaque && !shader.isSky && !( shader.contentFlags & CONTENTS_FOG ) && implicitMap[ 0 ] == '\0' )
 	{
-		return false;
+		shader.sort = Util::ordinal( shaderSort_t::SS_BLEND0 );
 	}
 
 	return true;
@@ -5697,12 +5697,6 @@ static void ValidateStage( shaderStage_t *pStage )
 // without a thorough investigation.
 static float DetermineShaderSort()
 {
-	// fogonly shaders don't have any stage passes
-	if ( numStages == 0 && !shader.isSky )
-	{
-		return Util::ordinal(shaderSort_t::SS_FOG);
-	}
-
 	for ( size_t stage = numStages; stage--; )
 	{
 		ASSERT( stages[ stage ].active );


### PR DESCRIPTION
- tr_shader: do not ignore shaders without a stage, it's a valid use case for a transparent surface
- tr_shader: do not assume shaders without a stage is fog

It makes possible to do this:

```c
// The transparent texture that is also transparent in editor too.
// It should not be listed and selectable in editor. It can be used
// on model surfaces to hide them.
gfx/shared_colors/transparent
{
	qer_editorImage textures/shared_colors_src/transparent_d
	qer_trans 0

	surfaceparm nolightmap
	surfaceparm nomarks
	surfaceparm trans
}


gfx/shared_colors/transparent_nonsolid
{
	qer_editorImage textures/shared_colors_src/transparent_d
	qer_trans 0

	surfaceparm nolightmap
	surfaceparm nomarks
	surfaceparm nonsolid
	surfaceparm trans
}
```