### PR TITLE
Some improvement on the deps building

### DIFF
--- a/external_deps/build.sh
+++ b/external_deps/build.sh
@@ -770,6 +770,7 @@ build_openal() {
 		cd "${dir_name}"
 
 		cmake_build \
+			-DALSOFT_UTILS=OFF \
 			"${openal_cmake_args[@]}"
 		;;
 	esac


### PR DESCRIPTION
- Do not cross-compile pkgconfig, it is part of the cross-compilation toolchain;
- Reword a comment because we don't build SDL with pkg-config anymore;
- Rework the macos-amd64 setup a bit;
- Do not build OpenAL utils.

Extracted from:

- https://github.com/DaemonEngine/Daemon/pull/1823
