### PR TITLE
Disable rim lighting (r_rimLighting) by default

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1249,7 +1249,7 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 		Cvar::Latch( r_cubeProbeSpacing );
 
 		r_halfLambertLighting = Cvar_Get( "r_halfLambertLighting", "1", CVAR_LATCH | CVAR_ARCHIVE );
-		r_rimLighting = Cvar_Get( "r_rimLighting", "1",  CVAR_LATCH | CVAR_ARCHIVE );
+		r_rimLighting = Cvar_Get( "r_rimLighting", "0",  CVAR_LATCH | CVAR_ARCHIVE );
 		r_rimExponent = Cvar_Get( "r_rimExponent", "3", CVAR_CHEAT | CVAR_LATCH );
 		AssertCvarRange( r_rimExponent, 0.5, 8.0, false );
 


### PR DESCRIPTION
"Rim lighting" purports to make the edges of models stand out. However in my tests, I don't see a very strong correlation between the parts which are lit up and the edges of models. For more geometrically complex models such as the Barricade, it sometimes randomly lightens the model all over the place, which seems bad.

No rim lighting:

![unvanquished-atcshd-under-fog-barricade](https://github.com/user-attachments/assets/8ffd01f1-2cf4-4f46-b86d-53e8c3cb09cc)
![unvanquished-plat23-dlight-psaw1](https://github.com/user-attachments/assets/57f38177-4d73-4fa9-8de3-a214d80d2650)

With rim lighting:

![unvanquished-atcshd-under-fog-barricade](https://github.com/user-attachments/assets/6a2526f7-4366-4adb-b2de-05a81c6b193f)

![unvanquished-plat23-dlight-psaw1](https://github.com/user-attachments/assets/613b4052-ba55-48db-9c4e-a7e96f78814c)


If the idea is accepted, I will also make a PR for the graphics presets.