### PR TITLE
WIP: lightMapping: blend a bit the normal map with the deluxe map

### DIFF
--- a/src/engine/renderer/glsl_source/lightMapping_fp.glsl
+++ b/src/engine/renderer/glsl_source/lightMapping_fp.glsl
@@ -139,6 +139,13 @@ void main()
 		// Compute light direction in world space from deluxe map.
 		vec4 deluxe = texture2D(u_DeluxeMap, var_TexLight);
 		vec3 lightDir = normalize(2.0 * deluxe.xyz - 1.0);
+
+		/* HACK: blend a bit the normal map with the deluxe map to make the normal
+		map align with the deluxe map to prevent NdotL collapsing to zero, while
+		retaining enough normal details.
+		See: https://github.com/DaemonEngine/Daemon/issues/1905 */
+		float normalBlendFactor = 0.5;
+		normal = normalize(normal * normalBlendFactor + lightDir * (1.0 - normalBlendFactor));
 	#elif defined(USE_GRID_DELUXE_MAPPING)
 		// Compute light direction in world space from light grid.
 		vec4 texel = texture3D(u_LightGrid2, lightGridPos);


### PR DESCRIPTION
HACK: blend a bit the normal map with the deluxe map to make the normal map align with the deluxe map to prevent NdotL collapsing to zero, while retaining enough normal details.

See: https://github.com/DaemonEngine/Daemon/issues/1905

Disclosure: the blend trick was suggested by an LLM (ChatGPT) in a “discussion” with it where I described the visual look of the bug.

The trick works but that can be pure AI overconfident bullshit. Here are the « explanations » provided :

> - High-frequency normal maps locally rotate the surface normal away from the smooth underlying surface.
> - The baked direction _[what we call deluxe maps]_ corresponds to the smooth underlying geometry, not the bumped normal.
> - Therefore, in some pixels the dot product between the bumped normal and the baked direction can be very small or even negative: dot(normalMapNormal, bakedNormal)≈0 or negative
> - This is not a bug in your code — it’s a physical consequence of combining a high-frequency normal with a low-frequency baked direction.