### PR TITLE
glsl: fix int/float type mismatch

### DIFF
--- a/src/engine/renderer/glsl_source/fogEquation_fp.glsl
+++ b/src/engine/renderer/glsl_source/fogEquation_fp.glsl
@@ -34,7 +34,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 float FogGradientFunction(float k, float t)
 {
-	return 1 - exp(-k * t);
+	return 1.0 - exp(-k * t);
 }
 
 float FogGradientAntiderivative(float k, float t)

--- a/src/engine/renderer/glsl_source/fog_fp.glsl
+++ b/src/engine/renderer/glsl_source/fog_fp.glsl
@@ -124,7 +124,7 @@ void	main()
 
 	float s = distInFog * GetFogGradientModifier(u_FogGradient.y, t0, t1) * u_FogGradient.x;
 
-	vec4 color = vec4(1, 1, 1, GetFogAlpha(s));
+	vec4 color = vec4(1.0, 1.0, 1.0, GetFogAlpha(s));
 
 	outputColor = UnpackColor( u_Color ) * color;
 }

--- a/src/engine/renderer/glsl_source/vertexAnimation_vp.glsl
+++ b/src/engine/renderer/glsl_source/vertexAnimation_vp.glsl
@@ -41,7 +41,7 @@ void VertexAnimation_P_N(	vec3 fromPosition, vec3 toPosition,
 	vec3 toNormal = QuatTransVec( toQTangent, vec3( 0.0, 0.0, 1.0 ) );
 
 	position.xyz = 512.0 * mix(fromPosition, toPosition, frac);
-	position.w = 1;
+	position.w = 1.0;
 
 	normal = normalize(mix(fromNormal, toNormal, frac));
 }
@@ -58,7 +58,7 @@ void VertexFetch(out vec4 position,
 	QTangentToLocalBasis( attr_QTangent2, toLB );
 
 	position.xyz = 512.0 * mix(attr_Position, attr_Position2, u_VertexInterpolation);
-	position.w = 1;
+	position.w = 1.0;
 	
 	LB.normal = normalize(mix(fromLB.normal, toLB.normal, u_VertexInterpolation));
 	LB.tangent = normalize(mix(fromLB.tangent, toLB.tangent, u_VertexInterpolation));


### PR DESCRIPTION
Some GL ES drivers running under GL4ES may be very picky about typing and GL4ES still has to implement casting.

Extacted from:

- https://github.com/DaemonEngine/Daemon/pull/1902

Standalone and obvious.