### PR TITLE
Remove compat-break bool from ABI detection protocol

### DIFF
--- a/src/common/IPC/Common.h
+++ b/src/common/IPC/Common.h
@@ -71,17 +71,15 @@ namespace IPC {
 	};
 
     // Version of the protocol for detecting what ABI version the VM has upon startup
-    constexpr uint32_t ABI_VERSION_DETECTION_ABI_VERSION = 4;
+    constexpr uint32_t ABI_VERSION_DETECTION_ABI_VERSION = 5;
 
     // Version for the syscall signatures between engine and VM. This must change if the syscall
     // IDs, argument types, or return types change, or if serialization procedures change.
-    // Follows Daemon major versions.
-    // This should be updated only by update-version-number.py when a "major" release is indicated
-    constexpr const char* SYSCALL_ABI_VERSION = "0.56";
-
-    // This should be manually set to true when starting a 'for-X.Y.Z/sync' branch.
-    // This should be set to false by update-version-number.py when a (major) release is created.
-    constexpr bool DAEMON_HAS_COMPATIBILITY_BREAKING_SYSCALL_CHANGES = true;
+    // This is updated by update-version-number.py when a "major" release is indicated.
+    // For the master branch with a stable ABI, this follows Daemon major versions.
+    // For next-release branches, the convention is to use "test/<next release version>". On
+    // the next-release branch the ABI is unstable so any two commits may be incompatible.
+    constexpr const char* SYSCALL_ABI_VERSION = "test/0.57.0";
 
     /*
      * The messages sent between the VM and the engine are defined by a numerical

--- a/src/engine/framework/VirtualMachine.cpp
+++ b/src/engine/framework/VirtualMachine.cpp
@@ -60,8 +60,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static Cvar::Cvar<std::string> abiVersionCvar(
 	"version.daemon.abi", "Virtual machine IPC ABI version", Cvar::SERVERINFO | Cvar::ROM,
-	std::string(IPC::SYSCALL_ABI_VERSION) +
-	(IPC::DAEMON_HAS_COMPATIBILITY_BREAKING_SYSCALL_CHANGES ? "+compatbreak" : ""));
+	IPC::SYSCALL_ABI_VERSION);
 
 static Cvar::Cvar<bool> workaround_naclArchitecture_arm64_disableQualification(
 	"workaround.linux.arm64.naclDisableQualification",
@@ -531,17 +530,6 @@ void VMBase::Create()
 	if (vmABI != IPC::SYSCALL_ABI_VERSION) {
 		Sys::Drop("Couldn't load the %s gamelogic module: it uses ABI version %s but this Daemon engine uses %s",
 		          this->name, vmABI, IPC::SYSCALL_ABI_VERSION);
-	}
-
-	bool vmCompatBreaking = reader.Read<bool>();
-	if (vmCompatBreaking && !IPC::DAEMON_HAS_COMPATIBILITY_BREAKING_SYSCALL_CHANGES) {
-		Sys::Drop("Couldn't load the %s gamelogic module: it has compatibility-breaking ABI changes but Daemon engine uses the vanilla %s ABI",
-		          this->name, IPC::SYSCALL_ABI_VERSION);
-	} else if (!vmCompatBreaking && IPC::DAEMON_HAS_COMPATIBILITY_BREAKING_SYSCALL_CHANGES) {
-		Sys::Drop("Couldn't load the %s gamelogic module: Daemon has compatibility-breaking ABI changes but the VM uses the vanilla %s ABI",
-		          this->name, IPC::SYSCALL_ABI_VERSION);
-	} else if (IPC::DAEMON_HAS_COMPATIBILITY_BREAKING_SYSCALL_CHANGES) {
-		Log::Notice("^6Using %s VM with unreleased ABI changes", this->name);
 	}
 
 	Log::Notice("Loaded %s VM module in %d msec", this->name, Sys::Milliseconds() - loadStartTime);

--- a/src/shared/VMMain.cpp
+++ b/src/shared/VMMain.cpp
@@ -69,7 +69,6 @@ static void CommonInit(Sys::OSHandle rootSocket)
 	Util::Writer writer;
 	writer.Write<uint32_t>(IPC::ABI_VERSION_DETECTION_ABI_VERSION);
 	writer.Write<std::string>(IPC::SYSCALL_ABI_VERSION);
-	writer.Write<bool>(IPC::DAEMON_HAS_COMPATIBILITY_BREAKING_SYSCALL_CHANGES);
 	VM::rootChannel.SendMsg(writer);
 
 	// Start the main loop


### PR DESCRIPTION
Companion: https://github.com/Unvanquished/Unvanquished/pull/3493

In discussion of https://github.com/DaemonEngine/Daemon/pull/1933 it has been observed that this causes issues with the version check when using the server list on an unstable branch, and that the bool is unnecessary complexity. Instead of having the bool we can just add something in the version string to indicate the unstable ABI. The only thing lost by removing DAEMON_HAS_COMPATIBILITY_BREAKING_SYSCALL_CHANGES is the log message advising that the unstable ABI branch is being used.