### PR TITLE
Add the linearColorMap, linearSpecularMap and linearRgbGen keywords and raw variants

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1287,7 +1287,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 	}
 
 	static float convertFloatFromSRGB_NOP( float f ) { return f; }
-	static Color::Color convertColorFromSRGB_NOP( Color::Color c ) { return c; }
+	Color::Color convertColorFromSRGB_NOP( Color::Color c ) { return c; }
 
 	/*
 	===============

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -979,6 +979,11 @@ enum
 		ALL = BIT( 3 )
 	};
 
+	using floatProcessor_t = float(*)(float);
+	using colorProcessor_t = Color::Color(*)(Color::Color);
+
+	Color::Color convertColorFromSRGB_NOP( Color::Color c );
+
 	struct shaderStage_t
 	{
 		stageType_t     type;
@@ -997,6 +1002,8 @@ enum
 		surfaceDataUpdater_t surfaceDataUpdater;
 		stageShaderBinder_t shaderBinder;
 		stageMaterialProcessor_t materialProcessor;
+
+		colorProcessor_t convertColorFromSRGB;
 
 		textureBundle_t bundle[ MAX_TEXTURE_BUNDLES ];
 
@@ -1021,6 +1028,7 @@ enum
 		Color::Color32Bit constantColor; // for CGEN_CONST and AGEN_CONST
 
 		uint32_t        stateBits; // GLS_xxxx mask
+		uint8_t colorspaceBits; // LINEAR_xxxx mask
 
 		bool            isCubeMap;
 
@@ -1270,6 +1278,12 @@ enum
 	                       | GLS_ALPHAMASK_FALSE,
 
 	  GLS_DEFAULT = GLS_DEPTHMASK_TRUE
+	};
+
+	enum {
+		LINEAR_RGBGEN = ( 1 << 0 ),
+		LINEAR_COLORMAP = ( 1 << 1 ),
+		LINEAR_SPECULARMAP = ( 1 << 2 ),
 	};
 
 // *INDENT-ON*
@@ -2396,9 +2410,6 @@ enum
 		int       w;
 		int       h;
 	};
-
-	using floatProcessor_t = float(*)(float);
-	using colorProcessor_t = Color::Color(*)(Color::Color);
 
 	/*
 	** trGlobals_t

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1723,7 +1723,7 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 			{
 				tess.svars.color = pStage->constantColor;
 				tess.svars.color.Clamp();
-				tess.svars.color = tr.convertColorFromSRGB( tess.svars.color );
+				tess.svars.color = pStage->convertColorFromSRGB( tess.svars.color );
 				break;
 			}
 
@@ -1733,7 +1733,7 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 				{
 					tess.svars.color = backEnd.currentEntity->e.shaderRGBA;
 					tess.svars.color.Clamp();
-					tess.svars.color = tr.convertColorFromSRGB( tess.svars.color );
+					tess.svars.color = pStage->convertColorFromSRGB( tess.svars.color );
 				}
 				else
 				{
@@ -1749,7 +1749,7 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 				{
 					tess.svars.color = backEnd.currentEntity->e.shaderRGBA;
 					tess.svars.color.Clamp();
-					tess.svars.color = tr.convertColorFromSRGB( tess.svars.color );
+					tess.svars.color = pStage->convertColorFromSRGB( tess.svars.color );
 				}
 				else
 				{
@@ -1782,7 +1782,7 @@ void Tess_ComputeColor( shaderStage_t *pStage )
 
 				tess.svars.color = Color::White * glow;
 				tess.svars.color.Clamp();
-				tess.svars.color = tr.convertColorFromSRGB( tess.svars.color );
+				tess.svars.color = pStage->convertColorFromSRGB( tess.svars.color );
 				break;
 			}
 


### PR DESCRIPTION
Add the `linearColorMap`, `linearSpecularMap` and `linearRgbGen` keywords and raw variants

- `linearColorMap`, `linearSpecularMap` and `linearRgbGen` expects
  `tr.worldLinearizeTexture`. They are meant to be used in assets targeting
  the linear pipeline only.
- `rawColorMap`, `rawSpecularMap` and `rawRgbGen` does the same, but there is no
  colorspace meaning. They are meant to be used when porting legacy assets
  that may be used in the naive pipeline to be rendered as they were before
  for historical purposes, while being ported the hacky way for the linear
  pipeline.

---

Previously named: Naive blending compatibility

Former comment:

Work-in-progress attempt to implement compatibility for naive blended assets in the linear pipeline.

It includes a patch to delay the loading of textures from pre-collapsed stages to the end of the stage parsing, after the blend mode is known, because it is required to select the right compatibility code for the given stage.
