### PR TITLE
Discard old server commands upon new gamestate

### DIFF
--- a/src/engine/client/cl_parse.cpp
+++ b/src/engine/client/cl_parse.cpp
@@ -409,6 +409,9 @@ void CL_ParseGamestate( msg_t *msg )
 
 		// a gamestate always marks a server command sequence
 		clc.serverCommandSequence = MSG_ReadLong( msg );
+
+		// trash any commands from previous game
+		clc.lastExecutedServerCommand = clc.serverCommandSequence;
 	}
 
 	// parse all the configstrings and baselines

--- a/src/engine/server/sv_client.cpp
+++ b/src/engine/server/sv_client.cpp
@@ -354,6 +354,7 @@ void SV_SendClientGameState( client_t *client )
 	// we have to do this cause we send the client->reliableSequence
 	// with a gamestate and it sets the clc.serverCommandSequence at
 	// the client side
+	// TODO(0.57): remove. The client will just throw away old commands on getting a gamestate
 	SV_UpdateServerCommandsToClient( client, &msg );
 
 	// send the gamestate


### PR DESCRIPTION
Fixes https://github.com/Unvanquished/Unvanquished/issues/1102.

This fixes a bug where the configstring state could be wrong due to `cs` server commands being executed out of order with respect to game state processing. Server commands are only processed when the cgame requests a snapshot, so commands received before the client loads the current map which were sent before the gamestate could be processed after the gamestate.