### PR TITLE
Fix broken shader that prevents game start

### DIFF
--- a/src/engine/renderer/glsl_source/generic_fp.glsl
+++ b/src/engine/renderer/glsl_source/generic_fp.glsl
@@ -83,7 +83,7 @@ void	main()
 	outputColor = color;
 
 // Debugging.
-if defined(USE_MATERIAL_SYSTEM) && defined(r_showGlobalMaterials)
+#if defined(USE_MATERIAL_SYSTEM) && defined(r_showGlobalMaterials)
 	outputColor.rgb = u_MaterialColour;
 #endif
 }


### PR DESCRIPTION
Fix broken shader compilation introduced in a50b9ba160abe38ac8f8d9bba7c3de8ade9a4f6b.

I believe this PR isn't subject to the 24h rules because the current master is obviously broken. Unless someone objects I would then merge after the first LGTM.