### PR TITLE
Print used SDL path and version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -689,6 +689,7 @@ if (BUILD_CLIENT OR WIN32)
     endif()
 
     find_package(SDL3 REQUIRED CONFIG)
+    message("Found SDL3 ${SDL3_VERSION}: ${SDL3_DIR}")
 
     if (WIN32)
         set(LIBS_ENGINE_BASE ${LIBS_ENGINE_BASE} SDL3::SDL3)


### PR DESCRIPTION
This helps debugging. Example result:

```
-- Found Threads: TRUE
-- Found OpenGL: /nix/store/x4sc437gdbhrfbm4b0hja9lfv38njvi1-libglvnd-1.7.0/lib/libOpenGL.so
-- Found OpenGL ABI: LEGACY
-- Found OpenGL library: /nix/store/x4sc437gdbhrfbm4b0hja9lfv38njvi1-libglvnd-1.7.0/lib/libGL.so
-- Found SDL3 3.2.22: /nix/store/jzxilrmnii3rwwzh2z5wg0q7dbzy7kpw-sdl3-3.2.28-dev/lib/cmake/SDL3     <-------------------------here
-- Found ZLIB: /nix/store/c2qsgf2832zi4n29gfkqgkjpvmbmxam6-zlib-1.3.1/lib/libz.so (found version "1.3.1")
-- Found CursesW: /nix/store/ddranxbikfg4jkf3n1m0a0h9qqxj1vf0-ncurses-6.5/lib/libncursesw.so
-- Found Nettle: /nix/store/nqzy77yq0wmx1mb5107a73jb7x1wbdxq-nettle-3.10.2/lib/libnettle.so
-- Found GMP: /nix/store/2qzc0x9nm5nwq83svddaybwx806pnlws-gmp-with-cxx-6.3.0/lib/libgmp.so
-- Found CURL: /nix/store/0apq92vpf3f3kll8vl9nhjq1gaaffibk-curl-8.17.0/lib/libcurl.so (found version "8.17.0")
-- Found Ogg: /nix/store/7g2hf8436pddgn4g9xaiz4z5832dp9sp-libogg-1.3.6/lib/libogg.so
-- Found Vorbis: /nix/store/ll3kl6ns493gv0facfrcpnjy1bp39yzm-libvorbis-1.3.7/lib/libvorbis.so
-- Found Opus: /nix/store/xyqdsh7gm1yxywhbk1ixaz33lqw9b765-opusfile-0.12/lib/libopusfile.so
-- Found WebP: /nix/store/i6742f2vdh0y6k1qyc0m7srk6h7ks0nh-libwebp-1.6.0/lib/libwebp.so
-- Performing Test _WEBP_COMPILATION_TEST
-- Performing Test _WEBP_COMPILATION_TEST - Success
-- Found JPEG: /nix/store/alddrrr7703gs9lhw7lknzwr51kj4jsl-libjpeg-turbo-3.1.3/lib/libjpeg.so (found version "62")
-- Found PNG: /nix/store/94dcyz2ssdhr0s2srnafpj49ia6shsn1-libpng-apng-1.6.52/lib/libpng.so (found version "1.6.52")
-- Found Freetype: /nix/store/cvckjvajk2pdlx7i573fnd7ycrl46f17-freetype-2.13.3/lib/libfreetype.so (found version "2.13.3")
-- Found GLEW: /nix/store/5swaf68kmkzvqcj9a76i2q58k4a5l6lv-glew-2.2.0/lib/libGLEW.so
-- Found OpenAL: /nix/store/klr6f2ir04i8w2icgy27iji3zbn23vl3-openal-soft-1.24.3/lib/libopenal.so
```