### PR TITLE
Add ppc64le/ppc64 architecture support MVP

### DIFF
--- a/cmake/DaemonArchitecture.cmake
+++ b/cmake/DaemonArchitecture.cmake
@@ -91,6 +91,12 @@ endif()
 
 daemon_add_buildinfo("char*" "DAEMON_NACL_ARCH_STRING" "\"${NACL_ARCH}\"")
 
+# NaCl runtime is only available on architectures that have a NaCl loader.
+set(NACL_RUNTIME_ARCH amd64 i686 armhf)
+if (NACL_ARCH IN_LIST NACL_RUNTIME_ARCH)
+	add_definitions(-DDAEMON_NACL_RUNTIME_ENABLED)
+endif()
+
 option(USE_ARCH_INTRINSICS "Enable custom code using intrinsics functions or asm declarations" ON)
 mark_as_advanced(USE_ARCH_INTRINSICS)
 
@@ -111,6 +117,7 @@ set_arch_intrinsics(${ARCH})
 
 set(amd64_PARENT "i686")
 set(arm64_PARENT "armhf")
+set(ppc64el_PARENT "ppc64")
 
 if (${ARCH}_PARENT)
 	set_arch_intrinsics(${${ARCH}_PARENT})

--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -659,6 +659,18 @@ elseif (NOT NACL)
 		set(GCC_GENERIC_ARCH "armv6")
 		# There is no generic tuning option for armv6.
 		unset(GCC_GENERIC_TUNE)
+	elseif (ARCH STREQUAL "ppc64el")
+		# POWER8 minimum (first little-endian POWER).
+		# GCC uses -mcpu instead of -march/-mtune for POWER.
+		unset(GCC_GENERIC_ARCH)
+		unset(GCC_GENERIC_TUNE)
+		set(GCC_GENERIC_CPU "power8")
+	elseif (ARCH STREQUAL "ppc64")
+		# POWER5 minimum (first 64-bit POWER in wide use).
+		# GCC uses -mcpu instead of -march/-mtune for POWER.
+		unset(GCC_GENERIC_ARCH)
+		unset(GCC_GENERIC_TUNE)
+		set(GCC_GENERIC_CPU "power5")
 	else()
 		message(WARNING "Unknown architecture ${ARCH}")
 	endif()
@@ -675,6 +687,11 @@ elseif (NOT NACL)
 
 		if (GCC_GENERIC_TUNE)
 			try_c_cxx_flag_werror(MTUNE "-mtune=${GCC_GENERIC_TUNE}")
+		endif()
+
+		# POWER architectures use -mcpu instead of -march/-mtune.
+		if (GCC_GENERIC_CPU)
+			try_c_cxx_flag_werror(MCPU "-mcpu=${GCC_GENERIC_CPU}")
 		endif()
 	endif()
 

--- a/cmake/DaemonNacl.cmake
+++ b/cmake/DaemonNacl.cmake
@@ -71,6 +71,11 @@ else()
     add_definitions( -DNACL_BUILD_SUBARCH=32 )
   elseif( NACL_ARCH STREQUAL "armhf" )
     add_definitions( -DNACL_BUILD_ARCH=arm )
+  elseif( NACL_ARCH STREQUAL "ppc64el" OR NACL_ARCH STREQUAL "ppc64" )
+    # NaCl does not support PPC, but these defines must be set for native
+    # builds. Use dummy x86 values as PNaCl does for arch-independent builds.
+    add_definitions( -DNACL_BUILD_ARCH=x86 )
+    add_definitions( -DNACL_BUILD_SUBARCH=64 )
   else()
     message(WARNING "Unknown architecture ${NACL_ARCH}")
   endif()

--- a/src/engine/framework/VirtualMachine.cpp
+++ b/src/engine/framework/VirtualMachine.cpp
@@ -88,6 +88,18 @@ static Cvar::Cvar<int> vm_timeout(
 	"Receive timeout in seconds",
 	Cvar::NONE, 2);
 
+#if defined(DAEMON_NACL_RUNTIME_ENABLED)
+static Cvar::Cvar<bool> vm_nacl_available(
+	"vm.nacl.available",
+	"Whether NaCl runtime is available on this platform",
+	Cvar::ROM, true);
+#else
+static Cvar::Cvar<bool> vm_nacl_available(
+	"vm.nacl.available",
+	"Whether NaCl runtime is available on this platform",
+	Cvar::ROM, false);
+#endif
+
 namespace VM {
 
 // https://github.com/Unvanquished/Unvanquished/issues/944#issuecomment-744454772
@@ -497,6 +509,13 @@ void VMBase::Create()
 	std::pair<IPC::Socket, IPC::Socket> pair = IPC::Socket::CreatePair();
 
 	IPC::Socket rootSocket;
+#if !defined(DAEMON_NACL_RUNTIME_ENABLED)
+	if (type == TYPE_NACL || type == TYPE_NACL_LIBPATH) {
+		Sys::Error("NaCl VM is not supported on this platform. "
+		           "Set vm.cgame.type and vm.sgame.type to 3 (native DLL) "
+		           "and use devmap instead of map.");
+	}
+#endif
 	if (type == TYPE_NACL || type == TYPE_NACL_LIBPATH) {
 		std::tie(processHandle, rootSocket) = CreateNaClVM(std::move(pair), name, params.debug.Get(), type == TYPE_NACL, params.debugLoader.Get());
 	} else if (type == TYPE_NATIVE_EXE) {


### PR DESCRIPTION
## Summary

Add build and runtime support for ppc64el (little-endian) and ppc64 (big-endian) POWER architectures. NaCl does not support PPC, so this ensures the engine builds cleanly and provides a clear error when NaCl is attempted on an unsupported platform.

### CMake changes
- **DaemonNacl.cmake**: Add ppc64el/ppc64 case with dummy x86 NaCl defines (NaCl has no PPC support, but the defines are still needed for native builds)
- **DaemonFlags.cmake**: Add `-mcpu=power8` (ppc64el) and `-mcpu=power5` (ppc64) compiler flags via new `GCC_GENERIC_CPU` variable, since GCC on POWER uses `-mcpu` instead of `-march`/`-mtune`
- **DaemonArchitecture.cmake**: Define `ppc64el_PARENT = ppc64` parent architecture relationship; add `NACL_RUNTIME_ARCH` allowlist and `DAEMON_NACL_RUNTIME_ENABLED` compile-time define that is only set when a NaCl loader exists for the target architecture (amd64, i686, armhf)

### Runtime changes
- **VirtualMachine.cpp**: Add `vm.nacl.available` ROM cvar (true on amd64/i686/armhf, false otherwise) so the game UI can detect NaCl availability at runtime; add `Sys::Error` guard in `VMBase::Create()` if NaCl VM type is attempted on a platform without a NaCl loader

### Usage on non-NaCl platforms

Dedicated server (sgame is not a CHEAT cvar):
```
./daemonded -set vm.sgame.type 3 +map plat23
```

Client (cgame is a CHEAT cvar, use `-set` to override before reset):
```
./daemon -set vm.cgame.type 3 -set vm.sgame.type 3 +devmap plat23
```
