### PR TITLE
Netcode cleanup and improved verbosity

### DIFF
--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -181,7 +181,7 @@ void MSG_WriteBits( msg_t *msg, int value, int bits )
 
 			*ip = LittleLong( value );
 			msg->cursize += 4;
-			msg->bit += 8;
+			msg->bit += 32;
 		}
 		else
 		{

--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -301,20 +301,6 @@ int MSG_ReadBits( msg_t *msg, int bits )
 // writing functions
 //
 
-void MSG_WriteChar( msg_t *sb, int c )
-{
-#ifdef PARANOID
-
-	if ( c < -128 || c > 127 )
-	{
-		Sys::Error( "MSG_WriteChar: range error" );
-	}
-
-#endif
-
-	MSG_WriteBits( sb, c, 8 );
-}
-
 void MSG_WriteByte( msg_t *sb, int c )
 {
 #ifdef PARANOID
@@ -356,18 +342,6 @@ void MSG_WriteShort( msg_t *sb, int c )
 void MSG_WriteLong( msg_t *sb, int c )
 {
 	MSG_WriteBits( sb, c, 32 );
-}
-
-void MSG_WriteFloat( msg_t *sb, float f )
-{
-	union
-	{
-		float f;
-		int   l;
-	} dat;
-
-	dat.f = f;
-	MSG_WriteBits( sb, dat.l, 32 );
 }
 
 void MSG_WriteString( msg_t *sb, const char *s )
@@ -468,25 +442,6 @@ int MSG_ReadLong( msg_t *msg )
 	}
 
 	return c;
-}
-
-float MSG_ReadFloat( msg_t *msg )
-{
-	union
-	{
-		byte  b[ 4 ];
-		float f;
-		int   l;
-	} dat;
-
-	dat.l = MSG_ReadBits( msg, 32 );
-
-	if ( msg->readcount > msg->cursize )
-	{
-		dat.f = -1;
-	}
-
-	return dat.f;
 }
 
 char           *MSG_ReadString( msg_t *msg )
@@ -609,31 +564,6 @@ int MSG_ReadDelta( msg_t *msg, int oldV, int bits )
 	if ( MSG_ReadBits( msg, 1 ) )
 	{
 		return MSG_ReadBits( msg, bits );
-	}
-
-	return oldV;
-}
-
-void MSG_WriteDeltaFloat( msg_t *msg, float oldV, float newV )
-{
-	if ( oldV == newV )
-	{
-		MSG_WriteBits( msg, 0, 1 );
-		return;
-	}
-
-	MSG_WriteBits( msg, 1, 1 );
-	MSG_WriteBits( msg, * ( int * ) &newV, 32 );
-}
-
-float MSG_ReadDeltaFloat( msg_t *msg, float oldV )
-{
-	if ( MSG_ReadBits( msg, 1 ) )
-	{
-		float newV;
-
-		* ( int * ) &newV = MSG_ReadBits( msg, 32 );
-		return newV;
 	}
 
 	return oldV;
@@ -964,8 +894,6 @@ void MSG_WriteDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to, b
 
 	MSG_WriteByte( msg, lc );  // # of changes
 
-//  Log::Notice( "Delta for ent %i: ", to->number );
-
 	for ( i = 0, field = entityStateFields; i < lc; i++, field++ )
 	{
 		fromF = ( int * )( ( byte * ) from + field->offset );
@@ -998,18 +926,12 @@ void MSG_WriteDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to, b
 					// send as small integer
 					MSG_WriteBits( msg, 0, 1 );
 					MSG_WriteBits( msg, trunc + FLOAT_INT_BIAS, FLOAT_INT_BITS );
-//                  if ( print ) {
-//                      Log::Notice( "%s:%i ", field->name, trunc );
-//                  }
 				}
 				else
 				{
 					// send as full floating point value
 					MSG_WriteBits( msg, 1, 1 );
 					MSG_WriteBits( msg, *toF, 32 );
-//                  if ( print ) {
-//                      Log::Notice( "%s:%f ", field->name, *(float *)toF );
-//                  }
 				}
 			}
 		}
@@ -1024,27 +946,9 @@ void MSG_WriteDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to, b
 				MSG_WriteBits( msg, 1, 1 );
 				// integer
 				MSG_WriteBits( msg, *toF, field->bits );
-//              if ( print ) {
-//                  Log::Notice( "%s:%i ", field->name, *toF );
-//              }
 			}
 		}
 	}
-
-//  Log::Notice( "" );
-
-	/*
-	        c = msg->cursize - c;
-
-	        if ( print ) {
-	                if ( msg->bit == 0 ) {
-	                        endBit = msg->cursize * 8 - GENTITYNUM_BITS;
-	                } else {
-	                        endBit = ( msg->cursize - 1 ) * 8 + msg->bit - GENTITYNUM_BITS;
-	                }
-	                Log::Notice( " (%i bits)", endBit - startBit  );
-	        }
-	*/
 }
 
 /*

--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -825,7 +825,7 @@ If force is not set, then nothing at all will be generated if the entity is
 identical, under the assumption that the in-order delta code will catch it.
 ==================
 */
-void MSG_WriteDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to, bool force )
+void MSG_WriteDeltaEntity( msg_t *msg, const entityState_t *from, const entityState_t *to, bool force )
 {
 	int        i, lc;
 	netField_t *field;
@@ -1232,7 +1232,7 @@ static void WriteStatsGroup(msg_t* msg, const int* from, const int* to)
 	MSG_WriteBits( msg, 1, 1 );  // changed
 	MSG_WriteUShort( msg, statsbits );
 
-	for ( int i = 0; i < MAX_STATS; i++ )
+	for ( int i = 0; i < STATS_GROUP_NUM_STATS; i++ )
 	{
 		if ( statsbits & ( 1 << i ) )
 		{

--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -190,9 +190,6 @@ void MSG_WriteBits( msg_t *msg, int value, int bits )
 	}
 	else
 	{
-		value &= ( 0xffffffff >> ( 32 - bits ) );
-
-		if ( bits & 7 )
 		{
 			int nbits;
 
@@ -207,13 +204,10 @@ void MSG_WriteBits( msg_t *msg, int value, int bits )
 			bits = bits - nbits;
 		}
 
-		if ( bits )
+		for ( i = 0; i < bits; i += 8 )
 		{
-			for ( i = 0; i < bits; i += 8 )
-			{
-				Huff_offsetTransmit( &msgHuff.compressor, ( value & 0xff ), msg->data, &msg->bit );
-				value = ( value >> 8 );
-			}
+			Huff_offsetTransmit( &msgHuff.compressor, ( value & 0xff ), msg->data, &msg->bit );
+			value = ( value >> 8 );
 		}
 
 		msg->cursize = ( msg->bit >> 3 ) + 1;
@@ -359,10 +353,7 @@ void MSG_WriteString( msg_t *sb, const char *s )
 	}
 	else
 	{
-		int  l;
-		char string[ MAX_STRING_CHARS ];
-
-		l = strlen( s );
+		size_t l = strlen( s );
 
 		if ( l >= MAX_STRING_CHARS )
 		{
@@ -371,9 +362,7 @@ void MSG_WriteString( msg_t *sb, const char *s )
 			return;
 		}
 
-		Q_strncpyz( string, s, sizeof( string ) );
-
-		MSG_WriteData( sb, string, l + 1 );
+		MSG_WriteData( sb, s, l + 1 );
 	}
 }
 
@@ -385,10 +374,7 @@ void MSG_WriteBigString( msg_t *sb, const char *s )
 	}
 	else
 	{
-		int  l;
-		char string[ BIG_INFO_STRING ];
-
-		l = strlen( s );
+		size_t l = strlen( s );
 
 		if ( l >= BIG_INFO_STRING )
 		{
@@ -397,9 +383,7 @@ void MSG_WriteBigString( msg_t *sb, const char *s )
 			return;
 		}
 
-		Q_strncpyz( string, s, sizeof( string ) );
-
-		MSG_WriteData( sb, string, l + 1 );
+		MSG_WriteData( sb, s, l + 1 );
 	}
 }
 

--- a/src/engine/qcommon/msg.cpp
+++ b/src/engine/qcommon/msg.cpp
@@ -301,16 +301,14 @@ int MSG_ReadBits( msg_t *msg, int bits )
 // writing functions
 //
 
+// uint8_t
 void MSG_WriteByte( msg_t *sb, int c )
 {
-#ifdef PARANOID
-
 	if ( c < 0 || c > 255 )
 	{
-		Sys::Error( "MSG_WriteByte: range error" );
+		Log::Warn( "MSG_WriteByte: value %d out of range", c );
 	}
 
-#endif
 
 	MSG_WriteBits( sb, c, 8 );
 }
@@ -325,20 +323,29 @@ void MSG_WriteData( msg_t *buf, const void *data, int length )
 	}
 }
 
+// int16_t
 void MSG_WriteShort( msg_t *sb, int c )
 {
-#ifdef PARANOID
-
-	if ( c < ( ( short ) 0x8000 ) || c > ( short ) 0x7fff )
+	if ( c < -0x8000 || c >= 0x8000 )
 	{
-		Sys::Error( "MSG_WriteShort: range error" );
+		Log::Warn( "MSG_WriteShort: value %d out of range", c );
 	}
 
-#endif
+	MSG_WriteBits( sb, c, -16 );
+}
+
+// uint16_t
+void MSG_WriteUShort( msg_t *sb, int c )
+{
+	if ( c & ~0xFFFF )
+	{
+		Log::Warn( "MSG_WriteUShort: value %d out of range", c );
+	}
 
 	MSG_WriteBits( sb, c, 16 );
 }
 
+// int32_t
 void MSG_WriteLong( msg_t *sb, int c )
 {
 	MSG_WriteBits( sb, c, 32 );
@@ -359,7 +366,7 @@ void MSG_WriteString( msg_t *sb, const char *s )
 
 		if ( l >= MAX_STRING_CHARS )
 		{
-			Log::Notice( "MSG_WriteString: MAX_STRING_CHARS exceeded" );
+			Log::Warn( "MSG_WriteString: MAX_STRING_CHARS exceeded" );
 			MSG_WriteData( sb, "", 1 );
 			return;
 		}
@@ -385,7 +392,7 @@ void MSG_WriteBigString( msg_t *sb, const char *s )
 
 		if ( l >= BIG_INFO_STRING )
 		{
-			Log::Notice( "MSG_WriteBigString: BIG_INFO_STRING exceeded" );
+			Log::Warn( "MSG_WriteBigString: BIG_INFO_STRING exceeded" );
 			MSG_WriteData( sb, "", 1 );
 			return;
 		}
@@ -402,11 +409,10 @@ void MSG_WriteBigString( msg_t *sb, const char *s )
 // reading functions
 //
 
+// uint8_t
 int MSG_ReadByte( msg_t *msg )
 {
-	int c;
-
-	c = ( unsigned char ) MSG_ReadBits( msg, 8 );
+	int c = MSG_ReadBits( msg, 8 );
 
 	if ( msg->readcount > msg->cursize )
 	{
@@ -416,11 +422,12 @@ int MSG_ReadByte( msg_t *msg )
 	return c;
 }
 
+// int16_t
 int MSG_ReadShort( msg_t *msg )
 {
 	int c;
 
-	c = ( short ) MSG_ReadBits( msg, 16 );
+	c = MSG_ReadBits( msg, -16 );
 
 	if ( msg->readcount > msg->cursize )
 	{
@@ -430,6 +437,22 @@ int MSG_ReadShort( msg_t *msg )
 	return c;
 }
 
+// uint16_t
+int MSG_ReadUShort( msg_t *msg )
+{
+	int c;
+
+	c = MSG_ReadBits( msg, 16 );
+
+	if ( msg->readcount > msg->cursize )
+	{
+		c = -1;
+	}
+
+	return c;
+}
+
+// int32_t
 int MSG_ReadLong( msg_t *msg )
 {
 	int c;
@@ -589,7 +612,7 @@ void MSG_WriteDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to )
 	if ( to->serverTime - from->serverTime < 256 )
 	{
 		MSG_WriteBits( msg, 1, 1 );
-		MSG_WriteBits( msg, to->serverTime - from->serverTime, 8 );
+		MSG_WriteByte( msg, to->serverTime - from->serverTime );
 	}
 	else
 	{
@@ -639,7 +662,7 @@ void MSG_ReadDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to )
 
 	if ( MSG_ReadBits( msg, 1 ) )
 	{
-		to->serverTime = from->serverTime + MSG_ReadBits( msg, 8 );
+		to->serverTime = from->serverTime + MSG_ReadByte( msg );
 	}
 	else
 	{
@@ -1223,13 +1246,13 @@ static void WriteStatsGroup(msg_t* msg, const int* from, const int* to)
 	}
 
 	MSG_WriteBits( msg, 1, 1 );  // changed
-	MSG_WriteShort( msg, statsbits );
+	MSG_WriteUShort( msg, statsbits );
 
 	for ( int i = 0; i < MAX_STATS; i++ )
 	{
 		if ( statsbits & ( 1 << i ) )
 		{
-			MSG_WriteShort( msg, to[i] );  //----(SA)    back to short since weapon bits are handled elsewhere now
+			MSG_WriteBits( msg, to[i], -16 );
 		}
 	}
 }
@@ -1375,13 +1398,13 @@ void MSG_WriteDeltaPlayerstate(
 static void ReadStatsGroup(msg_t* msg, int* to, const netField_t& field)
 {
 	LOG( field.name );
-	int bits = MSG_ReadShort( msg );
+	int bits = MSG_ReadUShort( msg );
 
 	for ( int i = 0; i < STATS_GROUP_NUM_STATS; i++ )
 	{
 		if ( bits & ( 1 << i ) )
 		{
-			to[i] = MSG_ReadShort( msg );  //----(SA)    back to short since weapon bits are handled elsewhere now
+			to[i] = MSG_ReadBits( msg, -16 );
 		}
 	}
 }

--- a/src/engine/qcommon/net_chan.cpp
+++ b/src/engine/qcommon/net_chan.cpp
@@ -134,7 +134,7 @@ void Netchan_TransmitNextFragment( netchan_t *chan )
 	// send the qport if we are a client
 	if ( chan->sock == netsrc_t::NS_CLIENT )
 	{
-		MSG_WriteShort( &send, qport.Get() );
+		MSG_WriteUShort( &send, qport.Get() );
 	}
 
 	// copy the reliable message to the packet first
@@ -216,7 +216,7 @@ void Netchan_Transmit( netchan_t *chan, int length, const byte *data )
 	// send the qport if we are a client
 	if ( chan->sock == netsrc_t::NS_CLIENT )
 	{
-		MSG_WriteShort( &send, qport.Get() );
+		MSG_WriteUShort( &send, qport.Get() );
 	}
 
 	MSG_WriteData( &send, data, length );
@@ -271,7 +271,7 @@ bool Netchan_Process( netchan_t *chan, msg_t *msg )
 	// read the qport if we are a server
 	if ( chan->sock == netsrc_t::NS_SERVER )
 	{
-		/*qport = */ MSG_ReadShort( msg );
+		/*qport = */ MSG_ReadUShort( msg );
 	}
 
 	// read the fragment information

--- a/src/engine/qcommon/q_shared.h
+++ b/src/engine/qcommon/q_shared.h
@@ -1893,12 +1893,13 @@ inline vec_t VectorNormalize2( const vec3_t v, vec3_t out )
 using GameStateCSs = std::array<std::string, MAX_CONFIGSTRINGS>;
 
 // bit field limits
-#define MAX_STATS              16
-#define MAX_PERSISTANT         16
-#define MAX_MISC               16
 
+#define MAX_PERSISTANT         16
 #define MAX_EVENTS             4 // max events per frame before we drop events
 
+// TODO: remove these 3 which are not engine-relevant
+#define MAX_STATS              16
+#define MAX_MISC               16
 #define PS_PMOVEFRAMECOUNTBITS 6
 
 struct netField_t

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -91,7 +91,7 @@ void  MSG_ReadData( msg_t *sb, void *buffer, int size );
 void  MSG_WriteDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to );
 void  MSG_ReadDeltaUsercmd( msg_t *msg, usercmd_t *from, usercmd_t *to );
 
-void  MSG_WriteDeltaEntity( msg_t *msg, entityState_t *from, entityState_t *to, bool force );
+void  MSG_WriteDeltaEntity( msg_t *msg, const entityState_t *from, const entityState_t *to, bool force );
 void  MSG_ReadDeltaEntity( msg_t *msg, const entityState_t *from, entityState_t *to, int number );
 
 void MSG_InitNetcodeTables(NetcodeTable playerStateTable, int playerStateSize);

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -66,11 +66,9 @@ struct entityState_t;
 
 void  MSG_WriteBits( msg_t *msg, int value, int bits );
 
-void  MSG_WriteChar( msg_t *sb, int c );
 void  MSG_WriteByte( msg_t *sb, int c );
 void  MSG_WriteShort( msg_t *sb, int c );
 void  MSG_WriteLong( msg_t *sb, int c );
-void  MSG_WriteFloat( msg_t *sb, float f );
 void  MSG_WriteString( msg_t *sb, const char *s );
 void  MSG_WriteBigString( msg_t *sb, const char *s );
 
@@ -83,7 +81,6 @@ int   MSG_ReadBits( msg_t *msg, int bits );
 int   MSG_ReadByte( msg_t *sb );
 int   MSG_ReadShort( msg_t *sb );
 int   MSG_ReadLong( msg_t *sb );
-float MSG_ReadFloat( msg_t *sb );
 char  *MSG_ReadString( msg_t *sb );
 char  *MSG_ReadBigString( msg_t *sb );
 char  *MSG_ReadStringLine( msg_t *sb );

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -68,6 +68,7 @@ void  MSG_WriteBits( msg_t *msg, int value, int bits );
 
 void  MSG_WriteByte( msg_t *sb, int c );
 void  MSG_WriteShort( msg_t *sb, int c );
+void  MSG_WriteUShort( msg_t *sb, int c );
 void  MSG_WriteLong( msg_t *sb, int c );
 void  MSG_WriteString( msg_t *sb, const char *s );
 void  MSG_WriteBigString( msg_t *sb, const char *s );
@@ -80,6 +81,7 @@ int   MSG_ReadBits( msg_t *msg, int bits );
 
 int   MSG_ReadByte( msg_t *sb );
 int   MSG_ReadShort( msg_t *sb );
+int   MSG_ReadUShort( msg_t *sb );
 int   MSG_ReadLong( msg_t *sb );
 char  *MSG_ReadString( msg_t *sb );
 char  *MSG_ReadBigString( msg_t *sb );


### PR DESCRIPTION
Clean up unused functions and simplify some implementations of netcode functions. Print a warning when passing an out-of-range value to `MSG_WriteByte` or `MSG_WriteShort`/

My ultimate goal is to enable warnings whenever a `playerState_t` or `entityState_t` field is outside of the range specified in the netcode table. I have an implementation, but it's not ready to merge yet since Unvanquished has various fields that trigger warnings. For example there are flags fields where 16 bits are transmitted, but additional upper bits are also used for sgame-only flags.