### PR TITLE
Add more texture barriers to prevent depth sampling issues

### DIFF
--- a/src/engine/renderer/Material.cpp
+++ b/src/engine/renderer/Material.cpp
@@ -2000,6 +2000,11 @@ void MaterialSystem::RenderMaterials( const shaderSort_t fromSort, const shaderS
 		}
 	}
 
+	// All material packs currently render depth-writing shaders.
+	// If we were to render depth fade or anything else sampling u_DepthMap with the material system,
+	// we would need to track this on a per-material basis.
+	backEnd.dirtyDepthBuffer = true;
+
 	GL_BindVAO( backEnd.defaultVAO );
 
 	// Draw the skybox here because we skipped R_AddWorldSurfaces()

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1246,6 +1246,11 @@ static void RenderDepthTiles()
 		return;
 	}
 
+	if ( glConfig.usingBindlessTextures )
+	{
+		RB_PrepareForSamplingDepthMap();
+	}
+
 	// 1st step
 	R_BindFBO( tr.depthtile1FBO );
 	GL_Viewport( 0, 0, tr.depthtile1FBO->width, tr.depthtile1FBO->height );
@@ -1382,6 +1387,8 @@ void RB_RenderGlobalFog()
 
 	GLIMP_LOGCOMMENT( "--- RB_RenderGlobalFog ---" );
 
+	RB_PrepareForSamplingDepthMap();
+
 	GL_Cull( cullType_t::CT_TWO_SIDED );
 
 	gl_fogGlobalShader->BindProgram( 0 );
@@ -1514,6 +1521,8 @@ void RB_RenderMotionBlur()
 	}
 
 	GLIMP_LOGCOMMENT( "--- RB_RenderMotionBlur ---" );
+
+	RB_PrepareForSamplingDepthMap();
 
 	GL_State( GLS_DEPTHTEST_DISABLE );
 	GL_Cull( cullType_t::CT_TWO_SIDED );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2923,6 +2923,7 @@ void GL_TexImage3D( GLenum target, GLint level, GLint internalFormat, GLsizei wi
 void GL_CompressedTexImage2D( GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, const void *data, bool isSRGB );
 void GL_CompressedTexSubImage3D( GLenum target, GLint level, GLint xOffset, GLint yOffset, GLint zOffset, GLsizei width, GLsizei height, GLsizei depth, GLenum internalFormat, GLsizei size, const void *data, bool isSRGB );
 	void R_ShutdownBackend();
+	void RB_PrepareForSamplingDepthMap();
 
 	/*
 	====================================================================

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1494,6 +1494,8 @@ void Render_liquid( shaderStage_t *pStage )
 
 	GLIMP_LOGCOMMENT( "--- Render_liquid ---" );
 
+	RB_PrepareForSamplingDepthMap();
+
 	// Tr3B: don't allow blend effects
 	GL_State( pStage->stateBits & ~( GLS_SRCBLEND_BITS | GLS_DSTBLEND_BITS | GLS_DEPTHMASK_TRUE ) );
 

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -874,12 +874,9 @@ void Render_generic3D( shaderStage_t *pStage )
 	bool hasDepthFade = pStage->hasDepthFade;
 	bool needDepthMap = pStage->hasDepthFade;
 
-	if ( needDepthMap && backEnd.dirtyDepthBuffer && glConfig.textureBarrierAvailable )
+	if ( needDepthMap )
 	{
-		// Flush depth buffer to make sure it is available for reading in the depth fade
-		// GLSL - prevents https://github.com/DaemonEngine/Daemon/issues/1676
-		glTextureBarrier();
-		backEnd.dirtyDepthBuffer = false;
+		RB_PrepareForSamplingDepthMap();
 	}
 
 	// choose right shader program ----------------------------------


### PR DESCRIPTION
Fixes this issue for me which can happen when SSAO + realtime lights + bindless textures are used:

![unvanquished_2025-09-18_235217_000](https://github.com/user-attachments/assets/d6cba107-4880-4dc6-b912-a1495802a640)

It's a weird bug since what seems to matter is whether realtime lights were rendered on the first frame after loading. Turning on or off `r_drawDynamicLights` afterward has no effect.

Although #1684 as a whole triggers the SSAO noise bug to occur all the time for me (not just on certain maps), one of the commits from it turned out to fix the bug. If I cherry-pick `Add 2 missing glTextureBarrier()` to master, the SSAO noise is gone. So this PR is an expanded version of that commit.

In the light tile case, I don't think there is normally a texture feedback loop because we are not writing to the main rendering FBO, only the depth tile one. But I found a comment saying that with bindless textures, feedback loops can depend in some way on whether a texture handle is resident. I don't understand what rules should be followed for that case.