### PR TITLE
Remove unused FBO code and add groundwork for FBO blit functions

### DIFF
--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -142,7 +142,7 @@ void R_AttachFBOTexture1D( int texId, int index )
 		return;
 	}
 
-	glFramebufferTexture1D( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, GL_TEXTURE_1D, texId, 0 );
+	GL_fboShim.glFramebufferTexture1D( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, GL_TEXTURE_1D, texId, 0 );
 }
 
 /*
@@ -180,7 +180,7 @@ void R_AttachFBOTexture3D( int texId, int index, int zOffset )
 		return;
 	}
 
-	glFramebufferTexture3D( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, GL_TEXTURE_3D, texId, 0, zOffset );
+	GL_fboShim.glFramebufferTexture3D( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, GL_TEXTURE_3D, texId, 0, zOffset );
 }
 
 /*

--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -35,13 +35,13 @@ bool R_CheckFBO( const FBO_t *fbo )
 	int id;
 
 	glGetIntegerv( GL_FRAMEBUFFER_BINDING, &id );
-	GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, fbo->frameBuffer );
+	GL_fboShim.glBindFramebuffer( GL_DRAW_FRAMEBUFFER, fbo->frameBuffer );
 
-	code = GL_fboShim.glCheckFramebufferStatus( GL_FRAMEBUFFER );
+	code = GL_fboShim.glCheckFramebufferStatus( GL_DRAW_FRAMEBUFFER );
 
 	if ( code == GL_FRAMEBUFFER_COMPLETE )
 	{
-		GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, id );
+		GL_fboShim.glBindFramebuffer( GL_DRAW_FRAMEBUFFER, id );
 		return true;
 	}
 
@@ -85,7 +85,7 @@ bool R_CheckFBO( const FBO_t *fbo )
 			break;
 	}
 
-	GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, id );
+	GL_fboShim.glBindFramebuffer( GL_DRAW_FRAMEBUFFER, id );
 
 	return false;
 }
@@ -142,7 +142,7 @@ void R_AttachFBOTexture1D( int texId, int index )
 		return;
 	}
 
-	glFramebufferTexture1D( GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, GL_TEXTURE_1D, texId, 0 );
+	glFramebufferTexture1D( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, GL_TEXTURE_1D, texId, 0 );
 }
 
 /*
@@ -164,7 +164,7 @@ void R_AttachFBOTexture2D( int target, int texId, int index )
 		return;
 	}
 
-	GL_fboShim.glFramebufferTexture2D( GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, target, texId, 0 );
+	GL_fboShim.glFramebufferTexture2D( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, target, texId, 0 );
 }
 
 /*
@@ -180,7 +180,7 @@ void R_AttachFBOTexture3D( int texId, int index, int zOffset )
 		return;
 	}
 
-	glFramebufferTexture3D( GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, GL_TEXTURE_3D, texId, 0, zOffset );
+	glFramebufferTexture3D( GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + index, GL_TEXTURE_3D, texId, 0, zOffset );
 }
 
 /*
@@ -190,8 +190,8 @@ R_AttachFBOTexturePackedDepthStencil
 */
 void R_AttachFBOTexturePackedDepthStencil( int texId )
 {
-	GL_fboShim.glFramebufferTexture2D( GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texId, 0 );
-	GL_fboShim.glFramebufferTexture2D( GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, texId, 0 );
+	GL_fboShim.glFramebufferTexture2D( GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, texId, 0 );
+	GL_fboShim.glFramebufferTexture2D( GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, texId, 0 );
 }
 
 /*
@@ -211,7 +211,7 @@ void R_BindFBO( FBO_t *fbo )
 
 	if ( glState.currentFBO != fbo )
 	{
-		GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, fbo->frameBuffer );
+		GL_fboShim.glBindFramebuffer( GL_DRAW_FRAMEBUFFER, fbo->frameBuffer );
 
 		glState.currentFBO = fbo;
 	}
@@ -228,7 +228,7 @@ void R_BindNullFBO()
 
 	if ( glState.currentFBO )
 	{
-		GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, 0 );
+		GL_fboShim.glBindFramebuffer( GL_DRAW_FRAMEBUFFER, 0 );
 		glState.currentFBO = nullptr;
 	}
 }

--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -104,12 +104,12 @@ FBO_t          *R_CreateFBO( const char *name, int width, int height )
 		Sys::Drop( "R_CreateFBO: \"%s\" is too long", name );
 	}
 
-	if ( width <= 0 || width > glConfig.maxRenderbufferSize )
+	if ( width <= 0 )
 	{
 		Sys::Drop( "R_CreateFBO: bad width %i", width );
 	}
 
-	if ( height <= 0 || height > glConfig.maxRenderbufferSize )
+	if ( height <= 0 )
 	{
 		Sys::Drop( "R_CreateFBO: bad height %i", height );
 	}
@@ -229,7 +229,6 @@ void R_BindNullFBO()
 	if ( glState.currentFBO )
 	{
 		GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, 0 );
-		GL_fboShim.glBindRenderbuffer( GL_RENDERBUFFER, 0 );
 		glState.currentFBO = nullptr;
 	}
 }

--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -201,18 +201,20 @@ R_BindFBO
 */
 void R_BindFBO( FBO_t *fbo )
 {
-	if ( !fbo )
+	R_BindFBO( GL_DRAW_FRAMEBUFFER, fbo );
+}
+
+void R_BindFBO( GLenum target, FBO_t *fbo )
+{
+	GLuint handle = fbo == nullptr ? 0 : fbo->frameBuffer;
+
+	if ( target != GL_DRAW_FRAMEBUFFER )
 	{
-		R_BindNullFBO();
-		return;
+		GL_fboShim.glBindFramebuffer( target, handle );
 	}
-
-	GLIMP_LOGCOMMENT( "--- R_BindFBO( %s ) ---", fbo->name );
-
-	if ( glState.currentFBO != fbo )
+	else if ( glState.currentFBO != fbo )
 	{
-		GL_fboShim.glBindFramebuffer( GL_DRAW_FRAMEBUFFER, fbo->frameBuffer );
-
+		GL_fboShim.glBindFramebuffer( target, handle );
 		glState.currentFBO = fbo;
 	}
 }
@@ -224,13 +226,7 @@ R_BindNullFBO
 */
 void R_BindNullFBO()
 {
-	GLIMP_LOGCOMMENT( "--- R_BindNullFBO ---" );
-
-	if ( glState.currentFBO )
-	{
-		GL_fboShim.glBindFramebuffer( GL_DRAW_FRAMEBUFFER, 0 );
-		glState.currentFBO = nullptr;
-	}
+	R_BindFBO( nullptr );
 }
 
 /*

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -867,7 +867,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		   bound.
 		 */
 
-		GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, 0 );
+		GL_fboShim.glBindFramebuffer( GL_DRAW_FRAMEBUFFER, 0 );
 		glState.currentFBO = nullptr;
 
 		GL_PolygonMode( GL_FRONT_AND_BACK, GL_FILL );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -868,7 +868,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		 */
 
 		GL_fboShim.glBindFramebuffer( GL_FRAMEBUFFER, 0 );
-		GL_fboShim.glBindRenderbuffer( GL_RENDERBUFFER, 0 );
 		glState.currentFBO = nullptr;
 
 		GL_PolygonMode( GL_FRONT_AND_BACK, GL_FILL );
@@ -949,7 +948,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			Log::Notice("GL_TEXTURE_MAX_ANISOTROPY_EXT: %f", glConfig.maxTextureAnisotropy );
 		}
 
-		Log::Notice("GL_MAX_RENDERBUFFER_SIZE: %d", glConfig.maxRenderbufferSize );
 		Log::Notice("GL_MAX_COLOR_ATTACHMENTS: %d", glConfig.maxColorAttachments );
 
 		Log::Notice("PIXELFORMAT: color(%d-bits)", glConfig.colorBits );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -563,21 +563,7 @@ enum class ssaoMode {
 	{
 		char     name[ MAX_QPATH ];
 
-		int      index;
-
 		uint32_t frameBuffer;
-
-		uint32_t colorBuffers[ 16 ];
-		int      colorFormat;
-
-		uint32_t depthBuffer;
-		int      depthFormat;
-
-		uint32_t stencilBuffer;
-		int      stencilFormat;
-
-		uint32_t packedDepthStencilBuffer;
-		int      packedDepthStencilFormat;
 
 		int      width;
 		int      height;
@@ -3287,14 +3273,9 @@ void GLimp_LogComment_( std::string comment );
 
 	FBO_t    *R_CreateFBO( const char *name, int width, int height );
 
-	void     R_CreateFBOColorBuffer( FBO_t *fbo, int format, int index );
-	void     R_CreateFBODepthBuffer( FBO_t *fbo, int format );
-	void     R_CreateFBOStencilBuffer( FBO_t *fbo, int format );
-
 	void     R_AttachFBOTexture1D( int texId, int attachmentIndex );
 	void     R_AttachFBOTexture2D( int target, int texId, int attachmentIndex );
 	void     R_AttachFBOTexture3D( int texId, int attachmentIndex, int zOffset );
-	void     R_AttachFBOTextureDepth( int texId );
 
 	void     R_BindFBO( FBO_t *fbo );
 	void     R_BindNullFBO();

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -3278,6 +3278,7 @@ void GLimp_LogComment_( std::string comment );
 	void     R_AttachFBOTexture3D( int texId, int attachmentIndex, int zOffset );
 
 	void     R_BindFBO( FBO_t *fbo );
+	void     R_BindFBO( GLenum target, FBO_t *fbo );
 	void     R_BindNullFBO();
 
 	void     R_InitFBOs();

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -223,8 +223,12 @@ struct glFboShim_t
 	PFNGLDELETERENDERBUFFERSPROC glDeleteRenderbuffers;
 	// void (*glFramebufferRenderbuffer) (GLenum target, GLenum attachment, GLenum renderbuffertarget, GLuint renderbuffer);
 	PFNGLFRAMEBUFFERRENDERBUFFERPROC glFramebufferRenderbuffer;
+	// void (*glFramebufferTexture1D) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
+	PFNGLFRAMEBUFFERTEXTURE1DPROC glFramebufferTexture1D;
 	// void (*glFramebufferTexture2D) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level);
 	PFNGLFRAMEBUFFERTEXTURE2DPROC glFramebufferTexture2D;
+	// void (*glFramebufferTexture3D) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLint zoffset);
+	PFNGLFRAMEBUFFERTEXTURE3DPROC glFramebufferTexture3D;
 	// void (*glGenerateMipmap) (GLenum target);
 	PFNGLGENERATEMIPMAPPROC glGenerateMipmap;
 	// void (*glGenFramebuffers) (GLsizei n, GLuint *framebuffers);
@@ -263,7 +267,9 @@ static inline void glFboSetArb()
 	GL_fboShim.glDeleteFramebuffers = glDeleteFramebuffers;
 	GL_fboShim.glDeleteRenderbuffers = glDeleteRenderbuffers;
 	GL_fboShim.glFramebufferRenderbuffer = glFramebufferRenderbuffer;
+	GL_fboShim.glFramebufferTexture1D = glFramebufferTexture1D;
 	GL_fboShim.glFramebufferTexture2D = glFramebufferTexture2D;
+	GL_fboShim.glFramebufferTexture3D = glFramebufferTexture3D;
 	GL_fboShim.glGenerateMipmap = glGenerateMipmap;
 	GL_fboShim.glGenFramebuffers = glGenFramebuffers;
 	GL_fboShim.glGenRenderbuffers = glGenRenderbuffers;
@@ -283,7 +289,9 @@ static inline void glFboSetExt()
 	GL_fboShim.glDeleteFramebuffers = glDeleteFramebuffersEXT;
 	GL_fboShim.glDeleteRenderbuffers = glDeleteRenderbuffersEXT;
 	GL_fboShim.glFramebufferRenderbuffer = glFramebufferRenderbufferEXT;
+	GL_fboShim.glFramebufferTexture1D = glFramebufferTexture1DEXT;
 	GL_fboShim.glFramebufferTexture2D = glFramebufferTexture2DEXT;
+	GL_fboShim.glFramebufferTexture3D = glFramebufferTexture3DEXT;
 	GL_fboShim.glGenerateMipmap = glGenerateMipmapEXT;
 	GL_fboShim.glGenFramebuffers = glGenFramebuffersEXT;
 	GL_fboShim.glGenRenderbuffers = glGenRenderbuffersEXT;

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -233,6 +233,8 @@ struct glFboShim_t
 	PFNGLGENRENDERBUFFERSPROC glGenRenderbuffers;
 	// void (*glRenderbufferStorage) (GLenum target, GLenum internalformat, GLsizei width, GLsizei height);
 	PFNGLRENDERBUFFERSTORAGEPROC glRenderbufferStorage;
+	// void (*glBlitFramebuffer) (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+	PFNGLBLITFRAMEBUFFERPROC glBlitFramebuffer;
 
 	/* Unused for now, part of GL_EXT_framebuffer_multisample:
 	// void (*glRenderbufferStorageMultisample) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
@@ -266,6 +268,7 @@ static inline void glFboSetArb()
 	GL_fboShim.glGenFramebuffers = glGenFramebuffers;
 	GL_fboShim.glGenRenderbuffers = glGenRenderbuffers;
 	GL_fboShim.glRenderbufferStorage = glRenderbufferStorage;
+	GL_fboShim.glBlitFramebuffer = glBlitFramebuffer;
 
 	/* Unused for now, part of GL_EXT_framebuffer_multisample:
 	GL_fboShim.glRenderbufferStorageMultisample = glRenderbufferStorageMultisample; */
@@ -273,6 +276,7 @@ static inline void glFboSetArb()
 
 static inline void glFboSetExt()
 {
+	// EXT_framebuffer_object
 	GL_fboShim.glBindFramebuffer = glBindFramebufferEXT;
 	GL_fboShim.glBindRenderbuffer = glBindRenderbufferEXT;
 	GL_fboShim.glCheckFramebufferStatus = glCheckFramebufferStatusEXT;
@@ -284,6 +288,9 @@ static inline void glFboSetExt()
 	GL_fboShim.glGenFramebuffers = glGenFramebuffersEXT;
 	GL_fboShim.glGenRenderbuffers = glGenRenderbuffersEXT;
 	GL_fboShim.glRenderbufferStorage = glRenderbufferStorageEXT;
+
+	// EXT_framebuffer_blit
+	GL_fboShim.glBlitFramebuffer = glBlitFramebufferEXT;
 
 	/* Unused for now, part of GL_EXT_framebuffer_multisample:
 	GL_fboShim.glRenderbufferStorageMultisample = glRenderbufferStorageMultisampleEXT; */

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -144,7 +144,6 @@ struct GLConfig
 	float textureAnisotropy;
 	bool textureAnisotropyAvailable;
 
-	int      maxRenderbufferSize;
 	int      maxColorAttachments;
 
 	bool getProgramBinaryAvailable;

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2338,7 +2338,6 @@ static void GLimp_InitExtensions()
 		glFboSetExt();
 	}
 
-	glGetIntegerv( GL_MAX_RENDERBUFFER_SIZE, &glConfig.maxRenderbufferSize );
 	glGetIntegerv( GL_MAX_COLOR_ATTACHMENTS, &glConfig.maxColorAttachments );
 
 	// made required in OpenGL 2.0


### PR DESCRIPTION
- Clean up unused code
- Fix an instance where GL_fboShim was not used
- Add optional target argument for R_BindFBO (lifted from #1480)
- Add BlitFramebuffer function to FBO shim

The last 2 things are needed for FBO blitting. I need FBO blitting to fix <!-- --> #1783, while it is also used in #1480 so I'm trying to reuse the code from there. But I've tried to make R_BindFBO more robust by making GL_DRAW_FRAMEBUFFER the default instead of GL_FRAMEBUFFER because with the latter, you get issues that it matters what order you do the bindings in because it overwrites both READ and DRAW framebuffers.