### PR TITLE
sdl_glimp: do not assume AMD hardware on non-Mesa Linux driver is OGLP

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2492,7 +2492,7 @@ static void GLimp_InitExtensions()
 			}
 
 			// AMD proprietary drivers are known to have buggy bindless texture implementation.
-			else if ( glConfig.hardwareVendor == glHardwareVendor_t::ATI )
+			else if ( glConfig.driverVendor == glDriverVendor_t::ATI )
 			{
 				// AMD proprietary driver for macOS does not implement bindless texture.
 				// Other systems like FreeBSD don't have AMD proprietary drivers.


### PR DESCRIPTION
Do not assume AMD hardware on non-Mesa Linux driver is OGLP, it can be AMD hardware on Mesa with a translation layer above.

Spotted when testing GL4ES on Mesa radeonsi.