### PR TITLE
Fix dynamic lights being always disabled

### DIFF
--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2685,7 +2685,8 @@ static void GLimp_EnableAvailableFeatures()
 
 	if ( glConfig.realtimeLighting )
 	{
-		if ( workaround_glDriver_zhaoxin_disableRealtimeLighting.Get() )
+		if ( workaround_glDriver_zhaoxin_disableRealtimeLighting.Get()
+		     && glConfig.driverVendor == glDriverVendor_t::ZHAOXIN )
 		{
 			Log::Warn("Tiled dynamic light renderer disabled because of buggy Zhaoxin driver.");
 			glConfig.realtimeLighting = false;


### PR DESCRIPTION
regression in 677656aaa9961ec05e7a37369ee5aa6e0961327f