### PR TITLE
Correctly set glConfig.reflectionMappingAvailable

### DIFF
--- a/src/engine/renderer/tr_init.cpp
+++ b/src/engine/renderer/tr_init.cpp
@@ -1439,30 +1439,6 @@ ScreenshotCmd screenshotPNGRegistration("screenshotPNG", ssFormat_t::SSF_PNG, "p
 			tr.lightMode = lightMode_t::VERTEX;
 		}
 
-		if ( r_reflectionMapping.Get() ) {
-			glConfig.reflectionMappingAvailable = true;
-
-			if ( !r_normalMapping->integer ) {
-				glConfig.reflectionMappingAvailable = false;
-				Log::Warn( "Unable to use static reflections without normal mapping, make sure you enable r_normalMapping" );
-			}
-
-			if ( !r_deluxeMapping->integer ) {
-				glConfig.reflectionMappingAvailable = false;
-				Log::Warn( "Unable to use static reflections without deluxe mapping, make sure you enable r_deluxeMapping" );
-			}
-
-			if ( !r_specularMapping->integer ) {
-				glConfig.reflectionMappingAvailable = false;
-				Log::Warn( "Unable to use static reflections without specular mapping, make sure you enable r_specularMapping" );
-			}
-
-			if ( r_physicalMapping->integer ) {
-				glConfig.reflectionMappingAvailable = false;
-				Log::Warn( "Unable to use static reflections with physical mapping, make sure you disable r_physicalMapping" );
-			}
-		}
-
 		backEndData[ 0 ] = ( backEndData_t * ) ri.Hunk_Alloc( sizeof( *backEndData[ 0 ] ), ha_pref::h_low );
 		backEndData[ 0 ]->polys = ( srfPoly_t * ) ri.Hunk_Alloc( r_maxPolys->integer * sizeof( srfPoly_t ), ha_pref::h_low );
 		backEndData[ 0 ]->polyVerts = ( polyVert_t * ) ri.Hunk_Alloc( r_maxPolyVerts->integer * sizeof( polyVert_t ), ha_pref::h_low );

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2812,6 +2812,30 @@ static void GLimp_EnableAvailableFeatures()
 	// This will be enabled later on by R_BuildCubeMaps()
 	glConfig.reflectionMapping = false;
 
+	glConfig.reflectionMappingAvailable = r_reflectionMapping.Get();
+	if ( glConfig.reflectionMappingAvailable )
+	{
+		if ( !r_normalMapping->integer ) {
+			glConfig.reflectionMappingAvailable = false;
+			Log::Warn( "Unable to use static reflections without normal mapping, make sure you enable r_normalMapping" );
+		}
+
+		if ( !r_deluxeMapping->integer ) {
+			glConfig.reflectionMappingAvailable = false;
+			Log::Warn( "Unable to use static reflections without deluxe mapping, make sure you enable r_deluxeMapping" );
+		}
+
+		if ( !r_specularMapping->integer ) {
+			glConfig.reflectionMappingAvailable = false;
+			Log::Warn( "Unable to use static reflections without specular mapping, make sure you enable r_specularMapping" );
+		}
+
+		if ( r_physicalMapping->integer ) {
+			glConfig.reflectionMappingAvailable = false;
+			Log::Warn( "Unable to use static reflections with physical mapping, make sure you disable r_physicalMapping" );
+		}
+	}
+
 	/* Intel GMA 3 only has 4 tex indirections, which is not enough for some shaders.
 	For example blurX requires 6, contrast requires 5, motionblur requires 5…
 	For comparison, ATI R300, R400 and R500 have 16 of them. We don't need a finer check as early R300

--- a/src/engine/sys/sdl_glimp.cpp
+++ b/src/engine/sys/sdl_glimp.cpp
@@ -2816,24 +2816,26 @@ static void GLimp_EnableAvailableFeatures()
 	if ( glConfig.reflectionMappingAvailable )
 	{
 		if ( !r_normalMapping->integer ) {
-			glConfig.reflectionMappingAvailable = false;
 			Log::Warn( "Unable to use static reflections without normal mapping, make sure you enable r_normalMapping" );
 		}
 
 		if ( !r_deluxeMapping->integer ) {
-			glConfig.reflectionMappingAvailable = false;
 			Log::Warn( "Unable to use static reflections without deluxe mapping, make sure you enable r_deluxeMapping" );
 		}
 
 		if ( !r_specularMapping->integer ) {
-			glConfig.reflectionMappingAvailable = false;
 			Log::Warn( "Unable to use static reflections without specular mapping, make sure you enable r_specularMapping" );
 		}
 
 		if ( r_physicalMapping->integer ) {
-			glConfig.reflectionMappingAvailable = false;
 			Log::Warn( "Unable to use static reflections with physical mapping, make sure you disable r_physicalMapping" );
 		}
+
+		glConfig.reflectionMappingAvailable =
+			glConfig.normalMapping &&
+			glConfig.deluxeMapping &&
+			glConfig.specularMapping &&
+			!glConfig.physicalMapping;
 	}
 
 	/* Intel GMA 3 only has 4 tex indirections, which is not enough for some shaders.


### PR DESCRIPTION
Fixes a crash with `r_showCubeProbes`.