### PR TITLE
Fix bug where updating archive cvars sometimes does not write autogen.cfg

### DIFF
--- a/src/engine/framework/CvarSystem.cpp
+++ b/src/engine/framework/CvarSystem.cpp
@@ -416,8 +416,8 @@ namespace Cvar {
             }
 
             cvar->flags |= flags;
+            cvar->ccvar.flags |= flags;
 
-            //TODO: remove it, overkill ?
             //Make sure to trigger the event as if this variable was changed
             cvar_modifiedFlags |= flags;
             return true; // success


### PR DESCRIPTION
For example if you do `/seta common.framerate.max 30` then `/set common.framerate.max 31`, the second command does not write out the cvars although it should since it still has the archive flag added by the first.