### PR TITLE
Entity cache-related cleanup

### DIFF
--- a/src/engine/null/null_renderer.cpp
+++ b/src/engine/null/null_renderer.cpp
@@ -80,8 +80,8 @@ void RE_EndRegistration() { }
 void RE_ClearScene() { }
 void RE_AddRefEntityToScene( const refEntity_t * ) { }
 void RE_SyncRefEntities( const std::vector<EntityUpdate>& ) {}
-std::vector<LerpTagSync> RE_SyncLerpTags( const std::vector<LerpTagUpdate>& ) {
-    return {};
+std::vector<LerpTagSync> RE_SyncLerpTags( const std::vector<LerpTagUpdate>& in ) {
+    return std::vector<LerpTagSync>(in.size());
 }
 void RE_AddPolyToScene( qhandle_t, int, const polyVert_t* ) { }
 void RE_AddPolysToScene( qhandle_t, int, const polyVert_t*, int ) { }

--- a/src/engine/renderer/EntityCache.cpp
+++ b/src/engine/renderer/EntityCache.cpp
@@ -264,7 +264,7 @@ void ClearEntityCache() {
 	}
 }
 
-std::vector<LerpTagSync> SyncEntityCacheToCGame( const std::vector<LerpTagUpdate>& lerpTags ) {
+std::vector<LerpTagSync> RE_SyncLerpTags( const std::vector<LerpTagUpdate>& lerpTags ) {
 	std::vector<LerpTagSync> entityOrientations;
 	entityOrientations.reserve( lerpTags.size() );
 
@@ -284,7 +284,7 @@ std::vector<LerpTagSync> SyncEntityCacheToCGame( const std::vector<LerpTagUpdate
 	return entityOrientations;
 }
 
-void SyncEntityCacheFromCGame( const std::vector<EntityUpdate>& ents ) {
+void RE_SyncRefEntities( const std::vector<EntityUpdate>& ents ) {
 	for ( const EntityUpdate& ent : ents ) {
 		bool flip = entities[ent.id].e.active != ent.ent.active;
 

--- a/src/engine/renderer/EntityCache.h
+++ b/src/engine/renderer/EntityCache.h
@@ -53,7 +53,7 @@ void TransformEntity( trRefEntity_t* ent );
 
 void ClearEntityCache();
 
-std::vector<LerpTagSync> SyncEntityCacheToCGame( const std::vector<LerpTagUpdate>& lerpTags );
-void SyncEntityCacheFromCGame( const std::vector<EntityUpdate>& ents );
+std::vector<LerpTagSync> RE_SyncLerpTags( const std::vector<LerpTagUpdate>& lerpTags );
+void RE_SyncRefEntities( const std::vector<EntityUpdate>& ents );
 
 #endif // ENTITY_CACHE_H

--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1693,8 +1693,8 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 
 		re.ClearScene = RE_ClearScene;
 		re.AddRefEntityToScene = RE_AddRefEntityToScene;
-		re.SyncRefEntities = SyncEntityCacheFromCGame;
-		re.SyncLerpTags = SyncEntityCacheToCGame;
+		re.SyncRefEntities = RE_SyncRefEntities;
+		re.SyncLerpTags = RE_SyncLerpTags;
 
 		re.AddPolyToScene = RE_AddPolyToSceneET;
 		re.AddPolysToScene = RE_AddPolysToScene;

--- a/src/engine/renderer/tr_types.h
+++ b/src/engine/renderer/tr_types.h
@@ -58,11 +58,11 @@ using bool8_t = uint8_t;
 
 // renderfx flags
 enum RenderFx : uint8_t {
-	RF_THIRD_PERSON = 0x000001, // don't draw through eyes, only mirrors (player bodies, chat sprites)
-	RF_FIRST_PERSON = 0x000002, // only draw through eyes (view weapon, damage blood blob)
-	RF_DEPTHHACK    = 0x000004, // for view weapon Z crunching
-	RF_NOSHADOW     = 0x000008, // don't add stencil shadows
-	RF_SWAPCULL     = 0x000010  // swap CT_FRONT_SIDED and CT_BACK_SIDED
+	RF_THIRD_PERSON = 0x01, // don't draw through eyes, only mirrors (player bodies, chat sprites)
+	RF_FIRST_PERSON = 0x02, // only draw through eyes (view weapon, damage blood blob)
+	RF_DEPTHHACK    = 0x04, // for view weapon Z crunching
+	RF_NOSHADOW     = 0x08, // don't add stencil shadows
+	RF_SWAPCULL     = 0x10  // swap CT_FRONT_SIDED and CT_BACK_SIDED
 };
 
 // refdef flags
@@ -230,14 +230,14 @@ struct refEntity_t
 
 	EntityTag positionOnTag;
 
-	int8_t    clearOrigin;
-	int8_t    clearOrigin2;
+	bool8_t   clearOrigin;
+	bool8_t   clearOrigin2;
 
-	int8_t    boundsAdd;
+	bool8_t   boundsAdd;
 
-	int8_t    nonNormalizedAxes; // axis are not normalized, i.e. they have scale
+	bool8_t   nonNormalizedAxes; // axis are not normalized, i.e. they have scale
 
-	int8_t    active;
+	bool8_t   active;
 
 	uint16_t  attachmentEntity;
 

--- a/src/shared/client/cg_api.h
+++ b/src/shared/client/cg_api.h
@@ -82,7 +82,6 @@ void            trap_R_ResetClipRegion();
 void            trap_R_DrawStretchPic( float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader );
 void            trap_R_DrawRotatedPic( float x, float y, float w, float h, float s1, float t1, float s2, float t2, qhandle_t hShader, float angle );
 void            trap_R_ModelBounds( clipHandle_t model, vec3_t mins, vec3_t maxs );
-int             trap_R_LerpTag( orientation_t *tag, const refEntity_t* refent, const char *tagName, int startIndex );
 void            trap_R_GetTextureSize( qhandle_t handle, int *x, int *y );
 qhandle_t       trap_R_GenerateTexture( const byte *data, int x, int y );
 void            trap_GetCurrentSnapshotNumber( int *snapshotNumber, int *serverTime );


### PR DESCRIPTION
The most important thing there is `Fix null renderer SyncLerpTags`: this ensures the tty client's IPC response has the expected number of requested items. The current behavior of returning and empty vector is prone to cause crashes if the cgame assumes the vector has the right length.

Rest of the commits are just cosmetic.