### PR TITLE
GL4ES compatibility

### DIFF
--- a/src/engine/renderer/GLUtils.h
+++ b/src/engine/renderer/GLUtils.h
@@ -128,6 +128,7 @@ struct GLConfig
 	bool gpuShader4Available;
 	bool gpuShader5Available;
 	bool textureGatherAvailable;
+	bool texture3DAvailable;
 	bool mat3x2Available;
 	bool incrementalShaderCompilation;
 	int maxDrawBuffers;

--- a/src/engine/renderer/GLUtils.h
+++ b/src/engine/renderer/GLUtils.h
@@ -128,6 +128,7 @@ struct GLConfig
 	bool gpuShader4Available;
 	bool gpuShader5Available;
 	bool textureGatherAvailable;
+	bool mat3x2Available;
 	bool incrementalShaderCompilation;
 	int maxDrawBuffers;
 

--- a/src/engine/renderer/GLUtils.h
+++ b/src/engine/renderer/GLUtils.h
@@ -128,6 +128,7 @@ struct GLConfig
 	bool gpuShader4Available;
 	bool gpuShader5Available;
 	bool textureGatherAvailable;
+	bool incrementalShaderCompilation;
 	int maxDrawBuffers;
 
 	float maxTextureAnisotropy;

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -585,6 +585,12 @@ R"(vec4 unpackUnorm4x8( uint value )
 		str += "#define atomicCounterAndARB atomicCounterAnd\n";
 	}
 
+	if ( glConfig.mat3x2Available ) 	{
+		str += "#define textureMatrix mat3x2\n";
+	} else {
+		str += "#define textureMatrix mat3\n";
+	}
+
 	str +=
 R"(#endif // GENERATED_COMPAT_HEADER
 
@@ -1839,7 +1845,7 @@ std::string GLShaderManager::ShaderPostProcess( GLShader *shader, const std::str
 	                           "	uvec2 u_GlowMap;\n"
 	                           "};\n\n"
 	                           + texBuf +
-		                       "#define u_TextureMatrix mat3x2( texData[( baseInstance >> 12 ) & 0xFFF].u_TextureMatrix.xy, texData[( baseInstance >> 12 ) & 0xFFF].u_TextureMatrix.zw, texData[( baseInstance >> 12 ) & 0xFFF].u_TextureMatrix2 )\n"
+		                       "#define u_TextureMatrix textureMatrix( texData[( baseInstance >> 12 ) & 0xFFF].u_TextureMatrix.xy, texData[( baseInstance >> 12 ) & 0xFFF].u_TextureMatrix.zw, texData[( baseInstance >> 12 ) & 0xFFF].u_TextureMatrix2 )\n"
 		                       "#define u_DiffuseMap_initial texData[( baseInstance >> 12 ) & 0xFFF].u_DiffuseMap\n"
 		                       "#define u_NormalMap_initial texData[( baseInstance >> 12 ) & 0xFFF].u_NormalMap\n"
 		                       "#define u_HeightMap_initial texData[( baseInstance >> 12 ) & 0xFFF].u_HeightMap\n"
@@ -2586,7 +2592,7 @@ GLShader_generic::GLShader_generic() :
 		false, "generic", "generic" ),
 	u_ColorMap( this ),
 	u_DepthMap( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_ViewOrigin( this ),
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
@@ -2621,7 +2627,7 @@ GLShader_genericMaterial::GLShader_genericMaterial() :
 		true, "generic", "generic" ),
 	u_ColorMap( this ),
 	u_DepthMap( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_ViewOrigin( this ),
 	u_AlphaThreshold( this ),
 	u_ModelMatrix( this ),
@@ -2657,7 +2663,7 @@ GLShader_lightMapping::GLShader_lightMapping() :
 	u_LightGrid1( this ),
 	u_LightGrid2( this ),
 	u_LightTiles( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_SpecularExponent( this ),
 	u_ColorModulateColorGen_Dispatch( this ),
 	u_Color_Dispatch( this ),
@@ -2723,7 +2729,7 @@ GLShader_lightMappingMaterial::GLShader_lightMappingMaterial() :
 	u_LightGrid1( this ),
 	u_LightGrid2( this ),
 	u_LightTiles( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_SpecularExponent( this ),
 	u_ColorModulateColorGen_Uint( this ),
 	u_Color_Uint( this ),
@@ -2761,7 +2767,7 @@ GLShader_reflection::GLShader_reflection():
 	u_ColorMapCube( this ),
 	u_NormalMap( this ),
 	u_HeightMap( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_ViewOrigin( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
@@ -2792,7 +2798,7 @@ GLShader_reflectionMaterial::GLShader_reflectionMaterial() :
 	u_ColorMapCube( this ),
 	u_NormalMap( this ),
 	u_HeightMap( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_ViewOrigin( this ),
 	u_ModelMatrix( this ),
 	u_ModelViewProjectionMatrix( this ),
@@ -2810,7 +2816,7 @@ GLShader_skybox::GLShader_skybox() :
 		false, "skybox", "skybox" ),
 	u_ColorMapCube( this ),
 	u_CloudMap( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_CloudHeight( this ),
 	u_UseCloudMap( this ),
 	u_AlphaThreshold( this ),
@@ -2829,7 +2835,7 @@ GLShader_skyboxMaterial::GLShader_skyboxMaterial() :
 		true, "skybox", "skybox" ),
 	u_ColorMapCube( this ),
 	u_CloudMap( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_CloudHeight( this ),
 	u_UseCloudMap( this ),
 	u_AlphaThreshold( this ),
@@ -2859,7 +2865,7 @@ GLShader_heatHaze::GLShader_heatHaze() :
 		false, "heatHaze", "heatHaze" ),
 	u_CurrentMap( this ),
 	u_NormalMap( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_DeformMagnitude( this ),
 	u_ModelViewProjectionMatrix( this ),
 	u_ModelViewMatrixTranspose( this ),
@@ -2884,7 +2890,7 @@ GLShader_heatHazeMaterial::GLShader_heatHazeMaterial() :
 		true, "heatHaze", "heatHaze" ),
 	u_CurrentMap( this ),
 	u_NormalMap( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_DeformEnable( this ),
 	u_DeformMagnitude( this ),
 	u_ModelViewProjectionMatrix( this ),
@@ -2972,7 +2978,7 @@ GLShader_liquid::GLShader_liquid() :
 	u_LightGrid1( this ),
 	u_LightGrid2( this ),
 	u_HeightMap( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_ViewOrigin( this ),
 	u_RefractionIndex( this ),
 	u_ModelMatrix( this ),
@@ -3016,7 +3022,7 @@ GLShader_liquidMaterial::GLShader_liquidMaterial() :
 	u_LightGrid1( this ),
 	u_LightGrid2( this ),
 	u_HeightMap( this ),
-	u_TextureMatrix( this ),
+	u_TextureMatrix_Dispatch( this ),
 	u_ViewOrigin( this ),
 	u_RefractionIndex( this ),
 	u_ModelMatrix( this ),

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -513,8 +513,20 @@ static std::string GenCompatHeader() {
 	std::string str;
 
 	// definition of functions missing in early GLSL
-	if( glConfig.shadingLanguageVersion <= 120 ) {
-		str += "float smoothstep(float edge0, float edge1, float x) { float t = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0); return t * t * (3.0 - 2.0 * t); }\n";
+
+	/* Some GLSL 1.20 software like GL4ES always implement smoothstep()
+	so we should not overwrite it with a function, but we can set a define
+	for when it's missing. */
+	if( glConfig.shadingLanguageVersion <= 120 )
+	{
+		str +=
+R"(float mySmoothstep(float edge0, float edge1, float x)
+{
+	float t = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+	return t * t * (3.0 - 2.0 * t);
+}
+#define smoothstep mySmoothstep
+)";
 	}
 
 	if ( !glConfig.gpuShader5Available && glConfig.gpuShader4Available )

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -516,6 +516,10 @@ R"(#if !defined(GENERATED_EXTENSIONS_HEADER)
 		addExtension( str, addedExtension.available, addedExtension.minGlslVersion, addedExtension.name );
 	}
 
+	if ( glConfig.texture3DAvailable ) {
+		str += "#define HAVE_texture3D 1\n";
+	}
+
 	str +=
 R"(#endif // GENERATED_EXTENSIONS_HEADER
 

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -487,17 +487,39 @@ static void AddConst( std::string& str, const std::string& name, float v1, float
 }
 #endif
 
-static std::string GenVersionDeclaration( const std::vector<addedExtension_t> &addedExtensions ) {
-	// Declare version.
-	std::string str = Str::Format( "#version %d %s\n\n",
+static std::string GenVersionLine() {
+	return Str::Format( "#version %d %s\n",
 		glConfig.shadingLanguageVersion,
 		glConfig.shadingLanguageVersion >= 150 ? ( glConfig.glCoreProfile ? "core" : "compatibility" ) : "" );
+}
+
+static std::string GenVersionDeclaration( const std::vector<addedExtension_t> &addedExtensions ) {
+	std::string str;
+
+	if ( !glConfig.incrementalShaderCompilation ) {
+		/* Add the version line, but commented out, to contribute to the shader cache checksum.
+		The #version line will be added when compiling the concatenated shader because we cannot
+		guard such line with some #ifdef, it has to be the first non-comment non-empty line. */
+		str += "// ";
+	}
+
+	// Declare version.
+	str += GenVersionLine() + "\n";
+
+	str +=
+R"(#if !defined(GENERATED_EXTENSIONS_HEADER)
+#define GENERATED_EXTENSIONS_HEADER
+)";
 
 	// Add supported GLSL extensions.
 	for ( const auto& addedExtension : addedExtensions ) {
 		addExtension( str, addedExtension.available, addedExtension.minGlslVersion, addedExtension.name );
 	}
 
+	str +=
+R"(#endif // GENERATED_EXTENSIONS_HEADER
+
+)";
 	return str;
 }
 
@@ -511,6 +533,11 @@ static std::string GenComputeVersionDeclaration() {
 
 static std::string GenCompatHeader() {
 	std::string str;
+
+	str +=
+R"(#if !defined(GENERATED_COMPAT_HEADER)
+#define GENERATED_COMPAT_HEADER
+)";
 
 	// definition of functions missing in early GLSL
 
@@ -558,22 +585,32 @@ R"(vec4 unpackUnorm4x8( uint value )
 		str += "#define atomicCounterAndARB atomicCounterAnd\n";
 	}
 
+	str +=
+R"(#endif // GENERATED_COMPAT_HEADER
+
+)";
+
 	return str;
 }
 
 static std::string GenVertexHeader() {
 	std::string str;
 
+	str +=
+R"(#if !defined(GENERATED_VERTEX_HEADER)
+#define GENERATED_VERTEX_HEADER
+)";
+
 	// Vertex shader compatibility defines
 	if( glConfig.shadingLanguageVersion > 120 ) {
-		str =   "#define IN in\n"
+		str += "#define IN in\n"
 			"#define OUT(mode) mode out\n"
 			"#define textureCube texture\n"
 			"#define texture2D texture\n"
 			"#define texture2DProj textureProj\n"
 			"#define texture3D texture\n";
 	} else {
-		str =   "#define IN attribute\n"
+		str += "#define IN attribute\n"
 			"#define OUT(mode) varying\n";
 	}
 
@@ -591,25 +628,35 @@ static std::string GenVertexHeader() {
 		AddDefine( str, "BIND_LIGHTMAP_DATA", BufferBind::LIGHTMAP_DATA );
 	}
 
+	str +=
+R"(#endif // GENERATED_VERTEX_HEADER
+
+)";
+
 	return str;
 }
 
 static std::string GenFragmentHeader() {
 	std::string str;
 
+	str +=
+R"(#if !defined(GENERATED_FRAGMENT_HEADER)
+#define GENERATED_FRAGMENT_HEADER
+)";
+
 	// Fragment shader compatibility defines
 	if( glConfig.shadingLanguageVersion > 120 ) {
-		str =   "#define IN(mode) mode in\n"
+		str += "#define IN(mode) mode in\n"
 			"#define DECLARE_OUTPUT(type) out type outputColor;\n"
 			"#define textureCube texture\n"
 			"#define texture2D texture\n"
 			"#define texture2DProj textureProj\n"
 			"#define texture3D texture\n";
 	} else if( glConfig.gpuShader4Available) {
-		str =   "#define IN(mode) varying\n"
+		str += "#define IN(mode) varying\n"
 			"#define DECLARE_OUTPUT(type) varying out type outputColor;\n";
 	} else {
-		str =   "#define IN(mode) varying\n"
+		str += "#define IN(mode) varying\n"
 			"#define outputColor gl_FragColor\n"
 			"#define DECLARE_OUTPUT(type) /* empty*/\n";
 	}
@@ -640,11 +687,21 @@ static std::string GenFragmentHeader() {
 		AddDefine( str, "USE_PUSH_BUFFER", 1 );
 	}
 
+	str +=
+R"(#endif // GENERATED_FRAGMENT_HEADER
+
+)";
+
 	return str;
 }
 
 static std::string GenComputeHeader() {
 	std::string str;
+
+	str +=
+R"(#if !defined(GENERATED_COMPUTE_HEADER)
+#define GENERATED_COMPUTE_HEADER
+)";
 
 	// Compute shader compatibility defines
 	if ( glConfig.usingMaterialSystem ) {
@@ -668,6 +725,11 @@ static std::string GenComputeHeader() {
 	if ( glConfig.pushBufferAvailable ) {
 		AddDefine( str, "USE_PUSH_BUFFER", 1 );
 	}
+
+	str +=
+R"(#endif // GENERATED_COMPUTE_HEADER
+
+)";
 
 	return str;
 }
@@ -936,11 +998,7 @@ static bool IsUnusedPermutation( const char *compileMacros )
 	return false;
 }
 
-void GLShaderManager::BuildShader( ShaderDescriptor* descriptor ) {
-	if ( descriptor->id ) {
-		return;
-	}
-
+void GLShaderManager::BuildShader( ShaderDescriptor* descriptor, bool force ) {
 	const int start = Sys::Milliseconds();
 
 	const GLchar* text[1] = { descriptor->shaderSource.data() };
@@ -950,29 +1008,32 @@ void GLShaderManager::BuildShader( ShaderDescriptor* descriptor ) {
 	GL_CheckErrors();
 
 	glShaderSource( shader, 1, text, length );
-	glCompileShader( shader );
 
-	GL_CheckErrors();
+	if ( glConfig.incrementalShaderCompilation || force ) {
+		glCompileShader( shader );
 
-	GLint compiled;
-	glGetShaderiv( shader, GL_COMPILE_STATUS, &compiled );
+		GL_CheckErrors();
 
-	if ( !compiled ) {
-		std::string log = GetInfoLog( shader );
-		std::vector<InfoLogEntry> infoLog = ParseInfoLog( log );
-		PrintShaderSource( descriptor->name, shader, infoLog );
+		GLint compiled;
+		glGetShaderiv( shader, GL_COMPILE_STATUS, &compiled );
 
-		Log::Warn( "Compile log:\n%s", log );
+		if ( !compiled ) {
+			std::string log = GetInfoLog( shader );
+			std::vector<InfoLogEntry> infoLog = ParseInfoLog( log );
+			PrintShaderSource( descriptor->name, shader, infoLog );
 
-		switch ( descriptor->type ) {
-			case GL_VERTEX_SHADER:
-				ThrowShaderError( Str::Format( "Couldn't compile vertex shader: %s", descriptor->name ) );
-			case GL_FRAGMENT_SHADER:
-				ThrowShaderError( Str::Format( "Couldn't compile fragment shader: %s", descriptor->name ) );
-			case GL_COMPUTE_SHADER:
-				ThrowShaderError( Str::Format( "Couldn't compile compute shader: %s", descriptor->name ) );
-			default:
-				break;
+			Log::Warn( "Compile log:\n%s", log );
+
+			switch ( descriptor->type ) {
+				case GL_VERTEX_SHADER:
+					ThrowShaderError( Str::Format( "Couldn't compile vertex shader: %s", descriptor->name ) );
+				case GL_FRAGMENT_SHADER:
+					ThrowShaderError( Str::Format( "Couldn't compile fragment shader: %s", descriptor->name ) );
+				case GL_COMPUTE_SHADER:
+					ThrowShaderError( Str::Format( "Couldn't compile compute shader: %s", descriptor->name ) );
+				default:
+					break;
+			}
 		}
 	}
 
@@ -981,7 +1042,10 @@ void GLShaderManager::BuildShader( ShaderDescriptor* descriptor ) {
 	const int time = Sys::Milliseconds() - start;
 	compileTime += time;
 	compileCount++;
-	Log::Debug( "Compilation: %i", time );
+
+	if ( glConfig.incrementalShaderCompilation || force ) {
+		Log::Debug( "Compilation: %i", time );
+	}
 }
 
 void GLShaderManager::BuildShaderProgram( ShaderProgramDescriptor* descriptor ) {
@@ -989,18 +1053,88 @@ void GLShaderManager::BuildShaderProgram( ShaderProgramDescriptor* descriptor ) 
 		return;
 	}
 
-	const int start = Sys::Milliseconds();
+	int start = Sys::Milliseconds();
 
 	GLuint program = glCreateProgram();
 	GL_CheckErrors();
 
-	for ( const GLuint& shader : descriptor->shaders ) {
-		if ( shader ) {
-			glAttachShader( program, shader );
-		} else {
-			break;
+	if ( glConfig.incrementalShaderCompilation ) {
+		for ( const GLuint& shader : descriptor->shaders ) {
+			if ( shader ) {
+				glAttachShader( program, shader );
+			} else {
+				break;
+			}
 		}
 	}
+	else {
+		std::unordered_map<GLint, ShaderDescriptor> concatenatedDescriptor = {
+			{ GL_FRAGMENT_SHADER, {} },
+			{ GL_VERTEX_SHADER, {} },
+			{ GL_COMPUTE_SHADER, {} },
+		};
+
+		std::unordered_map<GLint, std::string> shaderTypeName = {
+			{ GL_FRAGMENT_SHADER, "fragment" },
+			{ GL_VERTEX_SHADER, "vertex" },
+			{ GL_COMPUTE_SHADER, "compute" },
+		};
+
+		for ( const GLuint& shader : descriptor->shaders ) {
+			if ( shader ) {
+				GLint shaderType;
+				glGetShaderiv(shader, GL_SHADER_TYPE, &shaderType);
+
+				int maxLength;
+				int actualLength;
+				glGetShaderiv( shader, GL_SHADER_SOURCE_LENGTH, &maxLength );
+				GLchar* shaderSource = new GLchar[ maxLength ];
+				glGetShaderSource( shader, maxLength, &actualLength, shaderSource );
+
+				ShaderDescriptor &concatenated = concatenatedDescriptor[ shaderType ];
+
+				// If first unit of the shader.
+				if ( concatenated.type == 0 ) {
+					concatenated.shaderSource = GenVersionLine();
+				}
+
+				concatenated.type = shaderType;
+				concatenated.shaderSource.append( shaderSource, actualLength );
+
+				delete[] shaderSource;
+			} else {
+				break;
+			}
+		}
+
+		for ( auto &pair : concatenatedDescriptor )
+		{
+			ShaderDescriptor &concatenated = pair.second;
+
+			if ( concatenated.type != 0 )
+			{
+				Log::Debug( "Building concatenated %s program.", shaderTypeName[ concatenated.type ] );
+				GLShaderManager::BuildShader( &concatenated, true );
+			}
+		}
+
+		// Reset the attach & link timer, we wasted it when compiling shaders.
+		start = Sys::Milliseconds();
+
+		for ( auto &pair : concatenatedDescriptor )
+		{
+			ShaderDescriptor &concatenated = pair.second;
+
+			if ( concatenated.type != 0 )
+			{
+				if ( concatenated.id )
+				{
+					glAttachShader( program, concatenated.id );
+				}
+			}
+		}
+	}
+
 	GL_CheckErrors();
 
 	BindAttribLocations( program );

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -807,6 +807,24 @@ protected:
 	}
 };
 
+class GLUniformMatrix3f : protected GLUniform
+{
+protected:
+	GLUniformMatrix3f( GLShader *shader, const char *name, const UpdateType updateType ) :
+	GLUniform( shader, name, "mat3", 9, 4, updateType ) {
+	}
+
+	inline void SetValue( GLboolean transpose, const matrix_t m )
+	{
+		if ( !CacheValue( ( void* ) m ) ) {
+			return;
+		}
+
+		ShaderProgramDescriptor* p = _shader->GetProgram();
+		glUniformMatrix3fv( p->uniformLocations[ _locationIndex ], 1, transpose, m );
+	}
+};
+
 class GLUniformMatrix32f : protected GLUniform {
 	protected:
 	GLUniformMatrix32f( GLShader* shader, const char* name, const UpdateType updateType ) :
@@ -1736,16 +1754,41 @@ class u_CurrentMap :
 	}
 };
 
-class u_TextureMatrix :
+class u_TextureMatrix_Matrix3 :
+	GLUniformMatrix3f
+{
+public:
+	u_TextureMatrix_Matrix3( GLShader *shader ) :
+		GLUniformMatrix3f( shader, "u_TextureMatrix", TEXDATA_OR_PUSH )
+	{
+	}
+
+	void SetUniform_TextureMatrix_Matrix3( const matrix_t m )
+	{
+		vec_t m2[9];
+		m2[0] = m[0];
+		m2[1] = m[1];
+		m2[2] = 0;
+		m2[3] = m[4];
+		m2[4] = m[5];
+		m2[5] = 0;
+		m2[6] = m[12];
+		m2[7] = m[13];
+		m2[8] = 1;
+		this->SetValue( GL_FALSE, m2 );
+	}
+};
+
+class u_TextureMatrix_Matrix32 :
 	GLUniformMatrix32f
 {
 public:
-	u_TextureMatrix( GLShader *shader ) :
+	u_TextureMatrix_Matrix32( GLShader *shader ) :
 		GLUniformMatrix32f( shader, "u_TextureMatrix", TEXDATA_OR_PUSH )
 	{
 	}
 
-	void SetUniform_TextureMatrix( const matrix_t m )
+	void SetUniform_TextureMatrix_Matrix32( const matrix_t m )
 	{
 		/* We only actually need these 6 components to get the correct texture transformation,
 		the other ones are unused */
@@ -1757,6 +1800,28 @@ public:
 		m2[4] = m[12];
 		m2[5] = m[13];
 		this->SetValue( GL_FALSE, m2 );
+	}
+};
+
+class u_TextureMatrix_Dispatch :
+	u_TextureMatrix_Matrix3,
+	u_TextureMatrix_Matrix32
+{
+public:
+	u_TextureMatrix_Dispatch( GLShader *shader ) :
+		u_TextureMatrix_Matrix3( shader ),
+		u_TextureMatrix_Matrix32( shader ) {}
+
+	void SetUniform_TextureMatrix( const matrix_t m )
+	{
+		if ( glConfig.mat3x2Available )
+		{
+			SetUniform_TextureMatrix_Matrix32( m );
+		}
+		else
+		{
+			SetUniform_TextureMatrix_Matrix3( m );
+		}
 	}
 };
 
@@ -2939,7 +3004,7 @@ class GLShader_generic :
 	public GLShader,
 	public u_ColorMap,
 	public u_DepthMap,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_ViewOrigin,
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
@@ -2970,7 +3035,7 @@ class GLShader_genericMaterial :
 	public GLShader,
 	public u_ColorMap,
 	public u_DepthMap,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_ViewOrigin,
 	public u_AlphaThreshold,
 	public u_ModelMatrix,
@@ -3007,7 +3072,7 @@ class GLShader_lightMapping :
 	public u_LightGrid1,
 	public u_LightGrid2,
 	public u_LightTiles,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_SpecularExponent,
 	public u_ColorModulateColorGen_Dispatch,
 	public u_Color_Dispatch,
@@ -3059,7 +3124,7 @@ class GLShader_lightMappingMaterial :
 	public u_LightGrid1,
 	public u_LightGrid2,
 	public u_LightTiles,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_SpecularExponent,
 	public u_ColorModulateColorGen_Uint,
 	public u_Color_Uint,
@@ -3098,7 +3163,7 @@ class GLShader_reflection :
 	public u_ColorMapCube,
 	public u_NormalMap,
 	public u_HeightMap,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_ViewOrigin,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
@@ -3124,7 +3189,7 @@ class GLShader_reflectionMaterial :
 	public u_ColorMapCube,
 	public u_NormalMap,
 	public u_HeightMap,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_ViewOrigin,
 	public u_ModelMatrix,
 	public u_ModelViewProjectionMatrix,
@@ -3143,7 +3208,7 @@ class GLShader_skybox :
 	public GLShader,
 	public u_ColorMapCube,
 	public u_CloudMap,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_CloudHeight,
 	public u_UseCloudMap,
 	public u_AlphaThreshold,
@@ -3158,7 +3223,7 @@ class GLShader_skyboxMaterial :
 	public GLShader,
 	public u_ColorMapCube,
 	public u_CloudMap,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_CloudHeight,
 	public u_UseCloudMap,
 	public u_AlphaThreshold,
@@ -3186,7 +3251,7 @@ class GLShader_heatHaze :
 	public GLShader,
 	public u_CurrentMap,
 	public u_NormalMap,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_DeformMagnitude,
 	public u_ModelViewProjectionMatrix,
 	public u_ModelViewMatrixTranspose,
@@ -3207,7 +3272,7 @@ class GLShader_heatHazeMaterial :
 	public GLShader,
 	public u_CurrentMap,
 	public u_NormalMap,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_DeformEnable,
 	public u_DeformMagnitude,
 	public u_ModelViewProjectionMatrix,
@@ -3284,7 +3349,7 @@ class GLShader_liquid :
 	public u_LightGrid1,
 	public u_LightGrid2,
 	public u_HeightMap,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_ViewOrigin,
 	public u_RefractionIndex,
 	public u_ModelMatrix,
@@ -3320,7 +3385,7 @@ class GLShader_liquidMaterial :
 	public u_LightGrid1,
 	public u_LightGrid2,
 	public u_HeightMap,
-	public u_TextureMatrix,
+	public u_TextureMatrix_Dispatch,
 	public u_ViewOrigin,
 	public u_RefractionIndex,
 	public u_ModelMatrix,

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -539,7 +539,7 @@ private:
 	int cacheSaveTime;
 	uint32_t cacheSaveCount;
 
-	void BuildShader( ShaderDescriptor* descriptor );
+	void BuildShader( ShaderDescriptor* descriptor, bool force = false );
 	void BuildShaderProgram( ShaderProgramDescriptor* descriptor );
 
 	std::string GetDeformShaderName( const int index );

--- a/src/engine/renderer/glsl_source/generic_vp.glsl
+++ b/src/engine/renderer/glsl_source/generic_vp.glsl
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #insert shaderProfiler_vp
 
 #if !defined(USE_MATERIAL_SYSTEM)
-	uniform mat3x2 u_TextureMatrix;
+	uniform textureMatrix u_TextureMatrix;
 #endif
 
 uniform vec3 u_ViewOrigin;

--- a/src/engine/renderer/glsl_source/heatHaze_vp.glsl
+++ b/src/engine/renderer/glsl_source/heatHaze_vp.glsl
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 uniform float		u_Time;
 
 #if !defined(USE_MATERIAL_SYSTEM)
-	uniform mat3x2 u_TextureMatrix;
+	uniform textureMatrix u_TextureMatrix;
 #endif
 
 uniform mat4		u_ProjectionMatrixTranspose;

--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -46,10 +46,12 @@ IN(smooth) vec3		var_Binormal;
 IN(smooth) vec3		var_Normal;
 
 uniform sampler2D u_LightMap;
-uniform sampler3D u_LightGrid1;
-
 uniform sampler2D u_DeluxeMap;
-uniform sampler3D u_LightGrid2;
+
+#if defined(HAVE_texture3D)
+	uniform sampler3D u_LightGrid1;
+	uniform sampler3D u_LightGrid2;
+#endif
 
 #if defined(USE_LIGHT_MAPPING) || defined(USE_DELUXE_MAPPING)
 	IN(smooth) vec2 var_TexLight;
@@ -156,9 +158,15 @@ void main()
 		#endif
 		vec3 lightDir;
 		vec3 ambientColor, lightColor;
-		ReadLightGrid(texel1, texel2, lightFactor, lightDir, ambientColor, lightColor);
+		#if HAVE_texture3D
+			ReadLightGrid(texel1, texel2, lightFactor, lightDir, ambientColor, lightColor);
 
-		color.rgb = ambientColor * r_AmbientScale * diffuse.rgb;
+			color.rgb = ambientColor * r_AmbientScale * diffuse.rgb;
+		#else
+			ambientColor = vec3(1.0);
+			lightColor = vec3(1.0);
+			color.rgb = diffuse.rgb;
+		#endif
 	#endif
 
 	#if defined(USE_LIGHT_MAPPING) && defined(USE_DELUXE_MAPPING)

--- a/src/engine/renderer/glsl_source/lightMapping_vp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_vp.glsl
@@ -37,7 +37,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #endif
 
 #if !defined(USE_MATERIAL_SYSTEM)
-	uniform mat3x2 u_TextureMatrix;
+	uniform textureMatrix u_TextureMatrix;
 #endif
 
 uniform mat4 u_ModelMatrix;

--- a/src/engine/renderer/glsl_source/liquid_fp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_fp.glsl
@@ -47,8 +47,11 @@ uniform float		u_FresnelBias;
 uniform mat4		u_ModelMatrix;
 uniform mat4		u_UnprojectMatrix;
 
-uniform sampler3D       u_LightGrid1;
-uniform sampler3D       u_LightGrid2;
+#if HAVE_texture3D
+	uniform sampler3D       u_LightGrid1;
+	uniform sampler3D       u_LightGrid2;
+#endif
+
 uniform vec3            u_LightGridOrigin;
 uniform vec3            u_LightGridScale;
 
@@ -146,8 +149,12 @@ void	main()
 	#endif
 
 	// compute light direction in world space
-	vec4 texel = texture3D(u_LightGrid2, lightGridPos);
-	vec3 lightDir = normalize(texel.xyz - (128.0 / 255.0));
+	#if HAVE_texture3D
+		vec4 texel = texture3D(u_LightGrid2, lightGridPos);
+		vec3 lightDir = normalize(texel.xyz - (128.0 / 255.0));
+	#else
+		vec3 lightDir = vec3(1.0);
+	#endif
 
 	vec4 diffuse = vec4(0.0, 0.0, 0.0, 1.0);
 

--- a/src/engine/renderer/glsl_source/liquid_vp.glsl
+++ b/src/engine/renderer/glsl_source/liquid_vp.glsl
@@ -29,7 +29,7 @@ IN vec3			attr_Binormal;
 IN vec3			attr_Normal;
 
 #if !defined(USE_MATERIAL_SYSTEM)
-	uniform mat3x2 u_TextureMatrix;
+	uniform textureMatrix u_TextureMatrix;
 #endif
 
 uniform mat4		u_ModelMatrix;

--- a/src/engine/renderer/glsl_source/reflection_CB_vp.glsl
+++ b/src/engine/renderer/glsl_source/reflection_CB_vp.glsl
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #insert vertexAnimation_vp
 
 #if !defined(USE_MATERIAL_SYSTEM)
-	uniform mat3x2 u_TextureMatrix;
+	uniform textureMatrix u_TextureMatrix;
 #endif
 
 uniform mat4		u_ModelMatrix;

--- a/src/engine/renderer/glsl_source/skybox_fp.glsl
+++ b/src/engine/renderer/glsl_source/skybox_fp.glsl
@@ -34,7 +34,7 @@ uniform bool        u_UseCloudMap;
 uniform float       u_CloudHeight;
 
 #if !defined(USE_MATERIAL_SYSTEM)
-	uniform mat3x2 u_TextureMatrix;
+	uniform textureMatrix u_TextureMatrix;
 #endif
 
 uniform float		u_AlphaThreshold;

--- a/src/engine/renderer/tr_bsp.cpp
+++ b/src/engine/renderer/tr_bsp.cpp
@@ -3470,7 +3470,7 @@ R_LoadLightGrid
 */
 void R_LoadLightGrid( lump_t *l )
 {
-	if ( glConfig.max3DTextureSize == 0 )
+	if ( !glConfig.texture3DAvailable )
 	{
 		Log::Warn( "Grid lighting disabled because of missing 3D texture support." );
 

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -61,6 +61,10 @@ static Cvar::Cvar<bool> r_incrementalShaderCompilation(
 	"r_incrementalShaderCompilation", "Build separate shader units then link them alltogether at the end",
 	Cvar::NONE, true );
 
+static Cvar::Cvar<bool> r_useMat3x2(
+	"r_useMat3x2", "Use mat3x2 GLSL type",
+	Cvar::NONE, true );
+
 // OpenGL extension cvars.
 /* Driver bug: Mesa versions > 24.0.9 produce garbage rendering when bindless textures are enabled,
 and the shader compiler crashes with material shaders
@@ -146,6 +150,10 @@ static Cvar::Cvar<bool> workaround_glDriver_amd_oglp_disableBindlessTexture(
 static Cvar::Cvar<bool> workaround_glDriver_gl4es_disableIncrementalShaderCompilation(
 	"workaround.glDriver.gl4es.disableIncrementalShaderCompilation",
 	"Disable incremental shader compilation on GL4ES",
+	Cvar::NONE, true );
+static Cvar::Cvar<bool> workaround_glDriver_gl4es_disableMat3x2(
+	"workaround.glDriver.gl4es.disableMat3x2",
+	"Disable mat3x2 GLSL support on GL4ES",
 	Cvar::NONE, true );
 static Cvar::Cvar<bool> workaround_glDriver_mesa_ati_rv300_useFloatVertex(
 	"workaround.glDriver.mesa.ati.rv300.useFloatVertex",
@@ -2668,6 +2676,8 @@ static void GLimp_InitExtensions()
 
 	glConfig.incrementalShaderCompilation = r_incrementalShaderCompilation.Get();
 
+	glConfig.mat3x2Available = r_useMat3x2.Get();
+
 	if ( glConfig.driverVendor == glDriverVendor_t::GL4ES )
 	{
 		if ( glConfig.incrementalShaderCompilation
@@ -2675,6 +2685,13 @@ static void GLimp_InitExtensions()
 		{
 			logger.Notice( "Found GL4ES translation layer with OpenGL ES backend, disable incremental shader compilation." );
 			glConfig.incrementalShaderCompilation = false;
+		}
+
+		if ( glConfig.mat3x2Available
+			&& workaround_glDriver_gl4es_disableMat3x2.Get() )
+		{
+			logger.Notice( "Found GL4ES translation layer with OpenGL ES backend, disable mat3x2 GLSL support." );
+			glConfig.mat3x2Available = false;
 		}
 	}
 
@@ -2919,6 +2936,7 @@ bool GLimp_Init()
 	Cvar::Latch( workaround_glDriver_amd_adrenalin_disableBindlessTexture );
 	Cvar::Latch( workaround_glDriver_amd_oglp_disableBindlessTexture );
 	Cvar::Latch( workaround_glDriver_gl4es_disableIncrementalShaderCompilation );
+	Cvar::Latch( workaround_glDriver_gl4es_disableMat3x2 );
 	Cvar::Latch( workaround_glDriver_mesa_ati_rv300_useFloatVertex );
 	Cvar::Latch( workaround_glDriver_mesa_ati_rv600_disableHyperZ );
 	Cvar::Latch( workaround_glDriver_mesa_broadcom_vc4_useFloatVertex );
@@ -2936,6 +2954,7 @@ bool GLimp_Init()
 	Cvar::Latch( workaround_glHardware_mthreads_disableTextureBarrier );
 
 	Cvar::Latch( r_incrementalShaderCompilation );
+	Cvar::Latch( r_useMat3x2 );
 
 	/* Enable S3TC on Mesa even if libtxc-dxtn is not available
 	The environment variables is currently always set,

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -57,6 +57,10 @@ static Cvar::Range<Cvar::Cvar<int>> r_glDebugSeverity(
 	"minimum severity of r_glDebugProfile messages (1=NOTIFICATION, 2=LOW, 3=MEDIUM, 4=HIGH)",
 	Cvar::NONE, 2, 1, 4);
 
+static Cvar::Cvar<bool> r_incrementalShaderCompilation(
+	"r_incrementalShaderCompilation", "Build separate shader units then link them alltogether at the end",
+	Cvar::NONE, true );
+
 // OpenGL extension cvars.
 /* Driver bug: Mesa versions > 24.0.9 produce garbage rendering when bindless textures are enabled,
 and the shader compiler crashes with material shaders
@@ -138,6 +142,10 @@ static Cvar::Cvar<bool> workaround_glDriver_amd_adrenalin_disableBindlessTexture
 static Cvar::Cvar<bool> workaround_glDriver_amd_oglp_disableBindlessTexture(
 	"workaround.glDriver.amd.oglp.disableBindlessTexture",
 	"Disable ARB_bindless_texture on AMD OGLP driver",
+	Cvar::NONE, true );
+static Cvar::Cvar<bool> workaround_glDriver_gl4es_disableIncrementalShaderCompilation(
+	"workaround.glDriver.gl4es.disableIncrementalShaderCompilation",
+	"Disable incremental shader compilation on GL4ES",
 	Cvar::NONE, true );
 static Cvar::Cvar<bool> workaround_glDriver_mesa_ati_rv300_useFloatVertex(
 	"workaround.glDriver.mesa.ati.rv300.useFloatVertex",
@@ -2658,6 +2666,18 @@ static void GLimp_InitExtensions()
 	}
 #endif
 
+	glConfig.incrementalShaderCompilation = r_incrementalShaderCompilation.Get();
+
+	if ( glConfig.driverVendor == glDriverVendor_t::GL4ES )
+	{
+		if ( glConfig.incrementalShaderCompilation
+			&& workaround_glDriver_gl4es_disableIncrementalShaderCompilation.Get() )
+		{
+			logger.Notice( "Found GL4ES translation layer with OpenGL ES backend, disable incremental shader compilation." );
+			glConfig.incrementalShaderCompilation = false;
+		}
+	}
+
 	// Shader limits.
 
 	// From GL_ARB_vertex_shader.
@@ -2898,6 +2918,7 @@ bool GLimp_Init()
 
 	Cvar::Latch( workaround_glDriver_amd_adrenalin_disableBindlessTexture );
 	Cvar::Latch( workaround_glDriver_amd_oglp_disableBindlessTexture );
+	Cvar::Latch( workaround_glDriver_gl4es_disableIncrementalShaderCompilation );
 	Cvar::Latch( workaround_glDriver_mesa_ati_rv300_useFloatVertex );
 	Cvar::Latch( workaround_glDriver_mesa_ati_rv600_disableHyperZ );
 	Cvar::Latch( workaround_glDriver_mesa_broadcom_vc4_useFloatVertex );
@@ -2913,6 +2934,8 @@ bool GLimp_Init()
 	Cvar::Latch( workaround_glExtension_glsl120_disableGpuShader4 );
 	Cvar::Latch( workaround_glHardware_intel_useFirstProvokinVertex );
 	Cvar::Latch( workaround_glHardware_mthreads_disableTextureBarrier );
+
+	Cvar::Latch( r_incrementalShaderCompilation );
 
 	/* Enable S3TC on Mesa even if libtxc-dxtn is not available
 	The environment variables is currently always set,

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -159,6 +159,10 @@ static Cvar::Cvar<bool> workaround_glDriver_gl4es_disableMat3x2(
 	"workaround.glDriver.gl4es.disableMat3x2",
 	"Disable mat3x2 GLSL support on GL4ES",
 	Cvar::NONE, true );
+static Cvar::Cvar<bool> workaround_glDriver_gl4es_disableTexture3D(
+	"workaround.glDriver.gl4es.disableTexture3D",
+	"Disable texture3D support on GL4ES",
+	Cvar::NONE, true );
 static Cvar::Cvar<bool> workaround_glDriver_mesa_ati_rv300_useFloatVertex(
 	"workaround.glDriver.mesa.ati.rv300.useFloatVertex",
 	"Use float vertex instead of supported-but-slower half-float vertex on Mesa driver on ATI RV300 hardware",
@@ -2150,6 +2154,16 @@ static void GLimp_InitExtensions()
 		logger.Warn( "Missing 3D texture support because of null max size" );
 	}
 
+	if ( glConfig.driverVendor == glDriverVendor_t::GL4ES )
+	{
+		if ( glConfig.texture3DAvailable
+			&& workaround_glDriver_gl4es_disableTexture3D.Get() )
+		{
+			logger.Notice( "Found GL4ES translation layer with OpenGL ES backend, disable 3D texture support." );
+			glConfig.texture3DAvailable = false;
+		}
+	}
+
 	logger.Notice( "...using up to %d texture size.", glConfig.maxTextureSize );
 
 	if ( glConfig.texture3DAvailable )
@@ -2962,6 +2976,7 @@ bool GLimp_Init()
 	Cvar::Latch( workaround_glDriver_amd_oglp_disableBindlessTexture );
 	Cvar::Latch( workaround_glDriver_gl4es_disableIncrementalShaderCompilation );
 	Cvar::Latch( workaround_glDriver_gl4es_disableMat3x2 );
+	Cvar::Latch( workaround_glDriver_gl4es_disableTexture3D );
 	Cvar::Latch( workaround_glDriver_mesa_ati_rv300_useFloatVertex );
 	Cvar::Latch( workaround_glDriver_mesa_ati_rv600_disableHyperZ );
 	Cvar::Latch( workaround_glDriver_mesa_broadcom_vc4_useFloatVertex );

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -61,6 +61,10 @@ static Cvar::Cvar<bool> r_incrementalShaderCompilation(
 	"r_incrementalShaderCompilation", "Build separate shader units then link them alltogether at the end",
 	Cvar::NONE, true );
 
+static Cvar::Cvar<bool> r_useTexture3D(
+	"r_useTexture3D", "Use texture3D image format and sampler3D GLSL keyword",
+	Cvar::CHEAT, true );
+
 static Cvar::Cvar<bool> r_useMat3x2(
 	"r_useMat3x2", "Use mat3x2 GLSL type",
 	Cvar::NONE, true );
@@ -2111,6 +2115,8 @@ static void GLimp_InitExtensions()
 
 	// Stubbed or broken drivers may report garbage.
 
+	glConfig.texture3DAvailable = r_useTexture3D.Get();
+
 	if ( glConfig.maxTextureUnits < 0 )
 	{
 		Log::Warn( "Bad GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS value: %d", glConfig.maxTextureUnits );
@@ -2135,8 +2141,27 @@ static void GLimp_InitExtensions()
 		glConfig.maxCubeMapTextureSize = 0;
 	}
 
+	if ( glConfig.max3DTextureSize > 0 )
+	{
+		glConfig.texture3DAvailable = true;
+	}
+	else
+	{
+		logger.Warn( "Missing 3D texture support because of null max size" );
+	}
+
 	logger.Notice( "...using up to %d texture size.", glConfig.maxTextureSize );
-	logger.Notice( "...using up to %d 3D texture size.", glConfig.max3DTextureSize );
+
+	if ( glConfig.texture3DAvailable )
+	{
+		logger.Notice( "...using up to %d 3D texture size.", glConfig.max3DTextureSize );
+	}
+	else
+	{
+		logger.Notice( "...not using 3D textures." );
+		glConfig.max3DTextureSize = 0;
+	}
+
 	logger.Notice( "...using up to %d cube map texture size.", glConfig.maxCubeMapTextureSize );
 	logger.Notice( "...using up to %d texture units.", glConfig.maxTextureUnits );
 
@@ -2744,7 +2769,7 @@ static void GLimp_EnableAvailableFeatures()
 			glConfig.realtimeLighting = false;
 		}
 
-		if ( glConfig.max3DTextureSize == 0 )
+		if ( !glConfig.texture3DAvailable )
 		{
 			Log::Warn( "Tiled dynamic light renderer disabled because of missing 3D texture support." );
 			glConfig.realtimeLighting = false;
@@ -2778,7 +2803,7 @@ static void GLimp_EnableAvailableFeatures()
 
 	if ( glConfig.colorGrading )
 	{
-		if ( glConfig.max3DTextureSize == 0 )
+		if ( !glConfig.texture3DAvailable )
 		{
 			Log::Warn( "Color grading disabled because of missing 3D texture support." );
 			glConfig.colorGrading = false;
@@ -2954,6 +2979,7 @@ bool GLimp_Init()
 	Cvar::Latch( workaround_glHardware_mthreads_disableTextureBarrier );
 
 	Cvar::Latch( r_incrementalShaderCompilation );
+	Cvar::Latch( r_useTexture3D );
 	Cvar::Latch( r_useMat3x2 );
 
 	/* Enable S3TC on Mesa even if libtxc-dxtn is not available

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2107,6 +2107,27 @@ static void GLimp_InitExtensions()
 
 	logger.Notice("...using shading language version %i", glConfig.shadingLanguageVersion );
 
+	glConfig.incrementalShaderCompilation = r_incrementalShaderCompilation.Get();
+
+	glConfig.mat3x2Available = r_useMat3x2.Get();
+
+	if ( glConfig.driverVendor == glDriverVendor_t::GL4ES )
+	{
+		if ( glConfig.incrementalShaderCompilation
+			&& workaround_glDriver_gl4es_disableIncrementalShaderCompilation.Get() )
+		{
+			logger.Notice( "Found GL4ES translation layer with OpenGL ES backend, disable incremental shader compilation." );
+			glConfig.incrementalShaderCompilation = false;
+		}
+
+		if ( glConfig.mat3x2Available
+			&& workaround_glDriver_gl4es_disableMat3x2.Get() )
+		{
+			logger.Notice( "Found GL4ES translation layer with OpenGL ES backend, disable mat3x2 GLSL support." );
+			glConfig.mat3x2Available = false;
+		}
+	}
+
 
 	// OpenGL driver constants.
 
@@ -2712,27 +2733,6 @@ static void GLimp_InitExtensions()
 			"Update GLEW to 2.2+ to be able to use this extension" );
 	}
 #endif
-
-	glConfig.incrementalShaderCompilation = r_incrementalShaderCompilation.Get();
-
-	glConfig.mat3x2Available = r_useMat3x2.Get();
-
-	if ( glConfig.driverVendor == glDriverVendor_t::GL4ES )
-	{
-		if ( glConfig.incrementalShaderCompilation
-			&& workaround_glDriver_gl4es_disableIncrementalShaderCompilation.Get() )
-		{
-			logger.Notice( "Found GL4ES translation layer with OpenGL ES backend, disable incremental shader compilation." );
-			glConfig.incrementalShaderCompilation = false;
-		}
-
-		if ( glConfig.mat3x2Available
-			&& workaround_glDriver_gl4es_disableMat3x2.Get() )
-		{
-			logger.Notice( "Found GL4ES translation layer with OpenGL ES backend, disable mat3x2 GLSL support." );
-			glConfig.mat3x2Available = false;
-		}
-	}
 
 	// Shader limits.
 


### PR DESCRIPTION
I flag it as draft to make it obvious I'm not intending to merge this for the 0.56 release.

I'm just pushing it because it's somewhat usable and as Linus Torvalds said once:

> Only wimps use tape backup: real men just upload their important stuff on ftp, and let the rest of the world mirror it ;)

This implements some compatibility code path making possible to run the Dæmon engine and the Unvanquished game on OpenGL ES hardware using the [GL4ES](https://github.com/ptitSeb/gl4es/) translation layer.

In fact this basically implements some compatibility code path for GL ES 2 (what currently targets GL4ES) for when GL4ES isn't able to translate OpenGL to GL ES because of GL ES limitation.

The purpose of this is to allow me to test the engine on more hardware. I used this to confirm the bug we observe on PowerVR-derivated hardware like Apple AGX/Moore Threads is indeed reproducible on PowerVR:

- https://github.com/DaemonEngine/Daemon/issues/1892

The only Imagination-branded PowerVR device I own is soldered on a RISC-V board, and while there is a Vulkan Mesa driver being on development for it (purposed to be a backend for the Mesa zink OpenGL translation layer), the RISC-V architecture of the said board is very new and then the whole Linux support is experimental and so getting the game running on GL4ES is far less work than doing platform-enablement at the whole distro level. So that allows me to use the proprietary OpenGL ES Imagination driver for PowerVR which is bundled with the distro provided for the board (the Proprietary Imagination Vulkan driver isn't featureful enough to run Zink). I even don't have to rebuild neither the kernel, neither Mesa!

This also brings more rewrite of existing compatibility code in a better way.

I started to implement ways to detect the underlying hardware when running API translators, this may be extended to things like VirGL, Zink or Parallels in the future.

GL4ES actually added such wanted feature on my request:

- https://github.com/ptitSeb/gl4es/issues/502

I have more ideas for some rework on the driver/hardware detection (especially moving things like `TRANSLATOR` to a different variable than `HARDWARE`).

So this doesn't only benefit GL4ES and PowerVR.