### PR TITLE
Filesystem cleanup; avoid throwing non-serious exceptions

### DIFF
--- a/src/engine/RefAPI.h
+++ b/src/engine/RefAPI.h
@@ -206,9 +206,6 @@ struct refimport_t {
 	// a -1 return means the file does not exist
 	// nullptr can be passed for buf to just determine existence
 	int ( *FS_ReadFile )( const char* name, void** buf );
-	void ( *FS_FreeFile )( void* buf );
-	char** ( *FS_ListFiles )( const char* name, const char* extension, int* numfilesfound );
-	void ( *FS_FreeFileList )( char** filelist );
 	void ( *FS_WriteFile )( const char* qpath, const void* buffer, int size );
 	int ( *FS_Seek )( fileHandle_t f, long offset, fsOrigin_t origin );
 	int ( *FS_FTell )( fileHandle_t f );

--- a/src/engine/client/cl_main.cpp
+++ b/src/engine/client/cl_main.cpp
@@ -2216,10 +2216,7 @@ static bool CL_InitRef()
 	ri.Hunk_FreeTempMemory = Hunk_FreeTempMemory;
 
 	ri.FS_ReadFile = FS_ReadFile;
-	ri.FS_FreeFile = FS_FreeFile;
 	ri.FS_WriteFile = FS_WriteFile;
-	ri.FS_FreeFileList = FS_FreeFileList;
-	ri.FS_ListFiles = FS_ListFiles;
 	ri.FS_Seek = FS_Seek;
 	ri.FS_FTell = FS_FTell;
 	ri.FS_Read = FS_Read;

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -479,58 +479,6 @@ int FS_ReadFile(const char* path, void** buffer)
 	return length;
 }
 
-void FS_FreeFile(void* buffer)
-{
-	char* buf = static_cast<char*>(buffer);
-	delete[] buf;
-}
-
-char** FS_ListFiles(const char* directory, const char* extension, int* numFiles)
-{
-	std::vector<char*> files;
-	bool dirsOnly = extension && !strcmp(extension, "/");
-
-	try {
-		for (const std::string& x: FS::PakPath::ListFiles(directory)) {
-			if (extension && !Str::IsSuffix(extension, x))
-				continue;
-			if (dirsOnly != (x.back() == '/'))
-				continue;
-			char* s = new char[x.size() + 1];
-			memcpy(s, x.data(), x.size());
-			s[x.size() - (x.back() == '/')] = '\0';
-			files.push_back(s);
-		}
-	} catch (std::system_error&) {}
-	try {
-		for (const std::string& x: FS::HomePath::ListFiles(directory)) {
-			if (extension && !Str::IsSuffix(extension, x))
-				continue;
-			if (dirsOnly != (x.back() == '/'))
-				continue;
-			char* s = new char[x.size() + 1];
-			memcpy(s, x.data(), x.size());
-			s[x.size() - (x.back() == '/')] = '\0';
-			files.push_back(s);
-		}
-	} catch (std::system_error&) {}
-
-	*numFiles = files.size();
-	char** list = new char*[files.size() + 1];
-	std::copy(files.begin(), files.end(), list);
-	list[files.size()] = nullptr;
-	return list;
-}
-
-void FS_FreeFileList(char** list)
-{
-	if (!list)
-		return;
-	for (char** i = list; *i; i++)
-		delete[] *i;
-	delete[] list;
-}
-
 int FS_GetFileList(const char* path, const char* extension, char* listBuf, int bufSize)
 {
 	// Mods are not yet supported in the new filesystem

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -503,22 +503,21 @@ int FS_GetFileList(const char* path, const char* extension, char* listBuf, int b
 		numFiles++;
 	}
 
-	try {
-		for (const std::string& x: FS::HomePath::ListFiles(FS::Path::Build("game", path))) {
-			if (extension && !Str::IsSuffix(extension, x))
-				continue;
-			if (dirsOnly != (x.back() == '/'))
-				continue;
-			int length = x.size() + (x.back() != '/');
-			if (bufSize < length)
-				return numFiles;
-			memcpy(listBuf, x.c_str(), length);
-			listBuf[length - 1] = '\0';
-			listBuf += length;
-			bufSize -= length;
-			numFiles++;
-		}
-	} catch (std::system_error&) {}
+	std::error_code ignored;
+	for (const std::string& x: FS::HomePath::ListFiles(FS::Path::Build("game", path), ignored)) {
+		if (extension && !Str::IsSuffix(extension, x))
+			continue;
+		if (dirsOnly != (x.back() == '/'))
+			continue;
+		int length = x.size() + (x.back() != '/');
+		if (bufSize < length)
+			return numFiles;
+		memcpy(listBuf, x.c_str(), length);
+		listBuf[length - 1] = '\0';
+		listBuf += length;
+		bufSize -= length;
+		numFiles++;
+	}
 
 	return numFiles;
 }

--- a/src/engine/qcommon/files.cpp
+++ b/src/engine/qcommon/files.cpp
@@ -540,22 +540,21 @@ int FS_GetFileList(const char* path, const char* extension, char* listBuf, int b
 	int numFiles = 0;
 	bool dirsOnly = extension && !strcmp(extension, "/");
 
-	try {
-		for (const std::string& x: FS::PakPath::ListFiles(path)) {
-			if (extension && !Str::IsSuffix(extension, x))
-				continue;
-			if (dirsOnly != (x.back() == '/'))
-				continue;
-			int length = x.size() + (x.back() != '/');
-			if (bufSize < length)
-				return numFiles;
-			memcpy(listBuf, x.c_str(), length);
-			listBuf[length - 1] = '\0';
-			listBuf += length;
-			bufSize -= length;
-			numFiles++;
-		}
-	} catch (std::system_error&) {}
+	for (const std::string& x: FS::PakPath::ListFiles(path)) {
+		if (extension && !Str::IsSuffix(extension, x))
+			continue;
+		if (dirsOnly != (x.back() == '/'))
+			continue;
+		int length = x.size() + (x.back() != '/');
+		if (bufSize < length)
+			return numFiles;
+		memcpy(listBuf, x.c_str(), length);
+		listBuf[length - 1] = '\0';
+		listBuf += length;
+		bufSize -= length;
+		numFiles++;
+	}
+
 	try {
 		for (const std::string& x: FS::HomePath::ListFiles(FS::Path::Build("game", path))) {
 			if (extension && !Str::IsSuffix(extension, x))

--- a/src/engine/qcommon/qcommon.h
+++ b/src/engine/qcommon/qcommon.h
@@ -343,13 +343,9 @@ issues.
 ==============================================================
 */
 
-char **FS_ListFiles( const char *directory, const char *extension, int *numfiles );
-
 // directory should not have either a leading or trailing /
 // if extension is "/", only subdirectories will be returned
 // the returned files will not include any directories or /
-
-void         FS_FreeFileList( char **list );
 
 int          FS_GetFileList( const char *path, const char *extension, char *listbuf, int bufsize );
 int          FS_GetFileListRecursive( const char* path, const char* extension, char* listBuf, int bufSize );
@@ -394,10 +390,6 @@ int  FS_ReadFile( const char *qpath, void **buffer );
 void FS_ForceFlush( fileHandle_t f );
 
 // forces flush on files we're writing to.
-
-void FS_FreeFile( void *buffer );
-
-// frees the memory returned by FS_ReadFile
 
 void FS_WriteFile( const char *qpath, const void *buffer, int size );
 


### PR DESCRIPTION
A bit of filesystem cleanup. Most importantly, this avoids the throwing of exceptions for things that aren't serious errors. So now you can configure your debugger to break on all exceptions and get only relevant stuff.