### PR TITLE
cameraEffects: fix missing u_Exposure when high precision rendering is disabled

### DIFF
--- a/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
+++ b/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
@@ -54,6 +54,8 @@ void convertToSRGB(inout vec3 color) {
 	#endif
 }
 
+uniform float u_Exposure;
+
 // Tone mapping is not available when high-precision float framebuffer isn't enabled or supported.
 #if defined(r_highPrecisionRendering) && defined(HAVE_ARB_texture_float)
 /* x: contrast
@@ -62,7 +64,6 @@ z: shoulderClip
 w: highlightsCompression */
 uniform bool u_Tonemap;
 uniform vec4 u_TonemapParms;
-uniform float u_Exposure;
 
 vec3 TonemapLottes( vec3 color ) {
   // Lottes 2016, "Advanced Techniques and Optimization of HDR Color Pipelines"


### PR DESCRIPTION
Fix missing u_Exposure when high precision rendering is disabled.

Fixes:

- https://github.com/DaemonEngine/Daemon/issues/1900

Fixup for:

- https://github.com/DaemonEngine/Daemon/pull/1885