### PR TITLE
Fast `R_QtangentsToTBN()` variant to speed-up `Tess_SurfaceIQM()` and `Tess_SurfaceMD5()`

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -116,6 +116,15 @@ static inline void floatToSnorm16( const vec4_t in, i16vec4_t out )
 	out[ 3 ] = floatToSnorm16( in[ 3 ] );
 }
 
+static inline void floatToSnorm16_fast( const vec4_t in, i16vec4_t out )
+{
+	// Just truncate them all.
+	out[ 0 ] = in[ 0 ] * 32767.0f;
+	out[ 1 ] = in[ 1 ] * 32767.0f;
+	out[ 2 ] = in[ 2 ] * 32767.0f;
+	out[ 3 ] = in[ 3 ] * 32767.0f;
+}
+
 static inline void snorm16ToFloat( const i16vec4_t in, vec4_t out )
 {
 	out[ 0 ] = snorm16ToFloat( in[ 0 ] );
@@ -2868,7 +2877,13 @@ inline bool checkGLErrors()
 	 *   minimal error.
 	 */
 	void R_TBNtoQtangents( const vec3_t tangent, const vec3_t binormal,
-			       const vec3_t normal, i16vec4_t qtangent );
+		const vec3_t normal, i16vec4_t qtangent, bool fast = false );
+
+	inline void R_TBNtoQtangentsFast( const vec3_t tangent, const vec3_t binormal,
+		const vec3_t normal, i16vec4_t qtangent )
+	{
+		R_TBNtoQtangents( tangent, binormal, normal, qtangent, true );
+	}
 
 	void R_QtangentsToTBN( const i16vec4_t qtangent, vec3_t tangent,
 			       vec3_t binormal, vec3_t normal );

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -135,8 +135,8 @@ void R_CalcTangents( vec3_t tangent, vec3_t binormal,
 	binormal[1] = dtx[0] * dpy[1] - dpx[1] * dty[0];
 	binormal[2] = dtx[0] * dpy[2] - dpx[2] * dty[0];
 
-	VectorNormalize( tangent );
-	VectorNormalize( binormal );
+	VectorNormalizeFast( tangent );
+	VectorNormalizeFast( binormal );
 }
 
 

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -168,7 +168,7 @@ void R_QtangentsToNormal( const i16vec4_t qtangent, vec3_t normal )
 }
 
 void R_TBNtoQtangents( const vec3_t tangent, const vec3_t binormal,
-		       const vec3_t normal, i16vec4_t qtangent )
+	const vec3_t normal, i16vec4_t qtangent, bool fast )
 {
 	vec3_t tangent2, binormal2, normal2;
 	vec4_t q;
@@ -292,7 +292,15 @@ void R_TBNtoQtangents( const vec3_t tangent, const vec3_t binormal,
 	}
 
 	i16vec4_t resqtangent;
-	floatToSnorm16( q, resqtangent );
+
+	if ( fast )
+	{
+		floatToSnorm16_fast( q, resqtangent );
+	}
+	else
+	{
+		floatToSnorm16( q, resqtangent );
+	}
 
 	if( resqtangent[ 3 ] == 0 )
 	{

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -57,7 +57,7 @@ void R_CalcFaceNormal( vec3_t normal,
 	VectorSubtract( v1, v0, v );
 	CrossProduct( u, v, normal );
 
-	VectorNormalize( normal );
+	VectorNormalizeFast( normal );
 }
 
 

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -94,8 +94,8 @@ void R_CalcTangents( vec3_t tangent, vec3_t binormal,
 	binormal[1] = dtx[0] * dpy[1] - dpx[1] * dty[0];
 	binormal[2] = dtx[0] * dpy[2] - dpx[2] * dty[0];
 
-	VectorNormalize( tangent );
-	VectorNormalize( binormal );
+	VectorNormalizeFast( tangent );
+	VectorNormalizeFast( binormal );
 }
 
 void R_CalcTangents( vec3_t tangent, vec3_t binormal,

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -740,8 +740,7 @@ static void Tess_SurfacePolychain( srfPoly_t *p )
 			i16vec4_t qtangents;
 
 			VectorNormalizeFast(normals[i]);
-			R_TBNtoQtangents(tangents[i], binormals[i],
-				normals[i], qtangents);
+			R_TBNtoQtangentsFast(tangents[i], binormals[i], normals[i], qtangents);
 
 			VectorCopy(p->verts[i].xyz, tess.verts[tess.numVertexes + i].xyz);
 

--- a/src/engine/renderer/tr_surface.cpp
+++ b/src/engine/renderer/tr_surface.cpp
@@ -1120,7 +1120,7 @@ static void Tess_SurfaceMD5( md5Surface_t *srf )
 			VectorNormalizeFast( binormal );
 			VectorCopy( position, tessVertex->xyz );
 
-			R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
+			R_TBNtoQtangentsFast( tangent, binormal, normal, tessVertex->qtangents );
 
 			Vector2Copy( surfaceVertex->texCoords, tessVertex->texCoords );
 		}
@@ -1325,7 +1325,7 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 				VectorNormalizeFast( binormal );
 				VectorCopy( position, tessVertex->xyz );
 
-				R_TBNtoQtangents( tangent, binormal, normal, tessVertex->qtangents );
+				R_TBNtoQtangentsFast( tangent, binormal, normal, tessVertex->qtangents );
 
 				Vector2Copy( modelTexcoord, tessVertex->texCoords );
 			}
@@ -1342,7 +1342,7 @@ void Tess_SurfaceIQM( srfIQModel_t *surf ) {
 		{
 			VectorScale( modelPosition, scale, tessVertex->xyz );
 
-			R_TBNtoQtangents( modelTangent, modelBitangent, modelNormal, tessVertex->qtangents );
+			R_TBNtoQtangentsFast( modelTangent, modelBitangent, modelNormal, tessVertex->qtangents );
 
 			Vector2Copy( modelTexcoord, tessVertex->texCoords );
 		}


### PR DESCRIPTION
- renderer: introduce `R_TBNtoQtangentsFast()` and `floatToSnorm16_fast()`
- renderer: faster `Tess_SurfaceIQM()` and `Tess_SurfaceMD5()` with `R_TBNtoQtangentsFast()`

I noticed that the the `Tess_SurfaceIQM()` function (used in CPU model code) was spending significant time in `R_QtangentsToTBN()` and this was spending significant time in `floatToSnorm16()`. Then I discovered that this function was doing a rounding to the closest int on every component of the vector, calling `lrintf()` on every component one by one. But, this is model rendering code, we may not need that much exactitude, and a basic truncate can likely do the job as well and the result is likely good enough. Also, this CPU code is a fallback for when low-end devices can't process the current model on GPU, so the player is already using a low preset with low LOD and then, already gets worse results than that in other rendered things. Using a basic truncate means the compiler can vectorize, and it does.

I reported the trick to `Tess_SurfaceMD5()` as well.

Other model code (like the MD3 code) using `R_QtangentsToTBN()` at load time still use the properly-rounded, lrintf-based variant. Same for the IQM/MD5 loading code for the GPU code path.

Before, `97fps`, with generated code:

```asm
		floatToSnorm16( q, resqtangent );
0x5ae46f35db61:	mulss        xmm0, dword ptr [rip + 0x2b6537]
0x5ae46f35db69:	movss        dword ptr [rsp + 8], xmm3
0x5ae46f35db6f:	movss        dword ptr [rsp + 4], xmm2
0x5ae46f35db75:	movss        dword ptr [rsp + 0xc], xmm1
0x5ae46f35db7b:	call         0x5ae46f1c3440 (???)
0x5ae46f35db80:	movss        xmm1, dword ptr [rsp + 0xc]
0x5ae46f35db86:	movss        xmm0, dword ptr [rip + 0x2b6512]
0x5ae46f35db8e:	mov          rbp, rax
0x5ae46f35db91:	mulss        xmm0, xmm1
0x5ae46f35db95:	call         0x5ae46f1c3440 (???)
0x5ae46f35db9a:	movss        xmm2, dword ptr [rsp + 4]
0x5ae46f35dba0:	movss        xmm0, dword ptr [rip + 0x2b64f8]
0x5ae46f35dba8:	mov          r12, rax
0x5ae46f35dbab:	mulss        xmm0, xmm2
0x5ae46f35dbaf:	call         0x5ae46f1c3440 (???)
0x5ae46f35dbb4:	movss        xmm0, dword ptr [rip + 0x2b64e4]
0x5ae46f35dbbc:	movss        xmm3, dword ptr [rsp + 8]
0x5ae46f35dbc2:	mov          r13, rax
0x5ae46f35dbc5:	mulss        xmm0, xmm3
0x5ae46f35dbc9:	call         0x5ae46f1c3440 (???)
```

After, `103fps`, with generated code:

```asm
		floatToSnorm16_fast( q, resqtangent );
0x6132db310b42:	mulss        xmm0, dword ptr [rip + 0x2b6556]
	if ( fast )
0x6132db310b4a:	test         bpl, bpl
0x6132db310b4d:	je           0x6132db310ce0
0x6132db310b53:	mulss        xmm3, dword ptr [rip + 0x2b6545]
0x6132db310b5b:	cvttss2si    r14d, xmm0
0x6132db310b60:	mulss        xmm4, dword ptr [rip + 0x2b6538]
0x6132db310b68:	mulss        xmm5, dword ptr [rip + 0x2b6530]
0x6132db310b70:	cvttss2si    r13d, xmm3
0x6132db310b75:	cvttss2si    ebp, xmm4
0x6132db310b79:	cvttss2si    eax, xmm5
```

- renderer: faster `Tess_SurfacePolychain()` with `R_TBNtoQtangentsFast()`

I don't know what `Tess_SurfacePolychain()` is used for, so I don't know if it's safe to use `R_TBNtoQtangentsFast()` there.
I noticed this is another function that is called at render time, so making it faster can reduce frametime as well.

- renderer: faster `Tess_SurfacePolychain()` with `VectorNormalizeFast()`
- renderer: faster `Tess_SurfacePolychain()` with `VectorNormalizeFast()` in `R_CalcTangents()`
- renderer: faster other `R_CalcTangents()` with `VectorNormalizeFast()`

It is safe to use `VectorNormalizeFast()` anytime `VectorNormalize()` doesn't return anything (no difference in the final computation, just less branching).

I don't know what uses that other `R_CalcTangents()` variant, but we can blindly use `VectorNormalizeFast()` when there is no return, so let's do it as well.