### PR TITLE
Remove "StackTrace unavailable" message

### DIFF
--- a/src/common/StackTrace.h
+++ b/src/common/StackTrace.h
@@ -75,7 +75,6 @@ inline void PrintStackTrace( const std::stacktrace& stackTrace = std::stacktrace
 #else
 
 inline void PrintStackTrace() {
-    Log::Warn( "StackTrace unavailable: CPP23 required" );
 }
 
 #endif


### PR DESCRIPTION
This will at least prevent the crash described in #1828 from happening when the stack trace feature is disabled. The message was annoying anyway.