### PR TITLE
Adjust dynamic lights for linear blend regime

### DIFF
--- a/src/engine/renderer/gl_shader.cpp
+++ b/src/engine/renderer/gl_shader.cpp
@@ -2528,6 +2528,7 @@ GLShader_lightMapping::GLShader_lightMapping() :
 	u_LightGridScale( this ),
 	u_numLights( this ),
 	u_Lights( this ),
+	u_SRGB( this ),
 	u_ProfilerZero( this ),
 	u_ProfilerRenderSubGroups( this ),
 	GLDeformStage( this ),

--- a/src/engine/renderer/gl_shader.h
+++ b/src/engine/renderer/gl_shader.h
@@ -3012,6 +3012,7 @@ class GLShader_lightMapping :
 	public u_LightGridScale,
 	public u_numLights,
 	public u_Lights,
+	public u_SRGB,
 	public u_ProfilerZero,
 	public u_ProfilerRenderSubGroups,
 	public GLDeformStage,

--- a/src/engine/renderer/glsl_source/computeLight_fp.glsl
+++ b/src/engine/renderer/glsl_source/computeLight_fp.glsl
@@ -170,6 +170,7 @@ layout(std140) uniform u_Lights {
 #define GetLight( idx ) lights[idx]
 
 uniform int u_numLights;
+uniform bool u_SRGB;
 
 void computeDynamicLight( uint idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diffuse,
 	vec4 material, inout vec4 color )
@@ -204,8 +205,27 @@ void computeDynamicLight( uint idx, vec3 P, vec3 normal, vec3 viewDir, vec4 diff
 		attenuation = 1.0;
 	}
 
+	vec3 lightColor = attenuation * attenuation * light.color;
+
+	if ( u_SRGB )
+	{
+		// HACK: choose the light color so that the result would be close to naive blending in the
+		// case that the other lighting amounts to (0.8, 0.8, 0.8) and the cosine angle is 0.3.
+		// Just doing the gamma curve directly gives results that are too dim for weak lights, due
+		// to not accounting for the too-large results of naive, additive blending, and too bright for
+		// bright lights, due to the cosine angle factor reducing things too much in naive mode.
+		vec3 gamma = vec3(2.2);
+		vec3 refLightNaive = vec3(0.8);
+		vec3 refLightLinear = pow(refLightNaive, gamma);
+		float refNdotL = 0.3;
+		vec3 naiveOut = refLightNaive + lightColor * refNdotL;
+		vec3 linearOut = pow(naiveOut, gamma);
+		vec3 linearGain = (linearOut - refLightLinear) / refNdotL;
+		lightColor = linearGain;
+	}
+
 	computeDeluxeLight(
-		L, normal, viewDir, attenuation * attenuation * light.color,
+		L, normal, viewDir, lightColor,
 		diffuse, material, color );
 }
 

--- a/src/engine/renderer/tr_scene.cpp
+++ b/src/engine/renderer/tr_scene.cpp
@@ -334,12 +334,6 @@ void RE_AddDynamicLightToScene( const vec3_t org, float radius, float r, float g
 	light->color[ 0 ] = r;
 	light->color[ 1 ] = g;
 	light->color[ 2 ] = b;
-
-	// Linearize dynamic lights.
-	if ( tr.worldLinearizeTexture )
-	{
-		convertFromSRGB( light->color );
-	}
 }
 
 static void RE_RenderCubeProbeFace( const refdef_t* originalRefdef ) {

--- a/src/engine/renderer/tr_shade.cpp
+++ b/src/engine/renderer/tr_shade.cpp
@@ -1059,6 +1059,8 @@ void Render_lightMapping( shaderStage_t *pStage )
 
 		if ( backEnd.refdef.numLights > 0 )
 		{
+			gl_lightMappingShader->SetUniform_SRGB( tr.worldLinearizeTexture );
+
 			gl_lightMappingShader->SetUniformBlock_Lights( tr.dlightUBO );
 
 			// bind u_LightTiles


### PR DESCRIPTION
Once you [ensure the latest weapons pak is loaded](https://forums.unvanquished.net/viewtopic.php?p=19824#p19824) with the 0.56 RC, dynamic lights in the linear blend regime are hilariously broken:

![unvanquished_2026-03-14_090558_000](https://github.com/user-attachments/assets/0b111fb5-c19c-475e-aeee-78f961ebe1e2)

So do a hacky adjustment to try to make the result somewhat the same in linear blending mode as in naive mode. See screenshots: https://users.unvanquished.net/~slipher/screenshot-compare/linear-dlight/viewer.html