### PR TITLE
Remove useless trap_R_AddRefEntityToScene return value

### DIFF
--- a/src/shared/client/cg_api.cpp
+++ b/src/shared/client/cg_api.cpp
@@ -295,14 +295,9 @@ void trap_R_ClearScene()
 	cmdBuffer.SendMsg<Render::ClearSceneMsg>();
 }
 
-/* HACK: We need the entityNum to get the correct positions for entities that need to be attached to another entity's bone
-This must be equal to the r_numEntities in engine at the time of adding the entity */
-static int entityNum;
-int trap_R_AddRefEntityToScene( const refEntity_t *re )
+void trap_R_AddRefEntityToScene( const refEntity_t *re )
 {
 	cmdBuffer.SendMsg<Render::AddRefEntityToSceneMsg>(*re);
-	entityNum++;
-	return entityNum - 1;
 }
 
 void trap_R_SyncRefEntities( const std::vector<EntityUpdate>& ents ) {
@@ -380,7 +375,6 @@ void trap_R_AddLightToScene( const vec3_t origin, float radius, float intensity,
 
 void trap_R_RenderScene( const refdef_t *fd )
 {
-	entityNum = 0;
 	cmdBuffer.SendMsg<Render::RenderSceneMsg>(*fd);
 }
 

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -65,7 +65,7 @@ qhandle_t       trap_R_RegisterModel( const char *name );
 qhandle_t       trap_R_RegisterSkin( const char *name );
 qhandle_t       trap_R_RegisterShader( const char *name, int flags );
 void            trap_R_ClearScene();
-int  trap_R_AddRefEntityToScene( const refEntity_t *re );
+void trap_R_AddRefEntityToScene( const refEntity_t *re );
 void trap_R_SyncRefEntities( const std::vector<EntityUpdate>& ents );
 std::vector<LerpTagSync> trap_R_SyncLerpTags( const std::vector<LerpTagUpdate>& lerpTags );
 void            trap_R_AddPolyToScene( qhandle_t hShader, int numVerts, const polyVert_t *verts );


### PR DESCRIPTION
It returns how many entities have been added to the current scene, but there is nothing useful the cgame can do with this number. All the APIs with entity id require adding the entity to the cache to get an id, not to the scene.

Companion: https://github.com/Unvanquished/Unvanquished/pull/3528