### PR TITLE
Fix screenshots with read-only depth buffer

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -654,6 +654,8 @@ Cvar::Cvar<int> r_rendererAPI( "r_rendererAPI", "Renderer API: 0: OpenGL, 1: Vul
 	*/
 	const RenderCommand *ScreenshotCommand::ExecuteSelf( ) const
 	{
+		R_BindFBO( GL_READ_FRAMEBUFFER, nullptr );
+
 		switch ( format )
 		{
 			case ssFormat_t::SSF_TGA:


### PR DESCRIPTION
When the read-only depth buffer is used (if r_readonlyDepthBuffer is 2, or if it's 1 but the driver lacks certain extensions), the screenshots were done from the 3d rendering buffer instead of the final framebuffer. This caused screenshots to lack tonemapping, color grading and 2D rendering. Fix it by resetting GL_READ_FRAMEBUFFER to the default value after it is used.