### PR TITLE
Properly detect Linux with glibc to detect what's not

### DIFF
--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -693,6 +693,13 @@ if (APPLE)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH ON)
 endif()
 
+# Glibc-specific definitions
+if (LINUX)
+	# QUIRK: It does nothing when it is not needed on non-glibc Linux
+	# systems so it's harmless to always set it.
+	add_definitions(-D_FILE_OFFSET_BITS=64)
+endif()
+
 # Configuration specific definitions
 
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<${DEBUG_GENEXP_COND}:DEBUG_BUILD>)


### PR DESCRIPTION
Properly detect Linux with glibc to detect what's not, no need to list everything else.

It makes it easier to build for something else we currently don't support, either being another operating system, or Linux with another libc.

I yet again faced the problem of assuming Glibc on Linux when toying with [Fil-C](https://fil-c.org/) that uses [musl](https://musl.libc.org/) by default. I do remember having faced similar problems in the past with other stuff. Android? Zig? I don't remember precisely, but I knew that code was fragile, maybe it's better this way.

I'm curious to see if the CI will be happy or not.

If that works, then adding new operating systems would even require less code, not needing to list every of them.