### PR TITLE
gl_shader: fix shader dump line numbering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,6 +689,7 @@ if (BUILD_CLIENT OR WIN32)
     endif()
 
     find_package(SDL3 REQUIRED CONFIG)
+    message("Found SDL3 ${SDL3_VERSION}: ${SDL3_DIR}")
 
     if (WIN32)
         set(LIBS_ENGINE_BASE ${LIBS_ENGINE_BASE} SDL3::SDL3)

--- a/cmake/DaemonArchitecture.cmake
+++ b/cmake/DaemonArchitecture.cmake
@@ -81,6 +81,17 @@ if (LINUX OR FREEBSD)
 		# The nexe is system agnostic so there should be no difference with armel.
 		set(NACL_ARCH "armhf")
 	endif()
+
+	set(BOX64_USAGE ppc64el riscv64)
+	if (ARCH IN_LIST BOX64_USAGE)
+		option(DAEMON_NACL_BOX64_EMULATION "Use Box64 to emulate x86_64 NaCl loader on unsupported platforms" ON)
+		if (DAEMON_NACL_BOX64_EMULATION)
+			# Use Box64 to run x86_64 NaCl loader and amd64 nexe.
+			# Box64 must be installed and available in PATH at runtime.
+			set(NACL_ARCH "amd64")
+			add_definitions(-DDAEMON_NACL_BOX64_EMULATION)
+		endif()
+	endif()
 elseif(APPLE)
 	if ("${ARCH}" STREQUAL arm64)
 		# You can get emulated NaCl going like this:

--- a/cmake/DaemonArchitecture.cmake
+++ b/cmake/DaemonArchitecture.cmake
@@ -91,6 +91,12 @@ endif()
 
 daemon_add_buildinfo("char*" "DAEMON_NACL_ARCH_STRING" "\"${NACL_ARCH}\"")
 
+# NaCl runtime is only available on architectures that have a NaCl loader.
+set(NACL_RUNTIME_ARCH amd64 i686 armhf)
+if (NACL_ARCH IN_LIST NACL_RUNTIME_ARCH)
+	add_definitions(-DDAEMON_NACL_RUNTIME_ENABLED)
+endif()
+
 option(USE_ARCH_INTRINSICS "Enable custom code using intrinsics functions or asm declarations" ON)
 mark_as_advanced(USE_ARCH_INTRINSICS)
 
@@ -111,6 +117,7 @@ set_arch_intrinsics(${ARCH})
 
 set(amd64_PARENT "i686")
 set(arm64_PARENT "armhf")
+set(ppc64el_PARENT "ppc64")
 
 if (${ARCH}_PARENT)
 	set_arch_intrinsics(${${ARCH}_PARENT})

--- a/cmake/DaemonCBSE.cmake
+++ b/cmake/DaemonCBSE.cmake
@@ -45,7 +45,7 @@ function(CBSE target definition output)
         COMMAND ${DAEMON_CBSE_PYTHON_PATH} -c "import jinja2, yaml, collections, argparse, sys, os.path, re"
         RESULT_VARIABLE RET)
     if (NOT RET EQUAL 0)
-        message(FATAL_ERROR "Missing dependences for CBSE generation. Please ensure you have python ≥ 2, python-yaml, and python-jinja installed.
+        message(FATAL_ERROR "Missing dependences for CBSE generation. Please ensure you have python with python-yaml and python-jinja installed.
                              Use pip install -r src/utils/cbse/requirements.txt to install")
     endif()
     set(GENERATED_CBSE ${output}/backend/CBSEBackend.cpp

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -659,6 +659,18 @@ elseif (NOT NACL)
 		set(GCC_GENERIC_ARCH "armv6")
 		# There is no generic tuning option for armv6.
 		unset(GCC_GENERIC_TUNE)
+	elseif (ARCH STREQUAL "ppc64el")
+		# POWER8 minimum (first little-endian POWER).
+		# GCC uses -mcpu instead of -march/-mtune for POWER.
+		unset(GCC_GENERIC_ARCH)
+		unset(GCC_GENERIC_TUNE)
+		set(GCC_GENERIC_CPU "power8")
+	elseif (ARCH STREQUAL "ppc64")
+		# POWER5 minimum (first 64-bit POWER in wide use).
+		# GCC uses -mcpu instead of -march/-mtune for POWER.
+		unset(GCC_GENERIC_ARCH)
+		unset(GCC_GENERIC_TUNE)
+		set(GCC_GENERIC_CPU "power5")
 	else()
 		message(WARNING "Unknown architecture ${ARCH}")
 	endif()
@@ -675,6 +687,11 @@ elseif (NOT NACL)
 
 		if (GCC_GENERIC_TUNE)
 			try_c_cxx_flag_werror(MTUNE "-mtune=${GCC_GENERIC_TUNE}")
+		endif()
+
+		# POWER architectures use -mcpu instead of -march/-mtune.
+		if (GCC_GENERIC_CPU)
+			try_c_cxx_flag_werror(MCPU "-mcpu=${GCC_GENERIC_CPU}")
 		endif()
 	endif()
 

--- a/cmake/DaemonNacl.cmake
+++ b/cmake/DaemonNacl.cmake
@@ -71,13 +71,12 @@ else()
     add_definitions( -DNACL_BUILD_SUBARCH=32 )
   elseif( NACL_ARCH STREQUAL "armhf" )
     add_definitions( -DNACL_BUILD_ARCH=arm )
-  elseif( NACL_ARCH STREQUAL "ppc64el" OR NACL_ARCH STREQUAL "ppc64" )
-    # NaCl does not support PPC, but these defines must be set for native
-    # builds. Use dummy x86 values as PNaCl does for arch-independent builds.
+  else()
+    # NaCl does not support this architecture natively, but these defines must
+    # be set because nacl_config.h is included unconditionally. Use dummy x86
+    # values as PNaCl does for architecture-independent builds.
     add_definitions( -DNACL_BUILD_ARCH=x86 )
     add_definitions( -DNACL_BUILD_SUBARCH=64 )
-  else()
-    message(WARNING "Unknown architecture ${NACL_ARCH}")
   endif()
 endif()
 

--- a/cmake/DaemonNacl.cmake
+++ b/cmake/DaemonNacl.cmake
@@ -71,6 +71,11 @@ else()
     add_definitions( -DNACL_BUILD_SUBARCH=32 )
   elseif( NACL_ARCH STREQUAL "armhf" )
     add_definitions( -DNACL_BUILD_ARCH=arm )
+  elseif( NACL_ARCH STREQUAL "ppc64el" OR NACL_ARCH STREQUAL "ppc64" )
+    # NaCl does not support PPC, but these defines must be set for native
+    # builds. Use dummy x86 values as PNaCl does for arch-independent builds.
+    add_definitions( -DNACL_BUILD_ARCH=x86 )
+    add_definitions( -DNACL_BUILD_SUBARCH=64 )
   else()
     message(WARNING "Unknown architecture ${NACL_ARCH}")
   endif()

--- a/src/common/Defs.h
+++ b/src/common/Defs.h
@@ -64,7 +64,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define TEAMCONFIG_NAME     "teamconfig.cfg"
 
 #define UNNAMED_PLAYER      "UnnamedPlayer"
-#define UNNAMED_SERVER      PRODUCT_NAME " " PRODUCT_VERSION " Server"
+#define UNNAMED_SERVER      "Unnamed " PRODUCT_NAME " Server"
 
 /** file containing our RSA public and private keys */
 #define RSAKEY_FILE        "pubkey"

--- a/src/common/FileSystem.cpp
+++ b/src/common/FileSystem.cpp
@@ -477,6 +477,27 @@ std::string Build(Str::StringRef base, Str::StringRef path)
 	return out;
 }
 
+std::string NormalizeSlashes(Str::StringRef path)
+{
+	std::string out;
+	out.reserve(path.size());
+	bool lastSlash = true;
+
+	for (char c : path) {
+		if (c == '/' || c == '\\') {
+			if (!lastSlash) {
+				lastSlash = true;
+				out.push_back('/');
+			}
+		} else {
+			out.push_back( c );
+			lastSlash = false;
+		}
+	}
+
+	return out;
+}
+
 std::string DirName(Str::StringRef path)
 {
 	if (path.empty())

--- a/src/common/FileSystem.h
+++ b/src/common/FileSystem.h
@@ -177,6 +177,11 @@ namespace Path {
 	// Build a path from components
 	std::string Build(Str::StringRef base, Str::StringRef path);
 
+	// Replace \ with /
+	// Remove multiple consecutive slashes
+	// Remove initial slashes
+	std::string NormalizeSlashes(Str::StringRef path);
+
 	// Get the directory portion of a path:
 	// a/b/c => a/b
 	// a/b/ => a

--- a/src/common/cm/cm_local.h
+++ b/src/common/cm/cm_local.h
@@ -32,6 +32,9 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#ifndef COMMON_CM_CM_LOCAL_H_
+#define COMMON_CM_CM_LOCAL_H_
+
 #include "cm_public.h"
 #include "cm_polylib.h"
 
@@ -313,3 +316,5 @@ bool                       CM_BoundsIntersect( const vec3_t mins, const vec3_t m
 bool                       CM_BoundsIntersectPoint( const vec3_t mins, const vec3_t maxs, const vec3_t point );
 
 // XreaL END
+
+#endif // COMMON_CM_CM_LOCAL_H_

--- a/src/common/cm/cm_patch.h
+++ b/src/common/cm/cm_patch.h
@@ -32,6 +32,9 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#ifndef COMMON_CM_CM_PATCH_H_
+#define COMMON_CM_CM_PATCH_H_
+
 //#define   CULL_BBOX
 
 /*
@@ -86,3 +89,5 @@ void CM_SetGridWrapWidth( cGrid_t *grid );
 void CM_SubdivideGridColumns( cGrid_t *grid );
 void CM_RemoveDegenerateColumns( cGrid_t *grid );
 void CM_TransposeGrid( cGrid_t *grid );
+
+#endif // COMMON_CM_CM_PATCH_H_

--- a/src/common/cm/cm_public.h
+++ b/src/common/cm/cm_public.h
@@ -32,6 +32,9 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#ifndef COMMON_CM_CM_PUBLIC_H_
+#define COMMON_CM_CM_PUBLIC_H_
+
 #include "engine/qcommon/q_shared.h"
 
 void         CM_LoadMap(Str::StringRef name);
@@ -79,3 +82,5 @@ int      CM_WriteAreaBits( byte *buffer, int area );
 // cm_marks.c
 int      CM_MarkFragments( int numPoints, const vec3_t *points, const vec3_t projection,
                            int maxPoints, vec3_t pointBuffer, int maxFragments, markFragment_t *fragmentBuffer );
+
+#endif // COMMON_CM_CM_PUBLIC_H_

--- a/src/engine/client/cg_msgdef.h
+++ b/src/engine/client/cg_msgdef.h
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #define CG_MSGDEF_H
 
 #include "cg_api.h"
-#include "engine/RefAPI.h"
+#include "engine/renderer/tr_types.h"
 #include "common/IPC/CommonSyscalls.h"
 #include "common/KeyIdentification.h"
 

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -137,7 +137,8 @@ void CL_ConfigstringModified( Cmd::Args& csCmd )
 /*
 ===================
 CL_HandleServerCommand
-CL_GetServerCommand
+
+Returns true if the command should be passed to the cgame
 ===================
 */
 bool CL_HandleServerCommand(Str::StringRef text, std::string& newText) {

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -256,13 +256,6 @@ void CL_FillServerCommands(std::vector<std::string>& commands, int start, int en
 	// if we have irretrievably lost a reliable command, drop the connection
 	if ( start <= clc.serverCommandSequence - MAX_RELIABLE_COMMANDS )
 	{
-		// when a demo record was started after the client got a whole bunch of
-		// reliable commands then the client never got those first reliable commands
-		if ( clc.demoplaying )
-		{
-			return;
-		}
-
 		Sys::Drop( "CL_FillServerCommand: a reliable command was cycled out" );
 	}
 

--- a/src/engine/client/cl_parse.cpp
+++ b/src/engine/client/cl_parse.cpp
@@ -409,6 +409,9 @@ void CL_ParseGamestate( msg_t *msg )
 
 		// a gamestate always marks a server command sequence
 		clc.serverCommandSequence = MSG_ReadLong( msg );
+
+		// trash any commands from previous game
+		clc.lastExecutedServerCommand = clc.serverCommandSequence;
 	}
 
 	// parse all the configstrings and baselines

--- a/src/engine/client/cl_parse.cpp
+++ b/src/engine/client/cl_parse.cpp
@@ -408,7 +408,14 @@ void CL_ParseGamestate( msg_t *msg )
 		CL_ClearState();
 
 		// a gamestate always marks a server command sequence
-		clc.serverCommandSequence = MSG_ReadLong( msg );
+		int commandNum = MSG_ReadLong( msg );
+
+		if ( commandNum < clc.serverCommandSequence )
+		{
+			Sys::Drop( "Gamestate moved serverCommandSequence backward" );
+		}
+
+		clc.serverCommandSequence = commandNum;
 
 		// trash any commands from previous game
 		clc.lastExecutedServerCommand = clc.serverCommandSequence;
@@ -496,6 +503,13 @@ void CL_ParseCommandString( msg_t *msg )
 	// see if we have already executed stored it off
 	if ( clc.serverCommandSequence >= seq )
 	{
+		return;
+	}
+
+	if ( clc.serverCommandSequence + 1 != seq )
+	{
+		Sys::Drop( "Out-of-sequence server command: expected %d, got %d",
+		           clc.serverCommandSequence + 1, seq );
 		return;
 	}
 

--- a/src/engine/framework/VirtualMachine.cpp
+++ b/src/engine/framework/VirtualMachine.cpp
@@ -88,6 +88,18 @@ static Cvar::Cvar<int> vm_timeout(
 	"Receive timeout in seconds",
 	Cvar::NONE, 2);
 
+#if defined(DAEMON_NACL_RUNTIME_ENABLED)
+static Cvar::Cvar<bool> vm_nacl_available(
+	"vm.nacl.available",
+	"Whether NaCl runtime is available on this platform",
+	Cvar::ROM, true);
+#else
+static Cvar::Cvar<bool> vm_nacl_available(
+	"vm.nacl.available",
+	"Whether NaCl runtime is available on this platform",
+	Cvar::ROM, false);
+#endif
+
 namespace VM {
 
 // https://github.com/Unvanquished/Unvanquished/issues/944#issuecomment-744454772
@@ -497,6 +509,13 @@ void VMBase::Create()
 	std::pair<IPC::Socket, IPC::Socket> pair = IPC::Socket::CreatePair();
 
 	IPC::Socket rootSocket;
+#if !defined(DAEMON_NACL_RUNTIME_ENABLED)
+	if (type == TYPE_NACL || type == TYPE_NACL_LIBPATH) {
+		Sys::Error("NaCl VM is not supported on this platform. "
+		           "Set vm.cgame.type and vm.sgame.type to 3 (native DLL) "
+		           "and use devmap instead of map.");
+	}
+#endif
 	if (type == TYPE_NACL || type == TYPE_NACL_LIBPATH) {
 		std::tie(processHandle, rootSocket) = CreateNaClVM(std::move(pair), name, params.debug.Get(), type == TYPE_NACL, params.debugLoader.Get());
 	} else if (type == TYPE_NATIVE_EXE) {

--- a/src/engine/framework/VirtualMachine.cpp
+++ b/src/engine/framework/VirtualMachine.cpp
@@ -42,6 +42,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <spawn.h>
 #include <fcntl.h>
 #include <sys/wait.h>
+// POSIX: environ is the process environment, not always declared in headers.
+extern char **environ;
 #ifdef __linux__
 #include <sys/prctl.h>
 #if defined(DAEMON_ARCH_armhf)
@@ -72,6 +74,54 @@ static Cvar::Cvar<bool> workaround_naclSystem_freebsd_disableQualification(
 	"workaround.naclSystem.freebsd.disableQualification",
 	"Disable platform qualification when running Linux NaCl loader on FreeBSD through Linuxulator",
 	Cvar::NONE, true);
+
+#if defined(DAEMON_NACL_BOX64_EMULATION)
+static Cvar::Cvar<bool> workaround_box64_disableQualification(
+	"workaround.box64.disableQualification",
+	"Disable platform qualification when running amd64 NaCl loader under Box64 emulation",
+	Cvar::NONE, true);
+
+static Cvar::Cvar<bool> workaround_box64_disableBootstrap(
+	"workaround.box64.disableBootstrap",
+	"Disable NaCl bootstrap helper when using Box64 emulation",
+	Cvar::NONE, true);
+
+static Cvar::Cvar<std::string> vm_box64_path(
+	"vm.box64.path",
+	"Path to the box64 binary for NaCl emulation (empty = search PATH)",
+	Cvar::NONE, "");
+
+// Resolve box64 binary path by searching PATH if not explicitly set.
+static std::string ResolveBox64Path() {
+	std::string path = vm_box64_path.Get();
+	if (!path.empty()) {
+		return path;
+	}
+
+	const char* envPath = getenv("PATH");
+	if (!envPath) {
+		Sys::Error("Box64 emulation is enabled but PATH is not set and vm.box64.path is empty.");
+	}
+
+	std::string pathStr(envPath);
+	size_t start = 0;
+	while (start < pathStr.size()) {
+		size_t end = pathStr.find(':', start);
+		if (end == std::string::npos) {
+			end = pathStr.size();
+		}
+		std::string candidate = pathStr.substr(start, end - start) + "/box64";
+		if (access(candidate.c_str(), X_OK) == 0) {
+			return candidate;
+		}
+		start = end + 1;
+	}
+
+	Sys::Error("Box64 emulation is enabled but 'box64' was not found in PATH. "
+	           "Install Box64 or set vm.box64.path to the full path of the box64 binary.");
+	return ""; // unreachable
+}
+#endif
 
 static Cvar::Cvar<bool> vm_nacl_qualification(
 	"vm.nacl.qualification",
@@ -128,7 +178,7 @@ static void CheckMinAddressSysctlTooLarge()
 }
 
 // Platform-specific code to load a module
-static std::pair<Sys::OSHandle, IPC::Socket> InternalLoadModule(std::pair<IPC::Socket, IPC::Socket> pair, const char* const* args, bool reserve_mem, FS::File stderrRedirect = FS::File())
+static std::pair<Sys::OSHandle, IPC::Socket> InternalLoadModule(std::pair<IPC::Socket, IPC::Socket> pair, const char* const* args, bool reserve_mem, FS::File stderrRedirect = FS::File(), bool inheritEnvironment = false)
 {
 #ifdef _WIN32
 	// Inherit the socket in the child process
@@ -213,6 +263,7 @@ static std::pair<Sys::OSHandle, IPC::Socket> InternalLoadModule(std::pair<IPC::S
 	if (reserve_mem)
 		VirtualAllocEx(processInfo.hProcess, nullptr, 1 << 30, MEM_RESERVE, PAGE_NOACCESS);
 #endif
+	Q_UNUSED(inheritEnvironment);
 
 	ResumeThread(processInfo.hThread);
 	CloseHandle(processInfo.hThread);
@@ -233,7 +284,13 @@ static std::pair<Sys::OSHandle, IPC::Socket> InternalLoadModule(std::pair<IPC::S
 	}
 
 	pid_t pid;
-	int err = posix_spawn(&pid, args[0], &fileActions, nullptr, const_cast<char* const*>(args), nullptr);
+	// By default, the child process gets an empty environment for sandboxing.
+	// When Box64 emulation is used, the child needs to inherit the parent's
+	// environment so Box64 can find its configuration (e.g. ~/.box64rc, HOME)
+	// and honor settings like BOX64_DYNAREC_PERFMAP.
+	char* emptyEnv[] = {nullptr};
+	char** envp = inheritEnvironment ? environ : emptyEnv;
+	int err = posix_spawn(&pid, args[0], &fileActions, nullptr, const_cast<char* const*>(args), envp);
 	posix_spawn_file_actions_destroy(&fileActions);
 	if (err != 0) {
 		Sys::Drop("VM: Failed to spawn process: %s", strerror(err));
@@ -255,6 +312,10 @@ static std::pair<Sys::OSHandle, IPC::Socket> CreateNaClVM(std::pair<IPC::Socket,
 	char rootSocketRedir[32];
 	std::string module, nacl_loader, irt, bootstrap, modulePath, verbosity;
 	FS::File stderrRedirect;
+#if defined(DAEMON_NACL_BOX64_EMULATION)
+	std::string box64Path;
+	bool usingBox64 = false;
+#endif
 #if !defined(_WIN32) || defined(_WIN64)
 	constexpr bool win32Force64Bit = false;
 #else
@@ -304,6 +365,34 @@ static std::pair<Sys::OSHandle, IPC::Socket> CreateNaClVM(std::pair<IPC::Socket,
 	}
 
 #if defined(__linux__) || defined(__FreeBSD__)
+#if defined(DAEMON_NACL_BOX64_EMULATION)
+	/* Use Box64 to run the x86_64 NaCl loader on non-x86 architectures.
+	The bootstrap helper uses a double-exec pattern that Box64 cannot handle,
+	so we skip it and prepend "box64" to the nacl_loader command instead. */
+	if (!workaround_box64_disableBootstrap.Get() && vm_nacl_bootstrap.Get()) {
+		bootstrap = FS::Path::Build(naclPath, "nacl_helper_bootstrap");
+
+		if (!FS::RawPath::FileExists(bootstrap)) {
+			Sys::Error("NaCl bootstrap helper not found: %s", bootstrap);
+		}
+
+		args.push_back(bootstrap.c_str());
+		args.push_back(nacl_loader.c_str());
+		args.push_back("--r_debug=0xXXXXXXXXXXXXXXXX");
+		args.push_back("--reserved_at_zero=0xXXXXXXXXXXXXXXXX");
+	} else {
+		if (workaround_box64_disableBootstrap.Get()) {
+			Log::Notice("Skipping NaCl bootstrap helper for Box64 emulation.");
+		} else {
+			Log::Warn("Not using NaCl bootstrap helper.");
+		}
+		box64Path = ResolveBox64Path();
+		Log::Notice("Using Box64 emulator: %s", box64Path);
+		args.push_back(box64Path.c_str());
+		args.push_back(nacl_loader.c_str());
+		usingBox64 = true;
+	}
+#else
 	if (vm_nacl_bootstrap.Get()) {
 #if defined(DAEMON_ARCH_arm64)
 		bootstrap = FS::Path::Build(naclPath, "nacl_helper_bootstrap-armhf");
@@ -323,6 +412,7 @@ static std::pair<Sys::OSHandle, IPC::Socket> CreateNaClVM(std::pair<IPC::Socket,
 		Log::Warn("Not using NaCl bootstrap helper.");
 		args.push_back(nacl_loader.c_str());
 	}
+#endif
 #else
 	Q_UNUSED(bootstrap);
 	args.push_back(nacl_loader.c_str());
@@ -381,6 +471,17 @@ static std::pair<Sys::OSHandle, IPC::Socket> CreateNaClVM(std::pair<IPC::Socket,
 			enableQualification = false;
 		}
 #endif
+
+#if defined(DAEMON_NACL_BOX64_EMULATION)
+		/* When running the amd64 NaCl loader under Box64, the loader's
+		platform qualification will fail because the CPU is not actually x86_64.
+		Disabling qualification allows the emulated loader to proceed. */
+
+		if (workaround_box64_disableQualification.Get()) {
+			Log::Warn("Disabling NaCL platform qualification for Box64 emulation.");
+			enableQualification = false;
+		}
+#endif
 	}
 	else {
 		Log::Warn("Not using NaCl platform qualification.");
@@ -427,7 +528,11 @@ static std::pair<Sys::OSHandle, IPC::Socket> CreateNaClVM(std::pair<IPC::Socket,
 		Log::Notice("Using loader args: %s", commandLine.c_str());
 	}
 
-	return InternalLoadModule(std::move(pair), args.data(), true, std::move(stderrRedirect));
+	return InternalLoadModule(std::move(pair), args.data(), true, std::move(stderrRedirect)
+#if defined(DAEMON_NACL_BOX64_EMULATION)
+		, usingBox64
+#endif
+	);
 }
 
 static std::pair<Sys::OSHandle, IPC::Socket> CreateNativeVM(std::pair<IPC::Socket, IPC::Socket> pair, Str::StringRef name, bool debug) {

--- a/src/engine/null/null_renderer.cpp
+++ b/src/engine/null/null_renderer.cpp
@@ -80,8 +80,8 @@ void RE_EndRegistration() { }
 void RE_ClearScene() { }
 void RE_AddRefEntityToScene( const refEntity_t * ) { }
 void RE_SyncRefEntities( const std::vector<EntityUpdate>& ) {}
-std::vector<LerpTagSync> RE_SyncLerpTags( const std::vector<LerpTagUpdate>& ) {
-    return {};
+std::vector<LerpTagSync> RE_SyncLerpTags( const std::vector<LerpTagUpdate>& in ) {
+    return std::vector<LerpTagSync>(in.size());
 }
 void RE_AddPolyToScene( qhandle_t, int, const polyVert_t* ) { }
 void RE_AddPolysToScene( qhandle_t, int, const polyVert_t*, int ) { }

--- a/src/engine/qcommon/SurfaceFlags.h
+++ b/src/engine/qcommon/SurfaceFlags.h
@@ -28,6 +28,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ===========================================================================
 */
 
+#ifndef ENGINE_QCOMMON_SURFACEFLAGS_H_
+#define ENGINE_QCOMMON_SURFACEFLAGS_H_
+
 // this file is used by both engine and game code
 // see engine/qcommon/q_shared.h
 
@@ -114,3 +117,5 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Jedi Knights games (see OpenJK) also define a third bitfield for flags with MATERIAL prefix to tell surface is water, snow, sand, glass, short grasss, long grass, etc.
 // Jedi Knights games also redefine a lot of CONTENTS flags (introducing things like CONTENTS_LADDER) and SURF FLAGS (moving SURF_SKY to BIT(13) for example)
 // Smokin'Guns uses a special .tex sidecar files to tweak surfaces flags
+
+#endif // ENGINE_QCOMMON_SURFACEFLAGS_H_

--- a/src/engine/renderer/EntityCache.cpp
+++ b/src/engine/renderer/EntityCache.cpp
@@ -264,7 +264,7 @@ void ClearEntityCache() {
 	}
 }
 
-std::vector<LerpTagSync> SyncEntityCacheToCGame( const std::vector<LerpTagUpdate>& lerpTags ) {
+std::vector<LerpTagSync> RE_SyncLerpTags( const std::vector<LerpTagUpdate>& lerpTags ) {
 	std::vector<LerpTagSync> entityOrientations;
 	entityOrientations.reserve( lerpTags.size() );
 
@@ -284,7 +284,7 @@ std::vector<LerpTagSync> SyncEntityCacheToCGame( const std::vector<LerpTagUpdate
 	return entityOrientations;
 }
 
-void SyncEntityCacheFromCGame( const std::vector<EntityUpdate>& ents ) {
+void RE_SyncRefEntities( const std::vector<EntityUpdate>& ents ) {
 	for ( const EntityUpdate& ent : ents ) {
 		bool flip = entities[ent.id].e.active != ent.ent.active;
 

--- a/src/engine/renderer/EntityCache.h
+++ b/src/engine/renderer/EntityCache.h
@@ -53,7 +53,7 @@ void TransformEntity( trRefEntity_t* ent );
 
 void ClearEntityCache();
 
-std::vector<LerpTagSync> SyncEntityCacheToCGame( const std::vector<LerpTagUpdate>& lerpTags );
-void SyncEntityCacheFromCGame( const std::vector<EntityUpdate>& ents );
+std::vector<LerpTagSync> RE_SyncLerpTags( const std::vector<LerpTagUpdate>& lerpTags );
+void RE_SyncRefEntities( const std::vector<EntityUpdate>& ents );
 
 #endif // ENTITY_CACHE_H

--- a/src/engine/renderer/ShadeCommon.h
+++ b/src/engine/renderer/ShadeCommon.h
@@ -32,6 +32,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ===========================================================================
 */
 
+#ifndef ENGINE_RENDERER_SHADECOMMON_H_
+#define ENGINE_RENDERER_SHADECOMMON_H_
+
 inline size_t GetLightMapNum( const shaderCommands_t* tess )
 {
 	return tess->lightmapNum;
@@ -276,3 +279,5 @@ inline uint GetShaderProfilerRenderSubGroupsMode( const uint32_t stateBits ) {
 
 	return 0;
 }
+
+#endif // ENGINE_RENDERER_SHADECOMMON_H_

--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -490,9 +490,13 @@ static void AddConst( std::string& str, const std::string& name, float v1, float
 
 static std::string GenVersionDeclaration( const std::vector<addedExtension_t> &addedExtensions ) {
 	// Declare version.
-	std::string str = Str::Format( "#version %d %s\n\n",
+	std::string str = Str::Format( "#version %d %s\n",
 		glConfig.shadingLanguageVersion,
 		glConfig.shadingLanguageVersion >= 150 ? ( glConfig.glCoreProfile ? "core" : "compatibility" ) : "" );
+
+	str += "#line 1000000000\n";
+
+	str += "\n";
 
 	// Add supported GLSL extensions.
 	for ( const auto& addedExtension : addedExtensions ) {
@@ -859,7 +863,10 @@ std::string GLShaderManager::GetDeformShaderName( const int index ) {
 std::string GLShaderManager::BuildDeformShaderText( const std::string& steps ) {
 	std::string shaderText;
 
-	shaderText = steps + "\n";
+	shaderText = "\n" + steps + "\n";
+
+	shaderText += "#line 2000000000\n";
+
 	shaderText += GetShaderText( "deformVertexes_vp.glsl" );
 
 	return shaderText;
@@ -1223,6 +1230,13 @@ std::string GLShaderManager::ProcessInserts( const std::string& shaderText ) con
 
 	while ( std::getline( shaderTextStream, line, '\n' ) ) {
 		++lineCount;
+
+		/* The deform vertex header is prepended to the mainText and is part
+		of the shaderText, so we should reset line numbering after it. */
+		if ( line == "#line 0" ) {
+			lineCount = 0;
+		}
+
 		const std::string::size_type position = line.find( "#insert" );
 		if ( position == std::string::npos || line.find_first_not_of( " \t" ) != position ) {
 			out += line + "\n";
@@ -1353,7 +1367,9 @@ void GLShaderManager::InitShader( GLShader* shader ) {
 		if ( shaderType.enabled ) {
 			Com_sprintf( filename, sizeof( filename ), "%s%s.glsl", shaderType.path.c_str(), shaderType.postfix );
 
-			shaderType.mainText = GetShaderText( filename );
+			/* The deform vertex header is prepended to the mainText,
+			so we should reset line numbering after it. */
+			shaderType.mainText = "#line 0\n" + GetShaderText( filename );
 		}
 	}
 

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -1818,19 +1818,21 @@ Finds or loads the given image.
 Returns nullptr if it fails, not a default image.
 ==============
 */
-image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
+image_t *R_FindImageFile( const char *imageName0, imageParams_t &imageParams )
 {
-	if ( !imageName )
+	if ( !imageName0 )
 	{
 		return nullptr;
 	}
 
-	unsigned hash = GenerateImageHashValue( imageName );
+	std::string imageName = FS::Path::NormalizeSlashes( imageName0 );
+
+	unsigned hash = GenerateImageHashValue( imageName.c_str() );
 
 	// See if the image is already loaded.
 	for ( image_t *image = r_imageHashTable[ hash ]; image; image = image->next )
 	{
-		if ( !Q_strnicmp( imageName, image->name, sizeof( image->name ) ) )
+		if ( Str::IsIEqual( imageName, image->name ) )
 		{
 			if ( imageParams == image->initialParams || r_allowImageParamMismatch.Get() )
 			{
@@ -1889,7 +1891,7 @@ image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 	byte *pic[ MAX_TEXTURE_MIPS * MAX_TEXTURE_LAYERS ];
 	pic[ 0 ] = nullptr;
 
-	R_LoadImage( imageName, pic, &width, &height, &numLayers, &numMips, &imageParams.bits );
+	R_LoadImage( imageName.c_str(), pic, &width, &height, &numLayers, &numMips, &imageParams.bits);
 
 	if ( *pic )
 	{
@@ -1909,7 +1911,7 @@ image_t *R_FindImageFile( const char *imageName, imageParams_t &imageParams )
 		R_ProcessLightmap( *pic, width, height, imageParams.bits );
 	}
 
-	image_t *image = R_CreateImage( imageName, (const byte **)pic, width, height, numMips, imageParams );
+	image_t *image = R_CreateImage( imageName.c_str(), (const byte**)pic, width, height, numMips, imageParams);
 	image->initialParams = initialParams;
 
 	Z_Free( *pic );

--- a/src/engine/renderer/tr_image.cpp
+++ b/src/engine/renderer/tr_image.cpp
@@ -76,11 +76,6 @@ unsigned int GenerateImageHashValue( const char *fname )
 	{
 		letter = Str::ctolower( fname[ i ] );
 
-		if ( letter == '\\' )
-		{
-			letter = '/'; // damn path names
-		}
-
 		hash += ( unsigned )( letter ) * ( i + 119 );
 		i++;
 	}

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1693,8 +1693,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		re.ClearScene = RE_ClearScene;
 		re.AddRefEntityToScene = RE_AddRefEntityToScene;
-		re.SyncRefEntities = SyncEntityCacheFromCGame;
-		re.SyncLerpTags = SyncEntityCacheToCGame;
+		re.SyncRefEntities = RE_SyncRefEntities;
+		re.SyncLerpTags = RE_SyncLerpTags;
 
 		re.AddPolyToScene = RE_AddPolyToSceneET;
 		re.AddPolysToScene = RE_AddPolysToScene;

--- a/src/engine/renderer/tr_model.cpp
+++ b/src/engine/renderer/tr_model.cpp
@@ -442,6 +442,9 @@ int RE_LerpTagET( orientation_t* tag, const trRefEntity_t* ent, const char* tagN
 	float frontLerp = frac;
 	float backLerp  = 1.0f - frac;
 
+	AxisClear( tag->axis );
+	VectorClear( tag->origin );
+
 	if ( model->type == modtype_t::MOD_MD5 || model->type == modtype_t::MOD_IQM )
 	{
 		vec3_t tmp;
@@ -476,8 +479,6 @@ int RE_LerpTagET( orientation_t* tag, const trRefEntity_t* ent, const char* tagN
 
 		if ( !start || !end )
 		{
-			AxisClear( tag->axis );
-			VectorClear( tag->origin );
 			return -1;
 		}
 

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -123,17 +123,7 @@ static unsigned int generateHashValue( const char *fname, const int size )
 
 		if ( letter == '.' )
 		{
-			break; // don't include extension
-		}
-
-		if ( letter == '\\' )
-		{
-			letter = '/'; // damn path names
-		}
-
-		if ( letter == PATH_SEP )
-		{
-			letter = '/'; // damn path names
+			break; // don't include extension. FIXME: could have multiple dots
 		}
 
 		hash += ( unsigned )( letter ) * ( i + 119 );

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -6237,7 +6237,8 @@ shader_t       *R_FindShader( const char *name, int flags )
 		return tr.defaultShader;
 	}
 
-	COM_StripExtension3( name, strippedName, sizeof( strippedName ) );
+	COM_StripExtension3( FS::Path::NormalizeSlashes( name ).c_str(),
+	                     strippedName, sizeof( strippedName ) );
 
 	hash = generateHashValue( strippedName, FILE_HASH_SIZE );
 

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -58,11 +58,11 @@ using bool8_t = uint8_t;
 
 // renderfx flags
 enum RenderFx : uint8_t {
-	RF_THIRD_PERSON = 0x000001, // don't draw through eyes, only mirrors (player bodies, chat sprites)
-	RF_FIRST_PERSON = 0x000002, // only draw through eyes (view weapon, damage blood blob)
-	RF_DEPTHHACK    = 0x000004, // for view weapon Z crunching
-	RF_NOSHADOW     = 0x000008, // don't add stencil shadows
-	RF_SWAPCULL     = 0x000010  // swap CT_FRONT_SIDED and CT_BACK_SIDED
+	RF_THIRD_PERSON = 0x01, // don't draw through eyes, only mirrors (player bodies, chat sprites)
+	RF_FIRST_PERSON = 0x02, // only draw through eyes (view weapon, damage blood blob)
+	RF_DEPTHHACK    = 0x04, // for view weapon Z crunching
+	RF_NOSHADOW     = 0x08, // don't add stencil shadows
+	RF_SWAPCULL     = 0x10  // swap CT_FRONT_SIDED and CT_BACK_SIDED
 };
 
 // refdef flags
@@ -230,14 +230,14 @@ struct refEntity_t
 
 	EntityTag positionOnTag;
 
-	int8_t    clearOrigin;
-	int8_t    clearOrigin2;
+	bool8_t   clearOrigin;
+	bool8_t   clearOrigin2;
 
-	int8_t    boundsAdd;
+	bool8_t   boundsAdd;
 
-	int8_t    nonNormalizedAxes; // axis are not normalized, i.e. they have scale
+	bool8_t   nonNormalizedAxes; // axis are not normalized, i.e. they have scale
 
-	int8_t    active;
+	bool8_t   active;
 
 	uint16_t  attachmentEntity;
 

--- a/src/engine/server/sg_msgdef.h
+++ b/src/engine/server/sg_msgdef.h
@@ -20,6 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ===========================================================================
 */
 
+#ifndef ENGINE_SERVER_SG_MSGDEF_H_
+#define ENGINE_SERVER_SG_MSGDEF_H_
+
 #include "common/IPC/CommonSyscalls.h"
 
 // game-module-to-engine calls
@@ -196,3 +199,5 @@ using GameClientThinkMsg = IPC::SyncMessage<
 using GameRunFrameMsg = IPC::SyncMessage<
 	IPC::Message<IPC::Id<VM::QVM, GAME_RUN_FRAME>, int>
 >;
+
+#endif // ENGINE_SERVER_SG_MSGDEF_H_

--- a/src/engine/server/sv_client.cpp
+++ b/src/engine/server/sv_client.cpp
@@ -354,6 +354,7 @@ void SV_SendClientGameState( client_t *client )
 	// we have to do this cause we send the client->reliableSequence
 	// with a gamestate and it sets the clc.serverCommandSequence at
 	// the client side
+	// TODO(0.57): remove. The client will just throw away old commands on getting a gamestate
 	SV_UpdateServerCommandsToClient( client, &msg );
 
 	// send the gamestate

--- a/src/engine/sys/con_common.h
+++ b/src/engine/sys/con_common.h
@@ -31,6 +31,9 @@ Maryland 20850 USA.
 ===========================================================================
 */
 
+#ifndef ENGINE_SYS_CON_COMMON_H_
+#define ENGINE_SYS_CON_COMMON_H_
+
 #include "common/Color.h"
 #include "qcommon/q_shared.h"
 #include "qcommon/qcommon.h"
@@ -48,3 +51,5 @@ namespace Color {
 int To4bit( const Color& color ) NOEXCEPT;
 
 } // namespace Color
+
+#endif // ENGINE_SYS_CON_COMMON_H_

--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -295,14 +295,9 @@ void trap_R_ClearScene()
 	cmdBuffer.SendMsg<Render::ClearSceneMsg>();
 }
 
-/* HACK: We need the entityNum to get the correct positions for entities that need to be attached to another entity's bone
-This must be equal to the r_numEntities in engine at the time of adding the entity */
-static int entityNum;
-int trap_R_AddRefEntityToScene( const refEntity_t *re )
+void trap_R_AddRefEntityToScene( const refEntity_t *re )
 {
 	cmdBuffer.SendMsg<Render::AddRefEntityToSceneMsg>(*re);
-	entityNum++;
-	return entityNum - 1;
 }
 
 void trap_R_SyncRefEntities( const std::vector<EntityUpdate>& ents ) {
@@ -380,7 +375,6 @@ void trap_R_AddLightToScene( const vec3_t origin, float radius, float intensity,
 
 void trap_R_RenderScene( const refdef_t *fd )
 {
-	entityNum = 0;
 	cmdBuffer.SendMsg<Render::RenderSceneMsg>(*fd);
 }
 

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -33,8 +33,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define SHARED_CLIENT_API_H_
 
 #include "engine/qcommon/q_shared.h"
-#include "engine/RefAPI.h"
 #include "engine/client/cg_api.h"
+#include "engine/renderer/tr_types.h"
 #include "common/KeyIdentification.h"
 #include "shared/CommonProxies.h"
 #include <shared/CommandBufferClient.h>

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -82,7 +82,6 @@ void            trap_R_ResetClipRegion();
 void            trap_R_DrawStretchPic( float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader );
 void            trap_R_DrawRotatedPic( float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader, float angle );
 void            trap_R_ModelBounds( clipHandle_t model, vec3_t mins, vec3_t maxs );
-int             trap_R_LerpTag( orientation_t *tag, const refEntity_t* refent, const char *tagName, int startIndex );
 void            trap_R_GetTextureSize( qhandle_t handle, int *x, int *y );
 qhandle_t       trap_R_GenerateTexture( const byte *data, int x, int y );
 void            trap_GetCurrentSnapshotNumber( int *snapshotNumber, int *serverTime );

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -65,7 +65,7 @@ qhandle_t       trap_R_RegisterModel( const char *name );
 qhandle_t       trap_R_RegisterSkin( const char *name );
 qhandle_t       trap_R_RegisterShader( const char *name, int flags );
 void            trap_R_ClearScene();
-int  trap_R_AddRefEntityToScene( const refEntity_t *re );
+void trap_R_AddRefEntityToScene( const refEntity_t *re );
 void trap_R_SyncRefEntities( const std::vector<EntityUpdate>& ents );
 std::vector<LerpTagSync> trap_R_SyncLerpTags( const std::vector<LerpTagUpdate>& lerpTags );
 void            trap_R_AddPolyToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts );


### PR DESCRIPTION
- reset line number at GLSL shader start
- use custom line number for the GLSL header to avoid line number duplicates
- use custom line number for the deform vertex header
- reset line count on `#line 0`

Written to debug:

- https://github.com/DaemonEngine/Daemon/pull/1914