### PR TITLE
Migrate some `cl_` cvars

### DIFF
--- a/src/engine/RefAPI.h
+++ b/src/engine/RefAPI.h
@@ -217,7 +217,7 @@ struct refimport_t {
 	int ( *FS_FOpenFileRead )( const char* qpath, fileHandle_t* file );
 
 	// XreaL BEGIN
-	bool( *CL_VideoRecording )( );
+	int ( *CL_VideoRecording )( );
 	void ( *CL_WriteAVIVideoFrame )( const byte* buffer, int size );
 	// XreaL END
 

--- a/src/engine/client/cl_avi.cpp
+++ b/src/engine/client/cl_avi.cpp
@@ -358,7 +358,7 @@ bool CL_OpenAVIForWriting( const char *fileName )
 	afd.width = cls.windowConfig.vidWidth;
 	afd.height = cls.windowConfig.vidHeight;
 
-	if ( cl_aviMotionJpeg->integer )
+	if ( cl_aviMotionJpeg.Get() )
 	{
 		afd.motionJpeg = true;
 	}

--- a/src/engine/client/cl_avi.cpp
+++ b/src/engine/client/cl_avi.cpp
@@ -334,7 +334,7 @@ bool CL_OpenAVIForWriting( const char *fileName )
 	afd = {};
 
 	// Don't start if a framerate has not been chosen
-	if ( cl_aviFrameRate->integer <= 0 )
+	if ( cl_aviFrameRate.Get() <= 0 )
 	{
 		Log::Warn("cl_aviFrameRate must be ≥ 1" );
 		return false;
@@ -353,7 +353,7 @@ bool CL_OpenAVIForWriting( const char *fileName )
 
 	Q_strncpyz( afd.fileName, fileName, MAX_QPATH );
 
-	afd.frameRate = cl_aviFrameRate->integer;
+	afd.frameRate = cl_aviFrameRate.Get();
 	afd.framePeriod = ( int )( 1000000.0f / afd.frameRate );
 	afd.width = cls.windowConfig.vidWidth;
 	afd.height = cls.windowConfig.vidHeight;

--- a/src/engine/client/cl_avi.cpp
+++ b/src/engine/client/cl_avi.cpp
@@ -612,7 +612,7 @@ bool CL_CloseAVI()
 CL_VideoRecording
 ===============
 */
-bool CL_VideoRecording()
+int CL_VideoRecording()
 {
-	return afd.fileOpen;
+	return afd.fileOpen ? afd.frameRate : 0;
 }

--- a/src/engine/client/cl_cgame.cpp
+++ b/src/engine/client/cl_cgame.cpp
@@ -761,14 +761,14 @@ void CL_FirstSnapshot()
 	// execute the contents of activeAction now
 	// this is to allow scripting a timedemo to start right
 	// after loading
-	if ( cl_activeAction->string[ 0 ] )
+	if ( !cl_activeAction.Get().empty() )
 	{
-		Cmd::BufferCommandText(cl_activeAction->string);
-		Cvar_Set( "activeAction", "" );
+		Cmd::BufferCommandText( cl_activeAction.Get() );
+		cl_activeAction.Set( "" );
 	}
 
 #if defined(USE_MUMBLE)
-	if ( ( cl_useMumble->integer ) && !mumble_islinked() )
+	if ( ( cl_useMumble.Get() ) && !mumble_islinked() )
 	{
 		int ret = mumble_link( CLIENT_WINDOW_TITLE );
 		Log::Notice(ret == 0 ? "Mumble: Linking to Mumble application okay" : "Mumble: Linking to Mumble application failed" );
@@ -845,7 +845,7 @@ void CL_SetCGameTime()
 	// cl_timeNudge is a user adjustable cvar that allows more
 	// or less latency to be added in the interest of better
 	// smoothness or better responsiveness.
-	int tn = Math::Clamp( cl_timeNudge->integer, -30, 30 );
+	int tn = cl_timeNudge.Get();
 
 	cl.serverTime = cls.realtime + cl.serverTimeDelta - tn;
 

--- a/src/engine/client/cl_console.cpp
+++ b/src/engine/client/cl_console.cpp
@@ -49,6 +49,9 @@ console_t consoleState;
 
 Console::Field g_consoleField(INT_MAX);
 
+static Cvar::Range<Cvar::Cvar<int>> cl_noprint(
+	"cl_noprint", "don't show log messages in game (2 = nor in console)", Cvar::NONE, 0, 0, 2);
+
 Cvar::Range<Cvar::Cvar<float>> con_animationSpeed("con_animationSpeed", "speed of console fade in/out and scrolling", Cvar::NONE, 3, 0.1, 100);
 
 Cvar::Cvar<bool> con_autoclear("con_autoclear", "drop input upon closing console", Cvar::NONE, true);
@@ -451,12 +454,6 @@ bool CL_InternalConsolePrint( const char *text )
 {
 	int      wordLen = 0;
 
-	// for some demos we don't want to ever show anything on the console
-	if ( cl_noprint && cl_noprint->integer )
-	{
-		return true;
-	}
-
 	if ( !consoleState.initialized )
 	{
 		consoleState.textWidthInChars = -1;
@@ -473,7 +470,7 @@ bool CL_InternalConsolePrint( const char *text )
 	{
 		text += 12;
 	}
-	else if ( !consoleState.isOpened && strncmp( text, "EXCL: ", 6 ) )
+	else if ( !consoleState.isOpened && strncmp( text, "EXCL: ", 6 ) && !cl_noprint.Get() )
 	{
 		// feed the text to cgame
 		Cmd_SaveCmdContext();
@@ -1181,7 +1178,7 @@ class GraphicalTarget : public Log::Target {
 		virtual bool Process(const std::vector<Log::Event>& events) override {
 			// for some demos we don't want to ever show anything on the console
 			// flush the buffer
-			if ( cl_noprint && cl_noprint->integer )
+			if ( cl_noprint.Get() >= 2 )
 			{
 				return true;
 			}

--- a/src/engine/client/cl_download.cpp
+++ b/src/engine/client/cl_download.cpp
@@ -215,13 +215,13 @@ void CL_InitDownloads()
 	clc.bWWWDlAborting = false;
 	CL_ClearStaticDownload();
 
-	if ( cl_allowDownload->integer )
+	if ( cl_allowDownload.Get() )
 		FS_DeletePaksWithBadChecksum();
 
 	// reset the redirect checksum tracking
 	clc.redirectedList[ 0 ] = '\0';
 
-	if ( cl_allowDownload->integer && FS_ComparePaks( clc.downloadList, sizeof( clc.downloadList ) ) )
+	if ( cl_allowDownload.Get() && FS_ComparePaks( clc.downloadList, sizeof( clc.downloadList ) ) )
 	{
 		downloadLogger.Debug("Need paks: '%s'", clc.downloadList);
 

--- a/src/engine/client/cl_input.cpp
+++ b/src/engine/client/cl_input.cpp
@@ -942,7 +942,7 @@ void CL_WritePacket()
 		}
 
 		// begin a client move command
-		if ( cl_nodelta->integer || !cl.snap.valid || clc.demowaiting || clc.serverMessageSequence != cl.snap.messageNum )
+		if ( cl_nodelta.Get() || !cl.snap.valid || clc.demowaiting || clc.serverMessageSequence != cl.snap.messageNum )
 		{
 			MSG_WriteByte( &buf, clc_moveNoDelta );
 		}
@@ -1273,8 +1273,6 @@ void CL_InitInput()
 	}
 
 	Cmd_AddCommand( "keyup", IN_KeysUp_f );
-
-	cl_nodelta = Cvar_Get( "cl_nodelta", "0", 0 );
 }
 
 /*

--- a/src/engine/client/cl_input.cpp
+++ b/src/engine/client/cl_input.cpp
@@ -827,19 +827,11 @@ bool CL_ReadyToSendPacket()
 	}
 
 	// check for exceeding cl_maxpackets
-	if ( cl_maxpackets->integer < 15 )
-	{
-		Cvar_Set( "cl_maxpackets", "15" );
-	}
-	else if ( cl_maxpackets->integer > 125 )
-	{
-		Cvar_Set( "cl_maxpackets", "125" );
-	}
 
 	oldPacketNum = ( clc.netchan.outgoingSequence - 1 ) & PACKET_MASK;
 	delta = cls.realtime - cl.outPackets[ oldPacketNum ].p_realtime;
 
-	if ( delta < 1000 / cl_maxpackets->integer )
+	if ( delta < 1000 / cl_maxpackets.Get() )
 	{
 		// the accumulated commands will go out in the next packet
 		return false;
@@ -916,16 +908,8 @@ void CL_WritePacket()
 	// we want to send all the usercmds that were generated in the last
 	// few packet, so even if a couple packets are dropped in a row,
 	// all the cmds will make it to the server
-	if ( cl_packetdup->integer < 0 )
-	{
-		Cvar_Set( "cl_packetdup", "0" );
-	}
-	else if ( cl_packetdup->integer > 5 )
-	{
-		Cvar_Set( "cl_packetdup", "5" );
-	}
 
-	oldPacketNum = ( clc.netchan.outgoingSequence - 1 - cl_packetdup->integer ) & PACKET_MASK;
+	oldPacketNum = ( clc.netchan.outgoingSequence - 1 - cl_packetdup.Get() ) & PACKET_MASK;
 	count = cl.cmdNumber - cl.outPackets[ oldPacketNum ].p_cmdNumber;
 
 	if ( count > MAX_PACKET_USERCMDS )

--- a/src/engine/client/cl_keys.cpp
+++ b/src/engine/client/cl_keys.cpp
@@ -341,7 +341,7 @@ static void Console_Key( Keyboard::Key key )
 		if (cls.state != connstate_t::CA_ACTIVE) {
 			g_consoleField.RunCommand();
 		} else {
-			g_consoleField.RunCommand(cl_consoleCommand->string);
+			g_consoleField.RunCommand(cl_consoleCommand.Get());
 		}
 
 		if (cls.state == connstate_t::CA_DISCONNECTED) {

--- a/src/engine/client/cl_keys.cpp
+++ b/src/engine/client/cl_keys.cpp
@@ -520,25 +520,11 @@ static bool DetectBuiltInShortcut( Keyboard::Key key )
 			Cmd::BufferCommandText("quit");
 			return true;
 		}
-		else if ( key == Key(K_TAB) )
-		{
-			Key_ClearStates();
-			Cmd::BufferCommandText("minimize");
-			return true;
-		}
 	}
 #else
 	if ( key == Key(K_ENTER) && keys[ Key(K_ALT) ].down )
 	{
 		r_fullscreen.Set( !r_fullscreen.Get() );
-		return true;
-	}
-
-	// When not in full-screen mode, the OS should intercept this first
-	if ( cl_altTab->integer && keys[ Key(K_ALT) ].down && key == Key(K_TAB) )
-	{
-		Key_ClearStates();
-		Cmd::BufferCommandText("minimize");
 		return true;
 	}
 #endif

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2013,7 +2013,8 @@ void CL_Frame( int msec )
 	}
 
 	// if recording an avi, lock to a fixed fps
-	if ( CL_VideoRecording() && cl_aviFrameRate->integer && msec )
+	int framerate;
+	if ( ( framerate = CL_VideoRecording() ) && msec )
 	{
 		// save the current screen
 		if ( cls.state == connstate_t::CA_ACTIVE )
@@ -2021,7 +2022,7 @@ void CL_Frame( int msec )
 			CL_TakeVideoFrame();
 
 			// fixed time for next frame
-			msec = ( int ) ceil( ( 1000.0f / cl_aviFrameRate->value ) * com_timescale->value );
+			msec = ( int ) ceil( ( 1000.0f / framerate ) * com_timescale->value );
 
 			if ( msec == 0 )
 			{

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -132,8 +132,6 @@ Cvar::Cvar<std::string> cl_consoleCommand("cl_consoleCommand", "command prepende
 struct rsa_public_key  public_key;
 struct rsa_private_key private_key;
 
-cvar_t             *cl_altTab;
-
 // XreaL BEGIN
 Cvar::Cvar<bool> cl_aviMotionJpeg("cl_aviMotionJpeg", "use JPEG instead of bitmap for demo video recording", Cvar::NONE, true);
 // XreaL END
@@ -2312,8 +2310,6 @@ void CL_Init()
 	cl_packetdup = Cvar_Get( "cl_packetdup", "1", 0 );
 
 	cl_consoleFontKerning = Cvar_Get( "cl_consoleFontKerning", "0", 0 );
-
-	cl_altTab = Cvar_Get( "cl_altTab", "1", 0 );
 
 	// userinfo
 	cl_rate = Cvar_Get( "rate", XSTRING(NETWORK_DEFAULT_RATE), CVAR_USERINFO | CVAR_ARCHIVE);

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -60,18 +60,18 @@ Maryland 20850 USA.
 #endif
 
 #if defined(USE_MUMBLE)
-cvar_t *cl_useMumble;
-cvar_t *cl_mumbleScale;
+Cvar::Range<Cvar::Cvar<int>> cl_useMumble("cl_useMumble", "enable Mumble integration (2 = debug)", Cvar::NONE, 0, 0, 2);
+Cvar::Cvar<float> cl_mumbleScale("cl_mumbleScale", "multiplier of world coordinates passed to Mumble", Cvar::NONE, 0.0254);
 #endif
 
-cvar_t *cl_nodelta;
+Cvar::Cvar<bool> cl_nodelta("cl_nodelta", "disable network snapshot delta compression", Cvar::NONE, false);
 
 cvar_t *cl_noprint;
 
-cvar_t *cl_timeout;
+Cvar::Cvar<float> cl_timeout("cl_timeout", "disconnect after this many seconds without server packets", Cvar::NONE, 200);
 cvar_t *cl_maxpackets;
 cvar_t *cl_packetdup;
-cvar_t *cl_timeNudge;
+Cvar::Range<Cvar::Cvar<int>> cl_timeNudge("cl_timeNudge", "ms to extrapolate/interpolate ahead/behind latest snapshots (negative means extrapolate ahead)", Cvar::NONE, 0, -30, 30);
 cvar_t *cl_showTimeDelta;
 
 cvar_t *cl_shownet = nullptr; // NERVE - SMF - This is referenced in msg.c and we need to make sure it is nullptr
@@ -116,17 +116,18 @@ Cvar::Range<Cvar::Cvar<int>> j_forward_axis("j_forward_axis", "joystick forward 
 Cvar::Range<Cvar::Cvar<int>> j_side_axis("j_side_axis", "joystick side (strafe) axis number", Cvar::NONE, 0, 0, Util::ordinal(joystickAxis_t::MAX_JOYSTICK_AXIS) - 1);
 Cvar::Range<Cvar::Cvar<int>> j_up_axis("j_up_axis", "joystick up axis number", Cvar::NONE, 2, 0, Util::ordinal(joystickAxis_t::MAX_JOYSTICK_AXIS) - 1);
 
-cvar_t *cl_activeAction;
+Cvar::Cvar<std::string> cl_activeAction("activeAction", "one-time command executed upon entering game", Cvar::TEMPORARY, "");
 
-cvar_t *cl_autorecord;
+Cvar::Cvar<bool> cl_autorecord("cl_autorecord", "record a demo of every game", Cvar::NONE, false);
 
-cvar_t *cl_allowDownload;
+Cvar::Cvar<bool> cl_allowDownload("cl_allowDownload", "auto-download paks required by the server", Cvar::NONE, true);
 
-cvar_t                 *cl_consoleFont;
+Cvar::Cvar<std::string> cl_consoleFont("cl_consoleFont", "path (in homepath) for console typeface", Cvar::NONE, "");
 cvar_t                 *cl_consoleFontSize;
 cvar_t                 *cl_consoleFontScaling;
 cvar_t                 *cl_consoleFontKerning;
-cvar_t                 *cl_consoleCommand; //see also com_consoleCommand for terminal consoles
+//see also com_consoleCommand for terminal consoles
+Cvar::Cvar<std::string> cl_consoleCommand("cl_consoleCommand", "command prepended to console lines, when in game", Cvar::NONE, "say");
 
 struct rsa_public_key  public_key;
 struct rsa_private_key private_key;
@@ -134,7 +135,7 @@ struct rsa_private_key private_key;
 cvar_t             *cl_altTab;
 
 // XreaL BEGIN
-cvar_t             *cl_aviMotionJpeg;
+Cvar::Cvar<bool> cl_aviMotionJpeg("cl_aviMotionJpeg", "use JPEG instead of bitmap for demo video recording", Cvar::NONE, true);
 // XreaL END
 
 cvar_t             *cl_rate;
@@ -153,10 +154,10 @@ void        CL_CheckForResend();
 static void CL_UpdateMumble()
 {
 	vec3_t pos, forward, up;
-	float  scale = cl_mumbleScale->value;
+	float  scale = cl_mumbleScale.Get();
 	float  tmp;
 
-	if ( !cl_useMumble->integer )
+	if ( !cl_useMumble.Get() )
 	{
 		return;
 	}
@@ -176,7 +177,7 @@ static void CL_UpdateMumble()
 	up[ 1 ] = up[ 2 ];
 	up[ 2 ] = tmp;
 
-	if ( cl_useMumble->integer > 1 )
+	if ( cl_useMumble.Get() > 1 )
 	{
 		fprintf( stderr, "%f %f %f, %f %f %f, %f %f %f\n",
 		         pos[ 0 ], pos[ 1 ], pos[ 2 ],
@@ -789,7 +790,7 @@ void CL_Disconnect( bool showMainMenu )
 	CL_SendDisconnect();
 
 #if defined(USE_MUMBLE)
-	if ( cl_useMumble->integer && mumble_islinked() )
+	if ( cl_useMumble.Get() && mumble_islinked() )
 	{
 		Log::Notice("Mumble: Unlinking from Mumble application" );
 		mumble_unlink();
@@ -1962,7 +1963,7 @@ void CL_CheckTimeout()
 	//
 	// check timeout
 	//
-	if ( cls.state >= connstate_t::CA_CONNECTED && cls.realtime - clc.lastPacketTime > cl_timeout->value * 1000 )
+	if ( cls.state >= connstate_t::CA_CONNECTED && cls.realtime - clc.lastPacketTime > cl_timeout.Get() * 1000 )
 	{
 		if ( ++cl.timeoutcount > 5 )
 		{
@@ -2099,7 +2100,7 @@ bool CL_InitRenderer()
 		return false;
 	}
 
-	cl_consoleFont = Cvar_Get( "cl_consoleFont", "",  CVAR_LATCH );
+	Cvar::Latch(cl_consoleFont);
 	cl_consoleFontSize = Cvar_Get( "cl_consoleFontSize", "16",  CVAR_LATCH );
 	cl_consoleFontScaling = Cvar_Get( "cl_consoleFontScaling", "1", CVAR_LATCH );
 
@@ -2116,13 +2117,13 @@ bool CL_InitRenderer()
 		fontSize = cl_consoleFontSize->integer * fontScale / 12;
 	}
 
-	if ( cl_consoleFont->string[ 0 ] )
+	if ( !cl_consoleFont.Get().empty() )
 	{
-		cls.consoleFont = re.RegisterFont( cl_consoleFont->string, fontSize );
+		cls.consoleFont = re.RegisterFont( cl_consoleFont.Get().c_str(), fontSize );
 		if ( cls.consoleFont == nullptr )
 		{
 			Log::Warn( "Couldn't load font file '%s', falling back to default console font",
-			            cl_consoleFont->string );
+			            cl_consoleFont.Get() );
 		}
 	}
 
@@ -2301,29 +2302,16 @@ void CL_Init()
 	//
 	cl_noprint = Cvar_Get( "cl_noprint", "0", 0 );
 
-	cl_timeout = Cvar_Get( "cl_timeout", "200", 0 );
-
-	cl_timeNudge = Cvar_Get( "cl_timeNudge", "0", CVAR_TEMP );
 	cl_shownet = Cvar_Get( "cl_shownet", "0", CVAR_TEMP );
 	cl_showSend = Cvar_Get( "cl_showSend", "0", CVAR_TEMP );
 	cl_showTimeDelta = Cvar_Get( "cl_showTimeDelta", "0", CVAR_TEMP );
-	cl_activeAction = Cvar_Get( "activeAction", "", CVAR_TEMP );
-	cl_autorecord = Cvar_Get( "cl_autorecord", "0", CVAR_TEMP );
 
 	cl_aviFrameRate = Cvar_Get( "cl_aviFrameRate", "25", 0 );
-
-	// XreaL BEGIN
-	cl_aviMotionJpeg = Cvar_Get( "cl_aviMotionJpeg", "1", 0 );
-	// XreaL END
 
 	cl_maxpackets = Cvar_Get( "cl_maxpackets", "125", 0 );
 	cl_packetdup = Cvar_Get( "cl_packetdup", "1", 0 );
 
-	cl_allowDownload = Cvar_Get( "cl_allowDownload", "1", 0 );
-
 	cl_consoleFontKerning = Cvar_Get( "cl_consoleFontKerning", "0", 0 );
-
-	cl_consoleCommand = Cvar_Get( "cl_consoleCommand", "say", 0 );
 
 	cl_altTab = Cvar_Get( "cl_altTab", "1", 0 );
 
@@ -2331,8 +2319,7 @@ void CL_Init()
 	cl_rate = Cvar_Get( "rate", XSTRING(NETWORK_DEFAULT_RATE), CVAR_USERINFO | CVAR_ARCHIVE);
 
 #if defined(USE_MUMBLE)
-	cl_useMumble = Cvar_Get( "cl_useMumble", "0",  CVAR_LATCH );
-	cl_mumbleScale = Cvar_Get( "cl_mumbleScale", "0.0254", 0 );
+	Cvar::Latch(cl_useMumble);
 #endif
 
 	//

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -67,8 +67,8 @@ Cvar::Cvar<float> cl_mumbleScale("cl_mumbleScale", "multiplier of world coordina
 Cvar::Cvar<bool> cl_nodelta("cl_nodelta", "disable network snapshot delta compression", Cvar::NONE, false);
 
 Cvar::Cvar<float> cl_timeout("cl_timeout", "disconnect after this many seconds without server packets", Cvar::NONE, 200);
-cvar_t *cl_maxpackets;
-cvar_t *cl_packetdup;
+Cvar::Range<Cvar::Cvar<int>> cl_maxpackets("cl_maxpackets", "client->server max packets per second", Cvar::NONE, 125, 15, 125);
+Cvar::Range<Cvar::Cvar<int>> cl_packetdup("cl_packetdup", "send N extra copies of each usercmd_t", Cvar::NONE, 1, 0, 5);
 Cvar::Range<Cvar::Cvar<int>> cl_timeNudge("cl_timeNudge", "ms to extrapolate/interpolate ahead/behind latest snapshots (negative means extrapolate ahead)", Cvar::NONE, 0, -30, 30);
 cvar_t *cl_showTimeDelta;
 
@@ -89,7 +89,7 @@ Cvar::Cvar<std::string> cvar_demo_status_filename(
     ""
 );
 
-cvar_t *cl_aviFrameRate;
+Cvar::Cvar<int> cl_aviFrameRate("cl_aviFrameRate", "demo video framerate", Cvar::NONE, 25);
 
 Cvar::Cvar<bool> cl_freelook("cl_freelook", "vertical mouse movement always controls pitch", Cvar::NONE, true);
 
@@ -121,9 +121,9 @@ Cvar::Cvar<bool> cl_autorecord("cl_autorecord", "record a demo of every game", C
 Cvar::Cvar<bool> cl_allowDownload("cl_allowDownload", "auto-download paks required by the server", Cvar::NONE, true);
 
 Cvar::Cvar<std::string> cl_consoleFont("cl_consoleFont", "path (in homepath) for console typeface", Cvar::NONE, "");
-cvar_t                 *cl_consoleFontSize;
-cvar_t                 *cl_consoleFontScaling;
-cvar_t                 *cl_consoleFontKerning;
+Cvar::Cvar<int> cl_consoleFontSize("cl_consoleFontSize", "console font point size", Cvar::NONE, 16);
+Cvar::Cvar<bool> cl_consoleFontScaling("cl_consoleFontScaling", "rescale console font size by ratio of display size to 1080p", Cvar::NONE, true);
+Cvar::Cvar<float> cl_consoleFontKerning("cl_consoleFontKerning", "px of horizontal padding on console glyphs", Cvar::NONE, 0);
 //see also com_consoleCommand for terminal consoles
 Cvar::Cvar<std::string> cl_consoleCommand("cl_consoleCommand", "command prepended to console lines, when in game", Cvar::NONE, "say");
 
@@ -2098,20 +2098,20 @@ bool CL_InitRenderer()
 	}
 
 	Cvar::Latch(cl_consoleFont);
-	cl_consoleFontSize = Cvar_Get( "cl_consoleFontSize", "16",  CVAR_LATCH );
-	cl_consoleFontScaling = Cvar_Get( "cl_consoleFontScaling", "1", CVAR_LATCH );
+	Cvar::Latch(cl_consoleFontSize);
+	Cvar::Latch(cl_consoleFontScaling);
 
 	// Register console font specified by cl_consoleFont. Empty string means use the embbed Unifont
 
-	int fontSize = cl_consoleFontSize->integer;
+	int fontSize = cl_consoleFontSize.Get();
 
-	if ( cl_consoleFontScaling->integer )
+	if ( cl_consoleFontScaling.Get() )
 	{
 		// This gets 12px on 1920×1080 screen, which is libRocket default for 1em
 		int fontScale = std::min(cls.windowConfig.vidWidth, cls.windowConfig.vidHeight) / 90;
 
 		// fontScale / 12px gets 1px on 1920×1080 screen
-		fontSize = cl_consoleFontSize->integer * fontScale / 12;
+		fontSize = cl_consoleFontSize.Get() * fontScale / 12;
 	}
 
 	if ( !cl_consoleFont.Get().empty() )
@@ -2300,13 +2300,6 @@ void CL_Init()
 	cl_shownet = Cvar_Get( "cl_shownet", "0", CVAR_TEMP );
 	cl_showSend = Cvar_Get( "cl_showSend", "0", CVAR_TEMP );
 	cl_showTimeDelta = Cvar_Get( "cl_showTimeDelta", "0", CVAR_TEMP );
-
-	cl_aviFrameRate = Cvar_Get( "cl_aviFrameRate", "25", 0 );
-
-	cl_maxpackets = Cvar_Get( "cl_maxpackets", "125", 0 );
-	cl_packetdup = Cvar_Get( "cl_packetdup", "1", 0 );
-
-	cl_consoleFontKerning = Cvar_Get( "cl_consoleFontKerning", "0", 0 );
 
 	// userinfo
 	cl_rate = Cvar_Get( "rate", XSTRING(NETWORK_DEFAULT_RATE), CVAR_USERINFO | CVAR_ARCHIVE);

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -66,8 +66,6 @@ Cvar::Cvar<float> cl_mumbleScale("cl_mumbleScale", "multiplier of world coordina
 
 Cvar::Cvar<bool> cl_nodelta("cl_nodelta", "disable network snapshot delta compression", Cvar::NONE, false);
 
-cvar_t *cl_noprint;
-
 Cvar::Cvar<float> cl_timeout("cl_timeout", "disconnect after this many seconds without server packets", Cvar::NONE, 200);
 cvar_t *cl_maxpackets;
 cvar_t *cl_packetdup;
@@ -2298,8 +2296,6 @@ void CL_Init()
 	//
 	// register our variables
 	//
-	cl_noprint = Cvar_Get( "cl_noprint", "0", 0 );
-
 	cl_shownet = Cvar_Get( "cl_shownet", "0", CVAR_TEMP );
 	cl_showSend = Cvar_Get( "cl_showSend", "0", CVAR_TEMP );
 	cl_showTimeDelta = Cvar_Get( "cl_showTimeDelta", "0", CVAR_TEMP );

--- a/src/engine/client/cl_parse.cpp
+++ b/src/engine/client/cl_parse.cpp
@@ -223,7 +223,7 @@ void CL_ParseSnapshot( msg_t *msg )
 		}
 		else
 		{
-			if ( cl_autorecord->integer )
+			if ( cl_autorecord.Get() )
 			{
 				CL_Record("");
 			}
@@ -355,7 +355,7 @@ void CL_SystemInfoChanged()
 	if (!com_sv_running.Get()) {
 		FS::PakPath::ClearPaks();
 		if (!FS_LoadServerPaks(Info_ValueForKey(systemInfo, "sv_paks"), clc.demoplaying)) {
-			if (!cl_allowDownload->integer) {
+			if (!cl_allowDownload.Get()) {
 				Sys::Drop("Client is missing paks but downloads are disabled");
 			} else if (clc.demoplaying) {
 				Sys::Drop("Client is missing paks needed by the demo");

--- a/src/engine/client/cl_scrn.cpp
+++ b/src/engine/client/cl_scrn.cpp
@@ -282,7 +282,7 @@ void SCR_UpdateScreen()
 
 float SCR_ConsoleFontUnicharWidth( int ch )
 {
-	return Glyph( ch )->xSkip + cl_consoleFontKerning->value;
+	return Glyph( ch )->xSkip + cl_consoleFontKerning.Get();
 }
 
 float SCR_ConsoleFontCharWidth( const char *s )
@@ -292,7 +292,7 @@ float SCR_ConsoleFontCharWidth( const char *s )
 
 float SCR_ConsoleFontCharHeight()
 {
-	return cls.consoleFont->glyphBlock[0][(unsigned)'I'].imageHeight + CONSOLE_FONT_VPADDING * cl_consoleFontSize->value;
+	return cls.consoleFont->glyphBlock[0][(unsigned)'I'].imageHeight + CONSOLE_FONT_VPADDING * cl_consoleFontSize.Get();
 }
 
 float SCR_ConsoleFontCharVPadding()

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -369,8 +369,8 @@ extern struct rsa_private_key private_key;
 // cvars
 //
 extern Cvar::Cvar<bool> cl_nodelta;
-extern cvar_t *cl_maxpackets;
-extern cvar_t *cl_packetdup;
+extern Cvar::Range<Cvar::Cvar<int>> cl_maxpackets;
+extern Cvar::Range<Cvar::Cvar<int>> cl_packetdup;
 extern cvar_t *cl_shownet;
 extern cvar_t *cl_showSend;
 extern Cvar::Range<Cvar::Cvar<int>> cl_timeNudge;
@@ -413,15 +413,15 @@ extern Cvar::Cvar<bool> cl_allowDownload;
 // -NERVE - SMF
 
 extern Cvar::Cvar<std::string> cl_consoleFont;
-extern cvar_t *cl_consoleFontSize;
-extern cvar_t *cl_consoleFontScaling;
-extern cvar_t *cl_consoleFontKerning;
+extern Cvar::Cvar<int> cl_consoleFontSize;
+extern Cvar::Cvar<bool> cl_consoleFontScaling;
+extern Cvar::Cvar<float> cl_consoleFontKerning;
 extern Cvar::Cvar<std::string> cl_consoleCommand;
 
 extern Cvar::Range<Cvar::Cvar<int>> con_scrollLock;
 
 // XreaL BEGIN
-extern cvar_t *cl_aviFrameRate;
+extern Cvar::Cvar<int> cl_aviFrameRate;
 extern Cvar::Cvar<bool> cl_aviMotionJpeg;
 // XreaL END
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -411,8 +411,6 @@ extern Cvar::Cvar<bool> cl_autorecord;
 
 extern Cvar::Cvar<bool> cl_allowDownload;
 
-extern cvar_t *cl_altTab;
-
 // -NERVE - SMF
 
 extern Cvar::Cvar<std::string> cl_consoleFont;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -368,13 +368,13 @@ extern struct rsa_private_key private_key;
 //
 // cvars
 //
-extern cvar_t *cl_nodelta;
+extern Cvar::Cvar<bool> cl_nodelta;
 extern cvar_t *cl_noprint;
 extern cvar_t *cl_maxpackets;
 extern cvar_t *cl_packetdup;
 extern cvar_t *cl_shownet;
 extern cvar_t *cl_showSend;
-extern cvar_t *cl_timeNudge;
+extern Cvar::Range<Cvar::Cvar<int>> cl_timeNudge;
 extern cvar_t *cl_showTimeDelta;
 
 extern Cvar::Cvar<float> cl_yawspeed;
@@ -406,31 +406,31 @@ extern Cvar::Range<Cvar::Cvar<int>> j_up_axis;
 
 extern Cvar::Cvar<bool> cvar_demo_timedemo;
 
-extern cvar_t *cl_activeAction;
-extern cvar_t *cl_autorecord;
+extern Cvar::Cvar<std::string> cl_activeAction;
+extern Cvar::Cvar<bool> cl_autorecord;
 
-extern cvar_t *cl_allowDownload;
+extern Cvar::Cvar<bool> cl_allowDownload;
 
 extern cvar_t *cl_altTab;
 
 // -NERVE - SMF
 
-extern cvar_t *cl_consoleFont;
+extern Cvar::Cvar<std::string> cl_consoleFont;
 extern cvar_t *cl_consoleFontSize;
 extern cvar_t *cl_consoleFontScaling;
 extern cvar_t *cl_consoleFontKerning;
-extern cvar_t *cl_consoleCommand;
+extern Cvar::Cvar<std::string> cl_consoleCommand;
 
 extern Cvar::Range<Cvar::Cvar<int>> con_scrollLock;
 
 // XreaL BEGIN
 extern cvar_t *cl_aviFrameRate;
-extern cvar_t *cl_aviMotionJpeg;
+extern Cvar::Cvar<bool> cl_aviMotionJpeg;
 // XreaL END
 
 #if defined(USE_MUMBLE)
-extern cvar_t *cl_useMumble;
-extern cvar_t *cl_mumbleScale;
+extern Cvar::Range<Cvar::Cvar<int>> cl_useMumble;
+extern Cvar::Cvar<float> cl_mumbleScale;
 #endif
 
 //=================================================

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -369,7 +369,6 @@ extern struct rsa_private_key private_key;
 // cvars
 //
 extern Cvar::Cvar<bool> cl_nodelta;
-extern cvar_t *cl_noprint;
 extern cvar_t *cl_maxpackets;
 extern cvar_t *cl_packetdup;
 extern cvar_t *cl_shownet;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -667,7 +667,7 @@ bool CL_OpenAVIForWriting( const char *filename );
 void     CL_TakeVideoFrame();
 void     CL_WriteAVIVideoFrame( const byte *imageBuffer, int size );
 bool CL_CloseAVI();
-bool CL_VideoRecording();
+int CL_VideoRecording();
 
 // XreaL END
 


### PR DESCRIPTION
Migrate the majority of `cl_` cvars to new-style cvars.

Other notable changes:
- Remove redundant attempt to detect alt-tab
- Make `cl_noprint` more useful: make it possible to disable only the in-game logging that goes over the 3d rendering without also disabling logging in the console.