### PR TITLE
cmake: make the glibc file offset great again

### DIFF
--- a/cmake/DaemonFlags.cmake
+++ b/cmake/DaemonFlags.cmake
@@ -742,7 +742,7 @@ if (YOKAI_TARGET_SYSTEM_MACOS)
 endif()
 
 # Glibc-specific definitions
-if (LINUX)
+if (YOKAI_TARGET_SYSTEM_LINUX_COMPATIBILITY)
 	# QUIRK: It does nothing when it is not needed on non-glibc Linux
 	# systems so it's harmless to always set it.
 	add_definitions(-D_FILE_OFFSET_BITS=64)


### PR DESCRIPTION
I'm surprised the CI didn't catch it, that's a minor regression from me missing a rewrite after the porting to Yokai.

This affects `linux-i686` where we need to assume such file stuff size is 64-bit whatever the architecture.