### PR TITLE
sdl_glimp: make ARB_separate_shader_objects an explicit hard requirement

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2561,6 +2561,10 @@ static void GLimp_InitExtensions()
 	// made required in OpenGL 4.6
 	glConfig.shaderAtomicCounterOpsAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_shader_atomic_counter_ops, r_arb_shader_atomic_counter_ops.Get() );
 
+	/* Made required in OpenGL 4.1, but it only requires OpenGL 2.0 or ARB_shader_objects.
+	Mesa provides it with all known desktop OpenGL drivers, including GL 2.1 ones. */
+	LOAD_EXTENSION( ExtFlag_REQUIRED, ARB_separate_shader_objects );
+
 	// made required in OpenGL 4.6
 	glConfig.indirectParametersAvailable = LOAD_EXTENSION_WITH_TEST( ExtFlag_NONE, ARB_indirect_parameters, r_arb_indirect_parameters.Get() );
 


### PR DESCRIPTION
Our code require `ARB_separate_shader_objects`, so we should test for it explicitly.

The `ARB_separate_shader_objects` extension is made required in OpenGL 4., but it only requires OpenGL 2.0 or ARB_shader_objects.

Mesa provides it with all known desktop OpenGL drivers, including GL 2.1 ones.

GL4ES doesn't provide it despite providing OpenGL 2.1 over OpenGL ES because as far as I know GL ES doesn't provide such feature and then it doesn't translate.