### PR TITLE
r_forceBlendRegime to load legacy lightmaps in linear space or vice versa

### DIFF
--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -2636,10 +2636,7 @@ class u_ColorModulateColorGen_Uint :
 			ALPHA_ONE = 2,
 			ALPHA_MINUS_ONE = 3,
 			// <-- Insert new bits there.
-			LIGHTFACTOR_BIT0 = 28,
-			LIGHTFACTOR_BIT1 = 29,
-			LIGHTFACTOR_BIT2 = 30,
-			LIGHTFACTOR_BIT3 = 31,
+			LIGHTFACTOR_BIT0 = 11,
 			// There should be not bit higher than the light factor.
 		};
 
@@ -2653,8 +2650,11 @@ class u_ColorModulateColorGen_Uint :
 			<< Util::ordinal( ColorModulate_Bit::ALPHA_ONE );
 		colorModulate_Uint |= ( colorModulation.alphaGen == -1.0f )
 			<< Util::ordinal( ColorModulate_Bit::ALPHA_MINUS_ONE );
-		colorModulate_Uint |= uint32_t( colorModulation.lightFactor )
-			<< Util::ordinal( ColorModulate_Bit::LIGHTFACTOR_BIT0 );
+
+		// Light factor unit is 128 / ( 1 << 21 )
+		// needs to go up to pow( 8, 2.2 ) = 97.006
+		uint32_t lightFactorBits = lrintf( colorModulation.lightFactor * 16384.0f );
+		colorModulate_Uint |= lightFactorBits << Util::ordinal( ColorModulate_Bit::LIGHTFACTOR_BIT0 );
 
 		this->SetValue( colorModulate_Uint );
 	}

--- a/src/engine/renderer/glsl_source/common.glsl
+++ b/src/engine/renderer/glsl_source/common.glsl
@@ -68,8 +68,8 @@ colorMod << 0: color * 1
 colorMod << 1: color * ( -1 )
 colorMod << 2: alpha * 1
 colorMod << 3: alpha * ( -1 )
-colorMod << 4-27: available for future usage
-colorMod << 28-31: lightFactor
+colorMod << 4-10: available for future usage
+colorMod << 11-31: lightFactor
 
 colorMod float format:
 
@@ -98,7 +98,7 @@ vec4 ColorModulateToColor( const in colorModulatePack colorMod )
 float ColorModulateToLightFactor( const in colorModulatePack colorMod )
 {
 #if defined(HAVE_EXT_gpu_shader4)
-	return float( colorMod >> 28u );
+	return float( colorMod >> 11u ) * ( 1.0 / 16384 );
 #else
 	return colorMod.g;
 #endif

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -44,7 +44,7 @@ static byte       *fileBase;
 
 static void R_LinearizeLightingColorBytes( byte* bytes )
 {
-	if ( !tr.worldLinearizeLightMap )
+	if ( !tr.worldLinearizeTexture )
 	{
 		return;
 	}
@@ -486,7 +486,7 @@ static void R_LoadLightmaps( lump_t *l, const char *bspName )
 	int lightMapBits = IF_LIGHTMAP | IF_NOPICMIP;
 	int deluxeMapBits = IF_NORMALMAP | IF_NOPICMIP;
 
-	if ( tr.worldLinearizeLightMap )
+	if ( tr.worldLinearizeTexture )
 	{
 		lightMapBits |= IF_SRGB;
 	}
@@ -3969,15 +3969,18 @@ void R_LoadEntities( lump_t *l, std::string &externalEntities )
 				tr.worldLinearizeLightMap = true;
 			}
 
-			if ( sRGBcolor && sRGBtex )
+			if ( !r_forceBlendRegime.Get() )
 			{
-				Log::Debug( "Map features lights computed with linear colors and textures." );
-				tr.worldLinearizeTexture = true;
-			}
-			else if ( sRGBcolor != sRGBtex )
-			{
-				Log::Warn( "Map features lights computed with a mix of linear and non-linear colors or textures, acting like both colors and textures were linear when lights were computed." );
-				tr.worldLinearizeTexture = true;
+				if ( sRGBcolor && sRGBtex )
+				{
+					Log::Debug( "Map features lights computed with linear colors and textures." );
+					tr.worldLinearizeTexture = true;
+				}
+				else if ( sRGBcolor != sRGBtex )
+				{
+					Log::Warn( "Map features lights computed with a mix of linear and non-linear colors or textures, acting like both colors and textures were linear when lights were computed." );
+					tr.worldLinearizeTexture = true;
+				}
 			}
 
 			continue;
@@ -4659,12 +4662,23 @@ static void SetWorldLight() {
 
 	/* Set GLSL overbright parameters if the lighting mode is not fullbright. */
 	if ( tr.lightMode != lightMode_t::FULLBRIGHT ) {
+		float factor = float( 1 << tr.overbrightBits );
+
+		if ( tr.worldLinearizeLightMap && !tr.worldLinearizeTexture )
+		{
+			factor = powf( factor, 1.0f / 2.2f );
+		}
+		else if ( !tr.worldLinearizeLightMap && tr.worldLinearizeTexture )
+		{
+			factor = powf( factor, 2.2f );
+		}
+
 		if ( r_overbrightQ3.Get() ) {
 			// light factor is applied to entire color buffer; identityLight can be used to cancel it
-			tr.identityLight = 1.0f / float( 1 << tr.overbrightBits );
+			tr.identityLight = 1.0f / factor;
 		} else {
 			// light factor is applied wherever a precomputed light is sampled
-			tr.mapLightFactor = float( 1 << tr.overbrightBits );
+			tr.mapLightFactor = factor;
 		}
 	}
 }
@@ -4779,7 +4793,6 @@ void RE_LoadWorldMap( const char *name )
 	tr.overbrightBits = std::min( tr.mapOverBrightBits, r_overbrightBits.Get() ); // set by RE_LoadWorldMap
 	tr.mapLightFactor = 1.0f; // set by RE_LoadWorldMap
 	tr.identityLight = 1.0f; // set by RE_LoadWorldMap
-	tr.worldLinearizeTexture = false;
 	tr.worldLinearizeLightMap = false;
 
 	s_worldData = {};

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -98,6 +98,12 @@ Cvar::Cvar<int> r_rendererAPI( "r_rendererAPI", "Renderer API: 0: OpenGL, 1: Vul
 	Cvar::Cvar<bool> r_overbrightQ3("r_overbrightQ3", "brighten entire color buffer like Quake 3 (incompatible with newer assets)", Cvar::NONE, false);
 
 	Cvar::Cvar<bool> r_overbrightIgnoreMapSettings("r_overbrightIgnoreMapSettings", "force usage of r_overbrightDefaultClamp / r_overbrightDefaultExponent, ignoring worldspawn", Cvar::NONE, false);
+
+	// If you use this to compare results in different blend regimes you should disable tonemapping
+	// since applying the tonemap curve to sRGB vs. linear values gives very different results
+	Cvar::Range<Cvar::Cvar<int>> r_forceBlendRegime(
+		"r_forceBlendRegime", "override map settings to use: 1 = naive blending, 2 = linear blending", Cvar::NONE, 0, 0, 2);
+
 	Cvar::Range<Cvar::Cvar<int>> r_lightMode("r_lightMode", "lighting mode: 0: fullbright (cheat), 1: vertex light, 2: grid light (cheat), 3: light map", Cvar::NONE, Util::ordinal(lightMode_t::MAP), Util::ordinal(lightMode_t::FULLBRIGHT), Util::ordinal(lightMode_t::MAP));
 	Cvar::Cvar<bool> r_colorGrading( "r_colorGrading", "Use color grading", Cvar::NONE, true );
 	static Cvar::Range<Cvar::Cvar<int>> r_readonlyDepthBuffer(
@@ -1396,6 +1402,9 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		{
 			return false;
 		}
+
+		Cvar::Latch( r_forceBlendRegime );
+		tr.worldLinearizeTexture = r_forceBlendRegime.Get() == 2;
 
 		tr.lightMode = lightMode_t( r_lightMode.Get() );
 

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2431,8 +2431,8 @@ enum
 		bool   worldLightMapping;
 		bool   worldDeluxeMapping;
 		bool   worldHDR_RGBE;
-		bool worldLinearizeTexture;
-		bool worldLinearizeLightMap;
+		bool worldLinearizeTexture; // this determines whether linear or naive blending is used
+		bool worldLinearizeLightMap; // this is only used to decide the overbright behavior
 
 		floatProcessor_t convertFloatFromSRGB;
 		colorProcessor_t convertColorFromSRGB;
@@ -2649,6 +2649,7 @@ enum
 	extern Cvar::Range<Cvar::Cvar<int>> r_overbrightBits;
 	extern Cvar::Cvar<bool> r_overbrightQ3;
 	extern Cvar::Cvar<bool> r_overbrightIgnoreMapSettings;
+	extern Cvar::Range<Cvar::Cvar<int>> r_forceBlendRegime;
 	extern Cvar::Range<Cvar::Cvar<int>> r_lightMode;
 	extern Cvar::Cvar<bool> r_colorGrading;
 	extern Cvar::Cvar<bool> r_preferBindlessTextures;

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1486,7 +1486,7 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, stageType_t type,
 		if ( ! ( shader.registerFlags & RSF_2D ) )
 		{
 			stage->convertColorFromSRGB = stage->colorspaceBits & LINEAR_RGBGEN ?
-				convertColorFromSRGB_NOP : stage->convertColorFromSRGB;
+				convertColorFromSRGB_NOP : tr.convertColorFromSRGB;
 
 			switch ( type )
 			{


### PR DESCRIPTION
Allow loading maps with sRGB lightmaps with naive blending, or maps with non-sRGB lightmaps with linear blending. Use `r_forceBlendRegime 1` for naive blending or `r_forceBlendRegime 2` for linear blending.

TODO: models and vertex lighting. Out of precomputed lighting, just lightmaps work so far.

From some examples you can see that non-blended surfaces look similar between blend modes. Use of multi-texturing features like normal and specular increases the difference. But even non-blended, non-lit surfaces like the skybox can still have visible differences because texture filtering produces different results when the image is flagged as sRGB.

All screenshots are made with tonemapping disabled.

Non-sRGB lightmaps, naive blending:

![unvanquished-plat23-srgb-forcefield](https://github.com/user-attachments/assets/255e8c30-d66d-47d1-89b0-286863f22626)

Non-sRGB lightmaps, linear blending (new!):

![unvanquished-plat23-srgb-forcefield](https://github.com/user-attachments/assets/fb85f626-56a6-43c2-99a9-67bfe48afb10)

sRGB lightmaps, linear blending:


![unvanquished-plat23-srgb-forcefield](https://github.com/user-attachments/assets/a17e97da-0c67-4dc8-85c9-bdc45038b71b)

sRGB lightmaps, naive blending (new!):

![unvanquished-plat23-srgb-forcefield](https://github.com/user-attachments/assets/bfed6cd1-c62b-47e8-a28b-7e8734715fdf)
