### PR TITLE
cameraEffects: do the tone mapping operation before the color conversion

### DIFF
--- a/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
+++ b/src/engine/renderer/glsl_source/cameraEffects_fp.glsl
@@ -84,11 +84,6 @@ void main()
 	vec4 color = texture2D(u_CurrentMap, st);
 	color *= u_GlobalLightFactor;
 
-	if ( u_SRGB )
-	{
-		convertToSRGB( color.rgb );
-	}
-
 	color.rgb *= u_Exposure;
 
 #if defined(r_highPrecisionRendering) && defined(HAVE_ARB_texture_float)
@@ -98,6 +93,11 @@ void main()
 #endif
 
 	color.rgb = clamp( color.rgb, vec3( 0.0f ), vec3( 1.0f ) );
+
+	if ( u_SRGB )
+	{
+		convertToSRGB( color.rgb );
+	}
 
 #if defined(r_colorGrading)
 	// apply color grading


### PR DESCRIPTION
Do the tone mapping operation before the color conversion.

The author of the tone mapper we implement said it sould be done this way:

> Linear Color HDR Render Output After Auto-Exposure Adjustment → Tonemap Linear Color HDR To Linear In Range of Display → Grain and Conversion via Display Transfer Function
> -- Advanced Techniques and Optimization of HDR VDR Color Pipelines by Timothy Lottes (Game developers conference on March 14-18, 2016), presentation slides p. 4

<img width="3507" height="2480" alt="Image" src="https://github.com/user-attachments/assets/175557a0-3255-4d66-85b9-564b9403886d" />

Other authorities on the topic said the same:

> It is important to apply the conversion at the final stage of rendering (when the values are written to the display buffer for the last time), and not before. If post-processing is applied after gamma correction, post-processing effects will be computed in nonlinear space, which is incorrect and will often cause visible artifacts. So operations such as tone mapping [...] can be applied to images to adjust luminance balance, but gamma corection should always be done last.
> -- Real-Time Rendering 3rd by Möller, Haines and Hoffman, p. 145
> https://computergraphics.stackexchange.com/questions/5449/tone-mapping-gamma-correction
