### PR TITLE
Skip lightmap + deluxegrid shader permutations compilation and skip “proxy” shader compilation

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -1065,6 +1065,10 @@ bool GLShaderManager::BuildPermutation( GLShader* shader, int index, const bool 
 		return false;
 	}
 
+	if ( shader->SkipCompilation() ) {
+		return false;
+	}
+
 	if ( IsUnusedPermutation( compileMacros.c_str() ) ) {
 		return false;
 	}
@@ -3013,7 +3017,7 @@ GlobalUBOProxy::GlobalUBOProxy() :
 	/* HACK: A GLShader* is required to initialise uniforms,
 	but we don't need the GLSL shader itself, so we won't actually build it */
 	GLShader( "proxy", 0,
-		false, "screenSpace", "generic", true ),
+		false, "screenSpace", "generic", true, true ),
 	// CONST
 	u_ColorMap3D( this ),
 	u_DepthMap( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -188,6 +188,7 @@ private:
 
 	const bool worldShader;
 	const bool pushSkip;
+	const bool compileSkip;
 protected:
 	int _activeMacros = 0;
 	int _deformIndex = 0;
@@ -212,7 +213,7 @@ protected:
 	GLShader( const std::string& name, uint32_t vertexAttribsRequired,
 		const bool useMaterialSystem,
 		const std::string newVertexShaderName, const std::string newFragmentShaderName,
-		const bool newPushSkip = false ) :
+		const bool newPushSkip = false, const bool compileSkip = false ) :
 		_name( name ),
 		_vertexAttribsRequired( vertexAttribsRequired ),
 		_useMaterialSystem( useMaterialSystem ),
@@ -222,7 +223,8 @@ protected:
 		hasFragmentShader( true ),
 		hasComputeShader( false ),
 		worldShader( false ),
-		pushSkip( newPushSkip ) {
+		pushSkip( newPushSkip ),
+		compileSkip( compileSkip ) {
 	}
 
 	GLShader( const std::string& name,
@@ -236,7 +238,8 @@ protected:
 		hasFragmentShader( false ),
 		hasComputeShader( true ),
 		worldShader( newWorldShader ),
-		pushSkip( false ) {
+		pushSkip( false ),
+		compileSkip( false ) {
 	}
 
 public:
@@ -266,6 +269,10 @@ public:
 
 	ShaderProgramDescriptor* GetProgram() const {
 		return currentProgram;
+	}
+
+	bool SkipCompilation() const {
+		return compileSkip;
 	}
 
 protected:


### PR DESCRIPTION
Fix #1863 and #1925:

- https://github.com/DaemonEngine/Daemon/issues/1863
- https://github.com/DaemonEngine/Daemon/issues/1925

---

Not anymore:

~Includes #1922:~

- ~https://github.com/DaemonEngine/Daemon/pull/1922~