### PR TITLE
Enforce server command invariants more in the client

### DIFF
--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -137,7 +137,8 @@ void CL_ConfigstringModified( Cmd::Args& csCmd )
 /*
 ===================
 CL_HandleServerCommand
-CL_GetServerCommand
+
+Returns true if the command should be passed to the cgame
 ===================
 */
 bool CL_HandleServerCommand(Str::StringRef text, std::string& newText) {

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -256,13 +256,6 @@ void CL_FillServerCommands(std::vector<std::string>& commands, int start, int en
 	// if we have irretrievably lost a reliable command, drop the connection
 	if ( start <= clc.serverCommandSequence - MAX_RELIABLE_COMMANDS )
 	{
-		// when a demo record was started after the client got a whole bunch of
-		// reliable commands then the client never got those first reliable commands
-		if ( clc.demoplaying )
-		{
-			return;
-		}
-
 		Sys::Drop( "CL_FillServerCommand: a reliable command was cycled out" );
 	}
 

--- a/src/engine/client/cl_parse.cpp
+++ b/src/engine/client/cl_parse.cpp
@@ -408,7 +408,14 @@ void CL_ParseGamestate( msg_t *msg )
 		CL_ClearState();
 
 		// a gamestate always marks a server command sequence
-		clc.serverCommandSequence = MSG_ReadLong( msg );
+		int commandNum = MSG_ReadLong( msg );
+
+		if ( commandNum < clc.serverCommandSequence )
+		{
+			Sys::Drop( "Gamestate moved serverCommandSequence backward" );
+		}
+
+		clc.serverCommandSequence = commandNum;
 
 		// trash any commands from previous game
 		clc.lastExecutedServerCommand = clc.serverCommandSequence;
@@ -496,6 +503,13 @@ void CL_ParseCommandString( msg_t *msg )
 	// see if we have already executed stored it off
 	if ( clc.serverCommandSequence >= seq )
 	{
+		return;
+	}
+
+	if ( clc.serverCommandSequence + 1 != seq )
+	{
+		Sys::Drop( "Out-of-sequence server command: expected %d, got %d",
+		           clc.serverCommandSequence + 1, seq );
 		return;
 	}
 


### PR DESCRIPTION
The server reliable commands are expected to arrive in order and are re-sent if packets are dropped. Do a bit more checking on the client side that the protocol is observed.

I tested this along with #1954 by playing in some online games and replaying demos.