### PR TITLE
Don't use real unforms in uniform packing test

### DIFF
--- a/src/engine/renderer/gl_shader_test.cpp
+++ b/src/engine/renderer/gl_shader_test.cpp
@@ -36,6 +36,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace {
 
+struct u_float_A : GLUniform1f { u_float_A(GLShader* s) : GLUniform1f(s, "u_float_A") {} };
+struct u_float_B : GLUniform1f { u_float_B(GLShader* s) : GLUniform1f(s, "u_float_B") {} };
+struct u_vec2_A : GLUniform2f { u_vec2_A(GLShader* s) : GLUniform2f(s, "u_vec2_A") {} };
+struct u_vec3_A : GLUniform3f { u_vec3_A(GLShader* s) : GLUniform3f(s, "u_vec3_A") {} };
+struct u_vec3_B : GLUniform3f { u_vec3_B(GLShader* s) : GLUniform3f(s, "u_vec3_B") {} };
+struct u_mat4_A: GLUniformMatrix4f { u_mat4_A(GLShader* s) : GLUniformMatrix4f(s, "u_mat4_A") {} };
+struct u_vec4Array6_A : GLUniform4fv { u_vec4Array6_A(GLShader* s) : GLUniform4fv( s, "u_Vec4Array6_A", 6 ) {} };
+
 class MaterialUniformPackingTestShaderBase : public GLShader
 {
 public:
@@ -59,83 +67,83 @@ GLUniform* Get(ShaderT& shader)
 TEST(MaterialUniformPackingTest, OneMatrix)
 {
     class Shader1 : public MaterialUniformPackingTestShaderBase,
-                    public u_ModelViewMatrix //mat4
+                    public u_mat4_A
     {
     public:
-        Shader1() : u_ModelViewMatrix(this) {}
+        Shader1() : u_mat4_A(this) {}
     };
 
     Shader1 shader1;
     std::vector<GLUniform*> uniforms = shader1.GetUniforms();
     EXPECT_EQ(shader1.GetSTD140Size(), 16u);
     ASSERT_EQ(uniforms.size(), 1);
-    EXPECT_EQ(uniforms[0], Get<u_ModelViewMatrix>(shader1));
+    EXPECT_EQ(uniforms[0], Get<u_mat4_A>(shader1));
     EXPECT_EQ(uniforms[0]->_std430Size, 16u);
 }
 
 TEST(MaterialUniformPackingTest, TwoFloats)
 {
     class Shader1 : public MaterialUniformPackingTestShaderBase,
-                    public u_DeformMagnitude, //float
-                    public u_InverseGamma //float
+                    public u_float_A,
+                    public u_float_B
     {
     public:
-        Shader1() : u_DeformMagnitude(this), u_InverseGamma(this) {}
+        Shader1() : u_float_A(this), u_float_B(this) {}
     };
 
     Shader1 shader1;
     std::vector<GLUniform*> uniforms = shader1.GetUniforms();
     EXPECT_EQ(shader1.GetSTD140Size(), 4u);
     ASSERT_EQ(uniforms.size(), 2);
-    EXPECT_EQ(uniforms[0], Get<u_DeformMagnitude>(shader1));
+    EXPECT_EQ(uniforms[0], Get<u_float_A>(shader1));
     EXPECT_EQ(uniforms[0]->_std430Size, 1u);
-    EXPECT_EQ(uniforms[1], Get<u_InverseGamma>(shader1));
+    EXPECT_EQ(uniforms[1], Get<u_float_B>(shader1));
     EXPECT_EQ(uniforms[1]->_std430Size, 3u);
 }
 
 TEST(MaterialUniformPackingTest, Vec3Handling)
 {
     class Shader1 : public MaterialUniformPackingTestShaderBase,
-                    public u_DeformMagnitude, //float
-                    public u_SpecularExponent, //vec2
-                    public u_FogColor, //vec3
-                    public u_blurVec //vec3
+                    public u_float_A,
+                    public u_vec2_A,
+                    public u_vec3_A,
+                    public u_vec3_B
     {
     public:
-        Shader1() : u_DeformMagnitude(this),
-                    u_SpecularExponent(this),
-                    u_FogColor(this),
-                    u_blurVec(this) {}
+        Shader1() : u_float_A(this),
+                    u_vec2_A(this),
+                    u_vec3_A(this),
+                    u_vec3_B(this) {}
     };
 
     Shader1 shader1;
     std::vector<GLUniform*> uniforms = shader1.GetUniforms();
     EXPECT_EQ(shader1.GetSTD140Size(), 12u);
     ASSERT_EQ(uniforms.size(), 4);
-    EXPECT_EQ(uniforms[0], Get<u_FogColor>(shader1));
+    EXPECT_EQ(uniforms[0], Get<u_vec3_A>(shader1));
     EXPECT_EQ(uniforms[0]->_std430Size, 3u);
-    EXPECT_EQ(uniforms[1], Get<u_DeformMagnitude>(shader1));
+    EXPECT_EQ(uniforms[1], Get<u_float_A>(shader1));
     EXPECT_EQ(uniforms[1]->_std430Size, 1u);
-    EXPECT_EQ(uniforms[2], Get<u_blurVec>(shader1));
+    EXPECT_EQ(uniforms[2], Get<u_vec3_B>(shader1));
     EXPECT_EQ(uniforms[2]->_std430Size, 4u);
-    EXPECT_EQ(uniforms[3], Get<u_SpecularExponent>(shader1));
+    EXPECT_EQ(uniforms[3], Get<u_vec2_A>(shader1));
     EXPECT_EQ(uniforms[3]->_std430Size, 4u);
 }
 
 TEST(MaterialUniformPackingTest, Array)
 {
     class Shader1 : public MaterialUniformPackingTestShaderBase,
-                    public u_Frustum //vec4[6]
+                    public u_vec4Array6_A
     {
     public:
-        Shader1() : u_Frustum(this) {}
+        Shader1() : u_vec4Array6_A(this) {}
     };
 
     Shader1 shader1;
     std::vector<GLUniform*> uniforms = shader1.GetUniforms();
     EXPECT_EQ(shader1.GetSTD140Size(), 24u);
     ASSERT_EQ(uniforms.size(), 1);
-    EXPECT_EQ(uniforms[0], Get<u_Frustum>(shader1));
+    EXPECT_EQ(uniforms[0], Get<u_vec4Array6_A>(shader1));
     EXPECT_EQ(uniforms[0]->_std430Size, 4u);
 }
 


### PR DESCRIPTION
In the unit tests for GL shader uniform packing, avoid using real uniform classes (e.g. u_DeformMagnitude) and define uniform classes just for the test. This way tests don't get in the way when changing shaders.