### PR TITLE
Refactor Yokai system and architecture detection, detect architecture cross-compilation, extend architecture detection

### DIFF
--- a/cmake/Yokai/Architecture.cmake
+++ b/cmake/Yokai/Architecture.cmake
@@ -34,6 +34,89 @@
 option(USE_ARCH_INTRINSICS "Enable custom code using intrinsics functions or asm declarations" ON)
 mark_as_advanced(USE_ARCH_INTRINSICS)
 
+function(yokai_detect_host_arch)
+	set(arch_name "unknown")
+
+	string(TOLOWER "${CMAKE_HOST_SYSTEM_PROCESSOR}" processor_lower)
+
+	foreach(name
+		"amd64"
+		"arm"
+		"arm64"
+		"i686"
+		"mipsel"
+		"ppc64"
+		"riscv64"
+	)
+		if ("${processor_lower}" STREQUAL "${name}")
+			set(arch_name "${processor_lower}")
+		endif()
+	endforeach()
+
+	if ("${arch_name}" STREQUAL "unknown")
+		set(ARCHES_amd64 "em64t" "x86_64")
+		set(ARCHES_arm "armv6l" "armv7l")
+		set(ARCHES_arm64 "armv8l" "aarch64")
+		set(ARCHES_loong64 "loongarch64")
+		set(ARCHES_ppc64el "ppc64le")
+
+		foreach(name
+			"amd64"
+			"arm"
+			"arm64"
+			"loong64"
+			"ppc64el"
+		)
+			if ("${processor_lower}" IN_LIST ARCHES_${name})
+				set(arch_name "${name}")
+			endif()
+		endforeach()
+	endif()
+
+	if ("${arch_name}" STREQUAL "unknown")
+		if ("${processor_lower}")
+			message(WARNING "Undocumented host architecture: ${processor_lower}")
+		else()
+			message(WARNING "Undocumented host architecture")
+		endif()
+
+		set(arch_name "${processor_lower}")
+	endif()
+
+	string(TOUPPER "${arch_name}" arch_name_upper)
+
+	set(YOKAI_HOST_ARCH_NAME "${arch_name}" PARENT_SCOPE)
+	set(YOKAI_HOST_ARCH_NAME_UPPER "${arch_name_upper}" PARENT_SCOPE)
+
+	# Makes possible to do that in CMake code:
+	# > if (YOKAI_HOST_ARCH_AMD64)
+	set("YOKAI_HOST_ARCH_${arch_name_upper}" ON PARENT_SCOPE)
+
+	if ("${arch_name}" STREQUAL "unknown")
+		message(WARNING "Unknown host architecture: ${processor_lower}")
+
+		set(arch_name "${processor_lower}")
+	endif()
+
+	set(arm_CHILD
+		"armel"
+		"armhf"
+	)
+
+	foreach(name
+		"arm"
+	)
+		if ("${arch_name}" STREQUAL "${name}")
+			message(STATUS "Parent architecture: ${name}, can be ${${name}_CHILD}")
+
+			foreach(child_name ${${name}_CHILD})
+				string(TOUPPER "${child_name}" child_name_upper)
+				set(YOKAI_HOST_ARCH_${child_name_upper}_PARENT ON PARENT_SCOPE)
+			endforeach()
+		endif()
+	endforeach()
+endfunction()
+
 function(yokai_detect_target_arch)
 	yokai_run_detection("TARGET" "ARCH" "Architecture.c" "")
 
@@ -75,7 +158,24 @@ function(yokai_set_intrinsics)
 	endif()
 endfunction()
 
+yokai_detect_host_arch()
 yokai_detect_target_arch()
+
+if (YOKAI_HOST_ARCH_UNKNOWN AND NOT YOKAI_TARGET_ARCH_UNKNOWN)
+	message(WARNING "Assuming the host architecture is the same as the target: ${YOKAI_TARGET_ARCH_NAME}")
+	set(YOKAI_HOST_ARCH_NAME "${YOKAI_TARGET_ARCH_NAME}")
+	set(YOKAI_HOST_ARCH_NAME_UPPER "${YOKAI_TARGET_ARCH_NAME_UPPER}")
+	set(YOKAI_HOST_ARCH_${YOKAI_HOST_ARCH_NAME_UPPER} ON)
+	unset(YOKAI_HOST_ARCH_UNKNOWN)
+endif()
+
+if (YOKAI_TARGET_ARCH_UNKNOWN AND NOT YOKAI_HOST_ARCH_UNKNOWN)
+	message(WARNING "Assuming the target architecture is the same as the host: ${YOKAI_TARGET_ARCH_NAME}")
+	set(YOKAI_TARGET_ARCH_NAME "${YOKAI_HOST_ARCH_NAME}")
+	set(YOKAI_TARGET_ARCH_NAME_UPPER "${YOKAI_HOST_ARCH_NAME_UPPER}")
+	set(YOKAI_TARGET_ARCH_${YOKAI_TARGET_ARCH_NAME_UPPER} ON)
+	unset(YOKAI_TARGET_ARCH_UNKNOWN)
+endif()
 
 if (YOKAI_HOST_ARCH_UNKNOWN)
 	message(WARNING "Unknown host architecture")
@@ -87,6 +187,17 @@ if (YOKAI_TARGET_ARCH_UNKNOWN)
 	message(WARNING "Unknown target architecture")
 else()
 	message(STATUS "Detected target architecture: ${YOKAI_TARGET_ARCH_NAME}")
+endif()
+
+if (NOT "${YOKAI_HOST_ARCH_NAME}" STREQUAL "${YOKAI_TARGET_ARCH_NAME}")
+	if ("${YOKAI_HOST_ARCH_${YOKAI_TARGET_ARCH_NAME}_PARENT}")
+		message(STATUS "Assuming no architecture cross-compilation")
+	else()
+		message(STATUS "Detected architecture cross-compilation")
+		set(YOKAI_TARGET_CROSS ON)
+	endif()
+else()
+	message(STATUS "No architecture cross-compilation detected")
 endif()
 
 if (YOKAI_SOURCE_GENERATOR)

--- a/cmake/Yokai/Architecture.cmake
+++ b/cmake/Yokai/Architecture.cmake
@@ -28,20 +28,23 @@
 # Architecture detection.
 ################################################################################
 
-# When adding a new architecture, look at all the places YOKAI_TARGET_ARCH is used.
+# When adding a new architecture, look at all the places YOKAI_HOST_ARCH
+# and YOKAI_TARGET_ARCH are used.
 
 option(USE_ARCH_INTRINSICS "Enable custom code using intrinsics functions or asm declarations" ON)
 mark_as_advanced(USE_ARCH_INTRINSICS)
 
-function(yokai_detect_arch)
+function(yokai_detect_target_arch)
 	yokai_run_detection("TARGET" "ARCH" "Architecture.c" "")
 
 	set(YOKAI_TARGET_ARCH_NAME "${arch_name}" PARENT_SCOPE)
 	set(YOKAI_TARGET_ARCH_NAME_UPPER "${arch_name_upper}" PARENT_SCOPE)
 
-	message(STATUS "Detected target architecture: ${arch_name}")
-
 	add_definitions(-DYOKAI_ARCH_${arch_name_upper})
+
+	# Makes possible to do that in CMake code:
+	# > if (YOKAI_TARGET_ARCH_AMD64)
+	set("YOKAI_TARGET_ARCH_${arch_name_upper}" ON PARENT_SCOPE)
 endfunction()
 
 function(yokai_set_arch_intrinsics name)
@@ -49,9 +52,6 @@ function(yokai_set_arch_intrinsics name)
 	string(TOUPPER "${name}" name_upper)
 	add_definitions(-DYOKAI_USE_ARCH_INTRINSICS_${name_upper})
 endfunction()
-
-option(USE_ARCH_INTRINSICS "Enable custom code using intrinsics functions or asm declarations" ON)
-mark_as_advanced(USE_ARCH_INTRINSICS)
 
 function(yokai_set_intrinsics)
 	if (USE_ARCH_INTRINSICS)
@@ -61,7 +61,6 @@ function(yokai_set_intrinsics)
 
 		# Makes possible to do that in C++ code:
 		# > if defined(YOKAI_USE_ARCH_INTRINSICS_AMD64)
-		# > if defined(YOKAI_USE_ARCH_INTRINSICS_I686)
 		yokai_set_arch_intrinsics("${YOKAI_TARGET_ARCH_NAME}")
 
 		set(amd64_PARENT "i686")
@@ -76,14 +75,23 @@ function(yokai_set_intrinsics)
 	endif()
 endfunction()
 
-yokai_detect_arch()
-yokai_set_intrinsics()
+yokai_detect_target_arch()
 
-# Makes possible to do that in CMake code:
-# > if (YOKAI_TARGET_ARCH_ARM64)
-set("YOKAI_TARGET_ARCH_${YOKAI_TARGET_ARCH_NAME_UPPER}" ON)
+if (YOKAI_HOST_ARCH_UNKNOWN)
+	message(WARNING "Unknown host architecture")
+else()
+	message(STATUS "Detected host architecture: ${YOKAI_HOST_ARCH_NAME}")
+endif()
+
+if (YOKAI_TARGET_ARCH_UNKNOWN)
+	message(WARNING "Unknown target architecture")
+else()
+	message(STATUS "Detected target architecture: ${YOKAI_TARGET_ARCH_NAME}")
+endif()
 
 if (YOKAI_SOURCE_GENERATOR)
 	# Add printable strings to the executable.
 	yokai_add_buildinfo("char*" "YOKAI_ARCH_STRING" "\"${YOKAI_TARGET_ARCH_NAME}\"")
 endif()
+
+yokai_set_intrinsics()

--- a/cmake/Yokai/Detection/Architecture.c
+++ b/cmake/Yokai/Detection/Architecture.c
@@ -107,6 +107,11 @@ platform variants we cannot support anyway. */
 #elif defined(Q_PROCESSOR_RISCV_64)
 	#pragma message(REPORT_NAME("riscv64"))
 
+/* Devices like:
+ - Loongson 3A6000, 3A5000… */
+#elif defined(Q_PROCESSOR_LOONGARCH_64)
+	#pragma message(REPORT_NAME("loong64"))
+
 /* Remaining native NaCl architecture. */
 
 #elif defined(Q_PROCESSOR_MIPS_32) && Q_BYTE_ORDER == Q_LITTLE_ENDIAN

--- a/cmake/Yokai/Detection/qprocessordetection.h
+++ b/cmake/Yokai/Detection/qprocessordetection.h
@@ -1,6 +1,7 @@
 // Copyright (C) 2016 The Qt Company Ltd.
 // Copyright (C) 2016 Intel Corporation.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
+// Qt-Security score:significant reason:default
 
 
 #if 0
@@ -51,8 +52,8 @@
 
     Alpha is bi-endian, use endianness auto-detection implemented below.
 */
-// #elif defined(__alpha__) || defined(_M_ALPHA)
-// #  define Q_PROCESSOR_ALPHA
+#if defined(__alpha__) || defined(_M_ALPHA)
+#  define Q_PROCESSOR_ALPHA
 // Q_BYTE_ORDER not defined, use endianness auto-detection
 
 /*
@@ -61,8 +62,8 @@
     ARM is bi-endian, detect using __ARMEL__ or __ARMEB__, falling back to
     auto-detection implemented below.
 */
-#if defined(__arm__) || defined(__TARGET_ARCH_ARM) || defined(_M_ARM) || defined(_M_ARM64) || defined(__aarch64__) || defined(__ARM64__)
-#  if defined(__aarch64__) || defined(__ARM64__) || defined(_M_ARM64)
+#elif defined(__arm__) || defined(__TARGET_ARCH_ARM) || defined(_M_ARM) || defined(_M_ARM64) || defined(__aarch64__) || defined(__ARM64__) || defined(_ARM64EC_)
+#  if defined(__aarch64__) || defined(__ARM64__) || defined(_M_ARM64) || defined(_ARM64EC_)
 #    define Q_PROCESSOR_ARM_64
 #    define Q_PROCESSOR_WORDSIZE 8
 #  else
@@ -78,7 +79,8 @@
       || defined(__aarch64__) \
       || defined(__ARMv8__) \
       || defined(__ARMv8_A__) \
-      || defined(_M_ARM64)
+      || defined(_M_ARM64) \
+      || defined (_ARM64EC_)
 #    define Q_PROCESSOR_ARM 8
 #  elif defined(__ARM_ARCH_7__) \
       || defined(__ARM_ARCH_7A__) \
@@ -116,7 +118,10 @@
 #  else
 #    error "ARM architecture too old"
 #  endif
-#  if defined(__ARMEL__) || defined(_M_ARM64)
+#  if defined(_ARM64EC_)
+#    define Q_PROCESSOR_ARM_64_EC
+#  endif
+#  if defined(__ARMEL__) || defined(_M_ARM64) || defined(_ARM64EC_)
 #    define Q_BYTE_ORDER Q_LITTLE_ENDIAN
 #  elif defined(__ARMEB__)
 #    define Q_BYTE_ORDER Q_BIG_ENDIAN
@@ -198,6 +203,20 @@
 #  define Q_PROCESSOR_IA64
 #  define Q_PROCESSOR_WORDSIZE   8
 // Q_BYTE_ORDER not defined, use endianness auto-detection
+
+/*
+    LoongArch family, known variants: 32- and 64-bit
+
+    LoongArch is little-endian.
+*/
+#elif defined(__loongarch__)
+#  define Q_PROCESSOR_LOONGARCH
+#  if __loongarch_grlen == 64
+#    define Q_PROCESSOR_LOONGARCH_64
+#  else
+#    define Q_PROCESSOR_LOONGARCH_32
+#  endif
+#  define Q_BYTE_ORDER Q_LITTLE_ENDIAN
 
 /*
     Motorola 68000 family, no revisions or variants
@@ -327,6 +346,8 @@
 #  define Q_PROCESSOR_WORDSIZE 8
 #ifdef QT_COMPILER_SUPPORTS_SSE2
 #  define Q_PROCESSOR_X86 6   // enables SIMD support
+# define Q_PROCESSOR_X86_64 // wasm64
+#  define Q_PROCESSOR_WASM_64
 #endif
 
 #endif

--- a/cmake/Yokai/System.cmake
+++ b/cmake/Yokai/System.cmake
@@ -34,89 +34,103 @@
 function(yokai_detect_host_system)
 	set(system_name "Unknown")
 
-	foreach(name Linux;FreeBSD;Android;Windows)
+	foreach(name
+		"Linux"
+		"FreeBSD"
+		"Android"
+		"Windows"
+	)
 		if (CMAKE_HOST_SYSTEM_NAME MATCHES "${name}")
-			set(system_name "${CMAKE_SYSTEM_NAME}")
+			set(system_name "${CMAKE_HOST_SYSTEM_NAME}")
 		endif()
 	endforeach()
 
-	if (system_name STREQUAL "Unknown")
+	if ("${system_name}" STREQUAL "Unknown")
 		set(SYSTEM_Darwin "macOS")
 		set(SYSTEM_MSYS "Windows")
 
-		foreach(name Darwin;MSYS)
+		foreach(name
+			"Darwin"
+			"MSYS"
+		)
 			if ("${CMAKE_HOST_SYSTEM_NAME}" MATCHES "${name}")
 				set(system_name "${SYSTEM_${name}}")
 			endif()
 		endforeach()
 	endif()
 
-	if (system_name STREQUAL "Unknown")
-		message(WARNING "Host system detection failed, may misdetect the target as the host.")
-
-		if (WIN32)
-			set(system_name "Windows")
-		elseif (APPLE)
-			set(system_name "macOS")
-		endif()
-	endif()
+	string(TOUPPER "${system_name}" system_name_upper)
 
 	set(YOKAI_HOST_SYSTEM_NAME "${system_name}" PARENT_SCOPE)
 	set(YOKAI_HOST_SYSTEM_NAME_UPPER "${system_name_upper}" PARENT_SCOPE)
+
+	# Makes possible to do that in CMake code:
+	# > if (YOKAI_HOST_SYSTEM_LINUX)
+	set(YOKAI_HOST_SYSTEM_${system_name_upper} ON PARENT_SCOPE)
 endfunction()
 
-function(yokai_detect_system)
+function(yokai_detect_target_system)
 	yokai_run_detection("TARGET" "SYSTEM" "System.c" "Linux")
-
-	if (system_name STREQUAL "Unknown")
-		detect_cmake_host_system("system_name")
-	endif()
 
 	set(YOKAI_TARGET_SYSTEM_NAME "${system_name}" PARENT_SCOPE)
 	set(YOKAI_TARGET_SYSTEM_NAME_UPPER "${system_name_upper}" PARENT_SCOPE)
+
+	# Makes possible to do that in CMake code:
+	# > if (YOKAI_TARGET_SYSTEM_LINUX)
+	set(YOKAI_TARGET_SYSTEM_${system_name_upper} ON PARENT_SCOPE)
 endfunction()
 
 yokai_detect_host_system()
-yokai_detect_system()
+yokai_detect_target_system()
 
-if ("${YOKAI_HOST_SYSTEM_NAME}" STREQUAL "Unknown")
-	message(WARNING "Unknown host system")
-endif()
-
-if ("${YOKAI_TARGET_SYSTEM_NAME}" STREQUAL "Unknown")
-	message(WARNING "Unknown target system")
-endif()
-
-if ("${YOKAI_HOST_SYSTEM_NAME}" STREQUAL "Unknown" AND NOT "${YOKAI_TARGET_SYSTEM_NAME}" STREQUAL "Unknown")
+if (YOKAI_HOST_SYSTEM_UNKNOWN AND NOT YOKAI_TARGET_SYSTEM_UNKNOWN)
 	message(WARNING "Assuming the host system is the same as the target: ${YOKAI_TARGET_SYSTEM_NAME}")
 	set(YOKAI_HOST_SYSTEM_NAME "${YOKAI_TARGET_SYSTEM_NAME}")
+	set(YOKAI_HOST_SYSTEM_NAME_UPPER "${YOKAI_TARGET_SYSTEM_NAME_UPPER}")
+	set(YOKAI_HOST_SYSTEM_${YOKAI_HOST_SYSTEM_NAME_UPPER} ON)
+	unset(YOKAI_HOST_SYSTEM_UNKNOWN)
 endif()
 
-if ("${YOKAI_TARGET_SYSTEM_NAME}" STREQUAL "Unknown" AND NOT "${YOKAI_HOST_SYSTEM_NAME}" STREQUAL "Unknown")
+if (YOKAI_TARGET_SYSTEM_UNKNOWN AND NOT YOKAI_HOST_SYSTEM_UNKNOWN)
 	message(WARNING "Assuming the target system is the same as the host: ${YOKAI_TARGET_SYSTEM_NAME}")
 	set(YOKAI_TARGET_SYSTEM_NAME "${YOKAI_HOST_SYSTEM_NAME}")
+	set(YOKAI_TARGET_SYSTEM_NAME_UPPER "${YOKAI_HOST_SYSTEM_NAME_UPPER}")
+	set(YOKAI_TARGET_SYSTEM_${YOKAI_TARGET_SYSTEM_NAME_UPPER} ON)
+	unset(YOKAI_TARGET_SYSTEM_UNKNOWN)
 endif()
 
-message(STATUS "Detected host system: ${YOKAI_HOST_SYSTEM_NAME}")
-message(STATUS "Detected target system: ${YOKAI_TARGET_SYSTEM_NAME}")
+if (YOKAI_HOST_SYSTEM_UNKNOWN)
+	message(WARNING "Unknown host system")
+else()
+	message(STATUS "Detected host system: ${YOKAI_HOST_SYSTEM_NAME}")
+endif()
+
+if (YOKAI_TARGET_SYSTEM_UNKNOWN)
+	message(WARNING "Unknown target system")
+else()
+	message(STATUS "Detected target system: ${YOKAI_TARGET_SYSTEM_NAME}")
+endif()
 
 if (NOT "${YOKAI_HOST_SYSTEM_NAME}" STREQUAL "${YOKAI_TARGET_SYSTEM_NAME}")
-	message(STATUS "Detected cross-compilation")
+	message(STATUS "Detected system cross-compilation")
+	set(YOKAI_SYSTEM_CROSS ON)
+else()
+	message(STATUS "No system cross-compilation detected")
 endif()
-
-# Makes possible to do that in CMake code:
-# > if (YOKAI_HOST_SYSTEM_LINUX)
-# > if (YOKAI_TARGET_SYSTEM_WINDOWS)
-set("YOKAI_HOST_SYSTEM_${YOKAI_HOST_SYSTEM_NAME_UPPER}" ON)
-set("YOKAI_TARGET_SYSTEM_${YOKAI_TARGET_SYSTEM_NAME_UPPER}" ON)
 
 # This is for systems behaving similarly to a Linux Desktop,
 # implementing standards like FHS, XDG, GLVND…
 # Makes possible to do that in CMake code:
 # > if (YOKAI_HOST_SYSTEM_XDG_COMPATIBILITY)
 # > if (YOKAI_TARGET_SYSTEM_XDG_COMPATIBILITY)
-foreach(name LINUX;FREEBSD)
-	foreach(slug HOST_SYSTEM;TARGET_SYSTEM)
+foreach(name
+	"LINUX"
+	"FREEBSD"
+)
+	foreach(slug
+		"HOST_SYSTEM"
+		"TARGET_SYSTEM"
+	)
 		if (YOKAI_${slug}_${name})
 			set(YOKAI_${slug}_XDG_COMPATIBILITY ON)
 		endif()


### PR DESCRIPTION
- Update `qprocessordetection.h` from Qt upstream and recognize `loong64`.
  The Loongsoon architecture is one of the architectures supported by `box64`, so it's likely possible to run Unvanquished on it (like `ppc64el` and `riscv64`).
- Rework the architecture and system detection.
  Unify the woridng of the code, and better code in general, also fixes some edge cases Unvanquished/Dæmon wasn't triggering.
- Detect host architecture.
  Make possible to detect when cross-compiling from one architecture to another on the same system.

I started using Yokai in a local branch of the Saigo release scripts and I noticed a linking bug happening on FreeBSD when cross-compiling a 32-bit binutils on a 64-bit system (classic `-L/usr/lib32` thing). I finally fixed that by patching binutils, but that's a proof it is useful to detect that the target architecture differs from the host target.