### PR TITLE
Beautifying the tone mapped render

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -799,6 +799,17 @@ static std::string GenEngineConstants() {
 		AddDefine( str, "r_highPrecisionRendering", 1 );
 	}
 
+	if ( r_toneMappingLowLightRestorationSteps.Get() )
+	{
+		AddDefine( str, "r_toneMappingLowLightRestorationSteps", r_toneMappingLowLightRestorationSteps.Get() );
+		AddDefine( str, "r_toneMappingLowLightRestorationThreshold", r_toneMappingLowLightRestorationThreshold.Get() );
+
+		if ( r_showToneMappingLowLightRestoration.Get() )
+		{
+			AddDefine( str, "r_showToneMappingLowLightRestoration", 1 );
+		}
+	}
+
 	if ( r_lowLightDithering.Get() )
 	{
 		AddDefine( str, "r_lowLightDithering", 1 );

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -205,6 +205,16 @@ Cvar::Cvar<int> r_rendererAPI( "r_rendererAPI", "Renderer API: 0: OpenGL, 1: Vul
 		"r_toneMappingDarkAreaPointLDR", "Convert to this brightness at dark area cut-off",
 		Cvar::NONE, 0.268f, 0.0f, 1.0f );
 
+	Cvar::Range<Cvar::Cvar<int>> r_toneMappingLowLightRestorationSteps(
+		"r_toneMappingLowLightRestorationSteps", "Amount of steps to restore the low lights",
+		Cvar::NONE, 1, 0, 5 );
+	Cvar::Range<Cvar::Cvar<int>> r_toneMappingLowLightRestorationThreshold(
+		"r_toneMappingLowLightRestorationThreshold", "Color channel sRGB value under which low light is restored",
+		Cvar::NONE, 10, 2, 20 );
+	Cvar::Cvar<bool> r_showToneMappingLowLightRestoration(
+		"r_showToneMappingLowLightRestoration", "Show pixels affected by tone mapping low light restoration",
+		Cvar::CHEAT, false );
+
 	Cvar::Cvar<bool> r_lowLightDithering(
 		"r_lowLightDithering", "Use dithering in low light areas", Cvar::NONE, true );
 	Cvar::Range<Cvar::Cvar<int>> r_lowLightDitheringThreshold(
@@ -1277,6 +1287,10 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		Cvar::Latch( r_highPrecisionRendering );
 		Cvar::Latch( r_accurateSRGB );
+
+		Cvar::Latch( r_toneMappingLowLightRestorationSteps );
+		Cvar::Latch( r_toneMappingLowLightRestorationThreshold );
+		Cvar::Latch( r_showToneMappingLowLightRestoration );
 
 		Cvar::Latch( r_lowLightDithering );
 		Cvar::Latch( r_lowLightDitheringThreshold );

--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -2717,6 +2717,10 @@ enum
 	extern Cvar::Cvar<bool> r_highPrecisionRendering;
 	extern Cvar::Cvar<bool> r_accurateSRGB;
 
+	extern Cvar::Range<Cvar::Cvar<int>> r_toneMappingLowLightRestorationSteps;
+	extern Cvar::Range<Cvar::Cvar<int>> r_toneMappingLowLightRestorationThreshold;
+	extern Cvar::Cvar<bool> r_showToneMappingLowLightRestoration;
+
 	extern Cvar::Cvar<bool> r_lowLightDithering;
 	extern Cvar::Range<Cvar::Cvar<int>> r_lowLightDitheringThreshold;
 	extern Cvar::Range<Cvar::Cvar<float>> r_lowLightDitheringAmplitudeFactor;


### PR DESCRIPTION
1. Set the contrast to 1.4 instead of 1.6, this fits better Unvanquished needs.
2. Implement a dithering, this is enough to avoid the color banding happening when the tone mapper contrast turns dark shadows to black. This doesn't prevent the blackening, but it hides the distracting visual artifacts by smoothing the banding. This is good enough to make the tone mapper usable on every map and to not get a visual regression on dark shadows in gloomy room corner cases.
3. Restore low lights in shadows blackened by the tone mapper contrast. Those shadows are so dark that restoring a bit of light there doesn't change the perceptual contrast, it's always darky anyway, we just restore details lost by the tone mapper shadow blackening.

I'll detail the work in comments.

With this, I see no specific corner cases anymore that would make the tone mapped render look less good than without. We can fully embrace tone mapping, which is very good and wanted because we need tone mapping for adaptive lighting and we want adaptive lighting.

This includes the “tonemap before color conversion” fix as it is required to properly evaluate the renders produced by this branch:

- https://github.com/DaemonEngine/Daemon/pull/1912

Fixes:

- https://github.com/DaemonEngine/Daemon/issues/1913