### PR TITLE
Fix specular mapping with linear blend regime

### DIFF
--- a/src/engine/renderer/tr_local.h
+++ b/src/engine/renderer/tr_local.h
@@ -1280,7 +1280,6 @@ enum
 	enum {
 		LINEAR_RGBGEN = ( 1 << 0 ),
 		LINEAR_COLORMAP = ( 1 << 1 ),
-		LINEAR_SPECULARMAP = ( 1 << 2 ),
 	};
 
 // *INDENT-ON*

--- a/src/engine/renderer/tr_shader.cpp
+++ b/src/engine/renderer/tr_shader.cpp
@@ -1509,9 +1509,6 @@ static bool LoadMap( shaderStage_t *stage, const char *buffer, stageType_t type,
 				case stageType_t::ST_SKYBOXMAP:
 					imageParams.bits |= IF_SRGB;
 					break;
-				case stageType_t::ST_SPECULARMAP:
-					imageParams.bits |= stage->colorspaceBits & LINEAR_SPECULARMAP ? 0 : IF_SRGB;
-					break;
 				default:
 					break;
 			}
@@ -2678,19 +2675,6 @@ static bool ParseStage( shaderStage_t *stage, const char **text )
 			}
 
 			stage->colorspaceBits |= LINEAR_COLORMAP;
-		}
-		else if ( !Q_stricmp( token, "rawSpecularMap" ) )
-		{
-			stage->colorspaceBits |= LINEAR_SPECULARMAP;
-		}
-		else if ( !Q_stricmp( token, "linearSpecularMap" ) )
-		{
-			if ( !tr.worldLinearizeTexture )
-			{
-				Log::Warn("Usage of linearSpecularMap in naive pipeline, assuming rawSpecularMap");
-			}
-
-			stage->colorspaceBits |= LINEAR_SPECULARMAP;
 		}
 		// stage <type>
 		else if ( !Q_stricmp( token, "stage" ) )


### PR DESCRIPTION
The default behavior was to convert specular maps from sRGB to linear colorspace when using the linear blend regime. But for most of our assets, doing sRGB conversion of specular maps (when in the linear blend regime) looks almost the same as disabling specular mapping, while loading them as-is looks fairly comparable to naive mode.  So don't do the conversion.

Here are some screenshots, with tonemapping off for easier comparison, of the scene discussed at https://github.com/Unvanquished/Unvanquished/issues/3446#issuecomment-3863054781.

NAIVE (via [r_forceBlendRegime](https://github.com/DaemonEngine/Daemon/pull/1869))

![unvanquished-chasm-flake-1](https://github.com/user-attachments/assets/ee467cf0-5650-47de-954f-860e539a0d51)



LINEAR (before)

![unvanquished-chasm-flake-1](https://github.com/user-attachments/assets/b21e6962-8846-4a7a-a3a8-1ae971a87e18)



LINEAR (after)


![unvanquished-chasm-flake-1](https://github.com/user-attachments/assets/d06392c3-5511-4395-b49b-167cb1d9413a)



The wall under the light here is a nice easy-to-see example:



NAIVE (via [r_forceBlendRegime](https://github.com/DaemonEngine/Daemon/pull/1869)

![unvanquished-chasm-light-shortrange](https://github.com/user-attachments/assets/c6ea0957-e49b-4cc2-9fb5-fd23c5c271e4)


LINEAR (before)

![unvanquished-chasm-light-shortrange](https://github.com/user-attachments/assets/8f03dbf0-c26f-4d64-b49b-3c928c42e951)




LINEAR (after)

![unvanquished-chasm-light-shortrange](https://github.com/user-attachments/assets/310aa3d9-62d1-4bd5-8561-b00e3d39e1cc)
