### PR TITLE
Fix mouse accel + migrate cvars

### DIFF
--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2322,16 +2322,6 @@ void CL_Init()
 	cl_maxpackets = Cvar_Get( "cl_maxpackets", "125", 0 );
 	cl_packetdup = Cvar_Get( "cl_packetdup", "1", 0 );
 
-	cl_mouseAccel = Cvar_Get( "cl_mouseAccel", "0", 0 );
-
-	// 0: legacy mouse acceleration
-	// 1: new implementation
-
-	cl_mouseAccelStyle = Cvar_Get( "cl_mouseAccelStyle", "0", 0 );
-	// offset for the power function (for style 1, ignored otherwise)
-	// this should be set to the max rate value
-	cl_mouseAccelOffset = Cvar_Get( "cl_mouseAccelOffset", "5", 0 );
-
 	cl_allowDownload = Cvar_Get( "cl_allowDownload", "1", 0 );
 
 	cl_consoleFontKerning = Cvar_Get( "cl_consoleFontKerning", "0", 0 );

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -399,10 +399,6 @@ extern Cvar::Range<Cvar::Cvar<int>> cl_doubletapdelay;
 extern cvar_t *cl_sensitivity;
 extern Cvar::Cvar<bool> cl_freelook;
 
-extern cvar_t *cl_mouseAccel;
-extern cvar_t *cl_mouseAccelOffset;
-extern cvar_t *cl_mouseAccelStyle;
-
 extern Cvar::Cvar<float> m_pitch;
 extern Cvar::Cvar<float> m_yaw;
 extern Cvar::Cvar<float> m_forward;


### PR DESCRIPTION
Depends on #1860

Fix a bug where if mouse accel is enabled, the `sensitivity` is applied twice. So if sensitivity is 3, it suddenly behaves like sensitivity is 9 when `cl_mouseAccel` has a nonzero value.

Also migrate mouse accel cvars.