### PR TITLE
r_showVertexColors - don't black out generic shader

### DIFF
--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -83,9 +83,7 @@ void	main()
 	outputColor = color;
 
 // Debugging.
-#if defined(r_showVertexColors)
-	outputColor = vec4(0.0, 0.0, 0.0, 0.0);
-#elif defined(USE_MATERIAL_SYSTEM) && defined(r_showGlobalMaterials)
+if defined(USE_MATERIAL_SYSTEM) && defined(r_showGlobalMaterials)
 	outputColor.rgb = u_MaterialColour;
 #endif
 }


### PR DESCRIPTION
When r_showVertexColors is enabled, the lightMapping shader draws just the vertex colors. But the `generic` shader inexplicably was setting the color to (0, 0, 0, 0). Don't do that. It's stupid because it breaks the console and 2D drawing and does not help debugging.