### PR TITLE
use VectorNormalizeFast() instead of VectorNormalize() anytime the returned length isn't used

### DIFF
--- a/src/engine/qcommon/q_math.cpp
+++ b/src/engine/qcommon/q_math.cpp
@@ -544,7 +544,7 @@ void MakeNormalVectors( const vec3_t forward, vec3_t right, vec3_t up )
 
 	d = DotProduct( right, forward );
 	VectorMA( right, -d, forward, right );
-	VectorNormalize( right );
+	VectorNormalizeFast( right );
 	CrossProduct( right, forward, up );
 }
 
@@ -1082,7 +1082,7 @@ void PerpendicularVector( vec3_t dst, const vec3_t src )
 	/*
 	 * * normalize the result
 	 */
-	VectorNormalize( dst );
+	VectorNormalizeFast( dst );
 }
 
 // Ridah
@@ -1099,13 +1099,13 @@ void GetPerpendicularViewVector( const vec3_t point, const vec3_t p1, const vec3
 	vec3_t v1, v2;
 
 	VectorSubtract( point, p1, v1 );
-	VectorNormalize( v1 );
+	VectorNormalizeFast( v1 );
 
 	VectorSubtract( point, p2, v2 );
-	VectorNormalize( v2 );
+	VectorNormalizeFast( v2 );
 
 	CrossProduct( v1, v2, up );
-	VectorNormalize( up );
+	VectorNormalizeFast( up );
 }
 
 /*
@@ -1119,7 +1119,7 @@ void ProjectPointOntoVector( const vec3_t point, const vec3_t vStart, const vec3
 
 	VectorSubtract( point, vStart, pVec );
 	VectorSubtract( vEnd, vStart, vec );
-	VectorNormalize( vec );
+	VectorNormalizeFast( vec );
 	// project onto the directional vector for this segment
 	VectorMA( vStart, DotProduct( pVec, vec ), vec, vProj );
 }
@@ -1255,7 +1255,7 @@ void ProjectPointOntoVectorBounded( const vec3_t point, const vec3_t vStart, con
 
 	VectorSubtract( point, vStart, pVec );
 	VectorSubtract( vEnd, vStart, vec );
-	VectorNormalize( vec );
+	VectorNormalizeFast( vec );
 	// project onto the directional vector for this segment
 	VectorMA( vStart, DotProduct( pVec, vec ), vec, vProj );
 
@@ -2684,16 +2684,16 @@ void MatrixLookAtLH( matrix_t m, const vec3_t eye, const vec3_t dir, const vec3_
 
 #if 1
 	CrossProduct( up, dir, sideN );
-	VectorNormalize( sideN );
+	VectorNormalizeFast( sideN );
 
 	CrossProduct( dir, sideN, upN );
-	VectorNormalize( upN );
+	VectorNormalizeFast( upN );
 #else
 	CrossProduct( dir, up, sideN );
-	VectorNormalize( sideN );
+	VectorNormalizeFast( sideN );
 
 	CrossProduct( sideN, dir, upN );
-	VectorNormalize( upN );
+	VectorNormalizeFast( upN );
 #endif
 
 	VectorNormalize2( dir, dirN );
@@ -2723,10 +2723,10 @@ void MatrixLookAtRH( matrix_t m, const vec3_t eye, const vec3_t dir, const vec3_
 	vec3_t sideN;
 
 	CrossProduct( dir, up, sideN );
-	VectorNormalize( sideN );
+	VectorNormalizeFast( sideN );
 
 	CrossProduct( sideN, dir, upN );
-	VectorNormalize( upN );
+	VectorNormalizeFast( upN );
 
 	VectorNormalize2( dir, dirN );
 

--- a/src/engine/renderer/tr_backend.cpp
+++ b/src/engine/renderer/tr_backend.cpp
@@ -1142,7 +1142,7 @@ void RB_RunVisTests( )
 		Tess_MapVBOs( false );
 		VectorSubtract( backEnd.orientation.viewOrigin,
 				test->position, diff );
-		VectorNormalize( diff );
+		VectorNormalizeFast( diff );
 		VectorMA( test->position, test->depthAdjust, diff, center );
 
 		VectorScale( backEnd.viewParms.orientation.axis[ 1 ],

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -911,7 +911,7 @@ void ValidateVertex( srfVert_t* vertex, int vertexID, shader_t* shader ) {
 				VertexToString( vertex ), shader->name );
 			vertex->normal[i] = 0.0f;
 
-			VectorNormalize( vertex->normal );
+			VectorNormalizeFast( vertex->normal );
 		}
 	}
 
@@ -4667,7 +4667,7 @@ void RE_LoadWorldMap( const char *name )
 	tr.sunDirection[ 1 ] = 0.3f;
 	tr.sunDirection[ 2 ] = 0.9f;
 
-	VectorNormalize( tr.sunDirection );
+	VectorNormalizeFast( tr.sunDirection );
 
 	tr.worldMapLoaded = true;
 

--- a/src/engine/renderer/tr_curve.cpp
+++ b/src/engine/renderer/tr_curve.cpp
@@ -559,7 +559,7 @@ srfGridMesh_t  *R_SubdividePatchToGrid( int width, int height, srfVert_t points[
 				// dist-from-midpoint
 				VectorSubtract( midxyz, gridctrl[ i ][ j ].xyz, midxyz );
 				VectorSubtract( gridctrl[ i ][ j + 2 ].xyz, gridctrl[ i ][ j ].xyz, direction );
-				VectorNormalize( direction );
+				VectorNormalizeFast( direction );
 
 				d = DotProduct( midxyz, direction );
 				VectorScale( direction, d, projected );

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1120,7 +1120,7 @@ void R_UploadImage( const char *name, const byte **dataArray, int numLayers, int
 						n[ 1 ] = Tex_ByteToFloat( scaledBuffer[ j * 4 + 1 ] );
 						n[ 2 ] = Tex_ByteToFloat( scaledBuffer[ j * 4 + 2 ] );
 
-						VectorNormalize( n );
+						VectorNormalizeFast( n );
 
 						scaledBuffer[ j * 4 + 0 ] = Tex_FloatToByte( n[ 0 ] );
 						scaledBuffer[ j * 4 + 1 ] = Tex_FloatToByte( n[ 1 ] );

--- a/src/engine/renderer/tr_light.cpp
+++ b/src/engine/renderer/tr_light.cpp
@@ -162,7 +162,7 @@ int R_LightForPoint( vec3_t point, vec3_t ambientLight, vec3_t directedLight, ve
 		lightDir[ 1 ] = copysignf( 1.0f - fabsf( X ), Y );
 	}
 
-	VectorNormalize( lightDir );
+	VectorNormalizeFast( lightDir );
 
 	if ( ambientLight[ 0 ] < r_forceAmbient.Get() &&
 	     ambientLight[ 1 ] < r_forceAmbient.Get() &&

--- a/src/engine/renderer/tr_main.cpp
+++ b/src/engine/renderer/tr_main.cpp
@@ -1498,7 +1498,7 @@ static void R_SetupPortalFrustum( const viewParms_t& oldParms, const orientation
 
 	for (int i = 0; i < 4; i++)
 	{
-		VectorNormalize(frustum[i].normal);
+		VectorNormalizeFast(frustum[i].normal);
 		SetPlaneSignbits(&frustum[i]);
 		frustum[i].dist = 0; // all side planes intersect the view origin
 		frustum[i].type = PLANE_NON_AXIAL;

--- a/src/engine/renderer/tr_model.cpp
+++ b/src/engine/renderer/tr_model.cpp
@@ -470,9 +470,9 @@ int RE_LerpTagET( orientation_t *tag, const refEntity_t *refent, const char *tag
 		VectorCopy( tag->axis[ 1 ], tag->axis[ 2 ] );
 		VectorCopy( tag->axis[ 0 ], tag->axis[ 1 ] );
 		VectorCopy( tmp, tag->axis[ 0 ] );
-		VectorNormalize( tag->axis[ 0 ] );
-		VectorNormalize( tag->axis[ 1 ] );
-		VectorNormalize( tag->axis[ 2 ] );
+		VectorNormalizeFast( tag->axis[ 0 ] );
+		VectorNormalizeFast( tag->axis[ 1 ] );
+		VectorNormalizeFast( tag->axis[ 2 ] );
 		return retval;
 	}
 	else if ( model->type == modtype_t::MOD_MESH )
@@ -497,9 +497,9 @@ int RE_LerpTagET( orientation_t *tag, const refEntity_t *refent, const char *tag
 			tag->axis[ 2 ][ i ] = start->axis[ 2 ][ i ] * backLerp + end->axis[ 2 ][ i ] * frontLerp;
 		}
 
-		VectorNormalize( tag->axis[ 0 ] );
-		VectorNormalize( tag->axis[ 1 ] );
-		VectorNormalize( tag->axis[ 2 ] );
+		VectorNormalizeFast( tag->axis[ 0 ] );
+		VectorNormalizeFast( tag->axis[ 1 ] );
+		VectorNormalizeFast( tag->axis[ 2 ] );
 
 		return retval;
 	}

--- a/src/engine/renderer/tr_model_md3.cpp
+++ b/src/engine/renderer/tr_model_md3.cpp
@@ -306,8 +306,8 @@ bool R_LoadMD3( model_t *mod, int lod, const void *buffer, const char *modName )
 
 					for ( j = 0; j < surf->numVerts; j++ )
 					{
-						VectorNormalize( tangents[ j ] );
-						VectorNormalize( binormals[ j ] );
+						VectorNormalizeFast( tangents[ j ] );
+						VectorNormalizeFast( binormals[ j ] );
 						R_TBNtoQtangents(
 							tangents[ j ], binormals[ j ],
 							surf->normals[ f * surf->numVerts + j ].normal,

--- a/src/engine/renderer/tr_model_md5.cpp
+++ b/src/engine/renderer/tr_model_md5.cpp
@@ -77,11 +77,11 @@ static void CalcTangentSpaces( md5Surface_t &surf, const vec2_t *texCoords )
 	v = surf.verts;
 	for ( unsigned j = 0; j < surf.numVerts; j++, v++ )
 	{
-		VectorNormalize( v->tangent );
+		VectorNormalizeFast( v->tangent );
 		v->tangent[ 3 ] = 0;
-		VectorNormalize( v->binormal );
+		VectorNormalizeFast( v->binormal );
 		v->binormal[ 3 ] = 0;
-		VectorNormalize( v->normal );
+		VectorNormalizeFast( v->normal );
 		v->normal[ 3 ] = 0;
 	}
 }

--- a/src/engine/renderer/tr_shade_calc.cpp
+++ b/src/engine/renderer/tr_shade_calc.cpp
@@ -596,12 +596,12 @@ static void Autosprite2Deform( uint32_t numVertexes )
 			vec3_t quadCenter;
 			VectorMA( sides[ 2 ].firstVert, 0.5f, sides[ 2 ].vector, quadCenter );
 			VectorSubtract( quadCenter, backEnd.viewParms.orientation.origin, forward );
-			VectorNormalize( forward );
+			VectorNormalizeFast( forward );
 		}
 
 		vec3_t newMinorAxis;
 		CrossProduct( sides[ 1 ].vector, forward, newMinorAxis);
-		VectorNormalize( newMinorAxis );
+		VectorNormalizeFast( newMinorAxis );
 		plane_t projection;
 		VectorNormalize2( sides[ 0 ].vector, projection.normal );
 		projection.dist = DotProduct( sides[ 0 ].firstVert, projection.normal )
@@ -628,7 +628,7 @@ static void Autosprite2Deform( uint32_t numVertexes )
 			{
 				VectorNegate( normal, normal );
 			}
-			VectorNormalize( normal );
+			VectorNormalizeFast( normal );
 			// What the fuck are tangent and binormal even for?
 			// I'll just put in zeroes and let R_TBNtoQtangents make some up for me.
 			R_TBNtoQtangents( vec3_origin, vec3_origin, normal, qtangents );

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -4084,7 +4084,7 @@ static bool ParseShader( const char *_text )
 
 			tr.sunLight[ 2 ] = atof( token );
 
-			VectorNormalize( tr.sunLight );
+			VectorNormalizeFast( tr.sunLight );
 
 			token = COM_ParseExt2( text, false );
 


### PR DESCRIPTION
Use `VectorNormalizeFast()` instead of `VectorNormalize()` anytime the returned length isn't used.

It does the same, but with less computations since we don't need to compute the length.