### PR TITLE
tr_init: recalibrate the default tone mapper preset

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -286,7 +286,7 @@ Cvar::Cvar<int> r_rendererAPI( "r_rendererAPI", "Renderer API: 0: OpenGL, 1: Vul
 	cvar_t      *r_mergeLeafSurfaces;
 	
 	Cvar::Cvar<bool> r_bloom( "r_bloom", "Use bloom", Cvar::ARCHIVE, false );
-	Cvar::Cvar<float> r_bloomBlur( "r_bloomBlur", "Bloom strength", Cvar::NONE, 1.0 );
+	Cvar::Cvar<float> r_bloomBlur( "r_bloomBlur", "Bloom strength", Cvar::NONE, 0.2 );
 	Cvar::Cvar<int> r_bloomPasses( "r_bloomPasses", "Amount of bloom passes in each direction", Cvar::NONE, 2 );
 	cvar_t      *r_FXAA;
 	Cvar::Range<Cvar::Cvar<int>> r_msaa( "r_msaa", "Amount of MSAA samples. 0 to disable", Cvar::NONE, 0, 0, 64 );


### PR DESCRIPTION
- Restore most of the range of the high lights.
    
When the previous preset was calibrated, the engine was missing the single-bit clamping (it was a bug). Now that the single-bit clamping is restored in lightmap input, the high light range is caped twice. This restores most of of the range of high lights on the tone mapper side.

Also we don't need anymore to use the tone mapper to workaround the bloom that was too strong when the single-but clamping was missing, since that single-bit clamping is there.

- tr_init: reduce the default bloom strength

We inherited the default bloom strength from the implementation maybe decades ago and never questioned it, so it's time to adjust it and do some visual direction on that as well.

---

(old screenshots)

Here are some examples with a map not using the linear pipeline:

no tone mapping|current tone mapping preset|recalibrated tone mapping preset
-|-|-
[![screenshot](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164711_000.jpg)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164711_000.jpg)|[![screenshot](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164716_000.jpg)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164716_000.jpg)|[![screenshot](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_165918_000.jpg)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_165918_000.jpg)
[![histogram](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164711_000-histogram-intensity.png)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164711_000-histogram-intensity.png)|[![histogram](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164716_000-histogram-intensity.png)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164716_000-histogram-intensity.png)|[![histogram](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_165918_000-histogram-intensity.png)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_165918_000-histogram-intensity.png)
[![screenshot](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164749_000.jpg)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164749_000.jpg)|[![screenshot](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164754_000.jpg)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164754_000.jpg)|[![screenshot](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_165927_000.jpg)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_165927_000.jpg)
[![histogram](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164749_000-histogram-intensity.png)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164749_000-histogram-intensity.png)|[![histogram](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164754_000-histogram-intensity.png)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_164754_000-histogram-intensity.png)|[![histogram](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_165927_000-histogram-intensity.png)](https://dl.illwieckz.net/b/unvanquished/shots/tonemapping-configuration/unvanquished_2025-10-17_165927_000-histogram-intensity.png)

This new preset has been calibrated using both the historical pipeline and the linear pipeline.

This new preset is usable with both pipelines, which was not true with the current pipeline. This allows us to start delivering maps made for the linear pipeline while keeping the ability for users to enable the tone mapper.

It's possible that such default tone mapper preset have to be recalibrated later when dynamic exposure will be merged, but for now that one fits the need.