### PR TITLE
Fix lighting for movable BSP entities

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1489,7 +1489,7 @@ enum
 		surfaceType_t *surface; // any of surface*_t
 		shader_t      *shader;
 		uint64_t      sort;
-		bool          bspSurface;
+		bool          bspSurface; // only for the stationary part of the world, *not* BSP models
 		int fog;
 		int portalNum = -1;
 

--- a/src/engine/renderer/tr_world.cpp
+++ b/src/engine/renderer/tr_world.cpp
@@ -194,7 +194,8 @@ void R_AddBSPModelSurfaces( trRefEntity_t *ent )
 
 	for ( i = 0; i < bspModel->numSurfaces; i++ )
 	{
-		R_AddWorldSurface( bspModel->firstSurface + i, fogNum, -1, FRUSTUM_CLIPALL );
+		bspSurface_t *surf = bspModel->firstSurface + i;
+		R_AddDrawSurf( surf->data, surf->shader, surf->lightmapNum, fogNum );
 	}
 }
 


### PR DESCRIPTION
BSP model surfaces were wrongly flagged with the `bspSurface` bit which only works for fixed-location world surfaces. This flag was causing the code to skip setting up the model matrix for the lightMapping shader, meaning normals and dynamic light positions were not correct.

So stop flagging BSP models as `bspSurface`. Also skip the other things in R_AddWorldSurface, besides R_AddDrawSurf, because they are useless or redundant.

Fixes https://github.com/Unvanquished/Unvanquished/issues/3474.