### PR TITLE
Logging: improve suppression thread safety; fix file/line logging in gamelogic

### DIFF
--- a/src/common/Log.cpp
+++ b/src/common/Log.cpp
@@ -45,15 +45,16 @@ namespace Log {
     Logger::Logger(Str::StringRef name, std::string prefix, Level defaultLevel)
         : filterLevel(new Cvar::Cvar<Log::Level>(
               "logs.level." + name, "Log::Level - logs from '" + name + "' below the level specified are filtered", 0, defaultLevel)),
-          prefix(prefix), enableSuppression(true) {
+          enableSuppression(true)
+    {
+        if (!prefix.empty()) {
+            // TODO allow prefixes without a space, e.g. a color code
+            this->prefix = prefix + " ";
+        }
     }
 
-    std::string Logger::Prefix(std::string message) const {
-        if (prefix.empty()) {
-            return message;
-        } else {
-            return prefix + " " + message;
-        }
+    std::string Logger::Prefix(Str::StringRef message) const {
+        return prefix + message;
     }
 
     void Logger::Dispatch(std::string message, Log::Level level, Str::StringRef format) {

--- a/src/common/Log.h
+++ b/src/common/Log.h
@@ -131,22 +131,26 @@ namespace Log {
 
     /*
      * When debugging a function or before a logger is introduced for
-     * a module the following functions can be used for less typing.
+     * a module, the following signatures can be used for less typing.
      * However it shouldn't stay in production code because it
      * cannot be filtered and will clutter the console.
+     *
+     * These are not the real function declarations because macros are involved to get __LINE__ etc.
      */
 
+#if 0
     template<typename ... Args>
-    void Warn( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
+    void Warn( Str::StringRef format, Args&& ... args );
 
     template<typename ... Args>
-    void Notice( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
+    void Notice( Str::StringRef format, Args&& ... args );
 
     template<typename ... Args>
-    void Verbose( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
+    void Verbose( Str::StringRef format, Args&& ... args );
 
     template<typename ... Args>
-    void Debug( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args );
+    void Debug( Str::StringRef format, Args&& ... args );
+#endif
 
     /*
      * For messages which are not true log messages, but rather are produced by

--- a/src/common/Log.h
+++ b/src/common/Log.h
@@ -118,7 +118,7 @@ namespace Log {
         private:
             void Dispatch(std::string message, Log::Level level, Str::StringRef format);
 
-            std::string Prefix(std::string message) const;
+            std::string Prefix(Str::StringRef message) const;
 
             // the cvar logs.level.<name>
             std::shared_ptr<Cvar::Cvar<Level>> filterLevel;

--- a/src/common/Log.h
+++ b/src/common/Log.h
@@ -51,12 +51,6 @@ namespace Log {
     // The default filtering level
     const Level DEFAULT_FILTER_LEVEL = Level::WARNING;
 
-    extern Cvar::Cvar<bool> logExtendAll;
-    extern Cvar::Cvar<bool> logExtendWarn;
-    extern Cvar::Cvar<bool> logExtendNotice;
-    extern Cvar::Cvar<bool> logExtendVerbose;
-    extern Cvar::Cvar<bool> logExtendDebug;
-
     /*
      * Loggers are used to group logs by subsystems and allow logs
      * to be filtered by log level by subsystem. They are used like so
@@ -116,7 +110,8 @@ namespace Log {
             Logger WithoutSuppression();
 
         private:
-            void Dispatch(std::string message, Log::Level level, Str::StringRef format);
+            void Dispatch(std::string message, Log::Level level, Str::StringRef format,
+                          const char* file, const char* function, int line);
 
             std::string Prefix(Str::StringRef message) const;
 
@@ -203,62 +198,35 @@ namespace Log {
 
     // Logger
 
-    inline std::string AddSrcLocation( const std::string& message,
-        const char* file, const char* function, const int line,
-        const bool extend ) {
-        if ( logExtendAll.Get() || extend ) {
-            return message + Str::Format( " ^F(%s:%u, %s)",
-                file, line, function );
-        }
-
-        return message;
-    }
-
     template<typename ... Args>
     void Logger::WarnExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
         if ( filterLevel->Get() <= Level::WARNING ) {
-            this->Dispatch(
-                AddSrcLocation(
-                    Prefix( Str::Format( format, std::forward<Args>( args ) ... ) ),
-                    file, function, line, logExtendWarn.Get()
-                ),
-                Level::WARNING, format );
+            this->Dispatch(Prefix(Str::Format(format, std::forward<Args>(args)...)),
+                           Level::WARNING, format, file, function, line);
         }
     }
 
     template<typename ... Args>
     void Logger::NoticeExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
         if ( filterLevel->Get() <= Level::NOTICE ) {
-            this->Dispatch(
-                AddSrcLocation(
-                    Prefix( Str::Format( format, std::forward<Args>( args ) ... ) ),
-                    file, function, line, logExtendNotice.Get()
-                ),
-                Level::NOTICE, format );
+            this->Dispatch(Prefix(Str::Format(format, std::forward<Args>(args)...)),
+                           Level::NOTICE, format, file, function, line);
         }
     }
 
     template<typename ... Args>
     void Logger::VerboseExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
         if ( filterLevel->Get() <= Level::VERBOSE ) {
-            this->Dispatch(
-                AddSrcLocation(
-                    Prefix( Str::Format( format, std::forward<Args>( args ) ... ) ),
-                    file, function, line, logExtendVerbose.Get()
-                ),
-                Level::VERBOSE, format );
+            this->Dispatch(Prefix(Str::Format(format, std::forward<Args>(args)...)),
+                           Level::VERBOSE, format, file, function, line);
         }
     }
 
     template<typename ... Args>
     void Logger::DebugExt( const char* file, const char* function, const int line, Str::StringRef format, Args&& ... args ) {
         if ( filterLevel->Get() <= Level::DEBUG ) {
-            this->Dispatch(
-                AddSrcLocation(
-                    Prefix( Str::Format( format, std::forward<Args>( args ) ... ) ),
-                    file, function, line, logExtendDebug.Get()
-                ),
-                Level::DEBUG, format );
+            this->Dispatch(Prefix(Str::Format(format, std::forward<Args>(args)...)),
+                           Level::DEBUG, format, file, function, line);
         }
     }
 

--- a/src/engine/framework/LogSystem.cpp
+++ b/src/engine/framework/LogSystem.cpp
@@ -34,16 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "LogSystem.h"
 
 namespace Log {
-
-    static Cvar::Cvar<bool> suppressionEnabled(
-        "logs.suppression.enabled", "Whether to suppress log messages that are printed too many times", Cvar::NONE, true);
-    static Cvar::Range<Cvar::Cvar<int>> suppressionInterval(
-        "logs.suppression.interval", "Interval in milliseconds for detecting log spam", Cvar::NONE, 2000, 1, 1000000);
-    static Cvar::Range<Cvar::Cvar<int>> suppressionCount(
-        "logs.suppression.count", "Number of occurrences for a message to be considered log spam", Cvar::NONE, 10, 1, 1000000);
-    static Cvar::Range<Cvar::Cvar<int>> suppressionBufSize(
-        "logs.suppression.bufferSize", "How many distinct messages to track for log suppression", Cvar::NONE, 50, 1, 1000000);
-
     static Target* targets[MAX_TARGET_ID];
 
 


### PR DESCRIPTION
In the engine, access the `logs.suppression.*` cvars through their objects, instead of looking them up in the cvar map via their names. Looking them up via name is seriously unsafe on a non-main thread. Simply reading the int or bool is still technically thread-unsafe, but should be fine in practice.

Fix `logs.writeSrcLocation.*` access in gamelogic. These cvars will no longer emit warnings due to duplicate registration, and be obeyed by the gamelogic.