### PR TITLE
Copy depth texture to avoid texture feedback loops

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -904,7 +904,7 @@ void BindShaderGeneric3D( Material* material ) {
 	gl_genericShaderMaterial->SetUniform_ModelMatrix( backEnd.orientation.transformMatrix );
 	gl_genericShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 
-	gl_genericShaderMaterial->SetUniform_DepthMapBindless( GL_BindToTMU( 1, tr.currentDepthImage ) );
+	gl_genericShaderMaterial->SetUniform_DepthMapBindless( GL_BindToTMU( 1, tr.depthSamplerImage ) );
 
 	// u_DeformGen
 	gl_genericShaderMaterial->SetUniform_Time( backEnd.refdef.floatTime - backEnd.currentEntity->e.shaderTime );
@@ -1080,7 +1080,7 @@ void BindShaderLiquid( Material* material ) {
 	gl_liquidShaderMaterial->SetUniform_ModelViewProjectionMatrix( glState.modelViewProjectionMatrix[glState.stackIndex] );
 
 	// depth texture
-	gl_liquidShaderMaterial->SetUniform_DepthMapBindless( GL_BindToTMU( 2, tr.currentDepthImage ) );
+	gl_liquidShaderMaterial->SetUniform_DepthMapBindless( GL_BindToTMU( 2, tr.depthSamplerImage ) );
 
 	// bind u_PortalMap
 	gl_liquidShaderMaterial->SetUniform_PortalMapBindless( GL_BindToTMU( 1, tr.portalRenderImage ) );

--- a/src/engine/renderer/tr_fbo.cpp
+++ b/src/engine/renderer/tr_fbo.cpp
@@ -263,6 +263,14 @@ void R_InitFBOs()
 	R_AttachFBOTexturePackedDepthStencil( tr.currentDepthImage->texnum );
 	R_CheckFBO( tr.mainFBO[1] );
 
+	if ( glConfig.usingReadonlyDepth )
+	{
+		tr.readonlyDepthFBO = R_CreateFBO( "_depthReadonly", width, height );
+		R_BindFBO( tr.readonlyDepthFBO );
+		R_AttachFBOTexturePackedDepthStencil( tr.depthSamplerImage->texnum );
+		glConfig.usingReadonlyDepth = R_CheckFBO( tr.readonlyDepthFBO );
+	}
+
 	if ( glConfig.realtimeLighting )
 	{
 		/* It's only required to create frame buffers only used by the

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -2473,6 +2473,12 @@ static void R_CreateCurrentRenderImage()
 
 	tr.currentDepthImage = R_CreateImage( "*currentDepth", nullptr, width, height, 1, imageParams );
 
+	if ( glConfig.usingReadonlyDepth )
+	{
+		// For use with glBlitFramebuffer, format must be the same as currentDepthImage
+		tr.depthSamplerImage = R_CreateImage( "*readonlyDepth", nullptr, width, height, 1, imageParams );
+	}
+
 	if ( glConfig.usingMaterialSystem ) {
 		materialSystem.GenerateDepthImages( width, height, imageParams );
 	}

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -92,6 +92,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 	Cvar::Cvar<bool> r_overbrightIgnoreMapSettings("r_overbrightIgnoreMapSettings", "force usage of r_overbrightDefaultClamp / r_overbrightDefaultExponent, ignoring worldspawn", Cvar::NONE, false);
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	Cvar::Cvar<bool> r_colorGrading( "r_colorGrading", "Use color grading", Cvar::NONE, true );
+	static Cvar::Range<Cvar::Cvar<int>> r_readonlyDepthBuffer(
+		"r_readonlyDepthBuffer", "sample depth from a copy of the depth texture: 0 = no (unsafe), 1 = if necessary depending on GL features, 2 = yes",
+		Cvar::NONE, 1, 0, 2);
 	Cvar::Cvar<bool> r_preferBindlessTextures( "r_preferBindlessTextures", "use bindless textures even when material system is off", Cvar::NONE, false );
 	Cvar::Cvar<bool> r_materialSystem( "r_materialSystem", "Use Material System", Cvar::NONE, false );
 	Cvar::Cvar<bool> r_gpuFrustumCulling( "r_gpuFrustumCulling", "Use frustum culling on the GPU for the Material System", Cvar::NONE, true );
@@ -1193,6 +1196,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		Cvar::Latch( r_realtimeLighting );
 		Cvar::Latch( r_realtimeLightLayers );
+		Cvar::Latch( r_readonlyDepthBuffer );
 		Cvar::Latch( r_preferBindlessTextures );
 		Cvar::Latch( r_materialSystem );
 
@@ -1407,11 +1411,36 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			backEndData[ 1 ] = nullptr;
 		}
 
+		switch ( r_readonlyDepthBuffer.Get() )
+		{
+		case 0:
+			glConfig.usingReadonlyDepth = false;
+			break;
+		case 1:
+			glConfig.usingReadonlyDepth = !glConfig.textureBarrierAvailable;
+			break;
+		case 2:
+			glConfig.usingReadonlyDepth = true;
+			break;
+		}
+
+		if ( glConfig.usingReadonlyDepth && !r_depthShaders.Get() )
+		{
+			Log::Warn( "Disabling read-only depth buffer because depth pre-pass is disabled" );
+			glConfig.usingReadonlyDepth = false;
+		}
+
 		R_ToggleSmpFrame();
 
 		R_InitImages();
 
 		R_InitFBOs();
+
+		// This is here in case creating the depth-only FBO failed.
+		if ( !glConfig.usingReadonlyDepth )
+		{
+			tr.depthSamplerImage = tr.currentDepthImage;
+		}
 
 		R_InitVBOs();
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2454,6 +2454,7 @@ enum
 		image_t    *bloomRenderFBOImage[ 2 ];
 		image_t    *currentRenderImage[ 2 ];
 		image_t    *currentDepthImage;
+		image_t    *depthSamplerImage;
 		image_t    *depthtile1RenderImage;
 		image_t    *depthtile2RenderImage;
 		image_t    *lighttileRenderImage;
@@ -2465,6 +2466,7 @@ enum
 
 		// framebuffer objects
 		FBO_t *mainFBO[ 2 ];
+		FBO_t *readonlyDepthFBO;
 		FBO_t *depthtile1FBO;
 		FBO_t *depthtile2FBO;
 		FBO_t *lighttileFBO;

--- a/src/engine/renderer/tr_public.h
+++ b/src/engine/renderer/tr_public.h
@@ -111,6 +111,7 @@ struct GLConfig
 	bool computeShaderAvailable;
 	bool bindlessTexturesAvailable; // do the driver/hardware support it
 	bool usingBindlessTextures; // are we using them right now
+	bool usingReadonlyDepth;
 	bool shaderDrawParametersAvailable;
 	bool SSBOAvailable;
 	bool multiDrawIndirectAvailable;

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -951,7 +951,7 @@ void Render_generic3D( shaderStage_t *pStage )
 	if ( needDepthMap )
 	{
 		gl_genericShader->SetUniform_DepthMapBindless(
-			GL_BindToTMU( 1, tr.currentDepthImage )
+			GL_BindToTMU( 1, tr.depthSamplerImage )
 		);
 	}
 
@@ -1550,7 +1550,7 @@ void Render_liquid( shaderStage_t *pStage )
 	gl_liquidShader->SetUniform_PortalMapBindless( GL_BindToTMU( 1, tr.portalRenderImage ) );
 
 	// depth texture
-	gl_liquidShader->SetUniform_DepthMapBindless( GL_BindToTMU( 2, tr.currentDepthImage ) );
+	gl_liquidShader->SetUniform_DepthMapBindless( GL_BindToTMU( 2, tr.depthSamplerImage ) );
 
 	// bind u_HeightMap u_depthScale u_reliefOffsetBias
 	if ( pStage->enableReliefMapping )

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2024,6 +2024,7 @@ static void GLimp_InitExtensions()
 	Cvar::Latch( r_arb_shading_language_420pack );
 	Cvar::Latch( r_arb_shader_storage_buffer_object );
 	Cvar::Latch( r_arb_sync );
+	Cvar::Latch( r_arb_texture_barrier );
 	Cvar::Latch( r_arb_texture_gather );
 	Cvar::Latch( r_arb_uniform_buffer_object );
 	Cvar::Latch( r_arb_vertex_attrib_binding );


### PR DESCRIPTION
Depends on #1813.

Implement a code path for sampling `u_DepthMap` in shaders from a separate copy of the depth texture, instead of the same one that is attached to the rendering FBO. By default, this will be enabled if the driver does not implement `TextureBarrier`, in order to prevent texture feedback loops. Behavior is controlled by `r_copyDepthBuffer`. This is meant to fix #1783. Seems to work on my Mac system.

Also I keep having some issues with SSAO + bindless textures on a Mesa + AMD setup. In a game with map `survival-pit` I got the SSAO artifacts as shown below. (Same ones I used to get with dummygame. I still got those even after #1731 which I though would fix them but didn't, but they may have gone away after a Mesa update.) I can't reproduce the artifacts in a local game but if I play a demo recorded from an online game, I get the artifacts the whole time. Anyway `set r_copyDepthBuffer 2` from this PR fixes those artifacts for me.

![unvanquished_2025-09-05_142446_000](https://github.com/user-attachments/assets/ae9bf604-f08c-4eb4-9162-86f47019b3fb)


Things to do:
- Check if I'm copying the depth buffer in the best way. Is there a depth-only format I should be using instead of the depth + stencil?
- Disable depth buffer copy if `r_depthShaders` (incompatible debug cvar) is disabled
- Ask @illwieckz to assess the performance of this on low-end cards
- Determine which hardware/driver combinations still have issues with reading the depth buffer despite implementing texture barrier. (This could go in another PR)
- Maybe skip texture barriers if the duplicated depth buffer is used?